### PR TITLE
fix(dx): add pytest-xdist to dispatcher venv setup

### DIFF
--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -33,7 +33,7 @@ Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header an
 scripts/install-dispatcher-venv.sh
 ```
 
-This creates `scripts/dispatcher/.venv` and installs `pytest`, `ruff`, `boto3`, and an editable `packages/judgemind-config` — the four dependencies required by the dispatcher test suite. The script is idempotent: re-running it on an existing venv is safe.
+This creates `scripts/dispatcher/.venv` and installs `pytest`, `pytest-xdist`, `ruff`, `boto3`, and an editable `packages/judgemind-config` — the five dependencies required by the dispatcher test suite. The script is idempotent: re-running it on an existing venv is safe.
 
 **One-off and permanent markers.** **Every** top-level script must carry exactly one of the following markers, as a standalone top-level comment anywhere in the **first 50 lines** of the file (the header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring):
 

--- a/scripts/install-dispatcher-venv.sh
+++ b/scripts/install-dispatcher-venv.sh
@@ -6,7 +6,7 @@
 # scripts/install-package-venv.sh (which requires a packages/<name>/ directory
 # with a pyproject.toml) cannot bootstrap the dispatcher's venv. This dedicated
 # helper fills that gap: it creates scripts/dispatcher/.venv and installs the
-# four runtime dependencies the dispatcher tests need.
+# five runtime dependencies the dispatcher tests need.
 #
 # Usage:
 #   scripts/install-dispatcher-venv.sh
@@ -17,9 +17,10 @@
 # dependencies are already satisfied.
 #
 # Dependency installation order:
-#   1. pytest, ruff, boto3  (PyPI)
-#   2. judgemind-config      (local editable, last so a PyPI flake does not
-#                             leave a half-populated venv that claims readiness)
+#   1. pytest, pytest-xdist, ruff, boto3  (PyPI)
+#   2. judgemind-config                    (local editable, last so a PyPI flake
+#                                          does not leave a half-populated venv
+#                                          that claims readiness)
 #
 # Exit codes:
 #   0 — venv is populated and usable
@@ -80,8 +81,8 @@ fi
 # Install these first so a judgemind-config install failure does not leave
 # a venv that looks partially ready.
 
-echo "Installing PyPI dependencies: pytest ruff boto3"
-"$PIP" install --quiet pytest ruff boto3
+echo "Installing PyPI dependencies: pytest pytest-xdist ruff boto3"
+"$PIP" install --quiet pytest pytest-xdist ruff boto3
 
 # ── Install local sibling dependency ─────────────────────────────────────
 # judgemind-config is an unpublished local package. Install it last (editable)

--- a/scripts/tests/test_install_dispatcher_venv.sh
+++ b/scripts/tests/test_install_dispatcher_venv.sh
@@ -74,6 +74,16 @@ OUTPUT=$("$SCRIPT" --help 2>&1 || true)
 assert_exit_code 1 "$RC" "--help exits non-zero (unknown args rejected)"
 assert_contains "$OUTPUT" "Usage:" "usage message printed for --help"
 
+# --- Test 4: install line includes pytest-xdist ---
+echo "--- Test 4: install line includes pytest-xdist ---"
+if grep -E '^[^#].*install.*pytest-xdist' "$SCRIPT" >/dev/null 2>&1; then
+    echo "PASS: install line includes pytest-xdist"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL: install line does not include pytest-xdist in $SCRIPT"
+    FAIL=$((FAIL + 1))
+fi
+
 # --- Summary ---
 echo ""
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Added pytest-xdist to the dispatcher venv setup helper to support parallel test execution, matching the CI install set. Updated documentation and added a regression test to prevent future drift between local and CI dependency lists.

Closes #3810

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — shell tests in `scripts/tests/test_install_dispatcher_venv.sh` all pass (6/6), markdown links validated
- [x] CI green

### Post-deploy verification

- [ ] From a fresh worktree, run `scripts/install-dispatcher-venv.sh` and then `pytest scripts/dispatcher/tests/ -n auto -m "not integration"` to completion (Verify ACs 1, 2, 4)
- [ ] From the same venv, run `ruff check scripts/dispatcher/` and `ruff format --check scripts/dispatcher/` to verify no errors (Verify AC 3)
- [ ] Verification evidence posted on #3810 (see /task-v2-verify output)