### PR TITLE
feat(dispatcher): add v3 cohabitation columns + v3-only agent columns (#3872)

### DIFF
--- a/packages/api/migrations/56_dispatcher-v3-cohabitation-columns.sql
+++ b/packages/api/migrations/56_dispatcher-v3-cohabitation-columns.sql
@@ -1,0 +1,199 @@
+-- Up Migration
+--
+-- Dispatcher v3 buildout — schema foundation for v2/v3 cohabitation.
+-- Issue #3872.
+--
+-- Why
+-- ---
+-- v3 will cohabit with v2 in parallel during the rollout: both daemons
+-- read/write the same ``dispatcher.*`` tables, and per-row ownership is
+-- established via ``parent_run_id`` → ``runs.dispatcher_version``. v2
+-- needs to start writing ``dispatcher_version='v2'`` BEFORE v3's
+-- launcher boots so when v3 inserts its own ``runs`` row, every
+-- pre-existing row is correctly tagged as v2-owned. Same for
+-- ``terminal_outcomes.parent_run_id`` so each daemon's circuit breaker
+-- can scope its rolling-window scan to outcomes from its own run
+-- lineage. The v3-only columns on ``dispatcher.agents`` land now so
+-- v3 can write them once it deploys; v2 ignores unknown columns.
+--
+-- Three additive changes (no destructive migration; v2 keeps running
+-- against the existing schema with the defaults):
+--
+--   1. ``dispatcher.runs.dispatcher_version text NOT NULL DEFAULT 'v2'``
+--      The DEFAULT backfills every existing row to ``'v2'`` at ALTER
+--      time (Postgres rewrites the table for a NOT NULL ADD COLUMN
+--      without a defaulted volatile expression — the literal default
+--      writes once, fast). New v2 inserts continue to write the
+--      column either implicitly (via DEFAULT) or explicitly (the
+--      daemon's INSERT is updated in this same PR to make the value
+--      observable in psycopg-3 logging without depending on the
+--      DEFAULT firing). v3's launcher will INSERT
+--      ``dispatcher_version='v3'`` and the cohabitation predicate
+--      becomes a single equality check.
+--
+--   2. ``dispatcher.terminal_outcomes.parent_run_id uuid REFERENCES
+--      dispatcher.runs(run_id)`` — nullable, no DEFAULT. Backfilled
+--      from ``dispatcher.agents.parent_run_id`` via JOIN where the
+--      outcome's ``agent_id`` matches a known agent row. Rows whose
+--      ``agent_id`` is NULL (synthetic test inputs per migration 29)
+--      or whose agent row was hard-deleted leave ``parent_run_id``
+--      NULL — v2's circuit breaker tolerates NULL today (it scans by
+--      ``ended_at`` only; #2860). v3's per-run scope filter will read
+--      ``WHERE parent_run_id = current_run_id`` against rows it wrote
+--      itself, so historical NULLs are fine.
+--
+--      The daemon's ``_write_terminal_outcome`` is updated in this same
+--      PR to look up and write ``parent_run_id`` alongside the existing
+--      ``issue_number`` lookup so all NEW outcome rows carry the value.
+--
+--   3. Six v3-only columns on ``dispatcher.agents`` — all nullable,
+--      no DEFAULT, no index. v2 ignores them; v3 writes them once it
+--      deploys. The column choice mirrors the v3 spec's per-agent
+--      milestone-tracking surface (replaces v2's coarser
+--      ``phase``/``current_milestone_*`` split with explicit
+--      timestamped milestones the admin cockpit can render):
+--
+--        current_milestone        TEXT         — current pipeline milestone label (e.g. 'plan_complete', 'ralph_iter_2')
+--        current_milestone_detail TEXT         — free-form supplemental detail
+--        current_milestone_at     TIMESTAMPTZ  — when the milestone was entered
+--        session_s3_key           TEXT         — S3 key for the agent's transcript
+--        diagnoser_arn            TEXT         — ECS task ARN of the running diagnoser (when active)
+--        outcome_summary          TEXT         — one-line outcome description for the cockpit
+--
+-- Design notes
+-- ------------
+-- - All three changes are additive. v2 code keeps running against the
+--   schema unchanged: no v2 read path queries the new columns, and
+--   v2's INSERTs into ``runs`` and ``terminal_outcomes`` either rely
+--   on the column DEFAULT (runs) or get an explicit value via the
+--   daemon update bundled in this PR (terminal_outcomes).
+-- - ``ADD COLUMN IF NOT EXISTS`` everywhere so the migration is
+--   idempotent (mirrors migration 35's pattern).
+-- - No CHECK constraint on ``runs.dispatcher_version``. The set is
+--   daemon-code owned (today: ``'v2'``, soon: ``'v3'``); a CHECK
+--   would couple schema to that enum and require a follow-up
+--   migration when v4 lands.
+-- - The FK on ``terminal_outcomes.parent_run_id`` uses no ON DELETE
+--   action (default NO ACTION) — ``dispatcher.runs`` is append-only
+--   in production (lease history is forensic), so a cascade is moot
+--   and NO ACTION surfaces a bug if a delete ever sneaks in.
+-- - No index on the new columns. Reads scope to a small recent
+--   window already covered by ``idx_dispatcher_terminal_outcomes_ended_at``;
+--   adding a (parent_run_id, ended_at) composite is a Phase-2
+--   optimization that lands when v3 actually needs it.
+--
+-- Backfill
+-- --------
+-- Two UPDATEs:
+--
+--   1. ``dispatcher.runs.dispatcher_version`` — handled by the
+--      ``DEFAULT 'v2'`` on the ALTER itself. Postgres applies the
+--      default to every existing row at column-add time, so no
+--      separate UPDATE is needed. (Verified: the DEFAULT is a
+--      literal, not a volatile expression, so the rewrite is a
+--      single fast pass.)
+--
+--   2. ``dispatcher.terminal_outcomes.parent_run_id`` — backfilled
+--      from ``dispatcher.agents.parent_run_id`` via JOIN. Idempotent
+--      (guarded on the new column being NULL) so re-runs do not
+--      clobber values written by the daemon between migration apply
+--      and the next deploy.
+
+ALTER TABLE dispatcher.runs
+    ADD COLUMN IF NOT EXISTS dispatcher_version TEXT NOT NULL DEFAULT 'v2';
+
+COMMENT ON COLUMN dispatcher.runs.dispatcher_version IS
+    'Which dispatcher daemon owns this run: ''v2'' (the original '
+    'subprocess + ECS-launcher daemon) or ''v3'' (the cohabiting '
+    'launcher being rolled out under #3872 and follow-ups). The '
+    'DEFAULT ''v2'' backfills every pre-#3872 row at migration time. '
+    'Per-row ownership for downstream tables (agents, '
+    'terminal_outcomes) flows through ``parent_run_id``: each daemon '
+    'reads only rows whose run lineage matches its own version. No '
+    'CHECK constraint — the set is daemon-code owned. Issue #3872.';
+
+ALTER TABLE dispatcher.terminal_outcomes
+    ADD COLUMN IF NOT EXISTS parent_run_id UUID
+        REFERENCES dispatcher.runs(run_id);
+
+COMMENT ON COLUMN dispatcher.terminal_outcomes.parent_run_id IS
+    'The ``dispatcher.runs.run_id`` of the daemon whose terminal '
+    'transition produced this outcome. Backfilled from '
+    '``dispatcher.agents.parent_run_id`` JOIN on ``agent_id``. NULL '
+    'for rows whose agent_id is NULL (synthetic test input, per '
+    'migration 29) or whose agent row was hard-deleted. v2''s '
+    'circuit breaker ignores this column (it scans by ended_at '
+    'only, #2860); v3 will scope its rolling-window scan to its own '
+    'run lineage via ``WHERE parent_run_id = current_run_id``. '
+    'Issue #3872.';
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN IF NOT EXISTS current_milestone        TEXT,
+    ADD COLUMN IF NOT EXISTS current_milestone_detail TEXT,
+    ADD COLUMN IF NOT EXISTS current_milestone_at     TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS session_s3_key           TEXT,
+    ADD COLUMN IF NOT EXISTS diagnoser_arn            TEXT,
+    ADD COLUMN IF NOT EXISTS outcome_summary          TEXT;
+
+COMMENT ON COLUMN dispatcher.agents.current_milestone IS
+    'v3-only — current pipeline milestone label written by the v3 '
+    'agent runtime (e.g. ''plan_complete'', ''ralph_iter_2'', '
+    '''pr_opened''). v2 ignores this column. Paired with '
+    '``current_milestone_at`` for cockpit timing display. NULL on '
+    'every v2-written row. Issue #3872.';
+
+COMMENT ON COLUMN dispatcher.agents.current_milestone_detail IS
+    'v3-only — free-form supplemental detail for the current '
+    'milestone (e.g. failing test name, retry attempt count). NULL '
+    'on every v2-written row. Issue #3872.';
+
+COMMENT ON COLUMN dispatcher.agents.current_milestone_at IS
+    'v3-only — timestamp the current milestone was entered. NULL on '
+    'every v2-written row. Issue #3872.';
+
+COMMENT ON COLUMN dispatcher.agents.session_s3_key IS
+    'v3-only — S3 key of the agent''s transcript bundle. NULL on '
+    'every v2-written row. Issue #3872.';
+
+COMMENT ON COLUMN dispatcher.agents.diagnoser_arn IS
+    'v3-only — ECS task ARN of the running diagnoser when an '
+    'async-spawned diagnoser is in flight for this agent. NULL when '
+    'no diagnoser is active and on every v2-written row. Issue #3872.';
+
+COMMENT ON COLUMN dispatcher.agents.outcome_summary IS
+    'v3-only — one-line outcome description rendered in the admin '
+    'cockpit (succeeds v2''s ``failure_summary`` for both success '
+    'and failure paths). NULL on every v2-written row. Issue #3872.';
+
+-- Backfill ``terminal_outcomes.parent_run_id`` from ``agents``.
+-- Guarded on the new column being NULL so re-applying the migration
+-- (or applying after the daemon has started writing the column on
+-- new rows) does not clobber more-precise values.
+UPDATE dispatcher.terminal_outcomes t
+   SET parent_run_id = a.parent_run_id
+  FROM dispatcher.agents a
+ WHERE t.agent_id = a.agent_id
+   AND t.parent_run_id IS NULL;
+
+
+-- Down Migration
+--
+-- Drop all eight added columns. Down on production is unlikely (this
+-- is foundational infra for v3) but provided for local-dev rollback
+-- during the buildout. The order matters: ``terminal_outcomes.parent_run_id``
+-- has an FK to ``runs(run_id)`` but dropping the column drops the FK
+-- automatically, so no separate constraint-drop is needed.
+
+ALTER TABLE dispatcher.agents
+    DROP COLUMN IF EXISTS current_milestone,
+    DROP COLUMN IF EXISTS current_milestone_detail,
+    DROP COLUMN IF EXISTS current_milestone_at,
+    DROP COLUMN IF EXISTS session_s3_key,
+    DROP COLUMN IF EXISTS diagnoser_arn,
+    DROP COLUMN IF EXISTS outcome_summary;
+
+ALTER TABLE dispatcher.terminal_outcomes
+    DROP COLUMN IF EXISTS parent_run_id;
+
+ALTER TABLE dispatcher.runs
+    DROP COLUMN IF EXISTS dispatcher_version;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 55 migrations.
+-- Generated from 56 migrations.
 
 
 
@@ -368,7 +368,13 @@ CREATE TABLE dispatcher.agents (
     execution_mode text DEFAULT 'subprocess'::text NOT NULL,
     ralph_iterations_observed integer DEFAULT 0 NOT NULL,
     merge_unstick_attempts integer DEFAULT 0 NOT NULL,
-    merge_conflict_attempts integer DEFAULT 0 NOT NULL
+    merge_conflict_attempts integer DEFAULT 0 NOT NULL,
+    current_milestone text,
+    current_milestone_detail text,
+    current_milestone_at timestamp with time zone,
+    session_s3_key text,
+    diagnoser_arn text,
+    outcome_summary text
 );
 
 
@@ -418,6 +424,24 @@ COMMENT ON COLUMN dispatcher.agents.merge_unstick_attempts IS 'Count of stale-ro
 
 
 COMMENT ON COLUMN dispatcher.agents.merge_conflict_attempts IS 'Count of fix_conflict-phase claude-resolution attempts for this agent (#3225). Bounded at FIX_CONFLICT_MAX_ATTEMPTS (default 2) per agent lifetime: each invocation of handle_fix_conflict increments this column before spawning the claude skill; when the value is already >= budget the handler advances to the conflict_unresolvable terminal without spending compute. Covers both the pre-push rebase-conflict path (push_and_pr) and the start-of-ralph baseline rebase-conflict path (secondary mitigation). See .claude/skills/task-v2-fix-conflict/SKILL.md.';
+
+
+COMMENT ON COLUMN dispatcher.agents.current_milestone IS 'v3-only — current pipeline milestone label written by the v3 agent runtime (e.g. ''plan_complete'', ''ralph_iter_2'', ''pr_opened''). v2 ignores this column. Paired with ``current_milestone_at`` for cockpit timing display. NULL on every v2-written row. Issue #3872.';
+
+
+COMMENT ON COLUMN dispatcher.agents.current_milestone_detail IS 'v3-only — free-form supplemental detail for the current milestone (e.g. failing test name, retry attempt count). NULL on every v2-written row. Issue #3872.';
+
+
+COMMENT ON COLUMN dispatcher.agents.current_milestone_at IS 'v3-only — timestamp the current milestone was entered. NULL on every v2-written row. Issue #3872.';
+
+
+COMMENT ON COLUMN dispatcher.agents.session_s3_key IS 'v3-only — S3 key of the agent''s transcript bundle. NULL on every v2-written row. Issue #3872.';
+
+
+COMMENT ON COLUMN dispatcher.agents.diagnoser_arn IS 'v3-only — ECS task ARN of the running diagnoser when an async-spawned diagnoser is in flight for this agent. NULL when no diagnoser is active and on every v2-written row. Issue #3872.';
+
+
+COMMENT ON COLUMN dispatcher.agents.outcome_summary IS 'v3-only — one-line outcome description rendered in the admin cockpit (succeeds v2''s ``failure_summary`` for both success and failure paths). NULL on every v2-written row. Issue #3872.';
 
 
 CREATE TABLE dispatcher.blocked_snapshots (
@@ -713,7 +737,8 @@ CREATE TABLE dispatcher.runs (
     heartbeat_ts timestamp with time zone DEFAULT now() NOT NULL,
     version_sha text NOT NULL,
     host text NOT NULL,
-    pid integer NOT NULL
+    pid integer NOT NULL,
+    dispatcher_version text DEFAULT 'v2'::text NOT NULL
 );
 
 
@@ -724,6 +749,9 @@ COMMENT ON COLUMN dispatcher.runs.heartbeat_ts IS 'Daemon updates every tick. Cl
 
 
 COMMENT ON COLUMN dispatcher.runs.version_sha IS 'Git SHA of the daemon build; supports forensic questions after a crash.';
+
+
+COMMENT ON COLUMN dispatcher.runs.dispatcher_version IS 'Which dispatcher daemon owns this run: ''v2'' (the original subprocess + ECS-launcher daemon) or ''v3'' (the cohabiting launcher being rolled out under #3872 and follow-ups). The DEFAULT ''v2'' backfills every pre-#3872 row at migration time. Per-row ownership for downstream tables (agents, terminal_outcomes) flows through ``parent_run_id``: each daemon reads only rows whose run lineage matches its own version. No CHECK constraint — the set is daemon-code owned. Issue #3872.';
 
 
 CREATE TABLE dispatcher.scheduled_skills (
@@ -764,7 +792,8 @@ CREATE TABLE dispatcher.terminal_outcomes (
     agent_id uuid,
     issue_number integer,
     status text NOT NULL,
-    ended_at timestamp with time zone DEFAULT now() NOT NULL
+    ended_at timestamp with time zone DEFAULT now() NOT NULL,
+    parent_run_id uuid
 );
 
 
@@ -775,6 +804,9 @@ COMMENT ON COLUMN dispatcher.terminal_outcomes.agent_id IS 'Nullable — synthet
 
 
 COMMENT ON COLUMN dispatcher.terminal_outcomes.status IS 'Free-form text (succeeded | failed | crashed | plan_blocked | needs_review | ...). Classifier in daemon decides which count as bad.';
+
+
+COMMENT ON COLUMN dispatcher.terminal_outcomes.parent_run_id IS 'The ``dispatcher.runs.run_id`` of the daemon whose terminal transition produced this outcome. Backfilled from ``dispatcher.agents.parent_run_id`` JOIN on ``agent_id``. NULL for rows whose agent_id is NULL (synthetic test input, per migration 29) or whose agent row was hard-deleted. v2''s circuit breaker ignores this column (it scans by ended_at only, #2860); v3 will scope its rolling-window scan to its own run lineage via ``WHERE parent_run_id = current_run_id``. Issue #3872.';
 
 
 CREATE SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq
@@ -1558,6 +1590,10 @@ ALTER TABLE ONLY dispatcher.retry_markers
 
 ALTER TABLE ONLY dispatcher.scheduled_skills
     ADD CONSTRAINT scheduled_skills_last_triggered_agent_id_fkey FOREIGN KEY (last_triggered_agent_id) REFERENCES dispatcher.agents(agent_id) ON DELETE SET NULL;
+
+
+ALTER TABLE ONLY dispatcher.terminal_outcomes
+    ADD CONSTRAINT terminal_outcomes_parent_run_id_fkey FOREIGN KEY (parent_run_id) REFERENCES dispatcher.runs(run_id);
 
 
 ALTER TABLE ONLY dispatcher.unrecognized_diagnoser_actions

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2809,10 +2809,16 @@ class DispatcherDaemon:
                     f"heartbeat_ts={existing_hb!s}"
                 )
 
+            # ``dispatcher_version`` is written explicitly so the value
+            # is observable in psycopg-3 query logging without having
+            # to consult the column DEFAULT. v3's launcher will write
+            # ``'v3'`` here; this v2 daemon always writes ``'v2'``.
+            # Issue #3872.
             cur.execute(
                 "INSERT INTO dispatcher.runs "
-                "    (started_at, heartbeat_ts, version_sha, host, pid) "
-                "VALUES (now(), now(), %s, %s, %s) "
+                "    (started_at, heartbeat_ts, version_sha, host, pid, "
+                "     dispatcher_version) "
+                "VALUES (now(), now(), %s, %s, %s, 'v2') "
                 "RETURNING run_id",
                 (self._cfg.version_sha, self._cfg.host, self._cfg.pid),
             )
@@ -19273,30 +19279,40 @@ class DispatcherDaemon:
         """Append a row to ``dispatcher.terminal_outcomes``.
 
         Called by :meth:`_mark_agent_terminal` for every terminal
-        status. ``issue_number`` is looked up from ``dispatcher.agents``
-        so the outcome row is self-contained (no JOIN needed at scan
-        time). Append-only: the ring-buffer semantics come from the
-        rolling-window scan in :meth:`_evaluate_circuit_breaker`, not
-        from deleting rows on write.
+        status. ``issue_number`` and ``parent_run_id`` are looked up
+        from ``dispatcher.agents`` so the outcome row is self-contained
+        (no JOIN needed at scan time). Append-only: the ring-buffer
+        semantics come from the rolling-window scan in
+        :meth:`_evaluate_circuit_breaker`, not from deleting rows on
+        write.
 
         exec-mode-agnostic (#3158): circuit-breaker feed; a terminal
         is a terminal regardless of which runtime produced it.
+
+        ``parent_run_id`` (#3872) carries the daemon-run lineage so
+        v3's per-run circuit-breaker scope can filter
+        ``WHERE parent_run_id = current_run_id``. v2's breaker
+        ignores this column today.
         """
         assert self._conn is not None, "connect() must run before outcome write"
         with self._conn.cursor() as cur:
             cur.execute(
-                "SELECT issue_number FROM dispatcher.agents WHERE agent_id = %s",
+                "SELECT issue_number, parent_run_id "
+                "FROM dispatcher.agents WHERE agent_id = %s",
                 (agent_id,),
             )
             row = cur.fetchone()
-            issue_number = (
-                int(row[0]) if row is not None and row[0] is not None else None
-            )
+            if row is not None:
+                issue_number = int(row[0]) if row[0] is not None else None
+                parent_run_id = str(row[1]) if row[1] is not None else None
+            else:
+                issue_number = None
+                parent_run_id = None
             cur.execute(
                 "INSERT INTO dispatcher.terminal_outcomes "
-                "    (agent_id, issue_number, status, ended_at) "
-                "VALUES (%s, %s, %s, now())",
-                (agent_id, issue_number, status),
+                "    (agent_id, issue_number, status, parent_run_id, ended_at) "
+                "VALUES (%s, %s, %s, %s, now())",
+                (agent_id, issue_number, status, parent_run_id),
             )
         self._conn.commit()
 

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -196,10 +196,10 @@ class TestWriteTerminalOutcome:
     """``_write_terminal_outcome`` appends to ``dispatcher.terminal_outcomes``."""
 
     def test_writes_row_with_issue_number_lookup(self, tmp_path: Path) -> None:
-        """Row carries the issue_number looked up from ``dispatcher.agents``."""
+        """Row carries the issue_number + parent_run_id looked up from ``agents``."""
         d, conn, _h = _make_daemon(tmp_path)
-        # First fetchone returns the agent's issue_number.
-        conn.cursor_instance.fetch_queue = [(42,)]
+        # First fetchone returns (issue_number, parent_run_id) — #3872.
+        conn.cursor_instance.fetch_queue = [(42, "run-uuid-abc")]
 
         d._write_terminal_outcome("agent-42-uuid", "failed")
 
@@ -210,14 +210,16 @@ class TestWriteTerminalOutcome:
             if "INSERT INTO dispatcher.terminal_outcomes" in e[0]
         ]
         assert len(inserts) == 1
-        params = inserts[0][1]
-        assert params == ("agent-42-uuid", 42, "failed")
+        sql, params = inserts[0]
+        # parent_run_id is in the column list and the params tuple (#3872).
+        assert "parent_run_id" in sql
+        assert params == ("agent-42-uuid", 42, "failed", "run-uuid-abc")
         assert conn.commits >= 1
 
     def test_writes_row_with_null_issue_number_when_agent_missing(
         self, tmp_path: Path
     ) -> None:
-        """Fallback: agent row absent → issue_number is NULL. Still inserts."""
+        """Fallback: agent row absent → issue_number + parent_run_id NULL."""
         d, conn, _h = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [None]  # agent row absent
 
@@ -230,7 +232,30 @@ class TestWriteTerminalOutcome:
         ]
         assert len(inserts) == 1
         params = inserts[0][1]
-        assert params == ("orphan-agent", None, "succeeded")
+        assert params == ("orphan-agent", None, "succeeded", None)
+
+    def test_writes_row_with_null_parent_run_id_when_agent_has_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Agent exists but has NULL parent_run_id → outcome carries NULL too.
+
+        Regression guard for #3872: pre-migration agent rows or rows
+        inserted by a code path that doesn't set ``parent_run_id`` must
+        still flow through the new SELECT/INSERT shape without error.
+        """
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(7, None)]
+
+        d._write_terminal_outcome("legacy-agent", "succeeded")
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.terminal_outcomes" in e[0]
+        ]
+        assert len(inserts) == 1
+        params = inserts[0][1]
+        assert params == ("legacy-agent", 7, "succeeded", None)
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -160,6 +160,34 @@ class TestLeaseCheck:
         assert any("INSERT INTO dispatcher.runs" in sql for sql, _ in executed)
         assert fake_conn.commits == 1
 
+    def test_run_insert_writes_dispatcher_version_v2(self) -> None:
+        """v2 daemon stamps ``dispatcher_version='v2'`` on every run insert.
+
+        Regression guard for #3872 (v3 cohabitation): once v3 deploys and
+        starts inserting ``dispatcher_version='v3'`` rows, v2's runs MUST
+        be unambiguously tagged ``'v2'`` so the per-run scope filters on
+        downstream tables (agents.parent_run_id → runs.dispatcher_version)
+        return the right slice.
+        """
+        fake_conn = _FakeConnection()
+        fake_conn.cursor_instance.fetch_queue = [None, ("new-run-id",)]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        d.check_lease_and_register_run()
+
+        executed = fake_conn.cursor_instance.executed
+        run_inserts = [
+            e for e in executed if e[0].startswith("INSERT INTO dispatcher.runs")
+        ]
+        assert len(run_inserts) == 1
+        sql, _params = run_inserts[0]
+        # Column list contains dispatcher_version, and the literal 'v2'
+        # is in the VALUES clause (not bound — we want the value
+        # observable in psycopg-3 query logging without consulting the
+        # column DEFAULT).
+        assert "dispatcher_version" in sql
+        assert "'v2'" in sql
+
     def test_insert_returns_no_row_raises(self) -> None:
         fake_conn = _FakeConnection()
         # Weird state: lease OK, but INSERT ... RETURNING yields nothing.


### PR DESCRIPTION
## Summary

Foundational schema work for the dispatcher-v3 buildout: migration 56 adds the cohabitation columns (`runs.dispatcher_version`, `terminal_outcomes.parent_run_id`) plus six v3-only nullable columns on `dispatcher.agents`. v2 daemon updates write `dispatcher_version='v2'` on every run insert and propagate `parent_run_id` into every new `terminal_outcomes` row so v3's per-run scope filter works the moment its launcher deploys.

Closes #3872

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] After `deploy-api.yml` runs the migrate task on dev, query confirms `dispatcher.runs.dispatcher_version` exists with default `'v2'`, `dispatcher.terminal_outcomes.parent_run_id` exists, and the six v3 columns on `dispatcher.agents` exist
- [x] After `deploy-dispatcher.yml` redeploys the daemon, the next `dispatcher.runs` insert carries `dispatcher_version='v2'` (verified for SHA `d06628a` and `9469321`)
- [x] Verification evidence posted on issue ([comment](https://github.com/judgemind/judgemind/issues/3872#issuecomment-4363041994))

## Local validation

* All 56 migrations apply cleanly to a fresh local Postgres DB.
* The backfill `UPDATE` populates `terminal_outcomes.parent_run_id` from the `agents` JOIN; orphan rows (NULL `agent_id` per migration 29) and rows whose agent was hard-deleted stay NULL — the two intentional NULL classes documented in the column comment.
* Down migration drops all 8 columns cleanly (idempotent).
* Up migration is idempotent: a second apply emits "column already exists" NOTICEs but does nothing.
* `schema.sql` regenerated via `scripts/regenerate_schema.sh` reflects all eight new columns + their `COMMENT`s + the FK on `terminal_outcomes.parent_run_id`.
* Full dispatcher test suite: 2106 passed, 1 skipped (integration). Three test updates pin the new SQL shapes; one new test asserts the `'v2'` literal in the `INSERT INTO dispatcher.runs` SQL.
