### PR TITLE
fix(scraping): resolve SD judge lookup by storing both C-NN and NN keys (#3753)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -617,7 +617,9 @@ class SDCalendarScraper(BaseScraper):
             matching = [h for h in hearings if _case_numbers_match(doc.case_number, h.case_number)]
 
         if matching:
-            hearing = matching[0]
+            # Prefer the first row that has a real judge name; fall back to
+            # matching[0] when every row has judge_name=None.
+            hearing = next((h for h in matching if h.judge_name is not None), matching[0])
             # Populate metadata fields that are not already set.
             if not doc.department:
                 doc.department = hearing.department

--- a/packages/scraper-framework/src/courts/ca/sd_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/sd_dept_judges.py
@@ -21,6 +21,11 @@ This module provides:
 
 Department codes are normalized by stripping leading zeros for comparison,
 using the same normalization as the LA mapping module.
+
+SD convention: purely-numeric department codes in the assignments page (e.g. "64")
+correspond to the Central courthouse, which the civil calendar encodes explicitly
+as "C-NN" (e.g. "C-64").  ``build_department_judge_map`` stores both keys so
+lookups from either source format succeed.
 """
 
 from __future__ import annotations
@@ -135,6 +140,10 @@ def build_department_judge_map(
                 existing=dept_map[norm_dept],
                 duplicate=entry.judge_name,
             )
+        # SD convention: bare-numeric dept in the assignments page = Central courthouse;
+        # the calendar writes C-NN explicitly, so alias both keys.
+        if norm_dept.isdigit() and f"C-{norm_dept}" not in dept_map:
+            dept_map[f"C-{norm_dept}"] = entry.judge_name
     return dept_map
 
 

--- a/packages/scraper-framework/tests/courts/test_sd_calendar.py
+++ b/packages/scraper-framework/tests/courts/test_sd_calendar.py
@@ -1135,6 +1135,74 @@ class TestParseDocumentMetadata:
         assert config is not None
         assert config.method == ExtractionMethod.NONE
 
+    def test_prefers_real_judge_over_placeholder(self) -> None:
+        """parse_document picks the matching row with a real judge name, not the placeholder.
+
+        When multiple rows for the same case number exist — one with a generic
+        placeholder (e.g. 'Judge C-72 Central' → None) and one with a real judge
+        name — parse_document must return the real judge name.  The placeholder
+        row comes first to ensure the new selection logic, not insertion order,
+        drives the result.
+        """
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+
+        from framework.models import CapturedDocument
+
+        # Build a synthetic two-row calendar page: placeholder row first,
+        # then a real-judge row for the same case number in the same dept.
+        html = (
+            "<html><head></head><body>"
+            "<h1>CIVIL CALENDAR For Friday, 03/13/2026</h1>"
+            "<h3>CENTRAL DIVISION, CENTRAL COURTHOUSE</h3>"
+            '<div class="department">'
+            "<h2><a name='C-72'></a>Department: C-72</h2>"
+            '<table class="tables">'
+            "<thead><tr>"
+            "<th>Time</th><th>Case#</th><th>Title</th>"
+            "<th>Event</th><th>Officer</th><th>Party</th><th>Attorney</th>"
+            "</tr></thead>"
+            "<tbody>"
+            # Row 1: placeholder judge (parses to judge_name=None) — comes first.
+            "<tr>"
+            "<td>9:00 AM</td>"
+            "<td>24CU016153C</td>"
+            "<td>Smith vs Jones</td>"
+            "<td>Motion Hearing</td>"
+            "<td>Judge C-72 Central</td>"
+            "<td><p>(PL) John Smith</p></td>"
+            "<td><p>Jane Doe</p></td>"
+            "</tr>"
+            # Row 2: real judge name.
+            "<tr>"
+            "<td>9:00 AM</td>"
+            "<td>24CU016153C</td>"
+            "<td>Smith vs Jones</td>"
+            "<td>Motion Hearing</td>"
+            "<td>Judge MARCELLA O. MCLAUGHLIN</td>"
+            "<td><p>(PL) John Smith</p></td>"
+            "<td><p>Jane Doe</p></td>"
+            "</tr>"
+            "</tbody>"
+            "</table>"
+            "</div>"
+            "</body></html>"
+        )
+        doc = CapturedDocument(
+            scraper_id="ca-sd-calendar",
+            state="CA",
+            county="San Diego",
+            court="Superior Court",
+            source_url="http://example.com",
+            capture_timestamp=datetime(2026, 3, 13),
+            content_format=ContentFormat.HTML,
+            raw_content=html.encode("utf-8"),
+            content_hash="abc123",
+            case_number="24CU016153C",
+        )
+        result = scraper.parse_document(doc)
+        assert result.judge_name == "Marcella O. Mclaughlin"
+
 
 # ---------------------------------------------------------------------------
 # default_config — factory test

--- a/packages/scraper-framework/tests/courts/test_sd_dept_judges.py
+++ b/packages/scraper-framework/tests/courts/test_sd_dept_judges.py
@@ -151,6 +151,40 @@ class TestBuildDepartmentJudgeMap:
         dept_map = build_department_judge_map(entries)
         assert dept_map["N-18"] == "First Judge"
 
+    def test_central_dept_gets_both_keys(self) -> None:
+        """Purely-numeric Central dept creates both 'NN' and 'C-NN' keys."""
+        entries = [DepartmentJudge(department="64", judge_name="Loren G. Freestone")]
+        dept_map = build_department_judge_map(entries)
+        assert dept_map["64"] == "Loren G. Freestone"
+        assert dept_map["C-64"] == "Loren G. Freestone"
+
+    def test_non_numeric_dept_not_aliased(self) -> None:
+        """A non-numeric dept like 'N-18' must NOT get a spurious 'C-N-18' alias."""
+        entries = [DepartmentJudge(department="N-18", judge_name="Renee N.G. Stackhouse")]
+        dept_map = build_department_judge_map(entries)
+        assert "N-18" in dept_map
+        assert "C-N-18" not in dept_map
+
+    def test_existing_c_nn_entry_not_overwritten(self) -> None:
+        """If 'C-64' already exists, the alias write must not overwrite it."""
+        entries = [
+            DepartmentJudge(department="C-64", judge_name="Original Judge"),
+            DepartmentJudge(department="64", judge_name="Loren G. Freestone"),
+        ]
+        dept_map = build_department_judge_map(entries)
+        assert dept_map["C-64"] == "Original Judge"
+        assert dept_map["64"] == "Loren G. Freestone"
+
+    def test_fixture_central_depts_have_both_forms(self) -> None:
+        """Real fixture: bare-numeric Central entries are aliased to 'C-NN' form."""
+        html = _load("sd_judge_assignments.html")
+        entries = parse_judge_assignments_html(html)
+        dept_map = build_department_judge_map(entries)
+        # Dept 64 (Loren G. Freestone) is a bare-numeric Central entry in the fixture.
+        assert "64" in dept_map
+        assert "C-64" in dept_map
+        assert dept_map["64"] == dept_map["C-64"]
+
 
 # ---------------------------------------------------------------------------
 # lookup_judge_for_department — unit tests


### PR DESCRIPTION
## Summary

Fixed SD civil calendar `judge_name = NULL` issue caused by a department format mismatch between snapshot (bare-numeric: "64") and calendar (C-prefixed: "C-64") codes. Implemented two complementary fixes:

1. **Snapshot side**: `build_department_judge_map` now aliases purely-numeric Central departments to store both forms, enabling cross-format lookups.
2. **Calendar side**: `parse_document` prefers matching rows with real judge names over placeholder rows, recovering cases where the real judge is already present elsewhere in the page.

Closes #3753

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — all 6898 tests pass
- [x] CI green

### Post-deploy verification

- [ ] Re-snapshot SD directory via `scripts/fetch_rosters.py` to populate new C-NN keys
- [ ] Re-ingest via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "San Diego"`
- [ ] Verify NULL-`judge_id` count for SD calendar-sourced rulings drops to ≤ 5% via:
  ```bash
  scripts/dev-db-query.sh "SELECT COUNT(*) FILTER (WHERE judge_id IS NULL)::float / NULLIF(COUNT(*), 0) AS null_rate FROM derived.rulings r JOIN derived.documents d ON d.id = r.document_id JOIN derived.cases c ON c.id = r.case_id WHERE c.state = 'CA' AND c.county = 'San Diego'"
  ```
- [ ] Verification evidence posted on #3753 (see /task-v2-verify output)