### PR TITLE
feat(dispatcher): scope v2 dispatcher.agents queries to v2-owned rows (#3875)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -414,6 +414,42 @@ DEFAULT_AGENT_EXECUTION_MODE = "ecs"
 #: an unknown launch lane.
 AGENT_EXECUTION_MODES: frozenset[str] = frozenset({"subprocess", "ecs"})
 
+#: Cohabitation scoping (#3875). Every v2-daemon query against
+#: ``dispatcher.agents`` that selects or updates more than one row by
+#: criteria *other* than the row's ``agent_id`` UUID PK MUST include
+#: this fragment in its ``WHERE`` clause so v2 only sees v2-owned
+#: rows. v3 cohabits the same table — its rows have
+#: ``parent_run_id`` whose lineage in ``dispatcher.runs`` carries
+#: ``dispatcher_version='v3'`` (column added by migration 56,
+#: #3872). Without this filter, v2's recovery / sweep / reaper code
+#: would silently corrupt v3-owned rows during the rollout window —
+#: e.g. :meth:`_clear_stale_agent_task_arns` would null v3's task
+#: ARNs at the 2h mark, :meth:`_check_stuck_agents` would stop v3
+#: tasks via ``ecs:StopTask``, :meth:`recover_abandoned_agents`
+#: would flip v3 rows to ``crashed`` on every v2 redeploy.
+#:
+#: Queries scoped by ``WHERE agent_id = %s`` do NOT need this filter
+#: — ``agent_id`` is a UUID PK, and v3's UUIDs cannot collide with
+#: ``agent_id`` values v2 would have on hand (v2 only learns
+#: ``agent_id`` values from rows it itself inserted; v3 never hands
+#: a UUID into a v2 code path). Such sites are still tagged with the
+#: marker comment ``# v2-scoped: by-agent-id`` so the CI grep test
+#: (``tests/test_agent_query_scoping.py``) can recognize them as
+#: explicitly-considered-and-safe.
+#:
+#: The subquery against ``dispatcher.runs`` is uncached: every call
+#: re-evaluates it. The runs table is small (<100 rows lifetime) and
+#: the daemon's tick cadence is seconds, not microseconds — the
+#: extra plan time is unmeasurable next to the GitHub API round-
+#: trips that dominate every supervisor tick. A future optimization
+#: could materialize a per-tick cache of v2 run_ids if profiling
+#: ever surfaces the cost.
+V2_SCOPED_PARENT_RUN_FILTER = (
+    "parent_run_id IN ("
+    "SELECT run_id FROM dispatcher.runs WHERE dispatcher_version = 'v2'"
+    ")"
+)
+
 #: Number of ``ecs:RunTask`` attempts per agent launch. Three attempts
 #: with 1s + 2s backoff mirrors the retry shape used by
 #: :meth:`DispatcherDaemon._baseline_fetch_origin_main` (issue #3085)
@@ -4517,8 +4553,13 @@ class DispatcherDaemon:
                 # exec-mode-agnostic (#3158): concurrency-cap predicate;
                 # ``status='running'`` counts equally for subprocess
                 # and ECS agents — they both consume one cap slot.
+                # v2-scoped: parent-run-id-filter (#3875) — v3-owned
+                # running rows must not consume v2's cap slot.
                 cur.execute(
-                    "SELECT 1 FROM dispatcher.agents WHERE status = 'running' LIMIT 1",
+                    "SELECT 1 FROM dispatcher.agents "
+                    "WHERE status = 'running' "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
+                    "LIMIT 1",
                 )
                 row = cur.fetchone()
             self._conn.commit()
@@ -4560,8 +4601,12 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before checking"
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: parent-run-id-filter (#3875) — v3-owned
+                # running rows must not consume v2's cap slot.
                 cur.execute(
-                    "SELECT COUNT(*) FROM dispatcher.agents WHERE status = 'running'",
+                    "SELECT COUNT(*) FROM dispatcher.agents "
+                    "WHERE status = 'running' "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER}",
                 )
                 row = cur.fetchone()
             self._conn.commit()
@@ -5000,6 +5045,9 @@ class DispatcherDaemon:
         # exec-mode-agnostic (#3158): orphan-PR scan covers all failed agents
         # regardless of how they were launched; execution_mode does not affect
         # PR resurrection eligibility.
+        # v2-scoped: parent-run-id-filter (#3875) — only v2-claim-paths
+        # should defer to v2's resurrection sweep; a v3-failed agent on
+        # the same issue must not block a v2 claim attempt.
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
@@ -5010,6 +5058,7 @@ class DispatcherDaemon:
                     "  AND pr_number IS NOT NULL "
                     "  AND ended_at IS NOT NULL "
                     "  AND ended_at > now() - %s "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "ORDER BY ended_at DESC "
                     "LIMIT 1",
                     (issue_number, ORPHAN_PR_RESURRECTION_LOOKBACK),
@@ -5165,6 +5214,12 @@ class DispatcherDaemon:
 
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: daemon-write-with-run-id (#3875) — INSERT
+                # tags ``parent_run_id = self._run_id`` whose row in
+                # ``dispatcher.runs`` carries ``dispatcher_version='v2'``
+                # (set by :meth:`check_lease_and_register_run`). Source
+                # of truth for the V2_SCOPED_PARENT_RUN_FILTER on every
+                # subsequent v2 read/update.
                 cur.execute(
                     "INSERT INTO dispatcher.agents "
                     "    (agent_id, parent_run_id, kind, issue_number, "
@@ -5278,10 +5333,14 @@ class DispatcherDaemon:
                 # exec-mode-agnostic (#3158): race-lost diagnostic;
                 # both subprocess and ECS agents write ``kind='task'``
                 # and the race classification is identical.
+                # v2-scoped: parent-run-id-filter (#3875) — race-lost
+                # logging is a v2-only diagnostic; a v3 active row on
+                # the same issue is not the race v2 just lost.
                 cur.execute(
                     "SELECT kind FROM dispatcher.agents "
                     "WHERE issue_number = %s "
                     "  AND status IN ('running', 'retrying') "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "LIMIT 1",
                     (issue_number,),
                 )
@@ -5583,13 +5642,32 @@ class DispatcherDaemon:
                 # migration set ``DEFAULT 'subprocess' NOT NULL`` so in
                 # practice every row has a value, but NULL is
                 # defensively coerced to ``'subprocess'`` downstream.
+                # v2-scoped: parent-run-id-filter (#3875) — gate on
+                # ``parent_run_id`` lineage being v2 BEFORE the prior-
+                # run-mismatch test so v3-owned rows are never seen by
+                # this sweep. Without this, a v3-owned running row
+                # whose parent_run_id is one of v3's runs would match
+                # the ``parent_run_id <> self._run_id`` half (since
+                # any v3 run_id is non-equal to v2's self._run_id) and
+                # be flipped to crashed + daemon_restart_abandoned on
+                # every v2 redeploy. This is the most destructive of
+                # the v2/v3 collision sites — see #3875.
+                #
+                # The IN-subquery is NULL-rejecting, so pre-#3872
+                # NULL ``parent_run_id`` rows are dropped from this
+                # sweep. Those rows fall back to the existing
+                # stuck_timeout sweep on the next supervisor tick (a
+                # 30-minute delay vs. immediate recovery, but the
+                # backstop is still correct). #3872 landed weeks
+                # before v3 ships, so any in-production NULL rows are
+                # long-since terminal — the regression is theoretical.
                 cur.execute(
                     "SELECT agent_id, issue_number, phase, "
                     "       execution_mode, agent_task_arn "
                     "FROM dispatcher.agents "
                     "WHERE status = 'running' "
-                    "  AND (parent_run_id IS NULL "
-                    "       OR parent_run_id <> %s)",
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
+                    "  AND parent_run_id <> %s",
                     (self._run_id,),
                 )
                 for row in cur.fetchall():
@@ -10232,10 +10310,13 @@ class DispatcherDaemon:
                 # to order the right way anyway).
                 # #3158: ``COALESCE(execution_mode, 'subprocess') <> 'ecs'``
                 # excludes ECS-mode rows — see docstring.
+                # v2-scoped: parent-run-id-filter (#3875) — only v2 rows
+                # belong on the v2 subprocess-resume lane.
                 cur.execute(
                     "SELECT agent_id, issue_number FROM dispatcher.agents "
                     "WHERE status = 'retrying' "
                     "  AND COALESCE(execution_mode, 'subprocess') <> 'ecs' "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "ORDER BY started_at ASC "
                     "LIMIT 1",
                 )
@@ -10376,11 +10457,15 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before ecs retry check"
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: parent-run-id-filter (#3875) — v3-owned
+                # ECS retrying rows are v3's problem to surface, not
+                # v2's WARN-emitting diagnostic.
                 cur.execute(
                     "SELECT agent_id, issue_number "
                     "FROM dispatcher.agents "
                     "WHERE status = 'retrying' "
                     "  AND execution_mode = 'ecs' "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "LIMIT 5",
                 )
                 rows = cur.fetchall()
@@ -11131,6 +11216,10 @@ class DispatcherDaemon:
         non_infra_phases = list(_INFRA_PREEMPTION_CATEGORIES)
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: parent-run-id-filter (#3875) — prior-
+                # attempts context for a v2 ralph rerun should reflect
+                # only v2's prior attempts on the same issue. v3's
+                # failures are surfaced through v3's own retry context.
                 cur.execute(
                     "SELECT "
                     "  a.failure_summary, "
@@ -11145,6 +11234,7 @@ class DispatcherDaemon:
                     "WHERE a.issue_number = %s "
                     "  AND a.status IN ('failed', 'crashed') "
                     "  AND a.phase != ALL(%s) "
+                    f"  AND a.{V2_SCOPED_PARENT_RUN_FILTER} "
                     "ORDER BY a.started_at DESC "
                     "LIMIT 3",
                     (issue_number, non_infra_phases),
@@ -14029,6 +14119,10 @@ class DispatcherDaemon:
                 # a hard-coded ``interval '24 hours'`` into the SQL —
                 # makes the constant the single source of truth and
                 # keeps the query tunable from one place.
+                # v2-scoped: parent-run-id-filter (#3875) — v2's
+                # orphan-PR resurrection sweep must not touch v3 PRs.
+                # Without this, v2 would attempt to merge a v3-owned
+                # mergeable PR via :meth:`_mark_agent_resurrected_for_orphan_pr`.
                 cur.execute(
                     "SELECT agent_id, pr_number, issue_number "
                     "FROM dispatcher.agents "
@@ -14037,6 +14131,7 @@ class DispatcherDaemon:
                     "  AND issue_number IS NOT NULL "
                     "  AND ended_at IS NOT NULL "
                     "  AND ended_at > now() - %s "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "ORDER BY ended_at DESC",
                     (ORPHAN_PR_RESURRECTION_LOOKBACK,),
                 )
@@ -14271,6 +14366,9 @@ class DispatcherDaemon:
                 # while a NULL-issue row sits in any
                 # ``status='succeeded' phase IN ('done',
                 # 'retro_done', 'retro_failed')`` state).
+                # v2-scoped: parent-run-id-filter (#3875) — supervisor
+                # advance loop must not drive v3-owned agents through
+                # v2's merge / verify / retro state machine.
                 cur.execute(
                     "SELECT agent_id, issue_number, phase, pr_number, "
                     "       worktree_path, retries_used, status, "
@@ -14283,6 +14381,7 @@ class DispatcherDaemon:
                     "        AND phase IN ('awaiting_deploy', 'done', "
                     "                      'retro_done', 'retro_failed'))) "
                     "  AND issue_number IS NOT NULL "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "ORDER BY started_at ASC",
                 )
                 for row in cur.fetchall():
@@ -17954,6 +18053,10 @@ class DispatcherDaemon:
         ] = []
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: parent-run-id-filter (#3875) — stuck-
+                # timeout sweep would otherwise SIGKILL/StopTask v3
+                # agents and flip their rows to crashed. v3 owns its
+                # own stuck detection.
                 cur.execute(
                     "SELECT a.agent_id, a.issue_number, a.phase, "
                     "       EXTRACT(EPOCH FROM ("
@@ -17971,7 +18074,8 @@ class DispatcherDaemon:
                     "    FROM dispatcher.phase_transitions "
                     "    WHERE agent_id = a.agent_id"
                     ") pt ON TRUE "
-                    "WHERE a.status = 'running'",
+                    "WHERE a.status = 'running' "
+                    f"  AND a.{V2_SCOPED_PARENT_RUN_FILTER}",
                 )
                 rows = cur.fetchall()
                 for row in rows:
@@ -23951,9 +24055,14 @@ class DispatcherDaemon:
                 # same way, so the predicate doesn't need to branch on
                 # execution_mode. Mirrors :meth:`_has_active_agent`'s
                 # exec-mode-agnostic SELECT pattern.
+                # v2-scoped: parent-run-id-filter (#3875) — v2's
+                # scheduled-skill collision guard considers only v2-
+                # owned skill agents.
                 cur.execute(
                     "SELECT 1 FROM dispatcher.agents "
-                    " WHERE status = 'running' AND phase = %s LIMIT 1",
+                    " WHERE status = 'running' AND phase = %s "
+                    f"   AND {V2_SCOPED_PARENT_RUN_FILTER} "
+                    " LIMIT 1",
                     (name,),
                 )
                 row = cur.fetchone()
@@ -23976,15 +24085,21 @@ class DispatcherDaemon:
         try:
             with self._conn.cursor() as cur:
                 if since is None:
-                    cur.execute(
-                        "SELECT COUNT(*) FROM dispatcher.agents "
-                        " WHERE merged_at IS NOT NULL"
-                    )
-                else:
+                    # v2-scoped: parent-run-id-filter (#3875) — every_n_merges
+                    # trigger fires off v2 merges only.
                     cur.execute(
                         "SELECT COUNT(*) FROM dispatcher.agents "
                         " WHERE merged_at IS NOT NULL "
-                        "   AND merged_at > %s",
+                        f"   AND {V2_SCOPED_PARENT_RUN_FILTER}"
+                    )
+                else:
+                    # v2-scoped: parent-run-id-filter (#3875) — every_n_merges
+                    # trigger fires off v2 merges only.
+                    cur.execute(
+                        "SELECT COUNT(*) FROM dispatcher.agents "
+                        " WHERE merged_at IS NOT NULL "
+                        "   AND merged_at > %s "
+                        f"   AND {V2_SCOPED_PARENT_RUN_FILTER}",
                         (since,),
                     )
                 row = cur.fetchone()
@@ -24026,6 +24141,9 @@ class DispatcherDaemon:
         agent_id = str(uuid.uuid4())
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: daemon-write-with-run-id (#3875) — INSERT
+                # tags parent_run_id = self._run_id (v2). Source of
+                # truth for v2-scoping reads on this row.
                 cur.execute(
                     "INSERT INTO dispatcher.agents "
                     "    (agent_id, parent_run_id, kind, issue_number, "
@@ -25356,11 +25474,16 @@ class DispatcherDaemon:
         # filter does not pull in legacy work.
         try:
             with self._conn.cursor() as cur:
+                # v2-scoped: parent-run-id-filter (#3875) — ECS reaper
+                # would otherwise call ecs:DescribeTasks on v3's ARNs
+                # and route their STOPPED transitions through v2's
+                # _handle_agent_failure path.
                 cur.execute(
                     "SELECT agent_id, issue_number, agent_task_arn, "
                     "       phase, status "
                     "FROM dispatcher.agents "
                     "WHERE agent_task_arn IS NOT NULL "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER} "
                     "LIMIT 100"
                 )
                 rows = cur.fetchall()
@@ -26084,12 +26207,19 @@ class DispatcherDaemon:
         # parameter substitution rather than f-string interpolation —
         # mirrors the housekeeping DELETE pattern. ``cutoff_hours`` is
         # validated positive int by ``_read_retention_days``.
+        # v2-scoped: parent-run-id-filter (#3875) — without this, the
+        # 2h bulk clear would null v3's task ARNs at exactly the
+        # moment v3's per-agent Fargate tasks are still running. The
+        # adversarial review of the v3 spec called this the most
+        # destructive site in the v2 daemon. v3 owns its own stale-
+        # ARN cleanup against its own run lineage.
         with self._conn.cursor() as cur:
             cur.execute(
                 "UPDATE dispatcher.agents "
                 "SET agent_task_arn = NULL "
                 "WHERE agent_task_arn IS NOT NULL "
-                "  AND started_at < now() - make_interval(hours => %s)",
+                "  AND started_at < now() - make_interval(hours => %s) "
+                f"  AND {V2_SCOPED_PARENT_RUN_FILTER}",
                 (cutoff_hours,),
             )
             rows_cleared = cur.rowcount or 0
@@ -26141,12 +26271,16 @@ class DispatcherDaemon:
         # them via psycopg parameter substitution to keep parity with the
         # other housekeeping helpers.
         terminal_statuses = sorted(TERMINAL_AGENT_STATUSES)
+        # v2-scoped: parent-run-id-filter (#3875) — bulk ended_at
+        # backfill for v2 rows only; v3 owns its own ended_at
+        # invariant against its own run lineage.
         with self._conn.cursor() as cur:
             cur.execute(
                 "UPDATE dispatcher.agents "
                 "SET ended_at = now() "
                 "WHERE status = ANY(%s::text[]) "
-                "  AND ended_at IS NULL",
+                "  AND ended_at IS NULL "
+                f"  AND {V2_SCOPED_PARENT_RUN_FILTER}",
                 (terminal_statuses,),
             )
             rows_stamped = cur.rowcount or 0
@@ -26182,11 +26316,16 @@ class DispatcherDaemon:
                 # exec-mode-agnostic (#3158): merged_at reconcile scans all
                 # agents; pr_number semantics are identical across ECS and
                 # subprocess lanes — both set it after the gh pr merge call.
+                # v2-scoped: parent-run-id-filter (#3875) — without this,
+                # v2 would call gh pr view on v3-owned PRs and clear v3's
+                # merged_at if the PR isn't observed merged from gh's
+                # vantage. v3 owns its own merged_at reconciliation.
                 cur.execute(
                     "SELECT agent_id, pr_number FROM dispatcher.agents "
                     "WHERE merged_at IS NOT NULL "
                     "  AND pr_number IS NOT NULL "
-                    "  AND merged_at > now() - INTERVAL '24 hours'",
+                    "  AND merged_at > now() - INTERVAL '24 hours' "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER}",
                 )
                 rows = list(cur.fetchall())
             self._conn.commit()

--- a/scripts/dispatcher/daily_report.py
+++ b/scripts/dispatcher/daily_report.py
@@ -32,6 +32,11 @@ from typing import Any
 # SQL queries
 # ---------------------------------------------------------------------------
 
+# v2-scoped: parent-run-id-filter (#3875) — the daily report is v2's
+# operational health summary. Without scoping, a v3 cohabitation
+# rollout would mix v3 agents into v2's throughput / streak / failure
+# breakdown, distorting the v2 signal. v3 will get its own report when
+# the launcher ships.
 _SQL_THROUGHPUT = """
 SELECT
     COUNT(*) FILTER (WHERE started_at >= now() - INTERVAL '24 hours')
@@ -45,13 +50,17 @@ SELECT
         AND status = 'shipped'
     ) AS shipped_24h,
     COUNT(*) FILTER (WHERE status = 'running') AS running_now
-FROM dispatcher.agents;
+FROM dispatcher.agents
+WHERE parent_run_id IN (
+    SELECT run_id FROM dispatcher.runs WHERE dispatcher_version = 'v2'
+);
 """
 
 # Strict green streak: count consecutive shipped agents (ordered by ended_at
 # descending) until the first non-shipped row. Uses a window function to
 # assign a row_number; we count rows where the status at that position equals
 # 'shipped' AND no prior row (by row_number) was non-shipped.
+# v2-scoped: parent-run-id-filter (#3875) — streak is v2's metric.
 _SQL_GREEN_STREAK = """
 WITH ordered AS (
     SELECT
@@ -59,6 +68,9 @@ WITH ordered AS (
         ROW_NUMBER() OVER (ORDER BY ended_at DESC NULLS LAST) AS rn
     FROM dispatcher.agents
     WHERE ended_at IS NOT NULL
+      AND parent_run_id IN (
+          SELECT run_id FROM dispatcher.runs WHERE dispatcher_version = 'v2'
+      )
 ),
 streak AS (
     SELECT rn
@@ -101,6 +113,8 @@ GROUP BY
 ORDER BY count DESC;
 """
 
+# v2-scoped: parent-run-id-filter (#3875) — stuck issues from v2's
+# perspective only.
 _SQL_STUCK_ISSUES = """
 SELECT
     a.issue_number,
@@ -110,6 +124,9 @@ FROM dispatcher.agents a
 JOIN dispatcher.failures f USING (agent_id)
 WHERE f.ts >= now() - INTERVAL '24 hours'
   AND a.issue_number IS NOT NULL
+  AND a.parent_run_id IN (
+      SELECT run_id FROM dispatcher.runs WHERE dispatcher_version = 'v2'
+  )
 GROUP BY a.issue_number, f.category
 HAVING COUNT(*) >= 3
 ORDER BY failure_count DESC, a.issue_number;

--- a/scripts/dispatcher/tests/test_agent_query_scoping.py
+++ b/scripts/dispatcher/tests/test_agent_query_scoping.py
@@ -1,0 +1,433 @@
+"""CI guard: every v2-daemon query against ``dispatcher.agents`` must
+be scoped to v2-owned rows during v2/v3 cohabitation (#3875).
+
+Why this test exists
+--------------------
+v3 cohabits the same ``dispatcher.agents`` table as v2 during the
+rollout window. Per-row ownership is established via
+``parent_run_id`` → ``runs.dispatcher_version`` (column added by
+migration 56, #3872). v2's recovery / sweep / reaper code paths run
+bulk SELECTs and UPDATEs against ``dispatcher.agents``; without a
+v2-scoping filter, those paths would silently corrupt v3-owned rows:
+
+* :func:`_clear_stale_agent_task_arns` would null v3's task ARNs at
+  the 2h mark — the most destructive site.
+* :func:`recover_abandoned_agents` would flip v3 rows to
+  ``status='crashed'`` + ``phase='daemon_restart_abandoned'`` on
+  every v2 redeploy.
+* :func:`_check_stuck_agents` would issue ``ecs:StopTask`` against
+  v3's running Fargate tasks.
+* :func:`_advance_running_agents` would drive v3 agents through
+  v2's merge / verify / retro state machine.
+* :func:`_reap_completed_agent_tasks` would route v3's STOPPED
+  transitions through v2's ``_handle_agent_failure`` path.
+
+The ≥8 such sites identified by the v3-spec adversarial review (issue
+#3875) are scoped via the :data:`daemon.V2_SCOPED_PARENT_RUN_FILTER`
+constant. This test enforces the invariant going forward — any new
+query against ``dispatcher.agents`` added to ``daemon.py`` (or to
+``daily_report.py``) must satisfy at least one of:
+
+1. The query SQL contains ``parent_run_id`` (the cohabitation filter,
+   typically supplied via ``V2_SCOPED_PARENT_RUN_FILTER``).
+2. The query is a row-PK lookup (``WHERE agent_id = %s`` or
+   ``WHERE a.agent_id = %s``). Such lookups are intrinsically scoped
+   because ``agent_id`` is a UUID PK and v3's UUIDs are minted
+   independently of v2 — v2 only has ``agent_id`` values for rows it
+   itself inserted.
+3. An adjacent ``# v2-scoped: <reason>`` marker comment whitelists
+   the query (use this for the rare exception). The reason follows a
+   short controlled-vocabulary set:
+
+   * ``parent-run-id-filter`` — SQL contains the cohabitation filter
+     (case 1 above; the comment is informational, the test would
+     pass on the SQL alone).
+   * ``by-agent-id`` — SQL is a UUID-PK lookup (case 2 above; the
+     comment is informational, the test would pass on the SQL alone).
+   * ``daemon-write-with-run-id`` — INSERT writes
+     ``parent_run_id = self._run_id`` from a daemon whose run row
+     carries ``dispatcher_version='v2'``. This is the source of
+     truth for case 1 reads.
+
+This test was added as the mandatory CI guard called out in issue
+#3875's acceptance criteria. Without it, a future PR can introduce
+an unscoped query and silently re-open the corruption window.
+
+How the test works
+------------------
+The test reads ``daemon.py`` and ``daily_report.py`` as plain text,
+walks every line that contains ``FROM dispatcher.agents``,
+``UPDATE dispatcher.agents``, or ``INSERT INTO dispatcher.agents``,
+expands the surrounding ``cur.execute(...)`` block (or top-level SQL
+literal for ``daily_report.py``), and applies the three-clause
+recognizer above.
+
+Failures point at the exact line number and report which clause was
+expected. The pre-PR contract is: add the filter, the row-PK
+condition, or the marker comment — the test is happy with any of
+the three.
+
+Adding a deliberate regression
+------------------------------
+:func:`test_unscoped_query_detected_in_synthetic_fixture` proves the
+test catches an unscoped query: it constructs a synthetic source
+string in memory (no edits to daemon.py) containing
+``SELECT * FROM dispatcher.agents WHERE 1=1`` and asserts the
+classifier flags it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Files audited
+# ---------------------------------------------------------------------------
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+_DAEMON_PY = _SCRIPTS / "dispatcher" / "daemon.py"
+_DAILY_REPORT_PY = _SCRIPTS / "dispatcher" / "daily_report.py"
+
+# ---------------------------------------------------------------------------
+# Recognizer regexes
+# ---------------------------------------------------------------------------
+
+# Match SQL statements touching ``dispatcher.agents`` — not docstrings or
+# comments. We anchor on the verb (FROM / UPDATE / INSERT INTO) followed
+# by ``dispatcher.agents`` since that's the part of the SQL that signals
+# a real query (comments / docstrings reference the table by full name
+# but rarely with these verb prefixes inside a string literal).
+_VERB_PATTERN = re.compile(
+    r"(?:FROM|UPDATE|INSERT\s+INTO)\s+dispatcher\.agents\b",
+    re.IGNORECASE,
+)
+
+# Lines that are pure comments or docstrings — those don't represent
+# real SQL even when they happen to mention ``FROM dispatcher.agents``
+# (e.g. a docstring explaining what a query does). The simplest
+# heuristic: a line whose stripped form starts with ``#`` is a comment,
+# and a line whose stripped form starts with ``"""`` or ``'''`` opens or
+# closes a docstring. We also skip any line that does NOT contain a
+# Python string literal (no quote characters at all) — those are
+# free-form prose only.
+_COMMENT_LINE = re.compile(r"^\s*#")
+_DOCSTRING_BOUNDARY = re.compile(r'^\s*("""|\'\'\')')
+
+# A row-PK lookup is an intrinsically-safe read because ``agent_id`` is
+# a UUID minted by ``gen_random_uuid()`` and v2 only has a v2-owned
+# ``agent_id`` to query with — v3 never hands a UUID into a v2 code
+# path. Recognize both bare and prefix-aliased forms.
+_BY_AGENT_ID = re.compile(r"\bWHERE\b.*\b(?:[a-z]\.)?agent_id\s*=\s*%s")
+
+# The cohabitation filter, in either inlined form or the constant
+# substitution form.
+_PARENT_RUN_FILTER = re.compile(r"\bparent_run_id\b")
+
+# Marker comment — a previously-considered exception with an
+# explanatory tag.
+_SCOPING_MARKER = re.compile(
+    r"#\s*v2-scoped:\s*(parent-run-id-filter|by-agent-id|daemon-write-with-run-id)\b",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Block extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_query_blocks(source: str) -> list[tuple[int, str, str]]:
+    """Yield ``(line_no, block_text, preceding_context)`` for every SQL
+    statement in *source* that touches ``dispatcher.agents``.
+
+    The "block" is the smallest contiguous substring that spans both
+    the first line of the SQL literal AND the closing ``)`` of the
+    enclosing ``cur.execute(...)`` (or the closing triple-quote of a
+    top-level multi-line string assignment for ``daily_report.py``).
+
+    The "preceding context" is the up-to-12 source lines immediately
+    above the block — used to find ``# v2-scoped:`` marker comments.
+
+    Comment / docstring lines that happen to mention
+    ``FROM dispatcher.agents`` (e.g. function docstrings explaining
+    what a method does) are ignored.
+    """
+    lines = source.splitlines()
+    n = len(lines)
+    blocks: list[tuple[int, str, str]] = []
+    seen_starts: set[int] = set()
+
+    # Pre-pass: identify line ranges that are inside a top-level
+    # ``_SQL_X = """ ... """`` assignment. Lines in those ranges are
+    # bare SQL prose (no leading ``"``) but are real queries we must
+    # audit. Outside those ranges, we require a leading ``"`` to
+    # discriminate real SQL string literals from docstring prose that
+    # happens to mention ``UPDATE dispatcher.agents``.
+    sql_literal_ranges: list[tuple[int, int]] = []
+    in_sql_literal = False
+    sql_start = -1
+    for idx, raw in enumerate(lines):
+        if not in_sql_literal:
+            if re.search(r'_SQL_[A-Z_]+\s*=\s*("""|\'\'\')', raw):
+                in_sql_literal = True
+                sql_start = idx
+        else:
+            if '"""' in raw or "'''" in raw:
+                sql_literal_ranges.append((sql_start, idx))
+                in_sql_literal = False
+
+    def _in_sql_literal_block(idx: int) -> bool:
+        for s, e in sql_literal_ranges:
+            if s <= idx <= e:
+                return True
+        return False
+
+    for i, line in enumerate(lines):
+        if not _VERB_PATTERN.search(line):
+            continue
+        # Skip pure-comment lines (``#: like FROM dispatcher.agents`` etc).
+        if _COMMENT_LINE.match(line):
+            continue
+        # Discriminate real SQL from docstring prose. For lines inside
+        # a top-level ``_SQL_X = """ ... """`` assignment (daily_report
+        # style), every match is real. Outside such a block, we
+        # require the line's stripped form to start with ``"`` — a
+        # Python string literal opener.
+        stripped = line.lstrip()
+        if not _in_sql_literal_block(i) and not stripped.startswith('"'):
+            continue
+        # Find the start of the enclosing ``cur.execute(`` call (or
+        # top-level ``_SQL_X = """`` assignment) by walking backwards
+        # up to 25 lines (some daemon.py SELECTs are 15+ lines of
+        # column projections before the ``FROM`` clause — e.g.
+        # ``_check_stuck_agents`` is 15 lines pre-FROM).
+        block_start = i
+        for back in range(1, 26):
+            if i - back < 0:
+                break
+            prev = lines[i - back]
+            if "cur.execute(" in prev or re.search(
+                r'_SQL_[A-Z_]+\s*=\s*("""|\'\'\')', prev
+            ):
+                block_start = i - back
+                break
+        if block_start in seen_starts:
+            continue
+        seen_starts.add(block_start)
+        # Walk forward to find the end of the SQL block. Two end
+        # conditions, whichever fires first:
+        #
+        # 1. ``cur.execute(...)`` style: a line whose stripped form
+        #    is exactly ``)`` or ``),`` — the syntactic close of the
+        #    Python call. We can't naively count parens because the
+        #    SQL inside string literals has many ``(`` / ``)``
+        #    characters (``EXTRACT(...)``, ``COALESCE(...)``,
+        #    ``LEFT JOIN LATERAL(...)``) which would skew the count.
+        # 2. ``_SQL_X = """ ... """`` style: a closing triple-quote.
+        block_end = block_start
+        triple_quoted = '"""' in lines[block_start] or "'''" in lines[block_start]
+        for j in range(block_start + 1, min(n, block_start + 50)):
+            block_end = j
+            stripped_j = lines[j].strip()
+            if stripped_j in (")", "),"):
+                break
+            if triple_quoted and ('"""' in lines[j] or "'''" in lines[j]):
+                break
+        block_text = "\n".join(lines[block_start : block_end + 1])
+        # Walk backward up to 12 lines for marker comments. We stop at
+        # the first non-comment, non-blank, non-string line (typically
+        # ``with self._conn.cursor() as cur:``) — markers must be
+        # adjacent or in the same logical block.
+        ctx_start = max(0, block_start - 12)
+        preceding = "\n".join(lines[ctx_start:block_start])
+        blocks.append((block_start + 1, block_text, preceding))
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def _is_scoped(block_text: str, preceding: str) -> tuple[bool, str]:
+    """Return ``(scoped, reason)`` for one query block.
+
+    Order of precedence:
+      1. SQL contains ``parent_run_id`` -> scoped via cohabitation filter.
+      2. SQL has ``WHERE [alias.]agent_id = %s`` -> intrinsically scoped.
+      3. Adjacent ``# v2-scoped: <reason>`` marker -> whitelisted.
+    """
+    if _PARENT_RUN_FILTER.search(block_text):
+        return True, "parent_run_id present in SQL"
+    if _BY_AGENT_ID.search(block_text):
+        return True, "WHERE agent_id = %s (UUID PK lookup)"
+    marker = _SCOPING_MARKER.search(preceding)
+    if marker:
+        return True, f"v2-scoped marker: {marker.group(1)}"
+    return False, (
+        "no parent_run_id filter, no WHERE agent_id = %s, "
+        "and no '# v2-scoped: <reason>' marker comment"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _audit_file(path: Path) -> list[tuple[int, str, str]]:
+    """Run the audit on a single source file. Returns offending blocks."""
+    source = path.read_text()
+    blocks = _extract_query_blocks(source)
+    offenders: list[tuple[int, str, str]] = []
+    for line_no, block_text, preceding in blocks:
+        scoped, _reason = _is_scoped(block_text, preceding)
+        if not scoped:
+            offenders.append((line_no, block_text, preceding))
+    return offenders
+
+
+def test_daemon_py_queries_are_v2_scoped() -> None:
+    """Every ``dispatcher.agents`` query in daemon.py is v2-scoped."""
+    offenders = _audit_file(_DAEMON_PY)
+    if offenders:
+        msgs = []
+        for line_no, block_text, _preceding in offenders:
+            preview = block_text[:300].replace("\n", " | ")
+            msgs.append(f"  line {line_no}: {preview}")
+        pytest.fail(
+            "Found unscoped ``dispatcher.agents`` queries in daemon.py.\n"
+            "Each match must include `parent_run_id` filtering, a "
+            "`WHERE agent_id = %s` row-PK lookup, or a "
+            "`# v2-scoped: <reason>` marker comment within ~12 lines "
+            "above the `cur.execute(`. See "
+            "`scripts/dispatcher/tests/test_agent_query_scoping.py` "
+            "docstring + #3875 for the rationale.\n\n"
+            "Offending sites:\n" + "\n".join(msgs)
+        )
+
+
+def test_daily_report_py_queries_are_v2_scoped() -> None:
+    """Every ``dispatcher.agents`` query in daily_report.py is v2-scoped."""
+    offenders = _audit_file(_DAILY_REPORT_PY)
+    if offenders:
+        msgs = []
+        for line_no, block_text, _preceding in offenders:
+            preview = block_text[:300].replace("\n", " | ")
+            msgs.append(f"  line {line_no}: {preview}")
+        pytest.fail(
+            "Found unscoped ``dispatcher.agents`` queries in "
+            "daily_report.py. The daily report is v2's operational "
+            "summary; without scoping it mixes v3 rows into v2's "
+            "metrics during cohabitation. See #3875.\n\n"
+            "Offending sites:\n" + "\n".join(msgs)
+        )
+
+
+def test_audit_finds_at_least_one_block_per_file() -> None:
+    """Sanity check: the audit walker is not silently returning empty.
+
+    Without this, a regex regression that fails to find any
+    ``dispatcher.agents`` lines at all would make
+    :func:`test_daemon_py_queries_are_v2_scoped` pass vacuously. We
+    assert the floor count is high enough to reflect reality without
+    being so brittle that any edit breaks the test.
+    """
+    daemon_blocks = _extract_query_blocks(_DAEMON_PY.read_text())
+    daily_blocks = _extract_query_blocks(_DAILY_REPORT_PY.read_text())
+    # daemon.py has ~60 query sites; daily_report.py has 3.
+    assert len(daemon_blocks) >= 30, (
+        f"audit walker found only {len(daemon_blocks)} query blocks in "
+        "daemon.py; expected ≥30. Check the regex didn't regress."
+    )
+    assert len(daily_blocks) >= 2, (
+        f"audit walker found only {len(daily_blocks)} query blocks in "
+        "daily_report.py; expected ≥2. Check the regex didn't regress."
+    )
+
+
+def test_unscoped_query_detected_in_synthetic_fixture() -> None:
+    """Adversarial test: a deliberately-unscoped query is flagged.
+
+    Builds a synthetic source string containing one fully-unscoped
+    SELECT and asserts the classifier flags it. This proves the test
+    isn't trivially passing — if the regex regressed to "always
+    return scoped=True", this test would fail. AC #3 from #3875
+    (deliberately-introduced unscoped query is caught).
+    """
+    synthetic = '''
+def _bad_query(self):
+    """A deliberately unscoped sweep — should trip the audit."""
+    with self._conn.cursor() as cur:
+        cur.execute(
+            "SELECT agent_id FROM dispatcher.agents WHERE status = 'running'",
+        )
+        return cur.fetchall()
+'''
+    blocks = _extract_query_blocks(synthetic)
+    assert len(blocks) == 1, (
+        f"expected exactly 1 query block in synthetic fixture, got {len(blocks)}"
+    )
+    line_no, block_text, preceding = blocks[0]
+    scoped, reason = _is_scoped(block_text, preceding)
+    assert not scoped, (
+        f"synthetic unscoped query was incorrectly classified as scoped: "
+        f"reason={reason!r}, block={block_text!r}"
+    )
+
+
+def test_scoped_query_with_filter_passes() -> None:
+    """Positive control: a query containing ``parent_run_id`` passes."""
+    synthetic = """
+def _good_query(self):
+    with self._conn.cursor() as cur:
+        cur.execute(
+            "SELECT agent_id FROM dispatcher.agents "
+            "WHERE status = 'running' "
+            "  AND parent_run_id IN ("
+            "    SELECT run_id FROM dispatcher.runs WHERE dispatcher_version = 'v2'"
+            ")",
+        )
+"""
+    blocks = _extract_query_blocks(synthetic)
+    assert blocks
+    _, block_text, preceding = blocks[0]
+    scoped, reason = _is_scoped(block_text, preceding)
+    assert scoped, f"scoped query was incorrectly flagged: reason={reason!r}"
+
+
+def test_scoped_query_by_agent_id_passes() -> None:
+    """Positive control: ``WHERE agent_id = %s`` is intrinsically safe."""
+    synthetic = """
+def _by_id(self, agent_id):
+    with self._conn.cursor() as cur:
+        cur.execute(
+            "SELECT pr_number FROM dispatcher.agents WHERE agent_id = %s",
+            (agent_id,),
+        )
+"""
+    blocks = _extract_query_blocks(synthetic)
+    assert blocks
+    _, block_text, preceding = blocks[0]
+    scoped, reason = _is_scoped(block_text, preceding)
+    assert scoped, f"by-agent-id query was incorrectly flagged: reason={reason!r}"
+
+
+def test_scoped_query_by_marker_comment_passes() -> None:
+    """Positive control: an explicit marker comment whitelists a block."""
+    synthetic = """
+def _marked(self):
+    with self._conn.cursor() as cur:
+        # v2-scoped: by-agent-id (UUID PK lookup, see #3875)
+        cur.execute(
+            "SELECT pr_number FROM dispatcher.agents WHERE agent_id = %s",
+            (some_id,),
+        )
+"""
+    blocks = _extract_query_blocks(synthetic)
+    assert blocks
+    _, block_text, preceding = blocks[0]
+    scoped, reason = _is_scoped(block_text, preceding)
+    assert scoped, f"marker-tagged query was incorrectly flagged: reason={reason!r}"


### PR DESCRIPTION
## Summary

Scope every v2-daemon query against `dispatcher.agents` to v2-owned rows so v2's recovery / sweep / reaper code can no longer corrupt v3-owned rows during the v2/v3 cohabitation window. Adds `daemon.V2_SCOPED_PARENT_RUN_FILTER` and threads it through 14 bulk-scan/UPDATE sites in `daemon.py` plus 3 aggregations in `daily_report.py`. A new CI grep test (`test_agent_query_scoping.py`) enforces the invariant going forward.

The adversarial review of the v3 spec flagged this as the highest-risk PR in the v3 stack — at least one site (`_clear_stale_agent_task_arns`) is actively destructive (would null v3 task ARNs at the 2h mark).

Closes #3875

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (existing 2117 dispatcher tests + 7 new scoping tests)
- [x] CI green

### Post-deploy verification
- [x] No `daemon.recover_abandoned_agents` event fires against a v3-owned row after v2 redeploy. CloudWatch query returns zero ERROR/scan_failed/recover_* events post-deploy.
- [x] Manual smoke per AC #5: synthetic v3-owned row inserted on dev, v2 daemon ran ~6 supervisor ticks over 30s, row was NOT touched (status/phase/task_arn/ended_at/exit_code all unchanged). See verification evidence comment on #3875.
- [x] Verification evidence posted on issue.
