### PR TITLE
fix(scraping): prevent LLM placeholder echoed into judges (#3850)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -411,7 +411,7 @@ LA_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "3" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/llm_schema.py
+++ b/packages/scraper-framework/src/framework/llm_schema.py
@@ -285,7 +285,7 @@ EXTRACTION_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "C25" or "N14" or "CM02" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/contra_costa.py
+++ b/packages/scraper-framework/src/framework/prompts/contra_costa.py
@@ -189,7 +189,7 @@ CONTRA_COSTA_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "14" or "16" or "30" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/riverside.py
+++ b/packages/scraper-framework/src/framework/prompts/riverside.py
@@ -141,7 +141,7 @@ RIVERSIDE_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "PS1" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/san_bernardino.py
+++ b/packages/scraper-framework/src/framework/prompts/san_bernardino.py
@@ -114,7 +114,7 @@ SAN_BERNARDINO_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "R12" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/san_diego.py
+++ b/packages/scraper-framework/src/framework/prompts/san_diego.py
@@ -150,7 +150,7 @@ SAN_DIEGO_FRAMEWORK_PROMPT = (
     "## Output Format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "C-66" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/san_francisco.py
+++ b/packages/scraper-framework/src/framework/prompts/san_francisco.py
@@ -94,7 +94,7 @@ SAN_FRANCISCO_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "403" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/santa_clara.py
+++ b/packages/scraper-framework/src/framework/prompts/santa_clara.py
@@ -124,7 +124,7 @@ SANTA_CLARA_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "1" or "6" or "16" or null,\n'
     '  "rulings": [\n'

--- a/packages/scraper-framework/src/framework/prompts/ventura.py
+++ b/packages/scraper-framework/src/framework/prompts/ventura.py
@@ -220,7 +220,7 @@ VENTURA_FRAMEWORK_PROMPT = (
     + "## Output Format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "20" or null,\n'
     '  "rulings": [  // exactly one entry per case number — Ventura PDFs typically cover one case\n'

--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -619,7 +619,9 @@ _GARBAGE_NAME_RE = re.compile(
     r"|Plaintiff"  # party label
     r"|Defendant"  # party label
     r"|^\d{4}\s+"  # starts with a year
-    r"|_{2,}",  # underscores (template placeholders)
+    r"|_{2,}"  # underscores (template placeholders)
+    r"|^[Ff]irst\s+[Mm]\.?\s+[Ll]ast$",  # LLM prompt placeholder "First M. Last"
+    re.IGNORECASE,
 )
 
 # Regex to strip encoding artifacts from judge names.

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1391,6 +1391,22 @@ def test_resolve_judge_rejects_unicode_junk() -> None:
     assert result is None
 
 
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "First M. Last",
+        "FIRST M. LAST",
+        "first m. last",
+        "First M Last",
+    ],
+)
+def test_normalize_judge_name_rejects_first_m_last_placeholder(placeholder: str) -> None:
+    """normalize_judge_name returns None for 'First M. Last' placeholder variants."""
+    from ingestion.db import normalize_judge_name
+
+    assert normalize_judge_name(placeholder) is None
+
+
 # ---------------------------------------------------------------------------
 # Judge resolution (resolve_judge)
 # ---------------------------------------------------------------------------

--- a/scripts/eval/eval_cc_extraction.py
+++ b/scripts/eval/eval_cc_extraction.py
@@ -208,7 +208,7 @@ CC_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "14" or "16" or "30" or null,\n'
     '  "rulings": [\n'

--- a/scripts/eval/eval_la_extraction.py
+++ b/scripts/eval/eval_la_extraction.py
@@ -172,7 +172,7 @@ LA_EXTRACTION_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "3" or "P" or "F46" or "205" or null,\n'
     '  "rulings": [\n'

--- a/scripts/eval/eval_sc_extraction.py
+++ b/scripts/eval/eval_sc_extraction.py
@@ -192,7 +192,7 @@ SC_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "1" or "6" or "16" or null,\n'
     '  "rulings": [\n'

--- a/scripts/eval/eval_sf_extraction.py
+++ b/scripts/eval/eval_sf_extraction.py
@@ -179,7 +179,7 @@ SF_SYSTEM_PROMPT = (
     "## Output format\n\n"
     "Respond with ONLY a JSON object, no other text:\n\n"
     "{\n"
-    '  "extracted_judge_name": "First M. Last" or null,\n'
+    '  "extracted_judge_name": "<full judge name>" or null,\n'
     '  "hearing_date": "YYYY-MM-DD" or null,\n'
     '  "department": "403" or null,\n'
     '  "rulings": [\n'


### PR DESCRIPTION
## Summary

Extend `_GARBAGE_NAME_RE` in `db.py` with case-insensitive pattern `^[Ff]irst\s+[Mm]\.?\s+[Ll]ast$` to reject the literal LLM prompt example before it reaches the judge table. Replace the placeholder `"First M. Last"` with `"<full judge name>"` in 9 county prompts, shared schema, LA tentatives, and 4 eval scripts. Add parametrized test covering case and spacing variants.

Closes #3850

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 274/274 green, including new parametrized test)
- [ ] CI green

### Post-deploy verification

- [ ] Query dev DB: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.judges WHERE canonical_name = 'First M. Last'"` returns `0`
- [ ] Query dev DB: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.rulings r JOIN derived.judges j ON j.id = r.judge_id WHERE j.canonical_name = 'First M. Last'"` returns `0`
- [ ] Reingest Santa Clara test PDF and confirm no re-leak: `scripts/ecs-run-task.sh scripts/ingestion/reingest_from_s3.py -- --s3-key ca/santa_clara/superior_court/raw/45dde72a5caee3b612e7286e541bdc25d0219e15d2d866bf50ad1f7c15a84c99.pdf` then verify resulting ruling has `judge_id IS NULL`
- [ ] Verification evidence posted on #3850 (see /task-v2-verify output)