### PR TITLE
feat(dispatcher): add dispatcher-v3 Python package skeleton + runners.py (#3878)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,14 @@ jobs:
       - name: Test dispatcher daemon skeleton
         if: matrix.shard == 'python'
         run: pytest scripts/dispatcher/tests/ -v --tb=short -n auto -m "not integration"
+      # Dispatcher v3 task-runner tests (scripts/dispatcher_v3/tests/).
+      # Separate invocation because these live in their own package dir
+      # (scripts/dispatcher_v3/tests/) rather than under scripts/tests/.
+      # Pure Python — no DB or AWS imports. See issue #3878 for the
+      # package skeleton story.
+      - name: Test dispatcher v3 task-runner skeleton
+        if: matrix.shard == 'python'
+        run: pytest scripts/dispatcher_v3/tests/ -v --tb=short -n auto
       - name: Check AWS CLI boolean flag usage
         if: matrix.shard == 'python'
         run: scripts/check-aws-bool-flags.sh

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ __pycache__/
 .venv/
 # Dispatcher daemon venv (created by scripts/install-dispatcher-venv.sh)
 scripts/dispatcher/.venv/
+# Dispatcher v3 task-runner venv (created by scripts/install-dispatcher-v3-venv.sh)
+scripts/dispatcher_v3/.venv/
 .venv-scripts/
 venv/
 

--- a/scripts/dispatcher_v3/__init__.py
+++ b/scripts/dispatcher_v3/__init__.py
@@ -1,0 +1,8 @@
+"""dispatcher-v3 — per-phase task-runner package.
+
+Foundational Python package for the v3 dispatcher buildout. Loaded by the
+v3 task-runner ECS task and by future helper scripts. Pure Python — no
+DB or AWS imports at module-import time.
+
+See issue #3878 for the package skeleton story.
+"""

--- a/scripts/dispatcher_v3/runners.py
+++ b/scripts/dispatcher_v3/runners.py
@@ -1,0 +1,72 @@
+"""Runner argv builders for the dispatcher-v3 task-runner.
+
+The v3 task-runner ECS task launches one of several CLI agents (claude,
+gemini, opencode, cursor) per dispatched issue. Argv construction is
+centralized here so adding a new runner is one ``RUNNERS`` dict entry
+plus one test, and so the empirically-discovered ``--worktree=NAME``
+foot-gun (see PR #3868 and issue #3835) is documented in code rather
+than re-discovered at the call site.
+
+This module is intentionally tiny and dependency-free at import time so
+the dispatcher daemon, the task-runner entrypoint, and unit tests can
+all import it without dragging in boto3 or psycopg.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Callable
+
+# IMPORTANT: ``--worktree`` takes an OPTIONAL value, so passing it as
+# ``-w "<prompt>"`` causes the prompt to be consumed as the worktree
+# name. Always use ``--worktree=NAME`` form (with the ``=``), with the
+# prompt as the trailing positional argument. Established empirically
+# via PR #3868 / issue #3835 — do not "simplify" by switching to ``-w``.
+RUNNERS: dict[str, Callable[[str, str], list[str]]] = {
+    "claude": lambda n, agent_id: [
+        "claude",
+        "-p",
+        f"--worktree=agent-{agent_id}",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        f"/task #{n}",
+    ],
+    "gemini": lambda n, agent_id: [
+        "gemini",
+        "-p",
+        f"Run /task for issue #{n}",
+        "--output-format",
+        "stream-json",
+    ],
+    "opencode": lambda n, agent_id: [
+        "timeout",
+        "6h",
+        "opencode",
+        "run",
+        f"Run /task for issue #{n}",
+    ],
+    "cursor": lambda n, agent_id: [
+        "timeout",
+        "6h",
+        "cursor-agent",
+        "-p",
+        f"Run /task for issue #{n}",
+        "-m",
+        os.environ.get("MODEL", ""),
+    ],
+}
+
+
+def build_argv(runner: str, issue_number: str, agent_id: str) -> list[str]:
+    """Return the argv list for ``runner`` with the given issue + agent id.
+
+    Exits the process with a usage error if ``runner`` is not registered
+    in ``RUNNERS``. The dispatcher's task-runner is a one-shot subprocess
+    so ``sys.exit`` is the right escalation here — there is no reason to
+    raise and unwind when we cannot proceed.
+    """
+    if runner not in RUNNERS:
+        sys.exit(f"unknown runner: {runner}")
+    return RUNNERS[runner](issue_number, agent_id)

--- a/scripts/dispatcher_v3/tests/test_runners.py
+++ b/scripts/dispatcher_v3/tests/test_runners.py
@@ -1,0 +1,113 @@
+"""Unit tests for ``dispatcher_v3.runners``.
+
+The tests pin the exact argv shapes for each registered runner. They
+double as living spec for the ``--worktree=NAME`` foot-gun: if a future
+PR "simplifies" the claude form to ``-w "<prompt>"``, the
+``test_claude_uses_equals_worktree_form`` assertion fails loudly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dispatcher_v3.runners import RUNNERS, build_argv
+
+
+def test_runners_dict_has_expected_keys() -> None:
+    """The four registered runners are claude, gemini, opencode, cursor."""
+    assert sorted(RUNNERS.keys()) == ["claude", "cursor", "gemini", "opencode"]
+
+
+def test_build_argv_claude_returns_exact_argv() -> None:
+    """The claude argv is pinned, single-token --worktree=NAME and trailing prompt."""
+    argv = build_argv("claude", "3835", "abc-123")
+    assert argv == [
+        "claude",
+        "-p",
+        "--worktree=agent-abc-123",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "/task #3835",
+    ]
+
+
+def test_claude_uses_equals_worktree_form() -> None:
+    """``--worktree=agent-...`` is a single argv element (the equals form).
+
+    Regression guard for PR #3868 / issue #3835: ``-w "<prompt>"`` causes
+    the prompt to be consumed as the worktree name because ``-w`` takes
+    an optional value. The fix is the ``=`` form. If anyone splits this
+    into two argv elements (``--worktree`` then ``agent-...``) or
+    switches to ``-w``, this test fails.
+    """
+    argv = build_argv("claude", "1", "fixture-id")
+    assert "--worktree=agent-fixture-id" in argv
+    # --worktree must NOT appear as a bare token followed by a separate value.
+    assert "--worktree" not in argv
+    assert "-w" not in argv
+
+
+def test_build_argv_gemini_returns_expected_argv() -> None:
+    """The gemini argv shape is the per-spec ``gemini -p '<prompt>' --output-format stream-json``."""
+    argv = build_argv("gemini", "42", "agent-xyz")
+    assert argv == [
+        "gemini",
+        "-p",
+        "Run /task for issue #42",
+        "--output-format",
+        "stream-json",
+    ]
+
+
+def test_build_argv_opencode_returns_expected_argv() -> None:
+    """The opencode argv shape is wrapped in ``timeout 6h`` per spec §12."""
+    argv = build_argv("opencode", "100", "agent-foo")
+    assert argv == [
+        "timeout",
+        "6h",
+        "opencode",
+        "run",
+        "Run /task for issue #100",
+    ]
+
+
+def test_build_argv_cursor_returns_expected_argv_with_model_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cursor argv pulls the model from the ``MODEL`` env var at call time."""
+    monkeypatch.setenv("MODEL", "gpt-5")
+    argv = build_argv("cursor", "7", "agent-bar")
+    assert argv == [
+        "timeout",
+        "6h",
+        "cursor-agent",
+        "-p",
+        "Run /task for issue #7",
+        "-m",
+        "gpt-5",
+    ]
+
+
+def test_build_argv_cursor_falls_back_to_empty_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``MODEL`` is unset, cursor's ``-m`` arg is the empty string.
+
+    Lambdas in ``RUNNERS`` read ``os.environ`` lazily at call time, so an
+    unset env var resolves to ``""`` rather than ``None``. The cursor
+    CLI handles the empty default; the test pins this behavior so a
+    future refactor doesn't accidentally pass ``None``.
+    """
+    monkeypatch.delenv("MODEL", raising=False)
+    argv = build_argv("cursor", "7", "agent-bar")
+    assert argv[-1] == ""
+    assert argv[-2] == "-m"
+
+
+def test_build_argv_unknown_runner_raises_systemexit() -> None:
+    """Unknown runner names exit the process with a usage error."""
+    with pytest.raises(SystemExit) as excinfo:
+        build_argv("unknown", "1", "agent-1")
+    # SystemExit can carry a string or an int; ours is a string message.
+    assert "unknown runner: unknown" in str(excinfo.value)

--- a/scripts/install-dispatcher-v3-venv.sh
+++ b/scripts/install-dispatcher-v3-venv.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# install-dispatcher-v3-venv.sh — Create and populate a Python venv for the
+# dispatcher v3 task-runner scripts at scripts/dispatcher_v3/.
+#
+# Mirrors install-dispatcher-venv.sh: scripts/dispatcher_v3/ has no
+# pyproject.toml, so scripts/install-package-venv.sh (which requires a
+# packages/<name>/ directory) cannot bootstrap its venv. This dedicated
+# helper creates scripts/dispatcher_v3/.venv and installs the dependencies
+# needed to run the v3 unit tests.
+#
+# Usage:
+#   scripts/install-dispatcher-v3-venv.sh
+#
+# No arguments are accepted — the venv path is fixed at
+# scripts/dispatcher_v3/.venv relative to the repo root. Idempotent: if the
+# venv already exists it is reused; pip install is cheap when dependencies
+# are already satisfied.
+#
+# Dependency installation order:
+#   1. pytest, pytest-xdist, ruff, boto3  (PyPI)
+#
+# v3 has no judgemind-config dependency at this stage — boto3 is the only
+# AWS-side import needed by the task-runner. If a future v3 module imports
+# judgemind-config, add the editable install here and update this comment.
+#
+# Exit codes:
+#   0 — venv is populated and usable
+#   1 — usage error or install failure
+
+set -euo pipefail
+
+# ── Resolve repo root ────────────────────────────────────────────────────
+# Walk up from this script's location looking for a directory that has both
+# CLAUDE.md and .git. In worktrees .git is a file; the main repo has .git
+# as a directory. We accept either.
+find_repo_root() {
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/CLAUDE.md" && -e "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    echo "ERROR: cannot find repo root (looked for CLAUDE.md + .git)" >&2
+    return 1
+}
+REPO_ROOT="$(find_repo_root)"
+
+# ── Validate arguments ───────────────────────────────────────────────────
+
+if [[ $# -ne 0 ]]; then
+    echo "Usage: scripts/install-dispatcher-v3-venv.sh" >&2
+    echo "" >&2
+    echo "This script takes no arguments — the venv path is fixed at" >&2
+    echo "  scripts/dispatcher_v3/.venv" >&2
+    exit 1
+fi
+
+VENV_DIR="$REPO_ROOT/scripts/dispatcher_v3/.venv"
+PY=python3.12
+
+# ── Create the venv if missing ───────────────────────────────────────────
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "Creating venv at $VENV_DIR"
+    "$PY" -m venv "$VENV_DIR"
+fi
+
+PIP="$VENV_DIR/bin/pip"
+
+if [[ ! -x "$PIP" ]]; then
+    echo "ERROR: pip not found in venv at $VENV_DIR (venv may be corrupt)" >&2
+    echo "Delete it and re-run: rm -rf $VENV_DIR" >&2
+    exit 1
+fi
+
+# ── Install PyPI dependencies ─────────────────────────────────────────────
+# pytest + pytest-xdist + ruff for the test loop. boto3 for the v3
+# task-runner's AWS interactions (DescribeTasks, RunTask, etc.) — kept
+# in the venv even though runners.py itself doesn't import it, so future
+# v3 modules can be added without touching this install list.
+
+echo "Installing PyPI dependencies: pytest pytest-xdist ruff boto3"
+"$PIP" install --quiet pytest pytest-xdist ruff boto3
+
+echo "Done. Venv ready at $VENV_DIR"


### PR DESCRIPTION
## Summary

Adds the `scripts/dispatcher_v3/` Python package skeleton — `__init__.py`, `runners.py` (the `RUNNERS` dict + `build_argv()`), and unit tests. Foundational piece: most other v3 PRs (C2, C3, etc.) will import from `dispatcher_v3.runners`. Pins the empirically-discovered `--worktree=NAME` foot-gun (PR #3868 / issue #3835) in code + a regression test so it isn't accidentally "simplified" to `-w "<prompt>"`.

Also adds `scripts/install-dispatcher-v3-venv.sh` (bootstrap helper mirroring `install-dispatcher-venv.sh`), a CI step parallel to the v2 step, and a `.gitignore` entry for the v3 venv.

Closes #3878

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (Python package skeleton only; not yet wired into the daemon image or any ECS task definition). The new CI step `Test dispatcher v3 task-runner skeleton` will run the suite on every PR.
