### PR TITLE
feat(dx): add scripts/wait-for-ci.sh canonical CI-completion helper (#3900)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -552,7 +552,15 @@ Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {wo
 
 **Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher. **Use `timeout: 1200000`** as CI runs typically take 10-25 minutes.
 
-`gh run watch` has no MCP equivalent — stays on `gh`:
+Use `scripts/wait-for-ci.sh` as the canonical PR CI gate:
+
+```
+scripts/wait-for-ci.sh <PR-N>
+```
+
+This polls the check-runs API with `filter=latest` (deduplicates re-runs) and exits 0 only when `ci-passed` is success, no check has failed, and `mergeStateStatus` is CLEAN or UNSTABLE. Exit 1 = failure, Exit 2 = timeout.
+
+For workflow-run-level watching (deploy workflows in §A.8), `gh run watch` stays as the fallback:
 
 ```
 gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact

--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# test_wait_for_ci.sh — Unit tests for scripts/wait-for-ci.sh
+#
+# Exercises the check-runs polling loop against a mock gh CLI that emits a
+# sequence of pre-canned JSON responses keyed on call number. Verifies the
+# success (exit 0), early-failure (exit 1), timeout (exit 2), missing-arg,
+# and --help paths.
+#
+# Usage:
+#   scripts/tests/test_wait_for_ci.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/wait-for-ci.sh"
+
+if [ ! -x "$SCRIPT_UNDER_TEST" ]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+# shellcheck disable=SC2329  # invoked via trap below
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [ -n "$d" ] && [ -d "$d" ]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    mkdir -p "$dir/responses"
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+}
+
+# Create a mock `gh` CLI that reads a sequence of JSON blobs from a responses
+# directory, emitting each on successive calls. The mock handles:
+#   - `gh pr view ... --json headRefOid`  → canned SHA from SHA_RESPONSE env
+#   - `gh api repos/.../check-runs...`   → next response from $RESPONSES_DIR/NN.json
+#   - `gh pr view ... --json mergeStateStatus` → canned status from MERGE_STATE_RESPONSE env
+#
+# Usage: setup_mock_gh <tmpdir>
+setup_mock_gh() {
+    local tmpdir="$1"
+    local mock="$tmpdir/gh"
+
+    mkdir -p "$tmpdir/responses"
+
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+# Mock gh CLI — routes calls based on argument patterns.
+set -euo pipefail
+
+RESPONSES_DIR="${RESPONSES_DIR:?RESPONSES_DIR required}"
+CALL_COUNTER_FILE="${CALL_COUNTER_FILE:?CALL_COUNTER_FILE required}"
+SHA_RESPONSE="${SHA_RESPONSE:-deadbeefdeadbeef}"
+MERGE_STATE_RESPONSE="${MERGE_STATE_RESPONSE:-CLEAN}"
+
+ARGS="$*"
+
+# Route: pr view ... headRefOid — return canned SHA (plain string, like gh -q output).
+case "$ARGS" in
+    *"headRefOid"*)
+        printf '%s\n' "$SHA_RESPONSE"
+        exit 0
+        ;;
+    *"mergeStateStatus"*)
+        printf '%s\n' "$MERGE_STATE_RESPONSE"
+        exit 0
+        ;;
+    *"check-runs"*)
+        # Fall through to response-file dispatch below.
+        ;;
+    *)
+        echo "MOCK: unrecognised call: $ARGS" >&2
+        exit 1
+        ;;
+esac
+
+# Read and increment call counter.
+if [ -f "$CALL_COUNTER_FILE" ]; then
+    COUNT=$(cat "$CALL_COUNTER_FILE")
+else
+    COUNT=0
+fi
+COUNT=$((COUNT + 1))
+printf '%s' "$COUNT" > "$CALL_COUNTER_FILE"
+
+# Pick response file; clamp to highest available.
+RESPONSE_FILE=$(printf '%s/%02d.json' "$RESPONSES_DIR" "$COUNT")
+if [ ! -f "$RESPONSE_FILE" ]; then
+    # Fall back to the highest-numbered file.
+    RESPONSE_FILE=$(ls -1 "$RESPONSES_DIR"/*.json 2>/dev/null | sort | tail -n 1 || echo "")
+fi
+
+if [ -z "$RESPONSE_FILE" ] || [ ! -f "$RESPONSE_FILE" ]; then
+    echo "MOCK ERROR: no response file available for call $COUNT" >&2
+    exit 1
+fi
+
+cat "$RESPONSE_FILE"
+MOCK
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+# Run the script under test with the mock gh wired up.
+# Usage: run_script <tmpdir> [extra-args...]
+run_script() {
+    local tmpdir="$1"
+    shift
+    local mock_gh
+    mock_gh=$(setup_mock_gh "$tmpdir")
+
+    PATH="$tmpdir:$PATH" \
+    RESPONSES_DIR="$tmpdir/responses" \
+    CALL_COUNTER_FILE="$tmpdir/counter" \
+    SHA_RESPONSE="${SHA_RESPONSE:-deadbeefdeadbeef}" \
+    MERGE_STATE_RESPONSE="${MERGE_STATE_RESPONSE:-CLEAN}" \
+        "$SCRIPT_UNDER_TEST" "$@"
+}
+
+# Write a check-runs response where all checks are in_progress.
+write_in_progress_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",       "status": "in_progress", "conclusion": null, "details_url": "https://example.com/lint"},
+    {"name": "unit-tests", "status": "in_progress", "conclusion": null, "details_url": "https://example.com/unit"}
+  ]
+}
+JSON
+}
+
+# Write a check-runs response where all checks succeeded including ci-passed.
+write_all_success_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",       "status": "completed", "conclusion": "success", "details_url": "https://example.com/lint"},
+    {"name": "unit-tests", "status": "completed", "conclusion": "success", "details_url": "https://example.com/unit"},
+    {"name": "ci-passed",  "status": "completed", "conclusion": "success", "details_url": "https://example.com/ci"}
+  ]
+}
+JSON
+}
+
+# Write a check-runs response with one failed check.
+write_failure_response() {
+    local file="$1"
+    local check_name="${2:-web-tests}"
+    cat > "$file" << JSON
+{
+  "check_runs": [
+    {"name": "lint",        "status": "completed", "conclusion": "success",  "details_url": "https://example.com/lint"},
+    {"name": "$check_name", "status": "completed", "conclusion": "failure",  "details_url": "https://example.com/web-tests"}
+  ]
+}
+JSON
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: Happy path — first poll in-progress, second poll all success + ci-passed,
+# then mergeStateStatus=CLEAN. Expect exit 0.
+test_happy_path() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_in_progress_response "$tmpdir/responses/01.json"
+    write_all_success_response "$tmpdir/responses/02.json"
+
+    local output exit_code
+    exit_code=0
+    output=$(MERGE_STATE_RESPONSE=CLEAN \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "happy_path: exits 0 on success"
+    else
+        fail "happy_path: exits 0 on success" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "CI passed"; then
+        pass "happy_path: emits success message"
+    else
+        fail "happy_path: emits success message" "output=$output"
+    fi
+}
+
+# Test 2: Early failure — first check-runs poll returns web-tests=failure.
+# Expect exit 1, output mentions "web-tests".
+test_early_failure() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_response "$tmpdir/responses/01.json" "web-tests"
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "early_failure: exits 1 on failure"
+    else
+        fail "early_failure: exits 1 on failure" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "web-tests"; then
+        pass "early_failure: output mentions failed check name"
+    else
+        fail "early_failure: output mentions failed check name" "output=$output"
+    fi
+}
+
+# Test 3: Timeout — check-runs always returns in_progress. Use short timeout. Expect exit 2.
+test_timeout() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_in_progress_response "$tmpdir/responses/01.json"
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 42 --timeout-secs 2 --poll-interval 1 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 2 ]; then
+        pass "timeout: exits 2 on timeout"
+    else
+        fail "timeout: exits 2 on timeout" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "Timed out"; then
+        pass "timeout: emits timeout message"
+    else
+        fail "timeout: emits timeout message" "output=$output"
+    fi
+}
+
+# Test 4: Missing pr-number arg (no --help). Expect non-zero exit.
+test_missing_pr_arg() {
+    local output exit_code
+    exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -ne 0 ]; then
+        pass "missing_pr_arg: exits non-zero when no pr-number given"
+    else
+        fail "missing_pr_arg: exits non-zero when no pr-number given" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -qi "required\|usage"; then
+        pass "missing_pr_arg: emits helpful error"
+    else
+        fail "missing_pr_arg: emits helpful error" "output=$output"
+    fi
+}
+
+# Test 5: --help flag. Expect exit 0 and output mentions "Usage".
+test_help() {
+    local output exit_code
+    exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" --help 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "help: exits 0 with --help"
+    else
+        fail "help: exits 0 with --help" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -qi "usage"; then
+        pass "help: output mentions Usage"
+    else
+        fail "help: output mentions Usage" "output=$output"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_happy_path
+test_early_failure
+test_timeout
+test_missing_pr_arg
+test_help
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# wait-for-ci.sh — Poll a PR's check-runs until CI is definitively green or
+# definitively failed, then emit a structured exit code the caller can act on.
+#
+# # venv: none
+# # permanent: true
+#
+# ── Why check-runs?per_page=100&filter=latest — not the alternatives ─────────
+#
+# Several seemingly equivalent GitHub API surfaces are unreliable for this
+# purpose. Empirically documented in #3897:
+#
+# 1. `gh run view --json status` — rolls up workflow-level status. A workflow
+#    transitions to `completed` as soon as all its *jobs* are finished, but
+#    GitHub's rollup can briefly report `completed` while sibling jobs in other
+#    workflows are still queued. Misleading for multi-workflow repos.
+#
+# 2. `gh run list --json status` — same workflow-level rollup lag. Listing all
+#    runs and checking status has the same blind spot: each row is one workflow
+#    run, not one check.
+#
+# 3. `gh api repos/.../check-runs --paginate` — the paginate flag sends N
+#    separate page requests. Because GitHub can insert new check-runs (re-runs)
+#    between page fetches, a long-running re-run can appear on page 2 as
+#    `in_progress` while page 1 already returned the old completed entry.
+#    Inconsistent page splits produce false-positive "all passed" reads.
+#
+# 4. `gh pr view --json mergeStateStatus` — GitHub computes `mergeStateStatus`
+#    over the *entire history* of check runs on the head SHA (not the latest
+#    per-check attempt). A stale failed run from an earlier CI attempt keeps
+#    the PR in `UNSTABLE` forever even after a successful re-run flips the
+#    rollup green. Querying it as the primary CI gate produces false negatives
+#    for every PR that ever had a flaky check re-run. It lags job-state changes
+#    by ~10 minutes due to GitHub's PR rollup cache. (Still useful as a
+#    secondary guard after check-runs confirm green — see §Success below.)
+#
+# The canonical approach: `GET /repos/{owner}/{repo}/commits/{sha}/check-runs
+# ?per_page=100&filter=latest` returns exactly one entry per unique check name
+# — the most recent run — in a single non-paginated response (GitHub caps at
+# 100 checks per commit; repos with >100 checks need --paginate but that is an
+# edge case addressed by the per_page=100 guard). No page-split races, no
+# stale history.
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#
+# Usage: scripts/wait-for-ci.sh <pr-number> [options]
+#
+# Arguments:
+#   <pr-number>         PR number to monitor (required unless --help)
+#
+# Options:
+#   --timeout-secs N    Overall timeout in seconds (default: 1800)
+#   --poll-interval N   Polling interval in seconds (default: 30)
+#   --repo OWNER/REPO   GitHub repository (default: judgemind/judgemind)
+#   --help              Print this help and exit 0
+#
+# Exit codes:
+#   0 — Success: ci-passed check has conclusion=success, no other latest check
+#       has conclusion=failure/timed_out/action_required/cancelled, AND
+#       mergeStateStatus is CLEAN or UNSTABLE.
+#   1 — Early failure: one or more checks have a failed conclusion. Prints the
+#       failed check names and their details_url.
+#   2 — Timeout: --timeout-secs elapsed without reaching a terminal state.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+
+TIMEOUT_SECS=1800
+POLL_INTERVAL=30
+REPO="judgemind/judgemind"
+PR_NUMBER=""
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+print_help() {
+    grep '^# Usage:' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Arguments:' "$0" | sed 's/^# //'
+    grep '^#   <pr-number>' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Options:' "$0" | sed 's/^# //'
+    grep '^#   --' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Exit codes:' "$0" | sed 's/^# //'
+    grep '^#   [012]' "$0" | sed 's/^# //'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        --timeout-secs)
+            TIMEOUT_SECS="$2"
+            shift 2
+            ;;
+        --poll-interval)
+            POLL_INTERVAL="$2"
+            shift 2
+            ;;
+        --repo)
+            REPO="$2"
+            shift 2
+            ;;
+        --*)
+            echo "ERROR: Unknown option: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 1
+            ;;
+        *)
+            if [ -z "$PR_NUMBER" ]; then
+                PR_NUMBER="$1"
+                shift
+            else
+                echo "ERROR: Unexpected argument: $1" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+if [ -z "$PR_NUMBER" ]; then
+    echo "ERROR: <pr-number> is required." >&2
+    echo "Run with --help for usage." >&2
+    exit 1
+fi
+
+# ── Resolve PR head SHA ───────────────────────────────────────────────────────
+
+echo "Resolving head SHA for PR #${PR_NUMBER} in ${REPO}..."
+SHA=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid -q .headRefOid)
+
+if [ -z "$SHA" ]; then
+    echo "ERROR: Could not resolve head SHA for PR #${PR_NUMBER}." >&2
+    exit 1
+fi
+
+echo "PR #${PR_NUMBER} head SHA: ${SHA}"
+echo "Polling check-runs (timeout: ${TIMEOUT_SECS}s, interval: ${POLL_INTERVAL}s)..."
+echo ""
+
+# ── Poll loop ─────────────────────────────────────────────────────────────────
+
+START_TS=$(date +%s)
+DEADLINE=$((START_TS + TIMEOUT_SECS))
+
+while true; do
+    NOW_TS=$(date +%s)
+    ELAPSED=$((NOW_TS - START_TS))
+
+    # Fetch check-runs with filter=latest (one entry per check name, deduped).
+    CHECK_RUNS_JSON=$(gh api "repos/${REPO}/commits/${SHA}/check-runs?per_page=100&filter=latest" \
+        | jq '.check_runs')
+
+    # Count pending, passed, and failed checks.
+    PENDING_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status != "completed")] | length')
+    PASSED_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status == "completed" and (.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral"))] | length')
+    FAILED_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled"))] | length')
+
+    echo "[${ELAPSED}s] pending=${PENDING_COUNT} passed=${PASSED_COUNT} failed=${FAILED_COUNT}"
+
+    # Check for early failure: any check with a failed conclusion.
+    if [ "$FAILED_COUNT" -gt 0 ]; then
+        echo ""
+        echo "ERROR: ${FAILED_COUNT} check(s) failed:" >&2
+        echo "$CHECK_RUNS_JSON" | jq -r '.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled")) | "  - \(.name): conclusion=\(.conclusion)  \(.details_url // "(no details url)")"' >&2
+        exit 1
+    fi
+
+    # Check for success: ci-passed is success and no failures.
+    CI_PASSED_CONCLUSION=$(echo "$CHECK_RUNS_JSON" | jq -r '.[] | select(.name == "ci-passed") | .conclusion // ""')
+
+    if [ "$CI_PASSED_CONCLUSION" = "success" ] && [ "$FAILED_COUNT" -eq 0 ]; then
+        # Secondary guard: verify mergeStateStatus is CLEAN or UNSTABLE.
+        MERGE_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus -q .mergeStateStatus)
+        if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
+            echo ""
+            echo "CI passed after ${ELAPSED}s. ci-passed=success, mergeStateStatus=${MERGE_STATE}."
+            exit 0
+        else
+            echo "  ci-passed=success but mergeStateStatus=${MERGE_STATE}, still waiting..."
+        fi
+    fi
+
+    # Check timeout before sleeping.
+    if [ "$NOW_TS" -ge "$DEADLINE" ]; then
+        echo ""
+        echo "ERROR: Timed out after ${TIMEOUT_SECS}s waiting for CI on PR #${PR_NUMBER}." >&2
+        echo "Last state: pending=${PENDING_COUNT} passed=${PASSED_COUNT} failed=${FAILED_COUNT}" >&2
+        echo "ci-passed conclusion: ${CI_PASSED_CONCLUSION:-(not yet present)}" >&2
+        exit 2
+    fi
+
+    sleep "$POLL_INTERVAL"
+done


### PR DESCRIPTION
## Summary

Adds `scripts/wait-for-ci.sh` as the canonical PR CI-gate polling primitive. Resolves inconsistencies in GitHub API query surfaces that caused false-positive CI-completion signals (see #3897). Uses the authoritative `check-runs?per_page=100&filter=latest` endpoint, exits 0 only when `ci-passed` succeeds with no other failures and `mergeStateStatus` is CLEAN/UNSTABLE, exits 1/2 on failure/timeout. Includes comprehensive unit tests and detailed header documentation of why the alternatives are unreliable.

Closes #3900

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`scripts/tests/test_wait_for_ci.sh` — 5 tests all pass)
- [x] CI green

### Post-deploy verification

- [ ] Script behaves correctly on live PRs: `scripts/wait-for-ci.sh <PR-N>` exits 0 on passing CI, 1 on failure, 2 on timeout
- [ ] Verification evidence posted on #3900 (manual invocation output)