### PR TITLE
feat(dispatcher): rewrite /diagnose-failure SKILL for dispatcher-v3 (#3874)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -1,667 +1,419 @@
 ---
-description: Diagnose a dispatcher agent-terminal failure. Reads context from dispatcher.diagnoses.context, takes whatever action is needed (patch, file issue, comment, etc.) with the same authority as a /task agent, and writes a 3-state directive the daemon consumes deterministically.
-argument-hint: "<diagnosis_id>"
+description: Diagnose a dispatcher-v3 task-runner failure. Reads the agent's session transcript from S3 (compact), falling back to raw jsonl or CloudWatch Logs. Takes side effects directly with full peer-agent authority — close issue, file follow-up, comment, edit labels, or re-add `agent/ready` to retry. Writes `agents.outcome_summary` and exits.
+argument-hint: "<agent_id>"
 model: opus
 ---
 
-# /diagnose-failure skill — empowered diagnoser (issue #3366, #3455)
+# /diagnose-failure skill — v3 empowered diagnoser (issue #3874)
 
-Last-ditch resolution point for any failure the per-phase pipeline can't auto-recover from. Invoked as `claude -p '/diagnose-failure <diagnosis_id>'` by the daemon when an agent terminates with a tier-2/3 failure category. Reads the failure context, **does whatever needs doing** (patch the agent's branch, file a prerequisite issue, comment, edit labels), and writes a 3-state directive (`respawn_at=<phase>` / `terminal` / NULL) that the daemon's reaper consumes.
+The diagnoser is the v3 launcher's **failure authority**. When a `task-runner` ECS task exits non-zero (or is killed by silent-hang detection), the launcher spawns a `diagnoser` ECS task that runs `claude -p "/diagnose-failure $AGENT_ID"`. The diagnoser reads the failed agent's full session transcript, decides what to do, **takes side effects directly**, writes a one-line `agents.outcome_summary`, and exits. The launcher polls `dispatcher.agents.status` after the diagnoser exits — it does not consume any structured "recommendation" return value.
 
-This is the v1 mental model that v2 lost: one smart agent with broad context handles the long tail. The diagnoser has the same authority surface as a `/task` agent or the operator-laptop dispatcher session — bounded only by the bright lines below.
+**This is the v3 contract.** The v2 diagnoses ledger, the legacy 9-action recommendation enum, the legacy 3-state directive column, and the `_consume_action_*` daemon methods are not part of v3. The diagnoser is an **authority, not an advisor** — there is no orchestrator to advise.
 
-**No turn cap, no wall-clock cap (within reason).** The daemon's `DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS` is set to 90 minutes as a sanity ceiling for sub-skill invocations and real diagnostic work; operator visibility on long-running diagnoses comes via the structured-log stream, not a hard kill.
+Spec references (the dispatcher-v3 spec lands under `docs/specs/` alongside this SKILL): §4.2 (diagnoser contract), §4.1 (launcher invocation + per-issue claim budget), §5 (state model — five tables), §12 (multi-runner future).
 
-**Recommendation contract — 9 known actions; prefer `terminal`.** Issue #3032's recommendation field stays for audit / operator review and the weekly report — the daemon's deterministic consumer reads it and runs the matching action (`retry`, `retry_with_hint`, `reissue`, `escalate`, `close`, `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`). What's new in #3366 is that you ALSO write a `next_directive` column AND can take direct side effects (commit/push, gh issue create/edit) when the situation calls for it.
+## Cohabitation with v2 (transitional, see #3874)
 
-**Issue #3455 — collapse the executor layer.** Pre-#3455, `escalate` / `close` / `block_and_comment` / `file_prerequisite_task` / `block_on_existing_task` instructed the **daemon** to perform the gh writes (close, comment, label, file). That double-tiered the work — the diagnoser already has full peer-tier `gh` CLI authority — and any action without a daemon-side handler was dying at `agent_runner_route_stub`. Post-#3455 the **preferred** shape is `action="terminal"`: the SKILL itself runs `gh issue close`, `gh issue comment`, `gh issue edit`, `gh issue create`, etc., and emits a descriptive `action_taken` string for audit. The daemon's consumer just records the diagnosis and marks the agent terminal with phase `diagnoser_terminal` — one phase, no per-action variants. The legacy actions still work for backward compat (older skill outputs keep deserializing), but new diagnoses should use `terminal` whenever the SKILL has handled the gh side-effects directly. See §Action selection below.
+v2 keeps invoking this skill via `claude -p "/diagnose-failure <numeric-diagnosis_id>"` from `scripts/dispatcher/daemon.py::_spawn_diagnoser_subprocess`. This SKILL.md is now v3-shaped. **The deliberate decision (per #3874) is to accept v2 diagnoser degradation during cohab** rather than carry a dual-mode SKILL with conflicting contracts.
 
-**Prerequisites:** The daemon has already (a) written a `dispatcher.diagnoses` row with `status='pending'` and a serialized context bundle, (b) spawned this skill with the `diagnosis_id` as the argument AND with the `JUDGEMIND_DIAGNOSER_RUN=1` env var set (the bright-line hook reads this).
+What this means in practice:
 
-**Goal — three writes to the `dispatcher.diagnoses` row before exit:**
+- v2's daemon will spawn this SKILL with a numeric diagnosis-id positional arg + the legacy diagnoser sentinel env var. The SKILL will read the agent context as best it can from the v3-shaped sources (S3 transcript, agent row, issue/PR via `gh`) — the v2 diagnosis-id arg is ignored, and no rows are written to the legacy v2 diagnoses ledger. The v2 daemon's diagnosis-consumer will see a NULL recommendation after the SKILL exits and the 90-min `DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS` fallback kicks in — the v2 diagnoses status advances to `failed` via the v2 daemon's mark-failed path, which already routes to mechanical escalate (the same fallback path used for any diagnoser crash).
+- The v2 daemon's mechanical-escalate fallback is the safety net. Failures still get human attention via Telegram + `status/needs-human`; the loss is fidelity (the LLM-authored escalation prose), not safety.
+- This degradation is bounded by the v2→v3 ramp schedule (spec §9). Once v2 reaches cap=0 and is retired, the cohab path disappears.
+- An alternative considered: env-var-gated dual-mode SKILL that swaps to legacy v2 logic when the v2 sentinel is set, else runs v3 logic. Rejected because it doubles the contract surface, both branches drift, and the legacy v2 contract is being deliberately deleted (spec §7 — the legacy recommendation-action enum, the directive column, and the `_consume_action_*` daemon methods are all going away).
 
-1. `recommendation` (JSONB) — the 9-action shape (or a novel action string for operator review). See §Output contract.
-2. `next_directive` (TEXT) — `respawn_at=<phase>` | `terminal` | NULL.
-3. `actions_taken` (JSONB array) — append-only audit log of every side-effect you took.
+If the v2 cohab degradation produces operator pain in practice, the path forward is to land #3882 (v3 launcher invocation path) faster, not to re-introduce a dual-mode SKILL.
 
-Plus the existing `dispatcher.agents.failure_summary` upgrade (first 1-3 sentences of `recommendation.reasoning` ≤240 chars, issue #2900).
+---
 
-**Important — `status` ownership:** Do NOT set `status='completed'` in `write_recommendation.py`. Leave the row at `status='pending'` on SKILL exit. The daemon's reaper queries `WHERE status='pending'` and calls `_consume_diagnosis`; the daemon then writes `status='completed'` after the directive action runs. If the SKILL sets `status='completed'` before exiting, the reaper skips the row and the directive is silently dropped (issue #3422).
+## Inputs — env, args, and DB state
 
-**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task. All sub-skills run synchronously.
+The launcher spawns this skill with one positional argument and one env var:
+
+```
+claude -p "/diagnose-failure $AGENT_ID"
+```
+
+- **Argument:** `AGENT_ID` — UUID of the failed agent's `dispatcher.agents` row.
+- **Env:** `AGENT_ID` (also exported by the v3 task-runner entrypoint), `DATABASE_URL` (RDS connection string for `dispatcher.*`), `SESSIONS_BUCKET` (S3 bucket for archived transcripts), `AWS_REGION`.
+
+### What to read
+
+1. **The agent's row** — current state of the failed agent.
+   ```sql
+   SELECT agent_id, issue_number, task_arn, session_s3_key, status, exit_code,
+          exit_reason, pr_number, outcome_summary, current_milestone,
+          current_milestone_detail, current_milestone_at, started_at, ended_at,
+          parent_run_id
+   FROM dispatcher.agents
+   WHERE agent_id = $AGENT_ID;
+   ```
+   Key fields:
+   - `status` is typically `failed` at this point (the launcher wrote it before spawning you). `exit_code` and `exit_reason` give the proximate cause (`silent_hang`, ECS `stoppedReason`, or the runner's own non-zero exit).
+   - `pr_number` may be set (if the agent got far enough to push) — fetch the PR for current state.
+   - `current_milestone` is best-effort progress observation (`planning`, `ralph`, `summary`, `push_and_pr`, `awaiting_ci`, `fix_ci`, `merge`, `awaiting_deploy`, `verify`, `retro`); use it to anchor your transcript scan.
+
+2. **Cross-attempt history on the same issue** — was this a recurring failure or a first attempt?
+   ```sql
+   SELECT agent_id, status, exit_code, exit_reason, outcome_summary,
+          started_at, ended_at, pr_number
+   FROM dispatcher.agents
+   WHERE issue_number = $CURRENT_ISSUE_NUMBER
+     AND agent_id <> $AGENT_ID
+   ORDER BY started_at DESC
+   LIMIT 10;
+   ```
+   The per-issue claim budget (default `claim_attempts_max=3`) means the launcher will skip future claims of this issue once `count(agents) >= 3`. If you re-add `agent/ready` and the count is at 3, the launcher's claim step will instead set `status/needs-human` + Telegram-alert (see spec §4.1). Treat that as a hard cap on retry — beyond it, the issue needs human triage.
+
+3. **The session transcript** — what `/task` actually did, every tool call, every reviewer message. **Stderr is ground truth; prior decisions are priors, not evidence** (see §Step 1 below).
+
+   The diagnoser's read cascade matches `dispatcher-v3-spec.md` §4.1's two-capture design:
+
+   - **Primary: compact rendered transcript at `s3://$SESSIONS_BUCKET/<agent_id>.txt`.** The task-runner's EXIT trap runs `judgemind-transcripts/render-transcript.py` on the raw stream-json before uploading both files. The compact form is ~20:1 compressed (e.g. 41.9MB → 2.2MB) and is the diagnoser's default read.
+   - **Fallback: raw stream-json at `s3://$SESSIONS_BUCKET/<agent_id>.jsonl`.** Used when the compact transcript wasn't produced (rare — means the EXIT trap hit a render error after the upload preamble).
+   - **Last resort: CloudWatch Logs `GetLogEvents`** against the task's log stream. Used when the EXIT trap was bypassed entirely (SIGKILL/OOM/spot-reclaim). CloudWatch's per-event 256 KB and per-batch 1 MB limits can drop large tool-result events under burst, so it is lossy under burst — but it is the only survivor of EXIT-trap bypass. The log stream name follows ECS's `/ecs/judgemind-task-runner-dev/<task-id>` pattern; resolve the task-id from `dispatcher.agents.task_arn`.
+
+   Read the cascade in order. Stop at the first source that returns a usable transcript.
+
+4. **Issue body, comments, and PR** — the session is a snapshot at exit time; fetch current state via `gh` because the issue/PR may have changed since the agent started (operator may have edited the AC, another PR may have closed it, etc.).
+   ```
+   gh issue view <issue_number> --repo judgemind/judgemind --json number,title,body,labels,assignees,state,comments
+   gh pr view <pr_number> --repo judgemind/judgemind --json number,state,mergeable,statusCheckRollup,body --jq '...'
+   ```
+
+---
+
+## Step 1 — Parse the failure signature FIRST (anchor-bias defense — #3057)
+
+**This is a mandatory first step.** Before you read prior agent attempts on the same issue, fleet-wide failure patterns, or any other pattern-bearing context, find the **actual failure signature in the session transcript** and quote it verbatim.
+
+**The rule: stderr is ground truth; prior decisions are priors, not evidence.**
+
+### Procedure
+
+1. Scan the session transcript from the **bottom up** and extract the last concrete failure line. "Concrete" means one of:
+   - A line starting with `FAILED:` (pre-push hook convention).
+   - A line containing `[remote rejected]` or `! [rejected]` (git push output).
+   - A line starting with `error:` or `fatal:` (git / ruff / pytest conventions).
+   - An explicit banner like `Push aborted.`, `check(s) failed.`, `tests failed`, `coverage dropped`, `floor violation`.
+   - For pytest: the last `FAILED packages/... ::test_name` line from the summary.
+   - For CI log: the last `##[error]` line or the last non-zero-exit line.
+   - For ralph: the last `BLOCKED:` reason from the worker / reviewer transcripts.
+   - For silent-hang exits: there is no failure line — the launcher killed the task because the session-log `lastEventTimestamp` stopped advancing for `silent_hang_minutes`. In that case quote the last meaningful tool call or stdout line you can find, and note `exit_reason='silent_hang'`.
+
+2. **Quote that line verbatim** in your `outcome_summary` and in any escalation comment you post. Use backticks or double-quotes to set the quoted text apart. Do not paraphrase, do not summarize, do not compress. Copy-paste the exact characters.
+
+3. **Only then** consult cross-attempt history and fleet patterns. Treat them as priors — useful for detecting fleet-wide spates, dangerous as substitutes for reading the transcript.
+
+### When the transcript has no identifiable failure line
+
+Say so verbatim in your `outcome_summary`, then default to the **mark needs_review** action (§Step 3 — Action 4). The launcher's `status='needs_review'` path triggers the Telegram alert; an operator can take it from there.
+
+### Why this step exists — the #3057 anchor-bias regression
+
+On 2026-04-23 the diagnoser hallucinated a PAT-scope cascade push-rejection on a coverage-floor failure because the recent fleet decisions were dense with PAT-cascade diagnoses on different issues. The actual stderr ended with `"FAILED: coverage floor"` + `"coverage dropped 80.0% -> 68.6%"` and the push never reached the remote. The verbatim-quote requirement closes that failure mode by forcing the LLM to ground its classification in the actual transcript before consulting pattern-bearing context.
+
+The fleet-history cap remains tunable in v3 via `dispatcher.config.diagnoser_fleet_decisions_cap` (default 3). Larger windows raise anchor-bias risk; smaller windows lose useful pattern signal.
+
+---
+
+## Step 2 — Classify and decide
+
+Walk the decision tree. **Default to taking the action, not filing it.** The v3 diagnoser has the same authority surface as a `/task` agent or the operator's interactive dispatcher session. When a failure is **tractable** (the fix is mechanical and bounded — a small patch, a missing log line, a duplicate to close, a stale row to clean up), the diagnoser MUST do the work directly rather than escalating.
+
+### "Default to taking the action, not filing it" rule
+
+Examples of tractable actions the diagnoser SHOULD do inline:
+
+- **Instrumentation patch:** the worker's stdout/stderr was not captured; write the 3-line patch, open a PR, watch CI, merge. Then re-add `agent/ready` so the next attempt has full diagnostic output.
+- **Cleanup query:** a stale or duplicate DB row is blocking a pipeline step; write and run the targeted `UPDATE` / `DELETE` via `scripts/dev-db-query.sh`, confirm the row is gone, re-add `agent/ready`.
+- **Sibling-fix port:** the same bug was fixed in a sibling scraper last week; port the fix, open a PR, merge, re-add `agent/ready`.
+- **Missing diagnostic field:** a failure has ambiguous root cause because a key field isn't logged; add the field to the log statement, open a PR, merge, re-add `agent/ready`. Do NOT wait to see if the next run fails before acting.
+- **Duplicate PR consolidation:** when N>1 open PRs all carry `Closes #<issue>` (operator invariant violated), close the duplicates inline. See Example 4 below for the detection + selection pattern.
+
+**Reserved for needs_review (the diagnoser must NOT act unilaterally):**
+
+- PAT / secret rotation (auth tokens, API keys, AWS credentials).
+- Product or spec decisions (should this feature exist, should this UI work this way).
+- Infrastructure outside agent reach (Fargate task-def changes requiring human approval, DNS changes, CDN config).
+- Destructive operations without a safe preview (DROP TABLE, mass DELETE without query-first verification, irreversible S3 mutations).
+
+**The closing rule:** A failure pattern that says "instrument this and the answer becomes obvious" is NEVER `needs_review`.
+
+### "Chains, not blockers" rule
+
+When the work is tractable but larger than ~30 minutes (multi-file refactor, non-trivial new feature, data migration), prefer **filing a prerequisite task** over marking `needs_review`:
+
+- Write the prerequisite as a `type/task` issue with `agent/ready` and enough scope that an agent can pick it up immediately.
+- Append `Blocked by #<new>` to the failed agent's issue body via `gh issue edit --body-file`.
+- Add `status/blocked` to the failed agent's issue, remove `agent/ready` (the auto-unblock workflow will re-add it when the prerequisite PR merges with `Closes #<new>`).
+
+Never set `status/needs-human` on the failed agent's issue just because the fix requires a multi-step chain. `needs-human` is reserved for the four operator-only domains above — it is not a synonym for "complicated" or "uncertain."
+
+### The four authoritative actions
+
+There are four, not nine. The v3 diagnoser **does not** emit a structured recommendation-action — there is no orchestrator to consume it. Each action is a sequence of side effects you take directly via `gh` / `git` / `scripts/dev-db-query.sh`, followed by an `outcome_summary` write, followed by exit.
+
+#### Action 1 — Retry (re-add `agent/ready`)
+
+When the failure looks transient (network blip, Claude API 5xx/timeout, rate-limit pause, ECS spot-reclaim, single-shot CI flake) **and** the per-issue claim budget has headroom (`count(agents WHERE issue_number = X) < claim_attempts_max`):
+
+```
+gh issue edit <N> --repo judgemind/judgemind --add-label agent/ready
+```
+
+If `status/blocked` was added by an earlier attempt and the blocker is resolved, also remove `status/blocked`. Use `scripts/unblock-issue.sh <N>` rather than bare `gh issue edit --remove-label status/blocked` — it prunes stale closed-blocker lines and runs the all-blockers gate.
+
+The launcher's next 30s tick scans `agent/ready` and claims the issue. The retry loop is just "re-add the label" — there is no per-phase resume directive, no state surgery. `/task` runs end-to-end from `planning` again.
+
+#### Action 2 — File follow-up issue + mark agent failed
+
+When the failure points to a specific bug or missing prerequisite that needs its own ticket — `/task` exhausted internal retries on something fixable but distinct from the original AC:
+
+1. Write the follow-up body to `{worktree}/tmp/diagnoser/followup_body.md` (Parent: #<original-issue>, concrete repro from the transcript, suggested fix sketch).
+2. Run `gh issue create --repo judgemind/judgemind --title "<conventional-commits-title>" --body-file {worktree}/tmp/diagnoser/followup_body.md --label "agent/ready,<area>,<priority>"`. Capture the new issue number.
+3. Append `Blocked by #<new>` to the original issue body (fetch with `gh issue view --json body`, edit, push back with `gh issue edit --body-file`).
+4. Run `gh issue edit <original> --repo judgemind/judgemind --add-label status/blocked --remove-label agent/ready`.
+5. Post a short comment on the original issue explaining the block and naming the prerequisite.
+6. The agent stays at `status='failed'` (already set by the launcher) — no DB write needed beyond the `outcome_summary` write at end of run. The auto-unblock workflow will restore `agent/ready` when the prerequisite PR merges with `Closes #<new>`.
+
+#### Action 3 — Reissue the AC + retry
+
+When the failure reveals that the issue's acceptance criteria are infeasible as written (renamed field, dropped feature, AC describes a state that has since shipped, AC and reality have drifted) but the underlying **intent** is still valid:
+
+1. Read the current issue body. Compose a wholesale-replacement body that fixes the AC. The new body is the **complete rewritten issue body** — preserve `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References`, and any `Parent: #N` / `Blocked by #N` lines. Do NOT post a diff or a partial splice — `gh issue edit --body-file` does no parsing.
+2. Write the new body to `{worktree}/tmp/diagnoser/reissue_body.md`.
+3. Run `gh issue edit <N> --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/reissue_body.md`.
+4. Post a comment naming the AC change (`AC #2 was infeasible as written — the field was renamed in #3204; the AC has been rewritten to reference the new name.`).
+5. Re-add `agent/ready` (subject to claim budget).
+
+The launcher's next tick claims the issue with the rewritten body. `/task` runs end-to-end against the new AC.
+
+`new_scope` (the AC-rewrite term used in v2) was always required to be a **wholesale replace, not a partial splice**. v3 keeps that requirement — `gh issue edit --body-file` doesn't parse content, so any partial body truncates the issue.
+
+#### Action 4 — Mark `needs_review`
+
+When the failure is structurally unclear (the transcript shows no FAILED line, the AC isn't infeasible but the failure mode is novel, the fix requires an operator-only decision per the four categories above), update the agent row directly:
+
+```sql
+UPDATE dispatcher.agents
+SET status = 'needs_review'
+WHERE agent_id = $AGENT_ID;
+```
+
+The launcher detects `status='needs_review'` and Telegram-alerts the operator. Also add `status/needs-human` + `priority/p1` to the issue and post the escalation comment with the verbatim stderr quote. Do not re-add `agent/ready` — the issue is paused until the operator triages.
+
+---
+
+## Step 3 — Execute, then write `agents.outcome_summary` and exit
+
+The diagnoser does the work directly via `gh` / `git` / `aws` / `scripts/dev-db-query.sh` — there is no recommendation/directive return. The launcher polls `dispatcher.agents.status` after the diagnoser exits and proceeds based on the row state.
+
+### Final write — `agents.outcome_summary`
+
+Before exit, write a one-line human-readable narrative to `dispatcher.agents.outcome_summary`. The cockpit reads this column to render "what happened to this agent" in the admin UI. **First sentence MUST quote the verbatim stderr line** when one is identifiable (same rule as Step 1).
+
+```python
+# {worktree}/tmp/diagnoser/write_outcome.py
+import os, sys
+import psycopg
+
+agent_id = sys.argv[1]
+summary = sys.argv[2]
+with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE dispatcher.agents "
+            "SET outcome_summary = %s WHERE agent_id = %s",
+            (summary, agent_id),
+        )
+    conn.commit()
+```
+
+Run it as the last step:
+
+```
+python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "$OUTCOME"
+```
+
+The summary is a single line, ≤500 chars, present tense. Examples:
+
+- `"FAILED: coverage floor" — coverage dropped 80.0% to 68.6% on packages/api after the alerts refactor; re-added agent/ready, the next attempt will see the failing assertion in the prior_attempts.md context.`
+- `"remote: refusing to allow a Personal Access Token to create or update workflow" — filed prerequisite #4012 to bump the agent PAT scope; this issue blocked-on #4012.`
+- `silent_hang at ralph_iter_3 — task-runner stopped emitting log events for 31 min during reviewer subagent. Marked needs_review; transcript ends mid-Bash call to gh run watch.`
+
+### No recommendation/directive return — the launcher polls `agents.status`
+
+There is **no** structured recommendation JSONB field, no directive TEXT field, no actions-taken audit array, no v2-style diagnoses row to UPDATE. The diagnoser SKILL is contract-side-effects-then-exit. The launcher's next 30s tick reads `dispatcher.agents` and acts on `status` — `failed` (with `agent/ready` re-added → claim again on next tick), `needs_review` (Telegram + skip), `succeeded` (rare from the diagnoser path, possible if you closed the issue as already-shipped), or unchanged `failed` with no `agent/ready` (terminal — the issue is parked at the per-issue claim budget cap or you intentionally left it that way).
+
+The diagnoser's exit code is informational only — exit 0 if you took an action, exit non-zero if you crashed. The launcher's failure-of-the-diagnoser path (spec §4.2 — cap is 1 diagnoser per agent_id) marks the agent `status='needs_review'` and Telegram-alerts; there is no recursion into "diagnose the diagnoser."
+
+### Bright lines — irreducible (hook-enforced when the env var is set)
+
+These are policy, not parsimony — the same lines that bound `/task` agents and the operator-laptop preflight. v2's diagnoser-sentinel env var was the legacy enforcement mechanism; v3's task-runner role policy enforces the same constraints at the IAM layer (the diagnoser task role excludes the prod-account assume-role) plus the PreToolUse hook checks any of these bright lines that fire shell-side:
+
+1. **No production deploy.** `terraform apply` against `environments/production/`, ECS service writes against `*-production` clusters. Human-only per `CLAUDE.md`.
+2. **No PAT rotation / `gh auth switch`.** Operator-only.
+3. **No force-push to `main`, no amending merged commits.** Destructive across all agents.
+4. **No recursive `/diagnose-failure` invocation.** Depth-1 cap. The launcher caps at 1 diagnoser per agent_id; the SKILL must not spawn another diagnoser sub-skill.
+
+If a hook blocks a command, do NOT try to work around it. Default to **mark needs_review** instead.
+
+---
 
 ## Capabilities — same as a peer agent
 
 You can use the full toolset of a `/task` agent or the operator's dispatcher session:
 
 - **Bash** — `git`, `gh`, `aws`, `psql` (via `scripts/dev-db-query.sh`), any other shell command. Set `timeout: 1200000` on long-running commands per `CLAUDE.md`.
-- **Edit / Write / Read / Glob / Grep** — full filesystem access. Edit files in the failed agent's worktree, write helper scripts to `{worktree}/tmp/dispatcher-diagnoser/`, read PR diffs, etc.
-- **Agent (sub-skill invocation, uncapped)** — call `/task-v2-fix-conflict`, `/tdd`, `/ralph`, `/audit`, etc. as many times as judgment requires. Sub-skills run with their own normal contracts.
+- **Edit / Write / Read / Glob / Grep** — full filesystem access. Edit files in the failed agent's worktree (when present), write helpers to `{worktree}/tmp/diagnoser/`, read PR diffs, etc. Note: the v3 diagnoser runs in its own ECS task; it does not have the failed agent's worktree on disk by default. Use `git fetch origin pull/<PR>/head:adopt-<PR>` to materialize the agent's branch when you need to inspect or patch it.
+- **Agent (sub-skill invocation)** — call `/ralph`, `/tdd`, `/audit`, etc. when judgment requires. Sub-skills run with their own normal contracts.
 - **MCP servers** — `github`, `awslabs_cloudwatch-mcp-server`, `awslabs_ecs-mcp-server`, `plugin:telegram` (read/notify only — see Telegram Integration in `CLAUDE.md`).
-- **gh / git / aws CLI** — full operator-tier authority. You may commit and push to the failed agent's branch, file new issues, edit issue/PR bodies, add/remove labels, post comments. AWS reads (CloudWatch logs, ECS describe-tasks) plus same writes the daemon already has.
-
-## Bright lines — irreducible (hook-enforced)
-
-These are policy, not parsimony. Same lines that bound `/task` agents and the operator-laptop preflight. The diagnoser env var (`JUDGEMIND_DIAGNOSER_RUN=1`, set by the daemon when spawning this skill) lets `.claude/hooks/preflight-bash.sh` enforce them automatically:
-
-1. **No production deploy.** `terraform apply` against `environments/production/`, ECS service writes against `*-production` clusters. Human-only per `CLAUDE.md`. Hook blocks any matching command.
-2. **No PAT rotation / `gh auth switch`.** Operator-only. Hook blocks `gh auth switch`.
-3. **No force-push to main, no amending merged commits.** Destructive across all agents. Hook blocks `git push --force` / `--force-with-lease` to `main`/`master` and blocks `git commit --amend` against merged commits.
-4. **No recursive `/diagnose-failure` invocation.** Depth-1 cap. If a sub-action fails, escalate — don't re-enter. Hook blocks `claude -p '/diagnose-failure ...'` from within a diagnoser run.
-
-If a hook blocks a command, do NOT try to work around it. The hooks ARE policy. Default to `escalate` instead.
-
-## Audit trail — `dispatcher.diagnoses.actions_taken`
-
-Every side-effect action you take must be appended to `dispatcher.diagnoses.actions_taken` (JSONB array). Operators review post-hoc; git history covers code changes, this column covers everything else.
-
-Schema for each entry:
-
-```jsonb
-{"ts": "2026-04-25T18:42:00Z", "type": "git_commit", "sha": "abc123", "message": "fix(deps): align anthropic floor"}
-{"ts": "...", "type": "git_push", "branch": "worktree-agent-XYZ", "remote": "origin"}
-{"ts": "...", "type": "gh_issue_create", "issue_number": 3401, "title": "..."}
-{"ts": "...", "type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/blocked"], "labels_removed": ["agent/ready"]}
-{"ts": "...", "type": "gh_issue_comment", "issue_number": 3297, "body_preview": "first 200 chars..."}
-{"ts": "...", "type": "gh_issue_close", "issue_number": 3297, "reason": "not planned"}
-{"ts": "...", "type": "skill_invoke", "skill": "task-v2-fix-conflict", "exit_code": 0}
-{"ts": "...", "type": "bash_run", "cmd": "git rebase origin/main", "exit_code": 0}
-```
-
-Action types to log:
-
-- `git_commit` — every commit you (or a sub-skill on your behalf) make.
-- `git_push` — every push.
-- `gh_issue_create` — `gh issue create`, with the new issue number.
-- `gh_issue_edit` — `gh issue edit`, including label add/remove and body changes.
-- `gh_issue_comment` — `gh issue comment`.
-- `gh_issue_close` — `gh issue close`, with the reason.
-- `skill_invoke` — every sub-skill call.
-- `bash_run` — non-trivial commands (don't log every `cat`/`ls`/`grep`; log every `git rebase` / `gh issue close` / `aws ...` / `pytest` / etc.).
-
-Append-only writer:
-
-```python
-# {worktree}/tmp/dispatcher-diagnoser/log_action.py
-import json, os, sys
-from datetime import datetime, timezone
-import psycopg
-
-diagnosis_id = int(sys.argv[1])
-action = json.loads(sys.argv[2])
-action.setdefault("ts", datetime.now(timezone.utc).isoformat())
-with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE dispatcher.diagnoses "
-            "SET actions_taken = COALESCE(actions_taken, '[]'::jsonb) || %s::jsonb "
-            "WHERE diagnosis_id = %s",
-            (json.dumps([action]), diagnosis_id),
-        )
-    conn.commit()
-```
-
-## `next_directive` — the 3-state daemon signal
-
-Before you exit, the daemon's reaper needs to know whether to respawn the agent or free the slot. **Always write one of three values:**
-
-| Value | Meaning | What the daemon does |
-|---|---|---|
-| `respawn_at=<phase>` | You advanced the work (committed a fix, etc.). Resume the agent at the named phase. | Daemon launches a fresh agent-runner ECS task on the same `agent_id` with `START_PHASE=<phase>` env. Same branch, same issue. |
-| `terminal` | You explicitly say no further action. Whatever needed doing — issue closed, prerequisite filed, comment posted — you already did directly via gh/git. | Daemon frees the slot, logs `daemon.diagnoser_completed_terminal`. |
-| (absent / NULL) | You did not write a directive (crashed, OOM, network error, etc.). | Daemon falls back to `escalate` AND logs `daemon.diagnoser_did_not_complete` for operator visibility. |
-
-The explicit `terminal` directive is what makes "I ran and decided no more action" distinguishable from "I crashed before finishing." Always write one when you finished your run.
-
-Valid `respawn_at` phases (mirrored from `daemon.AGENT_RUNNER_VALID_START_PHASES` and the entrypoint's allowlist): `planning`, `setup`, `ralph`, `summary`, `push_and_pr`, `awaiting_ci`, `fix_ci`, `merge`, `awaiting_deploy`, `verify`. The daemon validates against this set; an unknown phase falls back to escalate.
-
-A small directive writer:
-
-```python
-# {worktree}/tmp/dispatcher-diagnoser/write_directive.py
-import os, sys
-import psycopg
-
-diagnosis_id = int(sys.argv[1])
-directive = sys.argv[2]  # "respawn_at=ralph" | "terminal"
-with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE dispatcher.diagnoses "
-            "SET next_directive = %s WHERE diagnosis_id = %s",
-            (directive, diagnosis_id),
-        )
-    conn.commit()
-```
-
----
-
-## Step 1 — Parse the failure signature FIRST (anchor-bias defense — #3057)
-
-**This is a mandatory first step.** Before you read `prior_diagnoses_this_issue`, `recent_fleet_decisions`, or any other pattern-bearing field, find the **actual failure signature in the raw stderr** and quote it verbatim.
-
-**The rule: stderr is ground truth; prior decisions are priors, not evidence.**
-
-### Procedure
-
-1. From the context bundle, locate the raw stderr text. Depending on the category, it lives in one of:
-   - `context.prior_failures[0].details.stderr_tail` (the most recent failure on this issue, when it matches the triggering failure_id)
-   - `context.details.stderr_tail` (when the daemon inlined the triggering failure's details at the top level — category-dependent)
-   - `context.ralph_done_content` (for ralph-phase failures)
-   - The `ci_log_url` / `gh run view --log-failed` output (for `ci_red_after_retries`)
-
-2. Scan the stderr from the **bottom up** and extract the **last** concrete failure line. "Concrete" means one of:
-   - A line starting with `FAILED:` (pre-push hook convention)
-   - A line containing `[remote rejected]` or `! [rejected]` (git push output)
-   - A line starting with `error:` or `fatal:` (git / ruff / pytest conventions)
-   - An explicit banner like `Push aborted.`, `check(s) failed.`, `tests failed`, `coverage dropped`, `floor violation`
-   - For pytest: the last `FAILED packages/... ::test_name` line from the summary
-   - For CI log: the last `##[error]` line or the last non-zero-exit line
-
-3. **Quote that line verbatim** in the `reasoning` field of your final recommendation. Use backticks or double-quotes to set the quoted text apart. **Do not paraphrase, do not summarize, do not compress.** Copy-paste the exact characters.
-
-4. **Only then** consult `prior_diagnoses_this_issue` and `recent_fleet_decisions`. Treat them as priors — useful for detecting fleet-wide spates, dangerous as substitutes for reading the stderr.
-
-### When the stderr has no identifiable failure line
-
-Say so verbatim in the reasoning, then default to `escalate` (with `next_directive=terminal` after you escalate via `gh`).
-
-### Why this step exists — the #3057 anchor-bias regression
-
-On 2026-04-23 the Opus diagnoser hallucinated a PAT-scope cascade push-rejection on a coverage-floor failure. Diagnosis #15 (agent `6d4029f0`, issue #2613) had `recent_fleet_decisions` populated with 9 prior `block_on_existing_task → #3038` decisions — all legitimate PAT cascades on different issues. The actual stderr ended with `"FAILED: coverage floor"` + `"coverage dropped 80.0% -> 68.6%"` and the push never reached the remote. The diagnoser confabulated a `"refusing to allow a Personal Access Token..."` rejection from the fleet pattern. The verbatim-quote requirement closes that failure mode by forcing the LLM to ground its classification in the actual stderr before consulting pattern-bearing context.
-
----
-
-## Step 2 — Decide the action shape
-
-Walk the decision tree below. For most cases the action shape is clear from the failure category and the verbatim stderr. **Pre-#3366 the diagnoser was constrained to recommendation-only output; post-#3366 you can also do the work directly** — patch the agent's branch, file the issue with `gh issue create`, etc. **Post-#3455 the preferred shape for any case where you've taken gh side-effects yourself is `action="terminal"`** — see "Inline-action terminal" below.
-
-### "Default to taking the action, not filing it" rule
-
-When a failure is **tractable** (the fix is mechanical and bounded — a small patch, a cleanup query, a duplicate deletion, a missing log line), the diagnoser MUST do the work directly rather than filing a task and escalating.
-
-**Examples of tractable actions the diagnoser SHOULD do inline:**
-
-- **Instrumentation patch**: the worker's stdout/stderr was not captured; write the 3-line patch to add the capture, open a PR, watch CI, merge. Return `action="terminal"` with `action_taken` summarizing the patch.
-- **Cleanup query**: a stale or duplicate row is blocking a pipeline step; write and run the targeted `DELETE` or `UPDATE` via `scripts/dev-db-query.sh`, confirm the row is gone, return `action="terminal"`.
-- **Sibling-fix duplication**: the same bug was fixed in a sibling scraper last week; port the fix to the current scraper, open a PR, merge. Return `action="terminal"`.
-- **Missing diagnostic data**: a failure has ambiguous root cause because a key field isn't logged; add the field to the log statement, open a PR, merge, return `action="terminal"`. Do NOT wait to see if the next run fails before acting.
-
-**Reserved for operator-only (the diagnoser must NOT act unilaterally):**
-
-- PAT / secret rotation (auth tokens, API keys, AWS credentials).
-- Product or spec decisions (should this feature exist, should this UI work this way).
-- Infrastructure outside agent reach (Fargate task definition changes requiring human approval, DNS changes, CDN config).
-- Destructive operations without explicit human confirmation (DROP TABLE, mass DELETE without a safe preview, irreversible S3 mutations).
-
-**The closing rule:** A failure pattern that says "instrument this and the answer becomes obvious" is NEVER `needs-human`.
-
-### "Chains, not blockers" rule
-
-When the work is tractable but larger than ~30 minutes (multi-file refactor, non-trivial new feature, data migration), prefer filing a prerequisite task over escalating:
-
-- Use `action="file_prerequisite_task"` so the **original issue auto-unblocks** via the Closes-keyword in the new task's PR.
-- Write the prerequisite task with enough context that an agent can pick it up immediately.
-- Return `action="file_prerequisite_task"` — the daemon will link the tasks and set the original back to `agent/ready` once the prerequisite merges.
-
-**Never** set `status/needs-human` on the original issue just because the fix requires a multi-step chain. `needs-human` is reserved for the four operator-only domains above — it is not a synonym for "complicated" or "uncertain."
-
-### Action selection — the nine known recommendations
-
-The first eight are the legacy decision tree (still supported for backward compat); the ninth (`terminal`) is the new collapsed shape preferred post-#3455.
-
-1. **External-dep transient** (`subprocess_crash` with 5xx/timeout, no fleet-wide pattern) → `retry`. No comment needed.
-2. **Scope ambiguity / missing context** (`subprocess_turn_limit` / `ci_red_after_retries` looping on a fixable thing) → `retry_with_hint`. Write a concrete `hint`.
-3. **AC mismatch with reality** (ralph SHIPped, CI caught a drift; the AC uses a renamed field) → `reissue`. Write a `new_scope` body (full rewrite — see below).
-4. **Needs human** (`type/decision`, missing secret, vendor billing) → either:
-   - **Preferred (#3455 inline):** post the `## Diagnosis (3D escalation)` comment yourself via `gh issue comment`, add `status/needs-human` + `priority/p1` via `gh issue edit --add-label`, then emit `action="terminal"` with `action_taken="escalate"`.
-   - Legacy fallback: `action="escalate"` and let the daemon do the gh writes.
-5. **Issue invalid** (duplicate, already-closed, not reproducible) → either:
-   - **Preferred (#3455 inline):** add `status/invalid` and run `gh issue close <N> --reason "not planned"` yourself with the diagnosis as the close comment, then emit `action="terminal"` with `action_taken="close"`.
-   - Legacy fallback: `action="close"` and let the daemon do the gh writes.
-6. **Operator-action blocker, in-flight** → either:
-   - **Preferred (#3455 inline):** post `## Diagnosis (3D block)` yourself, add `status/blocked`, remove `agent/ready`, then emit `action="terminal"` with `action_taken="block_and_comment"`.
-   - Legacy fallback: `action="block_and_comment"`.
-7. **Operator-action blocker, new** → either:
-   - **Preferred (#3455 inline):** run `gh issue create` yourself with the title + body, capture the new issue number, append `Blocked by #<new>` to the current issue body via `gh issue edit --body-file`, add `status/blocked`, post the explanatory comment, then emit `action="terminal"` with `action_taken="file_prerequisite_task"`.
-   - Legacy fallback: `action="file_prerequisite_task"` with `title` + `body`.
-8. **Tracking issue already exists** → either:
-   - **Preferred (#3455 inline):** validate the blocker is open via `gh issue view`, append `Blocked by #<N>` yourself, add `status/blocked`, remove `agent/ready`, post the comment, then emit `action="terminal"` with `action_taken="block_on_existing_task"`.
-   - Legacy fallback: `action="block_on_existing_task"` with `blocker_issue_number`.
-9. **Inline-action terminal (#3455)** → `action="terminal"`. Preferred whenever you've performed gh side-effects yourself. Required fields: `action_taken` (descriptive string — e.g. `"close"`, `"escalate"`, `"block_and_comment"`, `"file_prerequisite_task"`, `"block_on_existing_task"`, or any other string that names what you did) and `summary` (one paragraph, ≤500 chars, what you did and why). Optional: `evidence` (longer prose with log lines, gh output, etc.). For the duplicate-PR pattern (N>1 open PRs Closes-keyword'd to the same issue), see Example 8 — `action_taken="consolidate_duplicate_prs"`.
-
-**When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context.
-
-### Inline-action terminal — the concrete how-to
-
-When you decide to take gh side-effects yourself (the preferred path post-#3455), use this pattern:
-
-1. **Run the gh command(s) directly** via Bash. Examples:
-   - `gh issue close <N> --repo judgemind/judgemind --comment "<body>" --reason "not planned"`
-   - `gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/dispatcher-diagnoser/comment.md`
-   - `gh issue edit <N> --repo judgemind/judgemind --add-label status/blocked --remove-label agent/ready`
-   - `gh issue create --repo judgemind/judgemind --title "<title>" --body-file <body-file> --label "<labels>"`
-   - For manual unblock of a specific issue (prunes stale closed-blocker lines + ALL-blockers label gate): `scripts/unblock-issue.sh <N>` — prefer this over bare `gh issue edit --remove-label status/blocked`, which skips the body cleanup and the ALL-blockers gate.
-2. **Log each gh write to `actions_taken`** via `log_action.py` — `gh_issue_close`, `gh_issue_comment`, `gh_issue_edit`, `gh_issue_create` types.
-3. **Emit `action="terminal"`** in the recommendation with descriptive `action_taken` + `summary`.
-4. **Set `next_directive=terminal`** — the daemon's `_consume_action_terminal` simply records the diagnosis and marks the agent terminal at phase `diagnoser_terminal`. No additional gh writes from the daemon.
-
-### Per-category guidance — `conflict_unresolvable` (#3225 / #3366)
-
-Routed here on the bypass-fix from #3366. Read `context.details.conflict_files` + `resolution_notes` (and re-fetch the fix_conflict phase_outputs row if needed).
-
-**You can fix it directly.** If the conflict is small (e.g. anthropic SDK floor reconciliation, parallel renames), check out the agent's branch, edit the file, commit, push, and write `next_directive=respawn_at=push_and_pr`. The daemon's reaper will spawn a fresh agent-runner that resumes at `push_and_pr` and runs the rest of the pipeline against your committed resolution.
-
-If the conflict is structural (semantic collision — function rewritten on main, feature reverted), recommend `escalate` (or the inline-#3455 `terminal` shape) or `reissue` with a clarified `new_scope`, and write `next_directive=terminal`.
-
-### Per-category guidance — `agent_runner_route_stub` (#3366) — historical
-
-Pre-#3455 the agent-runner entrypoint hit a transition shape it didn't know how to route (often `ralph_not_ship` — ralph terminated with a non-SHIP verdict) and emitted `agent_runner_route_stub`. Post-#3455 those fall-throughs are eliminated — the entrypoint emits descriptive terminal phases (`ralph_baseline_transition_unrecognized`, `push_and_pr_transition_unrecognized`, `phase_unknown_<phase>`, etc.) via `agent_runner_reaped_failure`. Post-#3586 `ralph_not_ship` is routed through the diagnoser (see below). If you do see an `agent_runner_route_stub` row in the wild, that's a pre-#3455 agent or a regression — read `context.details.route_hint`, the agent's commits (`git log --oneline origin/main..HEAD`), and the latest reviewer feedback (`{worktree}/tmp/ralph/*-feedback.md` if present), and route to `retry_with_hint` (write a hint, set `next_directive=respawn_at=ralph` if you reset the agent's commits, otherwise `terminal`) or to the inline-#3455 `terminal` shape with `action_taken="block_and_comment"`.
-
-### Per-category guidance — `ralph_not_ship` (#3586)
-
-Routed here when ralph terminated with a non-SHIP verdict (typically `BLOCKED` — the implementation cannot proceed without a prerequisite). The agent-runner passes ralph's `block_reason` as the third arg to `agent_runner_reaped_failure`, so `context.details.stderr_tail` carries the block_reason verbatim. The ralph phase_outputs row (if present) also surfaces `verdict`, `iterations_used`, and `block_reason` via `context.details`.
-
-**Typical actions based on block_reason content:**
-
-- **`file_prerequisite_task`** — when the block_reason names a missing dependency, external prerequisite, or upstream issue that must land first. File a `type/task` issue for the prerequisite, then write `next_directive=terminal` with `action_taken="file_prerequisite_task"` and a `block_issued_number` in the directive. The daemon will `block_and_comment` automatically.
-- **`block_and_comment`** — when the block is in operator territory (ambiguous AC, product decision needed, requires human judgment). Post an informative comment on the issue, add `status/blocked`, remove `agent/ready`. Write `next_directive=terminal` with `action_taken="block_and_comment"`.
-- **`close`** — when the issue is stale, the block_reason reveals the task is a NOOP (already done, unreachable by design), or AC cannot be satisfied by any reasonable implementation. Write `next_directive=terminal` with `action_taken="close"`.
-- **`escalate`** — when the block_reason is ambiguous and you cannot determine the right action. Write `next_directive=terminal` with `action_taken="escalate"`.
-- **inline-#3455 `terminal` shape** — for any of the above, prefer `action="terminal"` with a descriptive `action_taken` + `summary` so the diagnoser collapses the executor layer rather than delegating back to the daemon.
-
-### Per-category guidance — AC-infeasibility (#3010)
-
-Same table as before #3366 — `ralph_ac_infeasible` and `summary_ac_infeasible` route to `reissue` (rewrite the AC), `close` (premise broken), or `escalate` (uncertain). The recommendation drives the daemon-side action; `next_directive=terminal` after `escalate` / `close` (no respawn), or `next_directive=respawn_at=planning` if you want a fresh plan→ralph against the rewritten body.
-
-The full AC-infeasibility tables (ralph_ac_infeasible vs summary_ac_infeasible decision matrices, `new_scope` semantics, `ralph_diff` salvage path) are documented in the surrounding code comments + the spec — re-read those when handling these categories. Key constraint: `new_scope` is **always the complete rewritten issue body**; the daemon's `gh issue edit --body-file` does no parsing or splicing. A diff or partial body will truncate the issue.
-
-### Per-category guidance — `merge_conflict_at_push` (#2964)
-
-Daemon-side pre-push rebase hit a conflict; rebase aborted, no PR opened. Read `context.details.conflict_files`. Pre-#3366 the recommendation was the only output; post-#3366 you can attempt to resolve the rebase yourself if the conflict looks routine (parallel imports, lockfile noise) and write `next_directive=respawn_at=push_and_pr`. For structural conflicts, recommend `block_and_comment` (or inline-#3455 `terminal` with `action_taken="block_and_comment"`) or `file_prerequisite_task` and `next_directive=terminal`.
-
-### Per-category guidance — `verify_failed_post_merge` (#3071)
-
-PR is already merged; deploy is live; verify caught a regression. The issue is closed-via-merge — `reissue` / `close` / `retry` are no-ops. **Do not pick `retry` or `retry_with_hint` for this category.** `retry` is a no-op in the post-merge flow (the daemon does not re-run `/task-v2-verify` from the retry-marker path; `phase='done'` is terminal in the post-merge pipeline). Recommend `file_prerequisite_task` (regression issue with the verify evidence_md as reproducer, p1) or `block_and_comment` (needs-human) — or the inline-#3455 `terminal` equivalent. `next_directive=terminal` always — there's no respawn that re-runs verify on a closed issue.
-
-**Do not pick `reissue` for this category.** The issue is already closed via merge; editing its body with a new scope will not re-open the PR or revert the merge. `reissue` is a pre-merge remedy.
-
-**Do not pick `close` for this category.** The issue is already closed. Re-closing is a no-op that destroys context.
-
----
-
-## Step 3 — Execute (recommendation OR direct action)
-
-If the recommendation alone is enough (the daemon's deterministic consumer handles `retry`/`reissue`/`escalate`/etc.), just write the recommendation + directive.
-
-If you need to do the work directly — commit a fix, file an issue, post a structured comment that needs LLM-authored prose — DO IT. Log every side effect to `actions_taken` (see §Audit trail). When the work is done, write `next_directive=respawn_at=<phase>` (if the agent should resume the pipeline) or `next_directive=terminal` (if you handled everything).
-
-**Post-#3455 preference:** for any case where you take gh side-effects, prefer `action="terminal"` (with `action_taken` + `summary`). This collapses the executor layer — the daemon stops doing redundant gh writes for actions the SKILL has already executed.
-
-### Sub-skill invocation
-
-You can call `/task-v2-fix-conflict`, `/tdd`, `/ralph`, etc. via the Agent tool. Each sub-skill runs synchronously, returns its verdict, and you log a `skill_invoke` entry. Sub-skills are uncapped — call as many as judgment requires.
-
-### Bright-line reminders
-
-The hooks block these automatically when `JUDGEMIND_DIAGNOSER_RUN=1` is set. If you trip a hook, default to `escalate`:
-
-- No production deploy.
-- No `gh auth switch` / PAT rotation.
-- No force-push to main / amending merged commits.
-- No recursive `/diagnose-failure` (don't call this skill from inside this skill).
-
----
-
-## Input contract — the `context` JSONB
-
-Same shape as before #3366 (the daemon serializes this in `_build_diagnoser_context`):
-
-- `agent_id` (str) — UUID. **Required for the `failure_summary` upgrade write (#2900).**
-- `failure_id` (int) — `dispatcher.failures.failure_id` for the triggering failure.
-- `failure_category` (str) — see `daemon.py` for the full list. New in #3366: `agent_runner_route_stub`.
-- `tier` (int) — 2 or 3.
-- `issue_number`, `issue_title`, `issue_body`.
-- `recent_phase_transitions` — last ~10.
-- `prior_failures` — same issue, all agents.
-- `prior_diagnoses_this_issue` — same issue, completed only.
-- `recent_fleet_decisions` — capped at 3 by default (anchor-bias defense, #3057). Operators can tune via `dispatcher.config.diagnoser_fleet_decisions_cap`.
-- `ralph_done_content` — `{worktree}/tmp/ralph/ralph-done.txt` if present.
-- `pr_url`, `pr_number`.
-- `ci_log_url`.
-- `prior_mechanical_fix` — tier 2 only.
-- `worktree_path` — absolute path; may be empty in ECS mode (the daemon's host doesn't have the agent's worktree on disk).
-- Per-category extras for `ralph_ac_infeasible` / `summary_ac_infeasible` / `conflict_unresolvable` / `merge_conflict_at_push` / `verify_failed_post_merge` (see `daemon._build_diagnoser_context`).
-
-For #3366 the daemon also inlines `details.route_hint` (for `agent_runner_route_stub`) and the fix_conflict phase output fields (`conflict_files`, `resolution_notes`, `budget_exhausted`) for `conflict_unresolvable`.
-
-Read it via:
-
-```python
-# {worktree}/tmp/dispatcher-diagnoser/read_context.py
-import json, os, sys
-import psycopg
-
-diagnosis_id = int(sys.argv[1])
-with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
-    with conn.cursor() as cur:
-        cur.execute(
-            "SELECT context FROM dispatcher.diagnoses WHERE diagnosis_id = %s",
-            (diagnosis_id,),
-        )
-        row = cur.fetchone()
-print(json.dumps(row[0] if row else {}, default=str))
-```
-
----
-
-## Output contract — recommendation writer
-
-Update `recommendation` + `dispatcher.agents.failure_summary` (issue #2900) in a single transaction. The SKILL writes `recommendation` only — `status` stays `'pending'` so the daemon's reaper picks it up. Use a small helper:
-
-```python
-# {worktree}/tmp/dispatcher-diagnoser/write_recommendation.py
-import json, os, re, sys
-import psycopg
-
-diagnosis_id = int(sys.argv[1])
-agent_id = sys.argv[2]  # UUID string from context.agent_id
-with open(sys.argv[3], "r", encoding="utf-8") as f:
-    recommendation = json.load(f)
-
-def _summary_from_reasoning(reasoning: str, cap: int = 240) -> str:
-    text = (reasoning or "").strip()
-    if not text:
-        return ""
-    sentences = re.split(r"(?<=[.!?])\s+", text)
-    head = " ".join(sentences[:3]).strip()
-    if len(head) > cap:
-        head = head[: cap - 1].rstrip() + "…"
-    return head
-
-summary = _summary_from_reasoning(recommendation.get("reasoning", ""))
-
-with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
-    with conn.cursor() as cur:
-        cur.execute(
-            "UPDATE dispatcher.diagnoses "
-            "SET recommendation = %s "
-            "WHERE diagnosis_id = %s",
-            (json.dumps(recommendation), diagnosis_id),
-        )
-        if summary:
-            cur.execute(
-                "UPDATE dispatcher.agents "
-                "SET failure_summary = %s WHERE agent_id = %s",
-                (summary, agent_id),
-            )
-    conn.commit()
-```
-
-**Do not add `status = 'completed'` or `completed_at = now()` to this UPDATE.** The daemon's `_consume_diagnosis` / `_mark_diagnosis_completed` owns the `status` transition. Premature `'completed'` causes the reaper (`WHERE status='pending'`) to skip the row and silently drop the directive (issue #3422).
-
-Recommendation shape:
-
-```json
-{
-  "action": "retry" | "retry_with_hint" | "reissue" | "escalate" | "close" | "block_and_comment" | "file_prerequisite_task" | "block_on_existing_task" | "terminal" | "<novel-action-string>",
-  "reasoning": "<one paragraph; first sentence MUST quote the verbatim stderr line — see §Step 1>",
-  "hint": "<conditional — retry_with_hint only>",
-  "new_scope": "<conditional — reissue only; full rewritten issue body>",
-  "title": "<conditional — file_prerequisite_task only>",
-  "body": "<conditional — file_prerequisite_task only>",
-  "block_labels": ["<conditional — file_prerequisite_task only>"],
-  "blocker_issue_number": 42,
-  "action_taken": "<conditional — terminal only; descriptive string naming what you did>",
-  "summary": "<conditional — terminal only; one paragraph, ≤500 chars>",
-  "evidence": "<optional — terminal only; longer prose with log/gh-output evidence>"
-}
-```
-
-Field rules:
-
-- `action` (required) — one of the nine known strings, OR a novel action string.
-- `reasoning` (required for legacy actions) — single paragraph (≤500 chars). **First sentence MUST quote the verbatim stderr line** (in backticks or double-quotes), per §Step 1. For `terminal` the same rule applies to `summary`.
-- `hint` (conditional) — required when `action='retry_with_hint'`.
-- `new_scope` (conditional) — required when `action='reissue'`. **Wholesale body rewrite** — preserve `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References` + any `Parent: #N` / `Blocked by #N` lines.
-- `title` + `body` (conditional) — required when `action='file_prerequisite_task'`. Title is conventional-commits style.
-- `block_labels` (optional) — for `file_prerequisite_task`.
-- `blocker_issue_number` (conditional) — required when `action='block_on_existing_task'`. Positive integer.
-- `action_taken` (conditional) — required when `action='terminal'` (#3455). Non-empty string describing what gh side-effect you performed (e.g. `"close"`, `"escalate"`, `"file_prerequisite_task"`).
-- `summary` (conditional) — required when `action='terminal'` (#3455). Non-empty paragraph. **First sentence MUST quote the verbatim stderr line** when one is identifiable (same rule as `reasoning`).
-- `evidence` (optional, terminal-only) — longer prose. Useful for capturing gh output / log lines without bloating `summary`.
-
-Exit 0 when all three writes (recommendation + directive + actions_taken) are persisted. The daemon writes `status='completed'` after consuming the directive — the SKILL does not. Exit non-zero on hard failure — the daemon marks the diagnosis `status='failed'` and falls back to mechanical escalation.
-
----
-
-## Step-by-step procedure
-
-1. **Set up.** Write `{worktree}/tmp/dispatcher-diagnoser/{read_context,write_recommendation,write_directive,log_action}.py` helpers. Run the reader to pull the JSONB context into memory.
-
-2. **Parse the failure signature FIRST (§Step 1, mandatory).** Quote the verbatim stderr line.
-
-3. **Classify.** Identify `failure_category` and `tier`. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3). Now scan `prior_diagnoses_this_issue` + `recent_fleet_decisions` for patterns. If a pattern conflicts with your verbatim quote, trust the quote.
-
-4. **Decide.** Walk the decision tree. Pick the action shape (preferring `terminal` post-#3455 when you'll be doing gh side-effects yourself) and the directive shape (respawn_at vs terminal).
-
-5. **Act.** Execute side effects (commit, push, gh issue create/edit, gh issue close, gh issue comment, etc.) if needed. Log each one via `log_action.py` to `actions_taken`. Or skip side effects entirely and let the daemon's recommendation consumer handle it (legacy path).
-
-6. **Write recommendation + directive.** Run `write_recommendation.py` and `write_directive.py`. Both update the same row. `status` stays `'pending'` — the daemon's reaper picks it up on the next tick and writes `'completed'` after applying the directive.
-
-7. **Exit 0.** Done. The daemon's next supervisor tick consumes the recommendation; its directive consumer reads `next_directive` and either spawns a new agent-runner with `START_PHASE` or frees the slot.
+- **gh / git / aws CLI** — full operator-tier authority. You may commit and push to the failed agent's branch, file new issues, edit issue/PR bodies, add/remove labels, post comments, close issues. AWS reads (CloudWatch logs, ECS describe-tasks) plus same writes the launcher already has on the dev account.
 
 ---
 
 ## Examples
 
-### Example 1 — anthropic-floor reconciliation, fix it directly
+### Example 1 — coverage-floor regression, retry with context
 
-```text
-context.failure_category = "ralph_not_ship" (route_stub terminal)
-context.details.route_hint = "ralph_not_ship: anthropic SDK version floor mismatch between sibling packages"
+**Failure context.** Agent on issue #3500 exited non-zero from the pre-push hook. Transcript ends with:
 
-Action: read both pyproject.toml files, pick the higher floor, edit, commit, push.
-Recommendation: {"action": "retry", "reasoning": "The stderr ends with `\"AC#1 unmet: ralph cannot satisfy floor reconciliation while siblings disagree\"` ..."}
-next_directive: "respawn_at=push_and_pr"
-actions_taken: [
-  {"type": "bash_run", "cmd": "grep anthropic packages/*/pyproject.toml", ...},
-  {"type": "git_commit", "sha": "abc123", "message": "fix(deps): align anthropic floor"},
-  {"type": "git_push", "branch": "worktree-agent-XYZ", "remote": "origin"}
-]
+```
+FAILED: coverage floor
+coverage dropped 80.0% -> 68.6% on packages/api
 ```
 
-### Example 2 — fleet-wide PAT-scope cascade, file a prerequisite (inline #3455)
+The agent's PR was never opened (push never reached remote). No prior attempts on this issue. No fleet-wide pattern.
 
-Training example — `#99001` is a synthetic placeholder. In a real diagnosis, file the issue and use the returned number.
+**Action.** Re-add `agent/ready`. The next attempt's `prior_attempts.md` will surface the coverage-floor failure as context, and the worker will see "the previous attempt landed under-covered" and write a test for the regression. Do NOT file a follow-up — the issue is the same; the fix is "the next agent reads the prior failure and writes more tests."
 
-```text
-context.failure_category = "push_failed"
-verbatim stderr: "remote: refusing to allow a Personal Access Token..."
-context.recent_fleet_decisions: 3 prior block_on_existing_task on the same blocker issue.
-
-Action (inline): gh issue create → got #99001; gh issue edit on the current
-issue to append "Blocked by #99001"; gh issue edit --add-label status/blocked;
-gh issue comment with the explanatory diagnosis.
-
-Recommendation: {
-  "action": "terminal",
-  "action_taken": "file_prerequisite_task",
-  "summary": "The stderr ends with `\"remote: refusing to allow a Personal Access Token...\"`. Filed #99001 as the prerequisite tracking issue and blocked the current issue on it.",
-  "reasoning": "..."
-}
-next_directive: "terminal"
-actions_taken: [
-  {"type": "gh_issue_create", "issue_number": 99001, "title": "..."},
-  {"type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/blocked"]},
-  {"type": "gh_issue_comment", "issue_number": 3297, "body_preview": "## Diagnosis (3D block-on-prerequisite) ..."}
-]
+```
+gh issue edit 3500 --repo judgemind/judgemind --add-label agent/ready
+python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "\"FAILED: coverage floor\" — coverage dropped 80.0% to 68.6% on packages/api before push. Re-added agent/ready; next attempt's prior_attempts.md will surface the regression."
 ```
 
-### Example 3 — AC infeasible, recommend reissue, fall back to daemon-driven
+### Example 2 — PAT-scope cascade, file prerequisite + block
 
-```text
-context.failure_category = "ralph_ac_infeasible"
-context.infeasible_acs: [{"index": 2, "evidence": "..."}]
+**Failure context.** Agent on issue #3297 hit:
 
-Action: think only — no direct gh writes (the daemon's `_consume_action_reissue` will write the new body via `gh issue edit --body-file`). Compose `new_scope` carefully.
-Recommendation: {"action": "reissue", "new_scope": "<full rewritten body>", "reasoning": "..."}
-next_directive: "respawn_at=planning"  (let a fresh plan→ralph run against the new body)
-actions_taken: []  (no direct side effects this run)
+```
+remote: refusing to allow a Personal Access Token to create or update workflow `.github/workflows/foo.yml`
 ```
 
-### Example 4 — uncertain stderr, escalate inline (#3455 preferred)
+Three prior fleet decisions all blocked-on the same PAT issue (#4012). The current agent's failure is an instance of the same root cause.
 
-```text
-context.failure_category = "subprocess_crash"
-verbatim stderr: empty (just progress output).
+**Action.** Append `Blocked by #4012` to issue #3297, add `status/blocked`, post the explanatory comment.
 
-Action (inline): gh issue comment with "## Diagnosis (3D escalation) ..." reasoning;
-gh issue edit --add-label status/needs-human,priority/p1.
-
-Recommendation: {
-  "action": "terminal",
-  "action_taken": "escalate",
-  "summary": "stderr_tail had no FAILED: line — only progress output. Posted the escalation comment and added status/needs-human + priority/p1.",
-  "reasoning": "..."
-}
-next_directive: "terminal"
-actions_taken: [
-  {"type": "gh_issue_comment", "issue_number": 3297, "body_preview": "## Diagnosis (3D escalation) ..."},
-  {"type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/needs-human", "priority/p1"]}
-]
+```
+gh issue view 3297 --repo judgemind/judgemind --json body --jq .body > {worktree}/tmp/diagnoser/orig_body.md
+# Append "Blocked by #4012" to a copy
+python3 {worktree}/tmp/diagnoser/append_blocked_by.py 4012 < {worktree}/tmp/diagnoser/orig_body.md > {worktree}/tmp/diagnoser/new_body.md
+gh issue edit 3297 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/new_body.md
+gh issue edit 3297 --repo judgemind/judgemind --add-label status/blocked --remove-label agent/ready
+gh issue comment 3297 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/block_comment.md
+python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "\"remote: refusing to allow a Personal Access Token to create or update workflow\" — same PAT-scope cascade as #4012. Blocked-on #4012; will auto-unblock when that PR merges."
 ```
 
-### Example 5 — conflict_unresolvable, semantic collision, escalate inline
+### Example 3 — AC infeasible as written, reissue + retry
 
-```text
-context.failure_category = "conflict_unresolvable"
-context.details.resolution_notes = "function X was rewritten on main; agent's call no longer type-checks"
+**Failure context.** Agent on issue #3601 exited with ralph block_reason `AC#1 unmet: field 'transcribed_text' does not exist on the Document type`. The field was renamed to `transcription_html` in #3204 (merged 3 weeks ago). The AC was authored before the rename.
 
-Action (inline): gh issue comment with the escalation diagnosis;
-gh issue edit --add-label status/needs-human,priority/p1.
+**Action.** Rewrite the issue body — replace `transcribed_text` with `transcription_html` throughout — and re-add `agent/ready`.
 
-Recommendation: {"action": "terminal", "action_taken": "escalate", "summary": "..."}
-next_directive: "terminal"
-actions_taken: [
-  {"type": "gh_issue_comment", ...},
-  {"type": "gh_issue_edit", "labels_added": ["status/needs-human", "priority/p1"]}
-]
+```
+gh issue view 3601 --repo judgemind/judgemind --json body --jq .body > {worktree}/tmp/diagnoser/orig_body.md
+python3 {worktree}/tmp/diagnoser/rewrite_field_name.py {worktree}/tmp/diagnoser/orig_body.md transcribed_text transcription_html > {worktree}/tmp/diagnoser/reissue_body.md
+gh issue edit 3601 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/reissue_body.md
+gh issue comment 3601 --repo judgemind/judgemind --body "AC #1 referenced 'transcribed_text', which was renamed to 'transcription_html' in #3204. The AC has been rewritten to use the current field name. Re-adding agent/ready."
+gh issue edit 3601 --repo judgemind/judgemind --add-label agent/ready
+python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "\"AC#1 unmet: field 'transcribed_text' does not exist on Document\" — the field was renamed to transcription_html in #3204. Reissued the AC and re-added agent/ready."
 ```
 
-### Example 6 — conflict_unresolvable, routine parallel-edit, fix it directly
+### Example 4 — duplicate-PR consolidation (#3725)
 
-```text
-context.failure_category = "conflict_unresolvable"
-context.details.conflict_files = ["packages/web/lock.json"]
-context.details.resolution_notes = "main landed a sibling lockfile bump; agent's diff is otherwise clean"
+**Failure context.** Agent on issue #3601 exited from the duplicate-PR check at `/task` Step 4a — two open PRs (#3628 and #3650) both carry `Closes #3601` in their body. The operator invariant "one PR per issue" is violated. This pattern triggers the duplicate-PR consolidation regardless of the proximate failure category.
 
-Action: checkout, regenerate lockfile, commit, push.
-Recommendation: {"action": "retry", "reasoning": "..."}
-next_directive: "respawn_at=push_and_pr"
-actions_taken: [
-  {"type": "bash_run", "cmd": "git rebase origin/main", ...},
-  {"type": "bash_run", "cmd": "npm install --no-save", ...},
-  {"type": "git_commit", "sha": "...", "message": "chore(deps): regenerate lockfile post-rebase"},
-  {"type": "git_push", ...}
-]
+**Detection (one gh search):**
+
+```
+gh pr list --repo judgemind/judgemind --state open \
+  --search "in:body Closes #3601" \
+  --json number,headRefName,updatedAt,statusCheckRollup
 ```
 
-### Example 7 — issue duplicate, close inline (#3455)
+Returns rows for #3628 and #3650 (N=2).
 
-```text
-context.failure_category = "ralph_ac_infeasible"
-verbatim stderr: "AC#1 unmet: feature already shipped in #3000"
+**Selection — pick the canonical PR to keep:**
 
-Action (inline): gh issue edit --add-label status/invalid;
-gh issue close <N> --reason "not planned" --comment "<body>".
+1. Most recent push: compare `updatedAt` across rows; pick max.
+2. Tie-break: fewest CI failures (count `statusCheckRollup` entries with `conclusion=FAILURE` per PR).
+3. Tie-break: largest diff: `gh pr diff <N> --patch | wc -l` (higher line count wins).
 
-Recommendation: {
-  "action": "terminal",
-  "action_taken": "close",
-  "summary": "The stderr ends with `\"AC#1 unmet: feature already shipped in #3000\"`. Closed as duplicate of #3000.",
-  "reasoning": "..."
-}
-next_directive: "terminal"
-actions_taken: [
-  {"type": "gh_issue_edit", "labels_added": ["status/invalid"]},
-  {"type": "gh_issue_close", "issue_number": 3297, "reason": "not planned"}
-]
+In this example: chosen = #3650; duplicates = [#3628].
+
+**Action — close duplicates inline (one Bash call per duplicate):**
+
 ```
-### Example 8 — duplicate-PR consolidation, close inline (#3725)
-
-```text
-Trigger: diagnoser invoked on any failure_category when N>1 open PRs all carry
-"Closes #<issue>" in their body. The operator invariant "one PR per issue" is
-violated. Detected during any diagnosis run, regardless of the triggering
-failure_category.
-
-Detection:
-  gh pr list --repo judgemind/judgemind --state open \
-    --search "in:body Closes #<issue>" \
-    --json number,headRefName,updatedAt,statusCheckRollup
-  returns rows for PR #3628 and PR #3650 (N=2).
-
-Selection (pick the canonical PR to keep):
-  1. Most recent push: compare updatedAt across rows -- pick max.
-  2. Tie-break: fewest CI failures (count statusCheckRollup entries with
-     status=FAILURE across each PR).
-  3. Tie-break: largest diff:
-       gh pr diff <N> --patch | wc -l   (higher line count wins)
-  chosen = #3650, duplicates = [#3628].
-
-Action (inline, one Bash call per duplicate):
-  gh pr close 3628 --repo judgemind/judgemind \
-    --comment "Closing as duplicate of #3650" --delete-branch
-
-Issue label state: leave status/in-progress in place.
-The daemon's existing CI-watch / merge logic on #3650 takes over from here.
-No agent/ready toggling needed.
-
-Recommendation: {
-  "action": "terminal",
-  "action_taken": "consolidate_duplicate_prs",
-  "summary": "detected N=2 open PRs with Closes #3601 -- #3628, #3650. Closed #3628 as duplicate of #3650 (most recent push). Daemon CI-watch proceeds on #3650.",
-  "reasoning": "..."
-}
-next_directive: "terminal"
-actions_taken: [
-  {"type": "gh_pr_close", "pr_number": 3628, "comment": "Closing as duplicate of #3650", "delete_branch": true}
-]
+gh pr close 3628 --repo judgemind/judgemind --comment "Closing as duplicate of #3650" --delete-branch
+python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "Detected N=2 open PRs with Closes #3601 — #3628, #3650. Closed #3628 as duplicate of #3650 (most recent push). Daemon CI-watch proceeds on #3650. action_taken=consolidate_duplicate_prs"
 ```
 
-### Example 9 — Empowered diagnoser walks #3694 (#3744)
+Issue label state: leave `status/in-progress` in place. The launcher's CI-watch / merge logic on #3650 takes over from here. No `agent/ready` toggling needed — #3650 is already the active PR for this issue.
 
-**Failure context:** Agent on issue #3694 has silently failed three times. Each run exits with `verdict=BLOCKED`, `block_reason="worker STUCK"`. The ECS logs show the ECS task completing, but the scraper worker's stdout and stderr were never captured — the dispatcher only sees the exit code.
+### Example 5 — silent-hang with no failure line, mark needs_review
 
-**WRONG path (pre-#3744 behavior):**
-1. Diagnoser reads the three BLOCKED rows.
+**Failure context.** Agent on issue #3700 exited with `exit_reason='silent_hang'` after 31 minutes of no log growth during `ralph_iter_3`. Transcript ends mid-`Bash` tool call to `gh run watch`. No FAILED line, no error banner, no exception. Two prior attempts on this issue both hit silent-hang at the same milestone.
+
+**Action.** Three silent-hangs at the same milestone is a recurring pattern that needs human triage — it might be a CI rate-limit cascade, a `gh` CLI bug, or a network egress issue. Don't retry blindly; mark `needs_review`.
+
+```sql
+UPDATE dispatcher.agents
+SET status = 'needs_review'
+WHERE agent_id = $AGENT_ID;
+```
+
+```
+gh issue edit 3700 --repo judgemind/judgemind --add-label status/needs-human,priority/p1
+gh issue comment 3700 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/escalation.md
+python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "silent_hang at ralph_iter_3 — task-runner stopped emitting log events for 31 min during reviewer subagent. Third silent-hang at the same milestone on this issue. Marked needs_review; transcript ends mid-Bash call to 'gh run watch'."
+```
+
+The launcher detects `status='needs_review'` on its next tick and Telegram-alerts.
+
+### Example 6 — empowered diagnoser walks #3694 (#3744)
+
+**Failure context.** Agent on issue #3694 has silently failed three times. Each run exits with `exit_reason='silent_hang'`. The ECS task completes (or is killed by silent-hang detection) but the scraper worker's stdout and stderr were never captured — the launcher only sees the exit code. Without those streams, no diagnoser can determine root cause.
+
+**WRONG path (pre-#3744 thinking):**
+
+1. Diagnoser reads the three failed rows.
 2. Diagnoser concludes: "I can't diagnose without the worker output."
-3. Diagnoser emits `action="escalate"`, adds `status/needs-human`, posts a comment: "Need operator to investigate ECS logging."
-4. Issue sits in needs-human queue for days.
+3. Diagnoser marks `needs_review` and posts a comment: "Need operator to investigate ECS logging."
+4. Issue sits in `needs-human` queue for days.
 
 **RIGHT path (post-#3744 empowered behavior):**
-1. Diagnoser reads the three BLOCKED rows.
-2. Diagnoser identifies the gap: worker stdout/stderr not captured in `dispatcher.phases`.
-3. **Diagnoser acts:** Opens a worktree, writes a 3-line patch adding `stdout=result.stdout, stderr=result.stderr` capture to `scripts/dispatcher/worker.py` (or whichever ECS launch wrapper is responsible for subprocess capture + ECS metadata logging).
+
+1. Diagnoser reads the three failed rows.
+2. Diagnoser identifies the gap: worker stdout/stderr not captured by the task-runner entrypoint.
+3. **Diagnoser acts:** opens a worktree, writes a small patch adding `stdout=result.stdout, stderr=result.stderr` capture to the task-runner subprocess launch (or whichever ECS launch wrapper is responsible for subprocess capture).
 4. Opens a PR, watches CI (`gh run watch`), merges.
-5. Returns `action="terminal"` with `action_taken="ship_instrumentation_patch: added stdout/stderr capture to worker subprocess launch in PR #XXXX"`.
-6. The original issue #3694 is now unblocked: the next dispatch will have full diagnostic output.
+5. Re-adds `agent/ready` on issue #3694 — the next dispatch will have full diagnostic output.
+6. Writes `outcome_summary`: `"silent_hang × 3 with no captured worker output — root cause was missing stdout/stderr capture in task-runner entrypoint. Shipped instrumentation patch in PR #4040; re-added agent/ready on #3694 so the next attempt has full diagnostics."`
 
-**Oversize fallback:** If the instrumentation fix is larger than ~30 min (e.g. requires a schema migration to add a `log_text` column to `dispatcher.phases`), use `action="file_prerequisite_task"` with a precise task body so the prerequisite can be picked up immediately and the Closes-keyword auto-unblocks #3694 on merge.
+**Oversize fallback.** If the instrumentation fix is larger than ~30 min (e.g. requires a schema migration to add a `log_text` column), use Action 2 (file follow-up) with a precise task body so the prerequisite can be picked up immediately and the auto-unblock workflow restores `agent/ready` on #3694 when the prerequisite PR merges.
 
-**The invariant:** In neither path does the diagnoser emit `status/needs-human` for issue #3694. That label means "a human must make a judgment call." Deciding where to add a log line is not a judgment call — it is mechanical and bounded.
+**The invariant.** In neither path does the diagnoser emit `status/needs-human` for issue #3694. That label means "a human must make a judgment call." Deciding where to add a log line is not a judgment call — it is mechanical and bounded.
 
 ---
 
 ## Reminders
 
-- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Write helper scripts to `{worktree}/tmp/dispatcher-diagnoser/` first, then invoke them.
+- No `$()`, no heredocs, no inline `python -c`. See `CLAUDE.md` Critical Rules. Write helper scripts to `{worktree}/tmp/diagnoser/` first, then invoke them.
 - All temp files go under `{worktree}/tmp/`, never `/tmp/`.
-- Bright lines are hook-enforced (`JUDGEMIND_DIAGNOSER_RUN=1` env). Do not work around a block — escalate instead.
-- `actions_taken` is mandatory for every side-effect action.
-- `next_directive` is mandatory before exit (use `terminal` if no respawn is needed). NULL means "I crashed", which falls back to escalate + a `diagnoser_did_not_complete` log event.
-- §Step 1 (verbatim stderr quote in reasoning / summary) is mandatory.
-- **Prefer `action="terminal"` (#3455) when you take gh side-effects yourself.** The legacy `escalate` / `close` / `block_and_comment` / `file_prerequisite_task` / `block_on_existing_task` actions still work — the daemon will perform the gh writes — but doubling up (SKILL does it AND emits a legacy action) causes duplicate comments and labels.
-- Exit 0 means "directive + recommendation + audit log written". Exit non-zero means "I could not diagnose" — the daemon falls back to fixed mechanical escalation.
-- **Do not set `status='completed'`** in `write_recommendation.py`. That column is owned by the daemon's `_mark_diagnosis_completed` method (issue #3422).
+- Bright lines (no prod deploy, no `gh auth switch`, no force-push to `main`, no recursive `/diagnose-failure`) are policy. Default to **mark needs_review** if a hook blocks a command.
+- **§Step 1 (verbatim transcript-line quote in `outcome_summary`) is mandatory** when a failure line is identifiable. This is the anchor-bias defense from #3057.
+- The diagnoser is **side-effects-then-exit**. No structured recommendation, no directive, no writes to the legacy v2 diagnoses ledger — the launcher polls `agents.status` and acts on it. (Cohabitation note: v2's daemon will see a NULL recommendation after this SKILL exits and fall back to mechanical escalate via its 90-min timeout. Accepted degradation per #3874; see §Cohabitation with v2.)
+- The per-issue claim budget (default 3, configurable via `dispatcher.config.claim_attempts_max`) caps retries. If you re-add `agent/ready` and the count is at 3, the launcher's next claim flips the issue to `status/needs-human` instead of claiming.
+- Exit 0 means "I took an action and wrote `outcome_summary`." Exit non-zero means "I crashed before finishing" — the launcher marks the agent `status='needs_review'` and Telegram-alerts.

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -808,60 +808,20 @@ class TestVerifyFailedPostMergeTierRegistration:
         )
 
 
-class TestVerifyFailedPostMergeSkillContract:
-    """Issue #3071 AC #3: diagnose-failure skill must have a section
-    for verify_failed_post_merge distinguishing post-merge from pre-
-    merge failures."""
-
-    def _skill_content(self) -> str:
-        skill_path = (
-            Path(__file__).resolve().parents[3]
-            / ".claude"
-            / "skills"
-            / "diagnose-failure"
-            / "SKILL.md"
-        )
-        return skill_path.read_text()
-
-    def test_skill_has_verify_failed_post_merge_section(self) -> None:
-        content = self._skill_content()
-        assert "verify_failed_post_merge" in content, (
-            "diagnose-failure/SKILL.md must have a verify_failed_post_merge "
-            "section (issue #3071)"
-        )
-
-    def test_skill_discourages_retry_for_post_merge(self) -> None:
-        """The post-merge section must explicitly tell the diagnoser
-        not to pick ``retry`` (the daemon doesn't re-run verify from
-        the retry-marker path, so a retry recommendation here would
-        leave the agent stuck)."""
-        content = self._skill_content().lower()
-        # Either phrasing is acceptable — the contract is "don't pick retry".
-        assert (
-            "do not pick `retry`" in content
-            or "do not pick retry" in content
-            or "retry` or `retry_with_hint`" in content
-        ), (
-            "diagnose-failure/SKILL.md must discourage `retry` for "
-            "verify_failed_post_merge (issue #3071)"
-        )
-
-    def test_skill_mentions_primary_actions(self) -> None:
-        """The post-merge section must name ``file_prerequisite_task``
-        and ``block_and_comment`` as primary actions — those are the
-        diagnoser responses the issue explicitly calls out."""
-        content = self._skill_content()
-        # Both action names should appear in the new section.
-        new_section_start = content.find("verify_failed_post_merge")
-        assert new_section_start != -1
-        # Look in roughly the next 3000 chars for both mentions.
-        window = content[new_section_start : new_section_start + 4000]
-        assert "file_prerequisite_task" in window, (
-            "verify_failed_post_merge section must name `file_prerequisite_task`"
-        )
-        assert "block_and_comment" in window, (
-            "verify_failed_post_merge section must name `block_and_comment`"
-        )
+# ------------------------------------------------------------------
+# Removed in #3874 — the v2 ``TestVerifyFailedPostMergeSkillContract``
+# class asserted that diagnose-failure/SKILL.md carry a per-category
+# section keyed on the v2 failure-category string ``verify_failed_post_merge``
+# and named the v2 ``file_prerequisite_task`` / ``block_and_comment`` action
+# enums. Both are v2-specific surface area (per-phase failure categories
+# come from v2's pipeline; the action enums are v2's
+# ``recommendation.action`` shape, retired in v3 per spec §4.2 and §7).
+# v3's diagnoser sees the whole agent context and decides — the daemon-side
+# routing of ``verify_failed_post_merge`` continues to live in
+# :class:`TestVerifyFailedPostMergeRouting` below (which exercises
+# :data:`FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE` in the daemon's
+# routing tables, not the SKILL prose).
+# ------------------------------------------------------------------
 
 
 class TestVerifyFailedPostMergeRouting:

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -311,27 +311,28 @@ class TestTaskV2VerifyContracts:
 
 
 class TestDiagnoseFailureContracts:
-    """diagnose-failure/SKILL.md must have per-category sections for
-    ralph_ac_infeasible and summary_ac_infeasible, plus the
-    wholesale-replace requirement for new_scope (issue #3010)."""
+    """diagnose-failure/SKILL.md must document the AC-rewrite requirement
+    (wholesale replace, not a partial splice), name the canonical action
+    vocabulary, and carry the #3057 anchor-bias defense framing.
 
-    def test_ralph_ac_infeasible_section(self) -> None:
-        content = _read(_DIAGNOSE_FAILURE_SKILL)
-        assert "ralph_ac_infeasible" in content, (
-            "diagnose-failure/SKILL.md must have a ralph_ac_infeasible "
-            "section (issue #3010)"
-        )
-
-    def test_summary_ac_infeasible_section(self) -> None:
-        content = _read(_DIAGNOSE_FAILURE_SKILL)
-        assert "summary_ac_infeasible" in content, (
-            "diagnose-failure/SKILL.md must have a summary_ac_infeasible "
-            "section (issue #3010)"
-        )
+    The original v2 ``ralph_ac_infeasible`` / ``summary_ac_infeasible``
+    per-category section assertions were dropped in #3874 — those failure
+    categories are v2-specific (v3 has no per-phase pipeline emitting
+    them; the diagnoser sees the whole agent context and decides).
+    The remaining assertions are framing principles preserved across
+    both contracts: "stderr is ground truth", verbatim-quote language,
+    AC-rewrite-as-wholesale-replace, the #3057 anchor-bias forensic.
+    """
 
     def test_default_action_vocabulary(self) -> None:
-        """The three default actions must all appear in the
-        per-category guidance."""
+        """The canonical action vocabulary must all appear in the SKILL.
+
+        v2 had nine actions; v3 has four. ``reissue``, ``escalate``,
+        and ``close`` are the three principle-level actions that exist
+        in both contracts (v3 frames them as "reissue the AC + retry",
+        "mark needs_review" / escalate, and "close the issue"). The
+        contract here is naming presence, not enum identity (issue #3010,
+        carried into #3874)."""
         content = _read(_DIAGNOSE_FAILURE_SKILL)
         for action in ("reissue", "escalate", "close"):
             assert action in content, (
@@ -340,8 +341,11 @@ class TestDiagnoseFailureContracts:
             )
 
     def test_new_scope_wholesale_replace_requirement(self) -> None:
-        """``new_scope`` is always the complete rewritten issue body —
-        not a diff, not a patch, not a partial splice."""
+        """The AC-rewrite (``new_scope`` in v2 prose, "reissue" action
+        body in v3 prose) is always the **complete rewritten issue body**
+        — not a diff, not a patch, not a partial splice. ``gh issue edit
+        --body-file`` doesn't parse content, so any partial body
+        truncates the issue. Issue #3010 (carried into #3874)."""
         content = _read(_DIAGNOSE_FAILURE_SKILL)
         # The SKILL.md uses "wholesale replace" or "complete rewritten
         # issue body" (or both) — lock on either phrase.
@@ -351,7 +355,7 @@ class TestDiagnoseFailureContracts:
             or "complete, well-formed issue body" in content.lower()
         ), (
             "diagnose-failure/SKILL.md must document the wholesale-replace "
-            "requirement for new_scope (issue #3010)"
+            "requirement for the AC-rewrite action (issue #3010)"
         )
 
     # ------------------------------------------------------------------
@@ -388,18 +392,23 @@ class TestDiagnoseFailureContracts:
 
     def test_verbatim_quote_requirement(self) -> None:
         """SKILL.md must require the diagnoser to quote the actual stderr
-        failure line verbatim in the ``reasoning`` field."""
+        failure line verbatim, and must name the field where that quote
+        lands. v2 named the field ``reasoning``; v3 names it
+        ``outcome_summary``. The contract is "verbatim quote into the
+        named output field" — either field name satisfies the assertion
+        (issue #3057, carried into #3874)."""
         content = _read(_DIAGNOSE_FAILURE_SKILL)
         lower = content.lower()
-        # The verbatim-quote language: must mention both "verbatim" and
-        # "reasoning" (the field where the quote lands).
         assert "verbatim" in lower, (
             "diagnose-failure/SKILL.md must mention 'verbatim' quoting "
             "of the stderr failure line (issue #3057)"
         )
-        assert "reasoning" in lower, (
+        # v2 used ``reasoning``; v3 uses ``outcome_summary``. Either
+        # is acceptable — the contract is naming the landing field.
+        assert "reasoning" in lower or "outcome_summary" in lower, (
             "diagnose-failure/SKILL.md must describe where the verbatim "
-            "stderr quote lands (the ``reasoning`` field — issue #3057)"
+            "stderr quote lands (v2: ``reasoning``; v3: ``outcome_summary``"
+            " — issue #3057, #3874)"
         )
 
     def test_3057_issue_reference(self) -> None:
@@ -676,4 +685,122 @@ class TestEmpoweredDiagnoserContracts:
         assert "#3744" in content, (
             "diagnose-failure/SKILL.md must reference '#3744' for traceability "
             "(issue #3744)"
+        )
+
+
+# ------------------------------------------------------------------
+# Issue #3874 — dispatcher-v3 SKILL contract.
+# ------------------------------------------------------------------
+
+
+class TestDiagnoseFailureV3Contracts:
+    """diagnose-failure/SKILL.md must reflect the dispatcher-v3 contract:
+    no v2 ``dispatcher.diagnoses`` / ``next_directive`` / ``recommendation.action``
+    / diagnoser-sentinel-env-var references; documents the S3 → CloudWatch
+    transcript fallback cascade; names the four authoritative actions;
+    writes ``agents.outcome_summary``; and asserts the launcher-polls
+    contract (no recommendation/directive return).
+
+    These are grep-style assertions mapped 1:1 to issue #3874's
+    acceptance-criteria Verify lines."""
+
+    def test_no_v2_legacy_strings(self) -> None:
+        """The four v2-specific identifiers must NOT appear verbatim
+        anywhere in the SKILL — they're the contract surface v3 has
+        explicitly retired (issue #3874 AC #1)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        forbidden = [
+            "dispatcher.diagnoses",
+            "next_directive",
+            "recommendation.action",
+            "JUDGEMIND_DIAGNOSER_RUN",
+        ]
+        hits = [s for s in forbidden if s in content]
+        assert not hits, (
+            f"diagnose-failure/SKILL.md still contains v2-legacy strings "
+            f"(issue #3874 AC #1): {hits}"
+        )
+
+    def test_session_log_cascade_documented(self) -> None:
+        """The SKILL must describe reading the session log via the
+        S3 → CloudWatch fallback cascade (issue #3874 AC #2)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "render-transcript" in content, (
+            "diagnose-failure/SKILL.md must reference render-transcript "
+            "(the compact-S3-transcript renderer) — issue #3874 AC #2"
+        )
+        # Permit either the literal s3:// scheme or the SESSIONS_BUCKET
+        # placeholder; the contract is "S3 archive is the primary read".
+        assert "s3://" in content, (
+            "diagnose-failure/SKILL.md must reference an s3:// URL for "
+            "the sessions bucket (issue #3874 AC #2)"
+        )
+        assert "GetLogEvents" in content, (
+            "diagnose-failure/SKILL.md must reference CloudWatch's "
+            "GetLogEvents as the last-resort fallback (issue #3874 AC #2)"
+        )
+
+    def test_four_authoritative_actions_documented(self) -> None:
+        """The SKILL must describe the four authoritative actions:
+        retry (re-add agent/ready), file follow-up + mark failed,
+        reissue AC + retry, mark needs_review (issue #3874 AC #3)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        # "four" appears in the prose ("four authoritative actions" /
+        # "four, not nine"). Lock on the prose phrase.
+        lower = content.lower()
+        assert "four authoritative actions" in lower or "four, not nine" in lower, (
+            "diagnose-failure/SKILL.md must name the v3 four-action "
+            "vocabulary explicitly (issue #3874 AC #3)"
+        )
+        # Each action's distinguishing string must appear.
+        assert "agent/ready" in content, (
+            "Action 1 (retry) must reference re-adding agent/ready (issue #3874 AC #3)"
+        )
+        assert "needs_review" in content, (
+            "Action 4 (mark needs_review) must reference the "
+            "needs_review status (issue #3874 AC #3)"
+        )
+
+    def test_outcome_summary_write_documented(self) -> None:
+        """The SKILL must document writing ``agents.outcome_summary``
+        as the final step (issue #3874 AC #4)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "outcome_summary" in content, (
+            "diagnose-failure/SKILL.md must document the "
+            "outcome_summary write (issue #3874 AC #4)"
+        )
+        # The write should be described as the final step.
+        lower = content.lower()
+        assert "agents.outcome_summary" in lower or (
+            "outcome_summary" in lower and "exit" in lower
+        ), (
+            "diagnose-failure/SKILL.md must describe the "
+            "outcome_summary write as the final step before exit "
+            "(issue #3874 AC #4)"
+        )
+
+    def test_launcher_polls_contract_documented(self) -> None:
+        """The SKILL must explicitly state that no recommendation or
+        directive is returned — the launcher polls ``agents.status``
+        instead (issue #3874 AC #5)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "launcher polls" in content, (
+            "diagnose-failure/SKILL.md must state that the launcher "
+            "polls agents.status (issue #3874 AC #5)"
+        )
+        # The "no recommendation/directive return" framing.
+        assert (
+            "no recommendation/directive" in content
+            or "no recommendation" in content.lower()
+        ), (
+            "diagnose-failure/SKILL.md must explicitly state there is "
+            "no recommendation/directive return (issue #3874 AC #5)"
+        )
+
+    def test_3874_issue_reference(self) -> None:
+        """SKILL.md must reference issue #3874 for traceability."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "#3874" in content, (
+            "diagnose-failure/SKILL.md must reference '#3874' for "
+            "traceability (issue #3874)"
         )


### PR DESCRIPTION
## Summary

Rewrites `.claude/skills/diagnose-failure/SKILL.md` for dispatcher-v3's authority-not-advisor contract: read the agent session transcript via S3 → CloudWatch fallback, take side effects directly via gh/git/aws, write a one-line `agents.outcome_summary`, exit. The launcher polls `agents.status` afterward — no structured recommendation/directive return. Documents the deliberate cohabitation decision (accept v2 diagnoser degradation during cohab rather than dual-mode SKILL with conflicting contracts) in the SKILL prose. Updates v2 contract tests to drop v2-specific assertions and adds a new `TestDiagnoseFailureV3Contracts` class with grep-style regression guards mirroring the issue's five Verify lines.

Closes #3874

## Test plan

### Automated checks
- [x] Lint passes (ruff check on edited test files — verified locally)
- [x] Format check passes (ruff format --check on edited test files — verified locally)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 2109 passed locally)
- [x] CI green (ci-passed: SUCCESS)
- [x] Markdown link check passes (verified locally — `scripts/check-markdown-links.sh` returns clean)
- [x] Issue #3874 verify-line greps all satisfied (verified locally — see process-summary comment on issue)

### Post-deploy verification
- [x] N/A — no deployed component (SKILL.md docs + test edits only). The SKILL is consumed by the dispatcher daemon at runtime, but the daemon is not deployed by this PR; the v3 launcher invocation is tracked separately as #3882.
- [x] Verification evidence posted on issue (see issue comment with per-AC table)
