### PR TITLE
fix(scraping): correct LA case_title party order when defendant is moving party (#3846)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -376,10 +376,14 @@ LA_SYSTEM_PROMPT = (
     "has 3 'Case Number:' entries, return 3 rulings.\n"
     "2. Extract the case number EXACTLY as it appears (including any "
     "leading digits).\n"
-    "3. For extracted_case_title, name the parties explicitly: "
-    "'<plaintiff_name> v. <defendant_name>' (e.g. 'Aasi v. American Honda Motor Co.'). "
+    "3. For extracted_case_title, ALWAYS list plaintiff/petitioner first, then 'v.', "
+    "then defendant/respondent — even when the defendant is the moving party. "
+    "Format: '<plaintiff_name> v. <defendant_name>' (e.g. 'Aasi v. American Honda Motor Co.'). "
     "Strip legal entity descriptors like 'an individual', 'a corporation', etc. "
     "Use title case. "
+    "Counter-example: if the caption block shows "
+    "'MOVING PARTY: Defendant Foo Corp / RESPONDING PARTY: Plaintiff Bar Inc', "
+    "the correct extracted_case_title is 'Bar Inc v. Foo Corp' — NOT 'Foo Corp v. Bar Inc'. "
     "If the caption does not name both parties, return null for extracted_case_title — "
     "do NOT use the literal words 'Plaintiff', 'Defendant', 'Petitioner', or 'Respondent' "
     "as party names in the title.\n"
@@ -388,7 +392,11 @@ LA_SYSTEM_PROMPT = (
     "truncate or summarize.\n"
     "5. For parties, extract each party with their role (plaintiff, "
     "defendant, petitioner, respondent, cross-complainant, "
-    "cross-defendant, moving_party, responding_party).\n"
+    "cross-defendant, moving_party, responding_party). "
+    "When the caption block identifies parties by plaintiff/defendant (or petitioner/respondent) "
+    "AND the body also identifies them as moving_party/responding_party, emit BOTH role pairs "
+    "as separate entries — e.g. emit {name: 'Bar Inc', role: 'plaintiff'} AND "
+    "{name: 'Bar Inc', role: 'responding_party'} for the same person.\n"
     "6. Skip the department header boilerplate — only extract from "
     "case entries.\n"
     "7. Pages with only department headers and no 'Case Number:' "
@@ -432,6 +440,114 @@ LA_SYSTEM_PROMPT = (
     "  ]\n"
     "}"
 )
+
+
+def _rebuild_reversed_title_from_parties(
+    title: str | None,
+    parties: list[dict[str, str]],
+) -> str | None:
+    """Rebuild a reversed case title when defendant appears first (#3846).
+
+    The LLM occasionally emits the defendant/respondent first in
+    ``extracted_case_title`` — for example ``"Rampart Property Management,
+    Inc v. Samson Hill"`` when the real caption has plaintiff Samson Hill and
+    defendant Rampart.  This happens most often when the defendant is the
+    moving party and appears prominently at the top of the motion caption.
+
+    This helper detects the reversal by substring-matching the title's first
+    segment against the stored plaintiff/petitioner names and defendant/respondent
+    names.  Specifically, the title is considered reversed when:
+
+    - the first segment (before ``" v. "``) substring-matches a
+      defendant/respondent name (normalized to lowercase, stripped), AND
+    - the first segment does NOT substring-match any plaintiff/petitioner name.
+
+    On a detected reversal, returns ``"<first plaintiff> v. <first defendant>"``.
+    Petition cases use petitioner/respondent roles instead.
+
+    Returns ``None`` in all other cases (no reversal detected, title unchanged).
+
+    Parameters
+    ----------
+    title:
+        The ``extracted_case_title`` from the LLM — may or may not be reversed.
+    parties:
+        The ``parties`` list from the same ruling entry, as dicts with
+        ``name`` and ``role`` keys.
+
+    Returns
+    -------
+    str | None
+        Corrected plaintiff-first title, or ``None`` if no reversal detected.
+    """
+    if not title:
+        return None
+
+    # Split on " v. " (case-insensitive) to get the first segment.
+    lower_title = title.lower()
+    sep = " v. "
+    sep_idx = lower_title.find(sep)
+    if sep_idx == -1:
+        return None
+
+    first_segment = lower_title[:sep_idx].strip()
+
+    # Collect plaintiff/petitioner and defendant/respondent names.
+    # Petition cases: petitioner/respondent.  Everything else: plaintiff/defendant.
+    plaintiff_names: list[str] = []
+    defendant_names: list[str] = []
+
+    # Determine role pairs based on parties present.  Check for petitioner first
+    # (a case has petitioner/respondent OR plaintiff/defendant, not both).
+    has_petitioner = any((p.get("role") or "").lower() == "petitioner" for p in parties)
+    if has_petitioner:
+        plaintiff_roles = {"petitioner"}
+        defendant_roles = {"respondent"}
+    else:
+        plaintiff_roles = {"plaintiff"}
+        defendant_roles = {"defendant"}
+
+    for party in parties:
+        role = (party.get("role") or "").lower()
+        name = (party.get("name") or "").strip()
+        if not name:
+            continue
+        if role in plaintiff_roles:
+            plaintiff_names.append(name.lower())
+        elif role in defendant_roles:
+            defendant_names.append(name.lower())
+
+    if not plaintiff_names or not defendant_names:
+        return None
+
+    # Check whether the first segment matches a defendant name (reversed)
+    # and does NOT match a plaintiff name (clean title).
+    def _segment_matches(segment: str, names: list[str]) -> bool:
+        for name in names:
+            if name in segment or segment in name:
+                return True
+        return False
+
+    first_matches_defendant = _segment_matches(first_segment, defendant_names)
+    first_matches_plaintiff = _segment_matches(first_segment, plaintiff_names)
+
+    if first_matches_defendant and not first_matches_plaintiff:
+        # Reversal detected — find the canonical (un-normalized) names.
+        plaintiff_name: str | None = None
+        defendant_name: str | None = None
+        for party in parties:
+            role = (party.get("role") or "").lower()
+            name = (party.get("name") or "").strip()
+            if not name:
+                continue
+            if role in plaintiff_roles and plaintiff_name is None:
+                plaintiff_name = name
+            elif role in defendant_roles and defendant_name is None:
+                defendant_name = name
+        if plaintiff_name and defendant_name:
+            return f"{plaintiff_name} v. {defendant_name}"
+
+    return None
 
 
 def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
@@ -518,6 +634,19 @@ def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
                     before=case_title,
                 )
                 case_title = None
+
+        # Reversed-title sanitizer (#3846): detect and correct cases where the
+        # defendant appears first in extracted_case_title (e.g. when the defendant
+        # is the moving party and appears at the top of the caption block).
+        if case_title is not None:
+            reversed_rebuilt = _rebuild_reversed_title_from_parties(case_title, parties)
+            if reversed_rebuilt is not None:
+                logger.info(
+                    "la.llm_reversed_title_rebuilt",
+                    before=case_title,
+                    after=reversed_rebuilt,
+                )
+                case_title = reversed_rebuilt
 
         rulings.append(
             LASplitRuling(

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -41,6 +41,7 @@ from courts.ca.la_tentatives import (
     _parse_appellate_dropdown_options,
     _parse_dropdown_options,
     _parse_option,
+    _rebuild_reversed_title_from_parties,
     _replace_ruling_text_from_html,
     _sanitize_title,
     _split_cases_html,
@@ -4027,3 +4028,275 @@ class TestLlmExtractRulingsRoleLiteralTitle:
         assert result is not None
         assert len(result) == 1
         assert result[0].case_title == "Aasi v. American Honda"
+
+
+# ---------------------------------------------------------------------------
+# TestLlmExtractRulingsReversedTitle — reversed case_title correction (#3846)
+# ---------------------------------------------------------------------------
+
+
+class TestLlmExtractRulingsReversedTitle:
+    """Tests for reversed case_title detection and correction in _llm_extract_rulings().
+
+    When the defendant is the moving party, the LLM occasionally emits the
+    defendant first in extracted_case_title — e.g. "Rampart Property Management,
+    Inc v. Samson Hill" when the real caption has plaintiff Samson Hill and
+    defendant Rampart.  The _rebuild_reversed_title_from_parties sanitizer
+    detects and corrects this before the title reaches the DB.  See #3846.
+    """
+
+    def test_reversed_title_rebuilt_from_parties(self) -> None:
+        """Rampart fixture: defendant-first title is corrected to plaintiff-first."""
+        rulings_data = [
+            {
+                "extracted_case_number": "24STCV12345",
+                "extracted_case_title": "Rampart Property Management, Inc v. Samson Hill",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [
+                    {"name": "Samson Hill", "role": "plaintiff"},
+                    {"name": "Rampart Property Management, Inc", "role": "defendant"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 24STCV12345</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Samson Hill v. Rampart Property Management, Inc"
+
+    def test_reversed_title_with_moving_responding_only_rebuilt_when_plaintiff_role_also_emitted(
+        self,
+    ) -> None:
+        """Dual-axis emission: caption plaintiff/defendant + body moving/responding roles.
+
+        When the caption identifies roles (plaintiff/defendant) AND the body
+        also identifies them as moving_party/responding_party, the LLM should
+        emit both role pairs.  The reversed-title sanitizer uses the
+        plaintiff/defendant pair to correct the title order.
+        """
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV67890",
+                "extracted_case_title": "Foo Corp v. Jane Doe",
+                "outcome": "granted",
+                "ruling_text": "The motion is GRANTED.",
+                "parties": [
+                    {"name": "Jane Doe", "role": "plaintiff"},
+                    {"name": "Foo Corp", "role": "defendant"},
+                    {"name": "Foo Corp", "role": "moving_party"},
+                    {"name": "Jane Doe", "role": "responding_party"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV67890</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        # Reversed title should be corrected to plaintiff-first.
+        assert result[0].case_title == "Jane Doe v. Foo Corp"
+        # Both role pairs should be present in parties.
+        party_roles = {(p["name"], p["role"]) for p in result[0].parties}
+        assert ("Jane Doe", "plaintiff") in party_roles
+        assert ("Foo Corp", "defendant") in party_roles
+        assert ("Foo Corp", "moving_party") in party_roles
+        assert ("Jane Doe", "responding_party") in party_roles
+
+    def test_reversed_title_petition_cases_use_petitioner_respondent(self) -> None:
+        """Petition case: respondent-first title is corrected to petitioner-first."""
+        rulings_data = [
+            {
+                "extracted_case_number": "24STCP11111",
+                "extracted_case_title": "Big Bank v. Alice Petitioner",
+                "outcome": "denied",
+                "ruling_text": "The petition is DENIED.",
+                "parties": [
+                    {"name": "Alice Petitioner", "role": "petitioner"},
+                    {"name": "Big Bank", "role": "respondent"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 24STCP11111</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Alice Petitioner v. Big Bank"
+
+    def test_reversed_title_left_unchanged_when_only_moving_responding_roles_stored(
+        self,
+    ) -> None:
+        """No plaintiff/defendant pair → reversed-title sanitizer is a no-op.
+
+        When the LLM only stores moving_party/responding_party (caption didn't
+        identify plaintiff/defendant roles), the sanitizer has no plaintiff/defendant
+        names to work with and must leave the title unchanged.
+        """
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV22222",
+                "extracted_case_title": "Acme Corp v. Bob Smith",
+                "outcome": "granted",
+                "ruling_text": "The motion is GRANTED.",
+                "parties": [
+                    {"name": "Acme Corp", "role": "moving_party"},
+                    {"name": "Bob Smith", "role": "responding_party"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV22222</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        # No plaintiff/defendant roles → title unchanged.
+        assert result[0].case_title == "Acme Corp v. Bob Smith"
+
+    def test_clean_plaintiff_first_title_passes_through(self) -> None:
+        """Control: a correct plaintiff-first title is not modified by the sanitizer."""
+        rulings_data = [
+            {
+                "extracted_case_number": "24STCV33333",
+                "extracted_case_title": "Maria Lopez v. City of Los Angeles",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [
+                    {"name": "Maria Lopez", "role": "plaintiff"},
+                    {"name": "City of Los Angeles", "role": "defendant"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 24STCV33333</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        # Plaintiff-first title should pass through unchanged.
+        assert result[0].case_title == "Maria Lopez v. City of Los Angeles"
+
+    def test_role_literal_then_reversed_chain_runs_role_literal_first(self) -> None:
+        """Order-of-operations: role-literal sanitizer fires first, then reversed-title check.
+
+        When a title matches _ROLE_LITERAL_TITLE_RE, the role-literal sanitizer
+        runs and replaces the title.  The reversed-title check then runs on the
+        rebuilt title.  This test verifies the two-step chain produces a
+        correctly ordered plaintiff-first title.
+        """
+        rulings_data = [
+            {
+                "extracted_case_number": "24STCV44444",
+                "extracted_case_title": "Plaintiff v. Defendant",
+                "outcome": "granted",
+                "ruling_text": "The motion is GRANTED.",
+                "parties": [
+                    {"name": "Carlos Rivera", "role": "plaintiff"},
+                    {"name": "Tech Solutions Inc", "role": "defendant"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 24STCV44444</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        # Role-literal sanitizer rebuilds first; reversed-title check is a no-op
+        # because the rebuilt title is already plaintiff-first.
+        assert result[0].case_title == "Carlos Rivera v. Tech Solutions Inc"
+
+
+# ---------------------------------------------------------------------------
+# TestRebuildReversedTitleFromParties — unit tests for the helper (#3846)
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildReversedTitleFromParties:
+    """Unit tests for _rebuild_reversed_title_from_parties()."""
+
+    def test_returns_none_on_none_title(self) -> None:
+        parties = [
+            {"name": "Samson Hill", "role": "plaintiff"},
+            {"name": "Rampart Corp", "role": "defendant"},
+        ]
+        assert _rebuild_reversed_title_from_parties(None, parties) is None
+
+    def test_returns_none_on_empty_string_title(self) -> None:
+        parties = [
+            {"name": "Samson Hill", "role": "plaintiff"},
+            {"name": "Rampart Corp", "role": "defendant"},
+        ]
+        assert _rebuild_reversed_title_from_parties("", parties) is None
+
+    def test_returns_none_when_no_v_separator(self) -> None:
+        parties = [
+            {"name": "Samson Hill", "role": "plaintiff"},
+            {"name": "Rampart Corp", "role": "defendant"},
+        ]
+        assert _rebuild_reversed_title_from_parties("Rampart Corp", parties) is None
+
+    def test_corrects_reversed_title(self) -> None:
+        parties = [
+            {"name": "Samson Hill", "role": "plaintiff"},
+            {"name": "Rampart Property Management, Inc", "role": "defendant"},
+        ]
+        result = _rebuild_reversed_title_from_parties(
+            "Rampart Property Management, Inc v. Samson Hill", parties
+        )
+        assert result == "Samson Hill v. Rampart Property Management, Inc"
+
+    def test_leaves_correct_title_unchanged(self) -> None:
+        parties = [
+            {"name": "Samson Hill", "role": "plaintiff"},
+            {"name": "Rampart Property Management, Inc", "role": "defendant"},
+        ]
+        result = _rebuild_reversed_title_from_parties(
+            "Samson Hill v. Rampart Property Management, Inc", parties
+        )
+        assert result is None
+
+    def test_petition_case_reversed(self) -> None:
+        parties = [
+            {"name": "Alice Petitioner", "role": "petitioner"},
+            {"name": "Big Bank", "role": "respondent"},
+        ]
+        result = _rebuild_reversed_title_from_parties("Big Bank v. Alice Petitioner", parties)
+        assert result == "Alice Petitioner v. Big Bank"
+
+    def test_petition_case_correct_order_unchanged(self) -> None:
+        parties = [
+            {"name": "Alice Petitioner", "role": "petitioner"},
+            {"name": "Big Bank", "role": "respondent"},
+        ]
+        result = _rebuild_reversed_title_from_parties("Alice Petitioner v. Big Bank", parties)
+        assert result is None
+
+    def test_returns_none_when_no_plaintiff_defendant_parties(self) -> None:
+        parties = [
+            {"name": "Acme Corp", "role": "moving_party"},
+            {"name": "Bob Smith", "role": "responding_party"},
+        ]
+        result = _rebuild_reversed_title_from_parties("Acme Corp v. Bob Smith", parties)
+        assert result is None
+
+    def test_returns_none_on_empty_parties(self) -> None:
+        result = _rebuild_reversed_title_from_parties("Foo v. Bar", [])
+        assert result is None


### PR DESCRIPTION
## Summary

Fixed LA tentative-rulings reversed case_title bug (#3846). The LLM occasionally emitted the defendant first in extracted_case_title when the defendant was the moving party (e.g., "Rampart Property Management, Inc v. Samson Hill" instead of "Samson Hill v. Rampart Property Management, Inc"). 39 LA cases in dev exhibited this bug.

Approach:
1. **Prompt strengthening**: Updated LA_SYSTEM_PROMPT Rule 3 with explicit "ALWAYS list plaintiff/petitioner first" language and a worked counter-example for defendant-as-moving-party captions. Extended Rule 5 to require dual-axis party emission (both plaintiff/defendant AND moving/responding pairs when caption + body identify both).
2. **Post-extraction sanitizer**: Added `_rebuild_reversed_title_from_parties()` helper to detect reversed titles (first segment matches a defendant, not a plaintiff) and rebuild to canonical plaintiff-first order. Wired into `_llm_extract_rulings()` after the existing role-literal sanitizer.
3. **Test coverage**: 15 new tests (6 integration, 9 unit) covering civil and petition cases, moving/responding-only fallback (when plaintiff/defendant roles are absent), dual-axis emission, and order-of-operations chains. Full package suite (262 tests) passes with 100% diff coverage.

Closes #3846

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework`): 262 tests, 100% diff coverage
- [x] CI green (verified in ralph phase)

### Post-deploy verification

- [ ] Verify plaintiff/defendant roles stored: `SELECT count(*) FROM derived.cases cs JOIN derived.courts c ON cs.court_id=c.id LEFT JOIN derived.case_parties cp ON cp.case_id=cs.id AND cp.role IN ('plaintiff','petitioner') WHERE c.county='Los Angeles' AND cs.created_at > <deploy-ts> GROUP BY cs.id HAVING count(cp.id) = 0` — should be near-zero for cases with caption blocks
- [ ] Verify reversed-title correction: re-run population scan (substring-match AC in issue #3846) — count of defendant-first titles should drop from 39 to ≤5 (residual edge cases acceptable)
- [ ] Backfill reversed cases: `scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county 'Los Angeles' --bust-llm-cache`
- [ ] Verification evidence posted on #3846 (see /task-v2-verify output)