### PR TITLE
chore(scrapers): move ExampleScraper template to docs/examples (#3835)

### DIFF
--- a/docs/examples/scraper_template.py
+++ b/docs/examples/scraper_template.py
@@ -1,7 +1,17 @@
-"""Example scraper — demonstrates the BaseScraper pattern with a dummy court.
+"""Reference template — demonstrates the BaseScraper pattern with a dummy court.
 
-This is not a real scraper. It shows how to implement BaseScraper correctly
-and is used as a reference when building per-court scrapers.
+This is not a real scraper and is not registered in the runner. It lives under
+``docs/examples/`` (rather than ``packages/scraper-framework/src/courts/``) so
+it cannot be mistaken for a production scraper. Use it as a starting point
+when building a new per-court scraper: copy it into
+``packages/scraper-framework/src/courts/<state>/<your_scraper>.py``, replace
+the dummy logic with real fetch/parse code, and register it in
+``framework/runner.py``.
+
+To run this template directly (for illustration), activate the
+``packages/scraper-framework/.venv`` and execute:
+
+    python docs/examples/scraper_template.py
 """
 
 from __future__ import annotations

--- a/docs/investigations/coverage-gap-audit-2026-03.md
+++ b/docs/investigations/coverage-gap-audit-2026-03.md
@@ -45,7 +45,7 @@ Most scrapers are at 93-100%: cc_tentatives (98%), oc_tentatives (96%), oc_famil
 
 ### Intentionally low-coverage
 
-- `src/courts/ca/example.py` (0%) — example/template file, not production code
+- `docs/examples/scraper_template.py` (not measured) — reference template, moved out of `src/courts/ca/` per #3835 so it isn't mistaken for a production scraper
 - `src/framework/__main__.py` (0%) — CLI entry point
 - `src/ingestion/__main__.py` (0%) — CLI entry point
 

--- a/packages/scraper-framework/tests/test_check_scraper_registry.py
+++ b/packages/scraper-framework/tests/test_check_scraper_registry.py
@@ -75,7 +75,6 @@ class TestFindScraperModules:
         """Helper modules without default_config are not included."""
         modules = check_registry.find_scraper_modules(COURTS_DIR)
         excluded = [
-            "courts.ca.example",
             "courts.ca.pdf_link_scraper",
             "courts.ca.la_dept_judges",
             "courts.ca.riverside_dept_judges",


### PR DESCRIPTION
## Summary

Moves `packages/scraper-framework/src/courts/ca/example.py` to `docs/examples/scraper_template.py` so the reference template no longer sits alongside production scrapers in `courts/ca/`. Refreshes the docstring with copy-into-place instructions, drops the now-stale `courts.ca.example` entry from the helper-modules-excluded test list, and updates the coverage-gap audit's path reference.

Closes #3835

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/test config only; the moved file was never registered in the runner and not imported by any production code path)
- [ ] Verification evidence posted on issue (see A.8)
