### PR TITLE
fix(dispatcher): re-register agent-runner task-def after ECR push (#3863)

### DIFF
--- a/.github/workflows/deploy-agent-runner.yml
+++ b/.github/workflows/deploy-agent-runner.yml
@@ -1,12 +1,16 @@
 name: Deploy Agent Runner
 
 # Builds and pushes the dispatcher agent-runner image
-# (`judgemind/dispatcher-agent-runner`) to ECR on merge to main. Mirrors
-# the build-and-push half of `deploy-dispatcher.yml`, without the
-# service rollout step — the agent-runner is a *task definition* family,
-# not a service. New `ecs:RunTask` launches pick up the latest image
-# naturally via the `:latest` tag pinned in the task-def (see
-# `infra/terraform/modules/dispatcher-agent-runner/main.tf`).
+# (`judgemind/dispatcher-agent-runner`) to ECR on merge to main, then
+# re-registers the agent-runner task definition so its `registeredAt`
+# timestamp moves alongside the ECR push. Mirrors the build-and-push
+# half of `deploy-dispatcher.yml`; the agent-runner is a *task
+# definition* family rather than a service, so there's no service to
+# roll — but the daemon's `_check_agent_runner_image_freshness` guard
+# (scripts/dispatcher/daemon.py, AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS)
+# refuses launches when ECR `:latest` was pushed more than 5 minutes
+# AFTER the task-def was last registered. Re-registering inside this
+# workflow keeps that invariant true (see #3863).
 #
 # Background
 # ----------
@@ -140,6 +144,49 @@ jobs:
             --output json \
             --query 'imageDetails[0].{digest:imageDigest,tags:imageTags,pushedAt:imagePushedAt}'
 
+      - name: Re-register agent-runner task definition
+        env:
+          FAMILY: judgemind-dispatcher-agent-runner-dev
+        run: |
+          # The daemon's `_check_agent_runner_image_freshness` guard
+          # (scripts/dispatcher/daemon.py) refuses agent launches when
+          # ECR `:latest` was pushed more than 5 min after the task-def
+          # was last registered. Re-register here so the guard's
+          # invariant holds for the lifetime of this image. Same shape
+          # as `aws ecs update-service --force-new-deployment` for
+          # service-backed task-defs; agent-runner is run-task-only
+          # (no service), so we just register a new revision pointing
+          # at the same `:latest` URI.  See #3863.
+          aws ecs describe-task-definition \
+            --task-definition "$FAMILY" \
+            --region "$AWS_REGION" \
+            --no-cli-pager \
+            > /tmp/agent_runner_td.json
+          jq '.taskDefinition | {
+            family,
+            networkMode,
+            executionRoleArn,
+            taskRoleArn,
+            containerDefinitions,
+            requiresCompatibilities,
+            cpu,
+            memory,
+            runtimePlatform,
+            ephemeralStorage,
+            placementConstraints,
+            volumes,
+            pidMode,
+            ipcMode,
+            proxyConfiguration
+          } | with_entries(select(.value != null))' \
+            /tmp/agent_runner_td.json > /tmp/agent_runner_td_input.json
+          aws ecs register-task-definition \
+            --region "$AWS_REGION" \
+            --cli-input-json file:///tmp/agent_runner_td_input.json \
+            --no-cli-pager \
+            --query 'taskDefinition.{revision: revision, registeredAt: registeredAt, image: containerDefinitions[0].image}' \
+            --output table
+
       - name: Publish build summary
         env:
           IMAGE_URI: ${{ steps.build.outputs.image_uri }}
@@ -155,4 +202,5 @@ jobs:
             echo "- **Also tagged:** \`latest\`, \`$BRANCH_TAG\`"
             echo ""
             echo "Next \`ecs:RunTask\` against the \`judgemind-dispatcher-agent-runner-dev\` family will pull this image via the \`:latest\` tag."
+            echo "Task-def re-registered to refresh the daemon's image-freshness guard (see #3863)."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds a `register-task-definition` step to `.github/workflows/deploy-agent-runner.yml` so the task-def's `registeredAt` timestamp moves alongside every ECR push.
- Updates the workflow header to remove the false ":latest picks up new image naturally" claim that originally seeded the bug.

Closes #3863.

## Why

`scripts/dispatcher/daemon.py::_check_agent_runner_image_freshness` (constant `AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS = 300`) refuses launches when ECR `:latest.imagePushedAt` is more than 5 min after `taskDefinition.registeredAt`. The author's design intent was for the deploy workflow to register a new task-def revision alongside every image push — keeping the freshness invariant true within ~90s of jitter. But the workflow never had that step, so every deploy silently broke the guard within 5 minutes and the daemon refused all subsequent launches with `agent_runner_image_stale` reason `ecr_pushed_after_task_def_registered`.

Today's incident at 03:20:30Z (May 2): five claim-phase refusals in 21s tripped the circuit breaker (cap=0). 30-min auto-close window expired → daemon dispatched 5 more → all refused → breaker re-opened. Pattern repeated five times, hours of zero throughput. Yesterday's 15:06Z incident was the same shape. Operator manually re-registered the task-def both times.

The freshness guard is the correct invariant for `:latest`-tagged task-defs (per the daemon's design comment). The fix is to honor it from the deploy side rather than relax it.

## Test plan

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(open(...))"`).
- [ ] CI passes on this PR (workflow files don't run on PRs, but lint should).
- [ ] After merge, the next `deploy-agent-runner` workflow run executes the new step and registers a new task-def revision. The daemon's next launch should succeed (no `agent_runner_image_stale` event).
- [ ] CloudWatch query post-merge: `filter event = "agent_runner_image_freshness_check_passed"` over `/ecs/judgemind-dispatcher-dev` should return rows; `filter event = "agent_runner_image_stale"` should not.

## Risk

- The new step needs `ecs:DescribeTaskDefinition` and `ecs:RegisterTaskDefinition` (and `iam:PassRole` for the executionRoleArn + taskRoleArn baked into the task-def). The workflow uses static `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` credentials (deploy-agent-runner.yml line 86-87). If the role lacks those perms, the workflow will fail loudly on its first post-merge run; the existing image push path (which happens earlier) is unaffected. I'll watch the first deploy after merge and follow up if perms need to be widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
