### PR TITLE
fix(scraping): reject placeholder judge names from Riverside link text (#3785)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -63,6 +63,18 @@ _LINK_TEXT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Riverside publishes these labels for departments without a permanent judge
+# assignment.  The link-text regex captures them as judge_name, but they are
+# not real judges — the PDF-text / dept-judge-map fallbacks should populate
+# the real name instead.
+_PLACEHOLDER_JUDGE_NAMES: frozenset[str] = frozenset({"assigned judge"})
+
+
+def _is_placeholder_judge(name: str | None) -> bool:
+    """Return True iff *name* is a known placeholder, not a real judge name."""
+    return bool(name and name.strip().casefold() in _PLACEHOLDER_JUDGE_NAMES)
+
+
 # Case numbers like "CVPS2306157", "CVRI2412345", "RIC1904113", "MCC2012345"
 # CV-prefixed: CV + 2-4 letter location code + 6-8 digits (e.g. CVPS2306157)
 # Location-prefixed: RIC, MCC, PSC, SWC, INC + 0-4 letters + 6-10 digits
@@ -185,6 +197,18 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
                 logger.warning("PDF text extraction failed", error=str(exc))
                 continue
 
+            # Reset placeholder judge names captured from link text (#3785).
+            # "Assigned Judge" (and variants) are department labels, not real
+            # judge names.  Clearing them here lets the PDF-text and
+            # dept-judge-map fallbacks below populate the real name.
+            if _is_placeholder_judge(doc.judge_name):
+                logger.info(
+                    "Resetting placeholder judge name from link text",
+                    department=doc.department,
+                    original=doc.judge_name,
+                )
+                doc.judge_name = None
+
             # Fallback: extract judge name from PDF text when link text
             # didn't provide one (#411).  Many Riverside PDFs contain
             # "Department X - Honorable Name" headers in the body text.
@@ -222,6 +246,9 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
         doc = super().parse_document(doc)
         if doc.ruling_text and not doc.hearing_date:
             doc.hearing_date = _riv_hearing_date_from_text(doc.ruling_text)
+        # Reset placeholder judge names before attempting fallbacks (#3785).
+        if _is_placeholder_judge(doc.judge_name):
+            doc.judge_name = None
         # Fallback: extract judge name from ruling text (#411)
         if not doc.judge_name and doc.ruling_text:
             pdf_judge = extract_judge_name(doc.ruling_text)

--- a/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
@@ -39,9 +39,11 @@ from courts.ca.pdf_link_scraper import PdfLinkScraper, _extract_pdf_text
 from courts.ca.riverside_tentatives import (
     _CASE_NUMBER_RE,
     _LINK_TEXT_RE,
+    _PLACEHOLDER_JUDGE_NAMES,
     INDEX_URL,
     RiversideTentativeRulingsScraper,
     _is_no_tentative_rulings,
+    _is_placeholder_judge,
     _riv_courthouse,
     _riv_hearing_date_from_text,
 )
@@ -345,6 +347,106 @@ class TestLinkTextRe:
 
 
 # ---------------------------------------------------------------------------
+# _is_placeholder_judge — unit tests (#3785)
+# ---------------------------------------------------------------------------
+
+
+def test_placeholder_judge_names_constant() -> None:
+    """_PLACEHOLDER_JUDGE_NAMES contains the expected placeholder strings."""
+    assert "assigned judge" in _PLACEHOLDER_JUDGE_NAMES
+
+
+def test_is_placeholder_judge_none_returns_false() -> None:
+    """None is not a placeholder."""
+    assert _is_placeholder_judge(None) is False
+
+
+def test_is_placeholder_judge_empty_returns_false() -> None:
+    """Empty string is not a placeholder."""
+    assert _is_placeholder_judge("") is False
+
+
+@pytest.mark.parametrize(
+    "variant",
+    ["Assigned Judge", "assigned judge", "ASSIGNED JUDGE", "  Assigned Judge  "],
+)
+def test_assigned_judge_placeholder_rejected(variant: str) -> None:
+    """All case/whitespace variants of 'Assigned Judge' are detected as placeholders.
+
+    Tests the full fetch_documents pipeline: a single-link synthetic HTML page
+    with the given variant produces a document with judge_name=None (#3785).
+    """
+    html = (
+        "<html><body>"
+        f'<a href="/system/files/2026-02/01ruling030226.pdf">'
+        f"Department 01 - {variant}</a>"
+        "</body></html>"
+    )
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    with respx.mock:
+        respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+        respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+        config = riv_default_config()
+        config.request_delay_seconds = 0
+        scraper = RiversideTentativeRulingsScraper(config=config)
+
+        # Patch extract_judge_name to return None so only the link-text path fires
+        with patch(
+            "courts.ca.riverside_tentatives.extract_judge_name",
+            return_value=None,
+        ):
+            docs = scraper.fetch_documents()
+
+    assert len(docs) == 1
+    assert docs[0].judge_name is None, (
+        f"Expected judge_name=None for placeholder variant {variant!r}, got {docs[0].judge_name!r}"
+    )
+
+
+@respx.mock
+def test_assigned_judge_placeholder_falls_back_to_dept_map() -> None:
+    """When 'Assigned Judge' placeholder is reset, the dept_judge_map fallback fires (#3785).
+
+    A scraper constructed with dept_judge_map={"1": "Honorable Real Name"} should
+    populate judge_name from the map after the placeholder is cleared.
+    Department "01" normalizes to "1" via normalize_department().
+    """
+    html = (
+        "<html><body>"
+        '<a href="/system/files/2026-02/01ruling030226.pdf">'
+        "Department 01 - Assigned Judge</a>"
+        "</body></html>"
+    )
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    # Department "01" normalizes to "1", so the key in the map must be "1"
+    scraper = RiversideTentativeRulingsScraper(
+        config=config,
+        dept_judge_map={"1": "Honorable Real Name"},
+    )
+
+    # Patch extract_judge_name to return None so the dept-map is the only fallback
+    with patch(
+        "courts.ca.riverside_tentatives.extract_judge_name",
+        return_value=None,
+    ):
+        docs = scraper.fetch_documents()
+
+    assert len(docs) == 1
+    assert docs[0].judge_name == "Honorable Real Name", (
+        f"Expected judge_name='Honorable Real Name' from dept map fallback, "
+        f"got {docs[0].judge_name!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Regression test — all three link-text shapes flow through fetch_documents
 # ---------------------------------------------------------------------------
 
@@ -389,9 +491,11 @@ def test_riv_all_link_text_shapes_processed() -> None:
     assert dept_map["04"].judge_name == "Daniel A. Ottolia"
     assert dept_map["04"].courthouse == "Hall of Justice"
 
-    # No-Honorable form — judge name still populated
+    # No-Honorable form — placeholder "Assigned Judge" is reset to None (#3785).
+    # The PDF fallback uses riv_ps1.pdf (Dept PS1, not 01), so it won't match
+    # dept 01; no dept_judge_map passed either.  Final value must be None.
     assert "01" in dept_map
-    assert dept_map["01"].judge_name == "Assigned Judge"
+    assert dept_map["01"].judge_name is None
 
     # No-dash form — department set, judge_name is None (fallback may fill later)
     assert "260" in dept_map


### PR DESCRIPTION
## Summary

Prevents the literal placeholder string "Assigned Judge" from being stored as a canonical judge name on Riverside rulings. Riverside courthouses publish placeholder labels for departments without permanent judge assignment; the link-text regex captures them as judge names, and existing fallbacks never fire because the string is truthy. Added `_PLACEHOLDER_JUDGE_NAMES` constant and `_is_placeholder_judge()` helper with reset logic before fallbacks in both `fetch_documents()` and `parse_document()`.

Closes #3785

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework/tests/courts/test_riverside_tentatives.py` — 74 tests all pass)
- [x] CI green

### Post-deploy verification

- [ ] Run `scripts/ecs-run-task.sh` to execute cleanup SQL against `derived.judges` and `derived.rulings` to remove the 6 affected rows from prior ingests
- [ ] Verify via database queries: `SELECT COUNT(*) FROM derived.judges WHERE canonical_name = 'Assigned Judge';` returns 0
- [ ] Re-run `scripts/ecs-run-task.sh scripts/spotcheck/run_spotcheck.py -- --n 20 --county Riverside` and confirm spotcheck output has no `judge_name = "Assigned Judge"` rows
- [ ] Verification evidence posted on #3785 (see /task-v2-verify output)