### PR TITLE
fix(scraping): sanitize LA LLM role-literal case_title placeholders in HTML extraction (#3749)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -85,6 +85,12 @@ from framework.la_parser_utils import (
 from framework.la_parser_utils import (
     SKIP_RESPONDING_PHRASES as _SKIP_RESPONDING_PHRASES,
 )
+from framework.llm_extractor import (
+    _ROLE_LITERAL_TITLE_RE as _ROLE_LITERAL_TITLE_RE,
+)
+from framework.llm_extractor import (
+    _rebuild_title_from_parties as _rebuild_title_from_parties,
+)
 from framework.llm_utils import parse_llm_json
 from framework.party_utils import (
     is_name_fragment as _is_name_fragment,  # noqa: F401 — re-exported for tests
@@ -370,9 +376,13 @@ LA_SYSTEM_PROMPT = (
     "has 3 'Case Number:' entries, return 3 rulings.\n"
     "2. Extract the case number EXACTLY as it appears (including any "
     "leading digits).\n"
-    "3. For case_title, use 'Plaintiff v. Defendant' format. Strip "
-    "legal entity descriptors like 'an individual', 'a corporation', "
-    "etc. Use title case.\n"
+    "3. For extracted_case_title, name the parties explicitly: "
+    "'<plaintiff_name> v. <defendant_name>' (e.g. 'Aasi v. American Honda Motor Co.'). "
+    "Strip legal entity descriptors like 'an individual', 'a corporation', etc. "
+    "Use title case. "
+    "If the caption does not name both parties, return null for extracted_case_title — "
+    "do NOT use the literal words 'Plaintiff', 'Defendant', 'Petitioner', or 'Respondent' "
+    "as party names in the title.\n"
     "4. For ruling_text, include the COMPLETE ruling text verbatim. "
     "Include all legal analysis, citations, and reasoning. Do NOT "
     "truncate or summarize.\n"
@@ -492,12 +502,29 @@ def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
                         continue
                     parties.append({"name": name, "role": str(p["role"])})
 
+        case_title = entry.get("extracted_case_title")
+        if case_title and _ROLE_LITERAL_TITLE_RE.match(case_title):
+            rebuilt = _rebuild_title_from_parties(case_title, parties)
+            if rebuilt is not None:
+                logger.info(
+                    "la.llm_role_literal_title_rebuilt",
+                    before=case_title,
+                    after=rebuilt,
+                )
+                case_title = rebuilt
+            else:
+                logger.info(
+                    "la.llm_role_literal_title_dropped",
+                    before=case_title,
+                )
+                case_title = None
+
         rulings.append(
             LASplitRuling(
                 ruling_index=idx + 1,
                 case_number=entry.get("extracted_case_number"),
                 ruling_text=entry.get("ruling_text") or "",
-                case_title=entry.get("extracted_case_title"),
+                case_title=case_title,
                 motion_type=entry.get("motion_type"),
                 outcome=outcome,
                 parties=parties,

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -1373,8 +1373,12 @@ def _rebuild_title_from_parties(
     plaintiff_name: str | None = None
     defendant_name: str | None = None
     for party in parties:
-        role = getattr(party, "role", None) or ""
-        name = getattr(party, "name", None) or ""
+        if isinstance(party, dict):
+            role = party.get("role") or ""
+            name = party.get("name") or ""
+        else:
+            role = getattr(party, "role", None) or ""
+            name = getattr(party, "name", None) or ""
         if not name:
             continue
         if role.lower() in plaintiff_roles and plaintiff_name is None:

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -3942,3 +3942,88 @@ def test_extract_ruling_fields_landaverde_fixture_end_to_end() -> None:
         assert "07-03-25" not in doc.case_title
         assert "Landaverde" in doc.case_title
         assert "Meller" in doc.case_title
+
+
+# ---------------------------------------------------------------------------
+# TestLlmExtractRulingsRoleLiteralTitle — role-literal case_title suppression
+# (#3749)
+# ---------------------------------------------------------------------------
+
+
+class TestLlmExtractRulingsRoleLiteralTitle:
+    """Tests for role-literal case_title sanitization in _llm_extract_rulings().
+
+    The LA LLM occasionally emits placeholders like "Plaintiff v. General Motors, LLC"
+    instead of real party names.  The post-processor should either rebuild the title
+    from extracted parties or drop it to None — never let a role-literal placeholder
+    reach the DB.  See #3749.
+    """
+
+    def test_role_literal_title_rebuilt_from_parties(self) -> None:
+        """LLM emits 'Plaintiff v. General Motors, LLC' + real parties → rebuilt title."""
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV35786",
+                "extracted_case_title": "Plaintiff v. General Motors, LLC",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [
+                    {"name": "Sumayya Aasi", "role": "plaintiff"},
+                    {"name": "General Motors, LLC", "role": "defendant"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV35786</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Sumayya Aasi v. General Motors, LLC"
+
+    def test_role_literal_title_dropped_when_parties_insufficient(self) -> None:
+        """LLM emits 'Plaintiff v. Defendant' with no parties → case_title is None."""
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV99999",
+                "extracted_case_title": "Plaintiff v. Defendant",
+                "outcome": "granted",
+                "ruling_text": "The motion is GRANTED.",
+                "parties": [],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV99999</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title is None
+
+    def test_clean_title_passes_through(self) -> None:
+        """A real party-name title is not affected by the role-literal sanitizer."""
+        rulings_data = [
+            {
+                "extracted_case_number": "24NNCV02551",
+                "extracted_case_title": "Aasi v. American Honda",
+                "outcome": "granted",
+                "ruling_text": "The motion is GRANTED.",
+                "parties": [
+                    {"name": "Sumayya Aasi", "role": "plaintiff"},
+                    {"name": "American Honda Motor Co., Inc.", "role": "defendant"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 24NNCV02551</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Aasi v. American Honda"

--- a/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
+++ b/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
@@ -209,6 +209,20 @@ def test_rebuild_role_literal_title_none_input() -> None:
     assert result is None
 
 
+def test_rebuild_title_from_parties_accepts_dict_shaped_parties() -> None:
+    """_rebuild_title_from_parties accepts dict-shaped parties (LA path) — #3749.
+
+    LA uses list[dict[str, str]] rather than pydantic ExtractedParty instances.
+    The dict-adapter branch must return the same rebuilt title as the getattr path.
+    """
+    parties = [
+        {"name": "Sumayya Aasi", "role": "plaintiff"},
+        {"name": "General Motors, LLC", "role": "defendant"},
+    ]
+    result = _rebuild_title_from_parties("Plaintiff v. General Motors, LLC", parties)
+    assert result == "Sumayya Aasi v. General Motors, LLC"
+
+
 # ---------------------------------------------------------------------------
 # _sanitize_san_bernardino_rulings — orchestrator covers all paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixed role-literal case_title placeholders in LA HTML LLM extraction (#3749). The LA_SYSTEM_PROMPT's instruction to "use 'Plaintiff v. Defendant' format" was ambiguous and caused the LLM to emit literal role words (Plaintiff, Defendant, etc.) as party names when the document caption was missing or incomplete. 

Updated prompt rule 3 to explicitly forbid literal role words and require null when both parties cannot be identified. Extended _rebuild_title_from_parties() to handle dict-shaped parties (LA path) in addition to pydantic ExtractedParty instances. Wired sanitizer into _llm_extract_rulings() to detect role-literal titles via the existing _ROLE_LITERAL_TITLE_RE regex, rebuild from extracted parties if available, or drop to None. Added structlog observability events for rebuilt/dropped titles.

Closes #3749

## Test plan

### Automated checks

- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (pytest) — three new regression tests in TestLlmExtractRulingsRoleLiteralTitle cover rebuild, null-drop, and pass-through paths; dict-adapter test added to test_san_bernardino_multi_case.py
- [x] CI green (all pre-push checks passed per ralph summary)

### Post-deploy verification

- [ ] Role-literal case_titles for LA drop to 0 (or ≤2 if genuine "Plaintiff Inc." cases exist): `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.cases cs JOIN derived.courts c ON cs.court_id = c.id WHERE c.county = 'Los Angeles' AND cs.case_title ~ '^Plaintiff(s)?\\s+v[s]?\\.?\\s'"` should return 0-2
- [ ] Run LA backfill: `scripts/rebuild_db.py --county "Los Angeles"` re-extracts the 37 affected cases with the new sanitizer in place
- [ ] Spot-check one affected case (`25STCV35786`) in derived.cases to confirm case_title is now a real plaintiff name (or null if insufficient party data exists) rather than the placeholder
- [ ] Verification evidence posted on #3749 (see /task-v2-verify output)