### PR TITLE
fix(dispatcher): _issue_already_attempted merged-aware gate and stale-row cleanup (#3738)

### DIFF
--- a/packages/api/migrations/57_dispatcher-issue-has-active-agent-merged-aware.sql
+++ b/packages/api/migrations/57_dispatcher-issue-has-active-agent-merged-aware.sql
@@ -1,0 +1,93 @@
+-- Up Migration
+--
+-- Dispatcher merged-aware active-agent gate — Issue #3738 + #3001.
+-- Fix ``dispatcher.issue_has_active_agent`` to ignore ``succeeded``
+-- rows whose PR has already merged.
+--
+-- Problem
+-- -------
+-- Prior to this migration the function matched every ``status IN
+-- ('running', 'retrying', 'succeeded', 'needs_review')`` row. A
+-- ``succeeded`` row whose PR merged stays in the table indefinitely
+-- (GC is retention-window-based, not event-based). Any new claim for
+-- the same issue hits this row, ``issue_has_active_agent`` returns
+-- TRUE, and the issue is permanently blocked from re-claim — even
+-- though the prior work shipped successfully and the issue should be
+-- re-claimable.
+--
+-- Fix
+-- ---
+-- Narrow the ``succeeded`` arm to only rows whose ``merged_at IS NULL``
+-- (i.e. the PR has not yet merged). Once ``merged_at`` is stamped the
+-- row no longer counts as an active blocker, so a new claim proceeds
+-- immediately.  The daemon's ``_cleanup_stale_succeeded_rows``
+-- housekeeping method closes the originating issue for the
+-- already-merged rows; the SQL gate change alone is sufficient for
+-- unblocking the re-claim.
+--
+-- The new gate:
+--   status IN ('running', 'retrying', 'needs_review')
+--   OR (status = 'succeeded' AND merged_at IS NULL)
+--
+-- ``ACTIVE_AGENT_STATUSES`` in ``scripts/dispatcher/daemon.py`` is
+-- intentionally NOT changed — that tuple governs the Python-side
+-- status membership check only; the SQL function is the single source
+-- of truth for queue filtering.  The comment above
+-- ``ACTIVE_AGENT_STATUSES`` is updated to note the divergence.
+--
+-- Issue #3738 + #3001.
+
+CREATE OR REPLACE FUNCTION dispatcher.issue_has_active_agent(
+    p_issue_number integer
+) RETURNS boolean
+    LANGUAGE sql
+    STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+          FROM dispatcher.agents
+         WHERE issue_number = p_issue_number
+           AND (
+               status IN ('running', 'retrying', 'needs_review')
+               OR (status = 'succeeded' AND merged_at IS NULL)
+           )
+    );
+$$;
+
+COMMENT ON FUNCTION dispatcher.issue_has_active_agent(integer) IS
+    'Returns TRUE when dispatcher.agents has any row for this issue '
+    'that is actively blocking re-claim: status IN (''running'', '
+    '''retrying'', ''needs_review''), OR status=''succeeded'' with '
+    'merged_at IS NULL (PR not yet merged). A succeeded row whose PR '
+    'has merged (merged_at IS NOT NULL) is NOT counted — it no longer '
+    'blocks re-claim. Diverges from ACTIVE_AGENT_STATUSES in '
+    'scripts/dispatcher/daemon.py intentionally; see #3738. '
+    'Issue #3738 + #3001.';
+
+
+-- Down Migration
+--
+-- Restore the migration-37 body verbatim.  Down re-creates the
+-- function with the original ``status IN (...)`` gate (no merged_at
+-- awareness), exactly as written in
+-- ``packages/api/migrations/37_dispatcher-queue-predicate-functions.sql``.
+
+CREATE OR REPLACE FUNCTION dispatcher.issue_has_active_agent(
+    p_issue_number integer
+) RETURNS boolean
+    LANGUAGE sql
+    STABLE
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+          FROM dispatcher.agents
+         WHERE issue_number = p_issue_number
+           AND status IN ('running', 'retrying', 'succeeded', 'needs_review')
+    );
+$$;
+
+COMMENT ON FUNCTION dispatcher.issue_has_active_agent(integer) IS
+    'Returns TRUE when dispatcher.agents has any row for this issue with status '
+    'IN (''running'', ''retrying'', ''succeeded'', ''needs_review''). '
+    'Mirrors ACTIVE_AGENT_STATUSES in scripts/dispatcher/daemon.py:354. '
+    'Issue #3001.';

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -102,12 +102,15 @@ CREATE FUNCTION dispatcher.issue_has_active_agent(p_issue_number integer) RETURN
         SELECT 1
           FROM dispatcher.agents
          WHERE issue_number = p_issue_number
-           AND status IN ('running', 'retrying', 'succeeded', 'needs_review')
+           AND (
+               status IN ('running', 'retrying', 'needs_review')
+               OR (status = 'succeeded' AND merged_at IS NULL)
+           )
     );
 $$;
 
 
-COMMENT ON FUNCTION dispatcher.issue_has_active_agent(p_issue_number integer) IS 'Returns TRUE when dispatcher.agents has any row for this issue with status IN (''running'', ''retrying'', ''succeeded'', ''needs_review''). Mirrors ACTIVE_AGENT_STATUSES in scripts/dispatcher/daemon.py:354. Issue #3001.';
+COMMENT ON FUNCTION dispatcher.issue_has_active_agent(p_issue_number integer) IS 'Returns TRUE when dispatcher.agents has any row for this issue that is actively blocking re-claim: status IN (''running'', ''retrying'', ''needs_review''), OR status=''succeeded'' with merged_at IS NULL (PR not yet merged). A succeeded row whose PR has merged (merged_at IS NOT NULL) is NOT counted — it no longer blocks re-claim. Diverges from ACTIVE_AGENT_STATUSES in scripts/dispatcher/daemon.py intentionally; see #3738. Issue #3738 + #3001.';
 
 
 CREATE FUNCTION public.update_updated_at() RETURNS trigger

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -911,6 +911,48 @@ describe('queueReady — SQL predicate functions contract (#3001)', () => {
     expect(queueDepth).toBe(0);
     expect(queueReady).toHaveLength(0);
   });
+
+  it('migration 57: succeeded+merged_at=NULL blocks re-claim; succeeded+merged_at=now() does not (#3738)', async () => {
+    // Pins migration 57's merged-aware gate against revert.
+    // A succeeded row with merged_at IS NULL must still block (function
+    // returns TRUE). Once merged_at is stamped the row must no longer
+    // block (function returns FALSE).
+    const ISSUE_M57 = 57001;
+
+    // Seed a succeeded row with merged_at NULL.
+    const { rows: seedRows } = await pool.query<{ agent_id: string }>(
+      `INSERT INTO dispatcher.agents (issue_number, worktree_path, phase, status, started_at, merged_at)
+       VALUES ($1, $2, 'push_and_pr', 'succeeded', now() - interval '1 hour', NULL)
+       RETURNING agent_id`,
+      [ISSUE_M57, `/tmp/${MARKER}/agent-m57`],
+    );
+    const agentIdM57 = seedRows[0].agent_id;
+    insertedAgentIds.push(agentIdM57);
+
+    // succeeded + merged_at IS NULL → function must return TRUE (still blocking).
+    const { rows: rowsBlocking } = await pool.query<{ result: boolean }>(
+      `SELECT dispatcher.issue_has_active_agent($1) AS result`,
+      [ISSUE_M57],
+    );
+    expect(rowsBlocking[0].result).toBe(true);
+
+    // Stamp merged_at = now() on the row.
+    await pool.query(
+      `UPDATE dispatcher.agents SET merged_at = now() WHERE agent_id = $1`,
+      [agentIdM57],
+    );
+
+    // succeeded + merged_at IS NOT NULL → function must return FALSE (re-claimable).
+    const { rows: rowsNotBlocking } = await pool.query<{ result: boolean }>(
+      `SELECT dispatcher.issue_has_active_agent($1) AS result`,
+      [ISSUE_M57],
+    );
+    expect(rowsNotBlocking[0].result).toBe(false);
+
+    // Cleanup.
+    await pool.query(`DELETE FROM dispatcher.agents WHERE agent_id = $1`, [agentIdM57]);
+    insertedAgentIds.splice(insertedAgentIds.indexOf(agentIdM57), 1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/scripts/cleanup-stale-succeeded-rows.sh
+++ b/scripts/cleanup-stale-succeeded-rows.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# venv: none
+# one-off: true
+#
+# cleanup-stale-succeeded-rows.sh — Close GitHub issues for dispatcher agent
+# rows where status='succeeded' AND merged_at IS NOT NULL.
+#
+# Issue #3738.  After migration 57 the SQL gate for
+# ``dispatcher.issue_has_active_agent`` ignores succeeded rows whose PR has
+# already merged (merged_at IS NOT NULL).  This script closes the originating
+# GitHub issues for those rows so they are removed from the agent/ready queue
+# and don't resurface in subsequent queue scans.
+#
+# Idempotent — issues that are already CLOSED are silently skipped.
+#
+# Usage
+# -----
+#   scripts/cleanup-stale-succeeded-rows.sh           # live run
+#   scripts/cleanup-stale-succeeded-rows.sh --dry-run # preview only, no writes
+#   scripts/cleanup-stale-succeeded-rows.sh --help
+#
+# Prerequisites
+# -------------
+#   - AWS CLI v2 with Session Manager plugin (for dev-db-query.sh)
+#   - gh CLI authenticated with judgemind/judgemind write access
+#   - GITHUB_REPO env var (default: judgemind/judgemind)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITHUB_REPO="${GITHUB_REPO:-judgemind/judgemind}"
+DRY_RUN=false
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: scripts/cleanup-stale-succeeded-rows.sh [--dry-run] [--help]
+
+Close GitHub issues for dispatcher.agents rows where:
+  status = 'succeeded' AND merged_at IS NOT NULL
+
+Issue #3738: after migration 57 the SQL gate for
+issue_has_active_agent ignores these rows. This script closes the
+originating GitHub issues so they leave the agent/ready queue.
+
+Flags:
+  --dry-run   List affected rows and issue states without making
+              any changes to GitHub.
+  --help      Show this message and exit.
+USAGE
+}
+
+# ─── Parse flags ──────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# ─── Query stale succeeded rows ───────────────────────────────────────────────
+
+echo "Querying stale succeeded rows (status='succeeded' AND merged_at IS NOT NULL)..." >&2
+
+rows_json=$(
+    "$SCRIPT_DIR/dev-db-query.sh" \
+        "SELECT issue_number, pr_number FROM dispatcher.agents WHERE status = 'succeeded' AND merged_at IS NOT NULL ORDER BY issue_number"
+)
+
+row_count=$(printf '%s' "$rows_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(len(data))
+")
+
+echo "Found ${row_count} stale succeeded row(s)." >&2
+
+if [[ "$row_count" -eq 0 ]]; then
+    echo "Nothing to do." >&2
+    exit 0
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[DRY RUN] Would process the following rows:" >&2
+    printf '%s\n' "$rows_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for row in data:
+    print(f\"  issue #{row['issue_number']}  pr #{row['pr_number']}\")
+" >&2
+    exit 0
+fi
+
+# ─── Process each row ─────────────────────────────────────────────────────────
+
+closed=0
+skipped=0
+errors=0
+
+tab_rows=$(printf '%s' "$rows_json" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for row in data:
+    print(str(row['issue_number']) + '\t' + str(row['pr_number']))
+")
+
+while IFS=$'\t' read -r issue_number pr_number; do
+    echo "Processing issue #${issue_number} (PR #${pr_number})..." >&2
+
+    # Check current issue state.
+    issue_state=$(
+        gh issue view "$issue_number" \
+            --repo "$GITHUB_REPO" \
+            --json state \
+            --jq '.state' \
+        2>/dev/null || echo "ERROR"
+    )
+
+    if [[ "$issue_state" == "ERROR" ]]; then
+        echo "  ERROR: could not fetch state for issue #${issue_number} — skipping." >&2
+        (( errors++ )) || true
+        continue
+    fi
+
+    if [[ "$issue_state" != "OPEN" ]]; then
+        echo "  SKIP: issue #${issue_number} is already ${issue_state}." >&2
+        (( skipped++ )) || true
+        continue
+    fi
+
+    # Issue is OPEN — close it with a comment naming the PR and issue #3738.
+    close_comment="Closed by PR #${pr_number} (autonomous post-merge cleanup, see #3738 — this issue had a dispatcher agent row with status=succeeded and merged_at set, indicating the PR merged successfully but the issue was not closed)."
+
+    gh issue close "$issue_number" \
+        --repo "$GITHUB_REPO" \
+        --comment "$close_comment" \
+        --reason "completed" \
+    && echo "  Closed issue #${issue_number}." >&2 \
+    || { echo "  ERROR: failed to close issue #${issue_number}." >&2; (( errors++ )) || true; continue; }
+
+    # Strip agent/ready label so the issue doesn't reappear in queue scans.
+    gh issue edit "$issue_number" \
+        --repo "$GITHUB_REPO" \
+        --remove-label "agent/ready" \
+    && echo "  Removed agent/ready label from issue #${issue_number}." >&2 \
+    || echo "  WARNING: could not remove agent/ready label from issue #${issue_number} (may already be absent)." >&2
+
+    (( closed++ )) || true
+
+done <<< "$tab_rows"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+
+echo "" >&2
+echo "Done.  closed=${closed}  skipped=${skipped}  errors=${errors}" >&2
+
+if [[ "$errors" -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -762,6 +762,16 @@ FIX_CI_LOG_TAIL_MAX_CHARS = 20000
 #:   same issue. Operator either merges (→ PR close auto-unblocks),
 #:   closes (→ dispatcher housekeeping reclaims), or keeps editing —
 #:   all three paths eventually cycle the row out of this set.
+#:
+#: .. note:: **Migration 57 divergence.**  The SQL function
+#:    ``dispatcher.issue_has_active_agent`` (migration 57, #3738)
+#:    no longer treats every ``succeeded`` row as blocking — it only
+#:    blocks if ``merged_at IS NULL``.  This tuple intentionally
+#:    retains ``'succeeded'`` because ``check-dispatcher-terminals-
+#:    consistent.sh`` validates its members against terminal status
+#:    handling.  The SQL gate is the definitive source of truth for
+#:    queue filtering; this tuple governs daemon-side status membership
+#:    checks only.
 ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review")
 
 #: GitHub label added to an issue on claim (by either the daemon or the
@@ -4806,11 +4816,13 @@ class DispatcherDaemon:
         observed by the queue scan — the ``gh issue list`` default is
         already priority-sorted by the GitHub API):
 
-        1. Skip if ``dispatcher.agents`` has a row for it with
-           ``status IN ('running', 'retrying', 'succeeded')``. A
-           ``failed`` or ``crashed`` row does NOT block re-claim via
-           the partial UNIQUE INDEX — manual retry is a documented
-           operator flow.
+        1. Skip if ``dispatcher.issue_has_active_agent`` returns True
+           (migration 57, #3738). As of migration 57 the gate is
+           merged-aware: ``status IN ('running', 'retrying',
+           'needs_review')`` blocks unconditionally; ``succeeded`` only
+           blocks if ``merged_at IS NULL``. A ``failed`` or ``crashed``
+           row does NOT block re-claim via the partial UNIQUE INDEX —
+           manual retry is a documented operator flow.
         2. **Per-issue cooldown (issue #2804):** skip if any
            ``dispatcher.agents`` row for this issue was created within
            the last :data:`FAILED_AGENT_COOLDOWN_SECONDS`. Guards
@@ -4929,8 +4941,20 @@ class DispatcherDaemon:
         """True if ``dispatcher.agents`` has any active/succeeded row for this issue.
 
         Delegates to ``dispatcher.issue_has_active_agent`` (SQL function,
-        migration 37).  The function mirrors :data:`ACTIVE_AGENT_STATUSES`
-        (``running``, ``retrying``, ``succeeded``, ``needs_review``).
+        migration 57, #3738 — supersedes migration 37).  As of migration 57
+        the function uses a merged-aware gate:
+
+        * ``status IN ('running', 'retrying', 'needs_review')`` — always
+          blocks re-claim.
+        * ``status = 'succeeded' AND merged_at IS NULL`` — blocks re-claim
+          only while the PR has not yet merged.  Once ``merged_at`` is
+          stamped the row no longer counts as an active blocker, so the issue
+          is immediately eligible for re-claim.
+
+        This diverges from :data:`ACTIVE_AGENT_STATUSES` intentionally;
+        the SQL function is the definitive gate for queue filtering.  The
+        housekeeping method :meth:`_cleanup_stale_succeeded_rows` closes the
+        originating issues for already-merged rows, completing the cleanup.
 
         The partial UNIQUE INDEX (migration 25) enforces uniqueness on
         ``running`` and ``retrying``. The extra ``succeeded`` / ``needs_review``
@@ -26251,6 +26275,73 @@ class DispatcherDaemon:
                 )
         return {"checked": checked, "cleared": cleared, "errors": errors}
 
+    def _cleanup_stale_succeeded_rows(self) -> dict[str, int]:
+        """Close GitHub issues for succeeded+merged agent rows (#3738).
+
+        SELECTs ``dispatcher.agents`` rows where ``status = 'succeeded' AND
+        merged_at IS NOT NULL``.  For each such row, calls
+        :meth:`_close_issue_post_merge` (already idempotent — handles
+        ``already_closed`` skip + ``agent/ready`` strip) to close the
+        originating GitHub issue.
+
+        Migration 57 narrows ``dispatcher.issue_has_active_agent`` so it
+        ignores succeeded rows whose PR has merged — those rows no longer
+        block re-claim.  This housekeeping method closes the issue so it
+        is also removed from the ``agent/ready`` queue and from the GitHub
+        issue list, completing the cleanup.
+
+        Per-row try/except + per-row commit for failure isolation so one
+        GitHub flake does not starve siblings.  Returns
+        ``{rows_scanned, issues_closed, errors}`` for observability.
+        Failures are caught by the caller (:meth:`_housekeeping_tick`).
+        """
+        assert self._conn is not None, "connect() must run before housekeeping"
+        rows: list[tuple[int, int | None]] = []
+        try:
+            with self._conn.cursor() as cur:
+                # exec-mode-agnostic (#3158): reads succeeded+merged rows for GH-side
+                # cleanup only; execution_mode has no bearing on whether a PR merged.
+                cur.execute(
+                    "SELECT issue_number, pr_number FROM dispatcher.agents "
+                    "WHERE status = 'succeeded' "
+                    "  AND merged_at IS NOT NULL",
+                )
+                rows = list(cur.fetchall())
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return {"rows_scanned": 0, "issues_closed": 0, "errors": 1}
+
+        rows_scanned = 0
+        issues_closed = 0
+        errors = 0
+        for row in rows:
+            issue_number_r: int = row[0]
+            pr_number_r: int | None = row[1]
+            rows_scanned += 1
+            try:
+                self._close_issue_post_merge(issue_number_r, pr_number_r)
+                issues_closed += 1
+            except Exception:
+                errors += 1
+                self._log.exception(
+                    "daemon.housekeeping_succeeded_cleanup_error",
+                    extra={
+                        "event": "housekeeping_succeeded_cleanup_error",
+                        "run_id": self._run_id,
+                        "issue_number": issue_number_r,
+                        "pr_number": pr_number_r,
+                    },
+                )
+        return {
+            "rows_scanned": rows_scanned,
+            "issues_closed": issues_closed,
+            "errors": errors,
+        }
+
     def _housekeeping_close_orphan_prs(self) -> dict[str, int]:
         """Close open ``agent/*`` PRs whose every target issue is CLOSED (#3852).
 
@@ -26504,6 +26595,31 @@ class DispatcherDaemon:
                 "daemon.reconcile_stale_merged_at_failed",
                 extra={
                     "event": "reconcile_stale_merged_at_failed",
+                    "run_id": self._run_id,
+                },
+            )
+
+        # Issue #3738: close GitHub issues for succeeded+merged rows
+        # whose SQL gate was narrowed by migration 57. Runs in its own
+        # try/except so a GitHub flake here does not break the prune
+        # loop or merged_at reconcile.
+        try:
+            _cleanup_result = self._cleanup_stale_succeeded_rows()
+            self._log.info(
+                "daemon.housekeeping_succeeded_cleanup",
+                extra={
+                    "event": "housekeeping_succeeded_cleanup",
+                    "run_id": self._run_id,
+                    "rows_scanned": _cleanup_result["rows_scanned"],
+                    "issues_closed": _cleanup_result["issues_closed"],
+                    "errors": _cleanup_result["errors"],
+                },
+            )
+        except Exception:
+            self._log.exception(
+                "daemon.housekeeping_succeeded_cleanup_failed",
+                extra={
+                    "event": "housekeeping_succeeded_cleanup_failed",
                     "run_id": self._run_id,
                 },
             )

--- a/scripts/dispatcher/tests/test_daemon_already_attempted_with_merged_pr.py
+++ b/scripts/dispatcher/tests/test_daemon_already_attempted_with_merged_pr.py
@@ -1,0 +1,288 @@
+"""Unit tests for migration 57 merged-aware ``_issue_already_attempted`` fix.
+
+Issue #3738.  ``dispatcher.issue_has_active_agent`` (migration 57) was
+narrowed so that a ``succeeded`` row with ``merged_at IS NOT NULL`` no
+longer blocks re-claim.  These tests pin:
+
+* ``_issue_already_attempted`` delegates to the SQL function and surfaces
+  True/False correctly.
+* ``_cleanup_stale_succeeded_rows`` iterates stale rows and calls
+  ``_close_issue_post_merge`` per row.
+* ``_housekeeping_tick`` emits ``daemon.housekeeping_succeeded_cleanup``
+  with the stubbed counts.
+
+All DB interaction is against ``_FakeCursor`` / ``_FakeConnection`` stubs
+matching the shape in ``test_daemon_execution_mode_audit.py``; no real
+Postgres is needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (same shape as test_daemon_execution_mode_audit.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(
+        f"dispatcher.test.already_attempted_merged.{id(tmp_path)}"
+    )
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# (a) _issue_already_attempted returns False when SQL stubs (False,)
+# --------------------------------------------------------------------------
+
+
+class TestIssueAlreadyAttemptedReturnsFalse:
+    """SQL function returning False → method returns False (eligible)."""
+
+    def test_returns_false_when_sql_returns_false(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # SQL stub: issue_has_active_agent returns FALSE (not blocked).
+        conn.cursor_instance.fetch_queue = [(False,)]
+
+        result = d._issue_already_attempted(3738)
+
+        assert result is False, (
+            "_issue_already_attempted must return False when SQL returns False "
+            "(issue is eligible for re-claim)"
+        )
+
+        selects = [
+            e for e in conn.cursor_instance.executed if "issue_has_active_agent" in e[0]
+        ]
+        assert selects, "expected SELECT dispatcher.issue_has_active_agent(%s)"
+        assert selects[0][1] == (3738,)
+
+
+# --------------------------------------------------------------------------
+# (b) _issue_already_attempted returns True when SQL stubs (True,)
+# --------------------------------------------------------------------------
+
+
+class TestIssueAlreadyAttemptedReturnsTrue:
+    """SQL function returning True → method returns True (blocked)."""
+
+    def test_returns_true_when_sql_returns_true(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # SQL stub: issue_has_active_agent returns TRUE (still blocked).
+        conn.cursor_instance.fetch_queue = [(True,)]
+
+        result = d._issue_already_attempted(1234)
+
+        assert result is True, (
+            "_issue_already_attempted must return True when SQL returns True "
+            "(issue is blocked from re-claim)"
+        )
+
+
+# --------------------------------------------------------------------------
+# (c) _cleanup_stale_succeeded_rows calls _close_issue_post_merge once
+#     and returns {rows_scanned:1, issues_closed:1, errors:0}
+# --------------------------------------------------------------------------
+
+
+class TestCleanupStaleSucceededRowsOneRow:
+    """One stale row → _close_issue_post_merge called once, counts correct."""
+
+    def test_calls_close_and_returns_counts(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # SELECT returns one (issue_number=999, pr_number=888) row.
+        conn.cursor_instance.fetchall_queue = [[(999, 888)]]
+
+        close_calls: list[tuple[int, int | None]] = []
+
+        def fake_close(issue_number: int, pr_number: int | None) -> None:
+            close_calls.append((issue_number, pr_number))
+
+        d._close_issue_post_merge = fake_close  # type: ignore[assignment]
+
+        result = d._cleanup_stale_succeeded_rows()
+
+        assert close_calls == [(999, 888)], (
+            "_cleanup_stale_succeeded_rows must call "
+            "_close_issue_post_merge(999, 888) exactly once"
+        )
+        assert result == {"rows_scanned": 1, "issues_closed": 1, "errors": 0}, (
+            f"expected {{rows_scanned:1, issues_closed:1, errors:0}}, got {result}"
+        )
+
+        # Confirm the SELECT targeted the right predicate.
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "status = 'succeeded'" in e[0] and "merged_at IS NOT NULL" in e[0]
+        ]
+        assert selects, (
+            "expected SELECT … WHERE status = 'succeeded' AND merged_at IS NOT NULL"
+        )
+
+
+# --------------------------------------------------------------------------
+# (d) empty fetchall_queue → all-zero counts
+# --------------------------------------------------------------------------
+
+
+class TestCleanupStaleSucceededRowsEmpty:
+    """Empty SELECT result → zero counts, no _close_issue_post_merge calls."""
+
+    def test_all_zero_counts_when_no_rows(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # SELECT returns no rows.
+        conn.cursor_instance.fetchall_queue = [[]]
+
+        close_calls: list[Any] = []
+
+        def fake_close(issue_number: int, pr_number: int | None) -> None:
+            close_calls.append((issue_number, pr_number))
+
+        d._close_issue_post_merge = fake_close  # type: ignore[assignment]
+
+        result = d._cleanup_stale_succeeded_rows()
+
+        assert close_calls == [], (
+            "_close_issue_post_merge must not be called when there are no rows"
+        )
+        assert result == {"rows_scanned": 0, "issues_closed": 0, "errors": 0}, (
+            f"expected all-zero counts, got {result}"
+        )
+
+
+# --------------------------------------------------------------------------
+# (e) _housekeeping_tick emits housekeeping_succeeded_cleanup log record
+# --------------------------------------------------------------------------
+
+
+class TestHousekeepingTickEmitsSucceededCleanupLog:
+    """_housekeeping_tick emits daemon.housekeeping_succeeded_cleanup."""
+
+    def test_log_record_emitted_with_stubbed_counts(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Stub _cleanup_stale_succeeded_rows to avoid real DB/GitHub calls
+        # and return a deterministic result.
+        stub_result = {"rows_scanned": 2, "issues_closed": 1, "errors": 0}
+
+        def fake_cleanup() -> dict[str, int]:
+            return stub_result
+
+        monkeypatch.setattr(d, "_cleanup_stale_succeeded_rows", fake_cleanup)
+
+        # Stub the other housekeeping helpers that would otherwise fail.
+        monkeypatch.setattr(d, "_reconcile_stale_merged_at", lambda: {})
+        monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0)
+        monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0)
+        monkeypatch.setattr(d, "_housekeeping_close_orphan_prs", lambda: {})
+
+        # Pad fetch_queue with None × len(_HOUSEKEEPING_TARGETS) so the
+        # retention-lookup path in _read_retention_days doesn't crash.
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        d._housekeeping_tick()
+
+        events = handler.events("housekeeping_succeeded_cleanup")
+        assert len(events) == 1, (
+            f"expected exactly one housekeeping_succeeded_cleanup event, "
+            f"got {len(events)}"
+        )
+        record = events[0]
+        assert getattr(record, "rows_scanned") == stub_result["rows_scanned"]
+        assert getattr(record, "issues_closed") == stub_result["issues_closed"]
+        assert getattr(record, "errors") == stub_result["errors"]
+        assert getattr(record, "run_id") == "test-run-id"


### PR DESCRIPTION
## Summary

Dispatcher daemon was blocked indefinitely on ~150 stale `succeeded` agent rows whose PRs had merged but issues weren't auto-closed. Migration 57 redefines `dispatcher.issue_has_active_agent` to ignore merged rows (merged_at IS NOT NULL), unblocking re-claim immediately. A new housekeeping method closes the originating issues for merged rows, completing the cleanup.

Closes #3738

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green (pre-push hook verified)

### Post-deploy verification

- [ ] Run `scripts/cleanup-stale-succeeded-rows.sh` against dev; observe queue depth becomes claimable post-run
- [ ] Observe `candidate_picked` events resume on previously-stuck issues in CloudWatch Logs
- [ ] Daemon idle hours drop to 0 (absent legitimate cooldowns)
- [ ] Verification evidence posted on #3738 (see /task-v2-verify output)