### PR TITLE
feat(dx): auto-resolve migration-number collisions via pick_next_free_number (#3790)

### DIFF
--- a/.claude/skills/task-v2-fix-ci/SKILL.md
+++ b/.claude/skills/task-v2-fix-ci/SKILL.md
@@ -53,7 +53,8 @@ Write `{worktree}/tmp/dispatcher-output/fix-ci.json`:
   "rebase_outcome": "clean" | "resolved" | "conflict_unresolvable" | "skipped",
   "failure_category": "lint" | "format" | "type_error" | "test_failure" | "coverage_floor" |
                        "infra_external" | "missing_secret_or_config" | "build_failure" |
-                       "markdown_links" | "hygiene_guard" | "ci_config" | "other",
+                       "markdown_links" | "hygiene_guard" | "ci_config" |
+                       "migration_collision" | "other",
   "changed_files": ["<path>", ...],
   "commit_message": "fix(<area>): <what was fixed> — CI (#<PR-N>)",
   "block_reason": null | "<string>",
@@ -117,6 +118,7 @@ For each `failing_jobs` entry, classify the root cause from the `log_tail`:
 | `markdown_links` | `scripts/check-markdown-links.sh` failures | Fix the broken link paths |
 | `hygiene_guard` | `scripts/check-no-*.sh` / `check-forbidden-*.sh` / `check-deprecated-*.sh` guards, or `scripts/check-ci-job-skipped.sh` (the #2410/#2505 footgun) | Follow the guard's error message; per CLAUDE.md, self-matching names in ci.yml are the usual cause |
 | `ci_config` | `.github/workflows/*.yml` parse error, job definition malformed | Edit the workflow — but only if the failure is genuinely in the workflow, not in code that the workflow runs |
+| `migration_collision` | `migration-collision-check` job fails: "migration number N is also claimed by PR #M" | See "Resolving migration_collision" sub-section in Step 3 below |
 | `other` | Not in the above | If you can't identify, classify as `BLOCKED` with a clear `block_reason` |
 
 **Unsafe shortcuts — do not use:**
@@ -157,6 +159,40 @@ For `coverage_floor`:
 - Rerun coverage locally to confirm the floor passes.
 
 For `hygiene_guard` failures in `.github/workflows/ci.yml` — the #2410/#2505 footgun is the most common cause. Follow the guard's own error message. If the guard is complaining about a job being SKIPPED on its own CI run, either modify a file that already matches the paths filter, or add `.github/workflows/ci.yml` to the filter.
+
+### Resolving migration_collision
+
+When `failure_category="migration_collision"`:
+
+1. **Confirm the failure source.** Read the `log_tail` for the `migration-collision-check` job and extract the colliding migration number N and the competing PR number(s) M.
+
+2. **Compute the next free number.** After the Step 0 rebase (branch is up to date with `origin/main`), import `pick_next_free_number` from `scripts/check-migration-number-collision.py` or call `scripts/check-migration-number-collision.py --print-next-free` if that flag exists. Pass the current open-PR list (`gh pr list --state open --json number,title,files --limit 200`) and the latest migration number on `origin/main` (`git ls-tree --name-only origin/main:packages/api/migrations | sort | tail -1`). Exclude `current_pr_number` so this PR doesn't count itself.
+
+   Concretely:
+   ```
+   # Run in the worktree
+   python3 scripts/check-migration-number-collision.py --base origin/main --current-pr <PR-N>
+   ```
+   Read the output to see what number is already free, or import `pick_next_free_number` directly in a small driver script written to `tmp/`.
+
+3. **Rename the migration file.**
+   ```
+   git -C <worktree_path> mv packages/api/migrations/<old_N>_<slug>.sql \
+       packages/api/migrations/<new_N>_<slug>.sql
+   ```
+   where `<new_N>` is the next free number from step 2.
+
+4. **Schema.sql does NOT need regeneration.** `packages/api/src/data-access/schema.sql` is a final-state dump and does not reference migration filenames. Do not regenerate it.
+
+5. **Verify the fix locally.**
+   - `bash scripts/check-migration-files.sh` — sequential numbering still passes after the rename.
+   - `python3 scripts/check-migration-number-collision.py --base origin/main --current-pr <PR-N>` — no collision reported.
+
+6. **Return verdict.**
+   - `verdict="PATCHED"`
+   - `failure_category="migration_collision"`
+   - `commit_message="fix(api): renumber migration to <new_N> to resolve collision — CI (#<PR-N>)"`
+   - `changed_files=["packages/api/migrations/<old_N>_<slug>.sql", "packages/api/migrations/<new_N>_<slug>.sql"]`
 
 ## Step 4 — Verify the fix locally
 

--- a/scripts/check-migration-number-collision.py
+++ b/scripts/check-migration-number-collision.py
@@ -234,6 +234,47 @@ def find_stale_numbers(
     return sorted(n for n in my_numbers if n <= latest_on_base)
 
 
+def pick_next_free_number(
+    my_numbers: list[int],
+    other_prs: list[OtherPR],
+    latest_on_base: int | None,
+    current_pr_number: int | None = None,
+) -> int:
+    """Return the next migration number that is free of collisions.
+
+    Computes ``max(claimed_others ∪ {latest_on_base}) + 1`` where
+    ``claimed_others`` is every migration number claimed by *other* open
+    PRs, excluding `current_pr_number` (so a PR never races with itself).
+
+    ``my_numbers`` is accepted for API symmetry with the other pure
+    helpers but is not used in the computation — the caller's own numbers
+    do not affect which next-free slot is available.
+
+    Examples::
+
+        # Three PRs all claim N=56; main is at 55.
+        # PR A calls first: claimed_others = {56 from B, 56 from C}; max=56 → 57
+        # PR B calls next (A's 57 now in other_prs): max=57 → 58
+        # PR C calls next (A=57, B=58 in other_prs): max=58 → 59
+
+    Returns at least 1 (never 0 or negative).
+    """
+    claimed_others: set[int] = set()
+    for pr in other_prs:
+        if current_pr_number is not None and pr.number == current_pr_number:
+            continue
+        claimed_others.update(pr.migration_numbers)
+
+    candidates: list[int] = list(claimed_others)
+    if latest_on_base is not None:
+        candidates.append(latest_on_base)
+
+    if not candidates:
+        return 1
+
+    return max(candidates) + 1
+
+
 # -----------------------------------------------------------------------------
 # I/O: git / gh / filesystem
 # -----------------------------------------------------------------------------

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1349,6 +1349,16 @@ FAILURE_CATEGORY_GIT_COMMIT_FAILED = "git_commit_failed"
 #: on the ``block_reason`` text fix-ci surfaced.
 FAILURE_CATEGORY_FIX_CI_BLOCKED = "fix_ci_blocked"
 
+#: Tier-2 category from issue #3790 — the ``migration-collision-check`` CI
+#: job detected that the PR's migration number is already claimed by another
+#: open PR. The ``/task-v2-fix-ci`` skill resolves this by calling
+#: ``pick_next_free_number`` (``scripts/check-migration-number-collision.py``)
+#: and renaming the migration file to the next free slot, then returning
+#: ``verdict='PATCHED'``. Self-healing: each competing PR independently picks
+#: a higher free number on its own fix-ci retry, so concurrent collisions
+#: converge without operator intervention.
+FAILURE_CATEGORY_MIGRATION_COLLISION = "migration_collision"
+
 #: Tier-2 first-occurrence category from issue #3069 — the
 #: ``_apply_fix_ci_patch`` method has eight ``_mark_agent_terminal``
 #: sites covering ``fix_ci_missing_commit_message`` + every git-add /

--- a/scripts/tests/test_check_migration_number_collision.py
+++ b/scripts/tests/test_check_migration_number_collision.py
@@ -28,6 +28,7 @@ parse_added_migration_numbers_from_diff = mod.parse_added_migration_numbers_from
 parse_gh_pr_list = mod.parse_gh_pr_list
 find_collisions = mod.find_collisions
 find_stale_numbers = mod.find_stale_numbers
+pick_next_free_number = mod.pick_next_free_number
 OtherPR = mod.OtherPR
 
 
@@ -334,3 +335,96 @@ class TestFindStaleNumbers:
 
     def test_result_sorted_ascending(self) -> None:
         assert find_stale_numbers([34, 30, 31], 33) == [30, 31]
+
+
+# ---------------------------------------------------------------------------
+# pick_next_free_number — next collision-free migration number
+# ---------------------------------------------------------------------------
+
+
+class TestPickNextFreeNumber:
+    def test_empty_other_prs_returns_latest_plus_one(self) -> None:
+        # No other PRs; highest claimed is latest_on_base=55 → next free = 56.
+        assert pick_next_free_number([], [], latest_on_base=55) == 56
+
+    def test_single_collision_returns_max_plus_one(self) -> None:
+        other = OtherPR(number=2899, title="other", migration_numbers=[56])
+        assert pick_next_free_number([56], [other], latest_on_base=55) == 57
+
+    def test_multi_collision_returns_global_max_plus_one(self) -> None:
+        # Two other PRs claiming 56 and 57; base is 55 → next free = 58.
+        other_a = OtherPR(number=2899, title="a", migration_numbers=[56])
+        other_b = OtherPR(number=2900, title="b", migration_numbers=[57])
+        assert pick_next_free_number([56], [other_a, other_b], latest_on_base=55) == 58
+
+    def test_self_pr_excluded(self) -> None:
+        # current_pr claims 56 in other_prs but should be excluded.
+        me = OtherPR(number=2901, title="me", migration_numbers=[56])
+        other = OtherPR(number=2899, title="other", migration_numbers=[58])
+        assert (
+            pick_next_free_number(
+                [56], [me, other], latest_on_base=55, current_pr_number=2901
+            )
+            == 59
+        )
+
+    def test_no_migrations_on_base_and_no_others(self) -> None:
+        # No base migration, no other PRs → return 1.
+        assert pick_next_free_number([], [], latest_on_base=None) == 1
+
+    def test_no_migrations_on_base_others_present(self) -> None:
+        # Base is empty (None) but another PR claims 3 → next free = 4.
+        other = OtherPR(number=100, title="first", migration_numbers=[3])
+        assert pick_next_free_number([], [other], latest_on_base=None) == 4
+
+    def test_three_concurrent_prs_get_distinct_numbers(self) -> None:
+        """Simulate three concurrent PRs all initially claiming N=56 with main at 55.
+
+        PR A resolves first (no peers yet claiming 56 aside from B and C):
+          called with other_prs=[B(56), C(56)], latest=55 → 57
+        PR B resolves next (A now shows 57):
+          called with other_prs=[A(57), C(56)], latest=55 → 58
+        PR C resolves last (A=57, B=58):
+          called with other_prs=[A(57), B(58)], latest=55 → 59
+        """
+        # Simulate PR A's call: peers B and C both still claim 56.
+        pr_b = OtherPR(number=2900, title="B", migration_numbers=[56])
+        pr_c = OtherPR(number=2901, title="C", migration_numbers=[56])
+        result_a = pick_next_free_number(
+            [56], [pr_b, pr_c], latest_on_base=55, current_pr_number=2899
+        )
+        assert result_a == 57
+
+        # Simulate PR B's call: A has been reassigned to 57, C still on 56.
+        pr_a_updated = OtherPR(number=2899, title="A", migration_numbers=[57])
+        result_b = pick_next_free_number(
+            [56], [pr_a_updated, pr_c], latest_on_base=55, current_pr_number=2900
+        )
+        assert result_b == 58
+
+        # Simulate PR C's call: A=57, B=58.
+        pr_b_updated = OtherPR(number=2900, title="B", migration_numbers=[58])
+        result_c = pick_next_free_number(
+            [56],
+            [pr_a_updated, pr_b_updated],
+            latest_on_base=55,
+            current_pr_number=2901,
+        )
+        assert result_c == 59
+
+    def test_latest_on_base_dominates_when_higher(self) -> None:
+        # Peers only claim 10, but base is at 50 → next free = 51.
+        other = OtherPR(number=1, title="old", migration_numbers=[10])
+        assert pick_next_free_number([10], [other], latest_on_base=50) == 51
+
+    def test_my_numbers_not_used_in_computation(self) -> None:
+        # my_numbers has a very high value (99) but that doesn't influence
+        # the result — only other_prs and latest_on_base matter.
+        other = OtherPR(number=5, title="other", migration_numbers=[56])
+        result = pick_next_free_number([99], [other], latest_on_base=55)
+        assert result == 57
+
+    def test_tie_between_base_and_other_pr_broken_correctly(self) -> None:
+        # Both base and another PR claim 56 → next free = 57.
+        other = OtherPR(number=100, title="tie", migration_numbers=[56])
+        assert pick_next_free_number([56], [other], latest_on_base=56) == 57


### PR DESCRIPTION
## Summary

Added `pick_next_free_number()` pure function to deterministically assign distinct migration numbers across concurrent PRs. Extends `task-v2-fix-ci` skill with full renumber procedure when `migration-collision-check` job detects a conflict. Added observability constant `FAILURE_CATEGORY_MIGRATION_COLLISION` to daemon. Resolves #3790's Option C recommendation: self-healing agent-driven renumbering with no operator intervention.

Closes #3790

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 46/46 passing, including three-concurrent-PR scenario simulation)
- [x] CI green

### Post-deploy verification

- [ ] Open three concurrent test PRs each adding a migration with the same target number; observe that `/task-v2-fix-ci` automatically renames migrations to distinct consecutive numbers without operator intervention (verify by checking migration filenames and CI logs)
- [ ] Verify `pick_next_free_number()` correctly handles self-exclusion: a PR that already holds a claimed number should not count itself when computing the next free slot (unit test `test_self_pr_excluded` passes locally)
- [ ] Verification evidence posted on #3790 (see /task-v2-verify output)