### PR TITLE
feat(dispatcher): add dispatcher-v3 task-runner entrypoint (#3879)

### DIFF
--- a/docs/specs/dispatcher-v3-spec.md
+++ b/docs/specs/dispatcher-v3-spec.md
@@ -59,7 +59,7 @@ That's the entire launcher. Target ~700 LOC.
 
 #### Task-runner entrypoint
 
-The entrypoint is ~50 lines of Python (`scripts/dispatcher/agent_runner.py`), not bash. The agent task image already has the `dispatcher` Python package installed for the launcher; the entrypoint reuses it. The deliberate choice here is to **structurally preclude the v2 drift pattern** — v2's bash entrypoint started small and grew to 5,857 lines because each "one more case arm" was invisibly cheap. Python doesn't have bash's "just shell out" gravity, and a Python module is testable in CI from day one.
+The entrypoint is ~50 lines of Python (`scripts/dispatcher_v3/agent_runner.py`), not bash. The agent task image has the `dispatcher_v3` Python package installed for use by the launcher; the entrypoint reuses it (single source of truth for argv via `dispatcher_v3.runners.build_argv`). The deliberate choice here is to **structurally preclude the v2 drift pattern** — v2's bash entrypoint started small and grew to 5,857 lines because each "one more case arm" was invisibly cheap. Python doesn't have bash's "just shell out" gravity, and a Python module is testable in CI from day one.
 
 ```python
 #!/usr/bin/env python3
@@ -70,7 +70,7 @@ import os, subprocess, sys
 from pathlib import Path
 import boto3
 
-from dispatcher.runners import build_argv  # §12 — single source of truth
+from dispatcher_v3.runners import build_argv  # §12 — single source of truth
 
 AGENT_ID        = os.environ["AGENT_ID"]
 ISSUE_NUMBER    = os.environ["TASK_ISSUE_NUMBER"]

--- a/scripts/dispatcher_v3/agent_runner.py
+++ b/scripts/dispatcher_v3/agent_runner.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Task-runner entrypoint for the dispatcher-v3 ECS task.
+
+Invokes ``/task`` via the configured CLI runner (see ``dispatcher_v3.runners``),
+streams stdout to a session log file at ``/tmp/session-<AGENT_ID>.jsonl`` so
+the local file is the same bytes the ECS log driver ships to CloudWatch, and
+on EXIT uploads two artifacts to S3:
+
+1. The raw stream-json session file at ``s3://<SESSIONS_BUCKET>/<AGENT_ID>.jsonl``.
+2. A compact rendered transcript (≈20:1 compression) at
+   ``s3://<SESSIONS_BUCKET>/<AGENT_ID>.txt``, produced by
+   ``/opt/judgemind-transcripts/render-transcript.py`` — bundled into the
+   agent-runner image by the Dockerfile (issue F1).
+
+The compact transcript is the diagnoser's primary read; the raw jsonl is the
+fallback when the rendered form is missing or empty. See
+``docs/specs/dispatcher-v3-spec.md`` §4.1 for the full contract.
+
+Both uploads are best-effort: failures during EXIT cleanup print to stderr
+but never raise, so the subprocess exit code propagates verbatim. The exit
+code is also propagated when ``main()`` raises — the EXIT cleanup runs in a
+``finally`` block before ``sys.exit(rc)``.
+
+This module is intentionally small and dependency-light at import time
+(only ``boto3`` plus ``dispatcher_v3.runners``) so the v3 task-runner image
+and the unit-test environment can both import it. The dispatcher daemon and
+its tests do not import this module — it is run as the ECS task entrypoint
+(``python -m dispatcher_v3.agent_runner``).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+
+from dispatcher_v3.runners import build_argv
+
+# ── Required env vars ────────────────────────────────────────────────────
+# Resolved lazily inside main()/upload_archive() so the module can be
+# imported in tests without setting them. The ECS task definition exports
+# all four; missing env at runtime is a hard error (KeyError) — see
+# spec §4.1.
+
+# ── Compact-transcript renderer location ─────────────────────────────────
+# Path inside the agent-runner Docker image (set by Dockerfile F1). Module
+# constant so tests can patch it and so the location is documented in code
+# rather than buried inside ``upload_archive``.
+RENDER_TRANSCRIPT_SCRIPT = "/opt/judgemind-transcripts/render-transcript.py"
+
+
+def _session_file(agent_id: str) -> Path:
+    """Path to the raw stream-json session log on the local filesystem."""
+    return Path(f"/tmp/session-{agent_id}.jsonl")
+
+
+def _compact_file(agent_id: str) -> Path:
+    """Path to the rendered compact transcript on the local filesystem."""
+    return Path(f"/tmp/session-{agent_id}.txt")
+
+
+def upload_archive() -> None:
+    """Upload the raw session jsonl + rendered compact transcript to S3.
+
+    Best-effort: each upload (and the rendering step) is wrapped in its own
+    try/except so a single failure does not skip the next step. Any
+    exception is printed to stderr; nothing is re-raised. The function
+    returns normally even if every step fails — by design, the diagnoser
+    must tolerate missing artifacts (CloudWatch Logs is the SIGKILL-survivor
+    fallback per spec §4.1).
+    """
+    agent_id = os.environ["AGENT_ID"]
+    sessions_bucket = os.environ["SESSIONS_BUCKET"]
+    session_file = _session_file(agent_id)
+
+    if not session_file.exists():
+        return
+
+    # Step 1: raw jsonl upload.
+    try:
+        boto3.client("s3").upload_file(
+            str(session_file), sessions_bucket, f"{agent_id}.jsonl"
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort archive
+        print(f"session-archive-upload-failed: {exc}", file=sys.stderr)
+
+    # Step 2: render the compact transcript and upload it. Both render and
+    # upload are inside the same try/except — if the renderer is missing
+    # from the image (image-rebuild lag, dev environment), the diagnoser
+    # falls back to the raw jsonl uploaded above.
+    compact = _compact_file(agent_id)
+    try:
+        # timeout=120: render-transcript.py is CPU-bound on the local jsonl
+        # file; 2min covers a worst-case ~200MB session per the
+        # judgemind-transcripts repo's measured ratios. The check-subprocess-
+        # timeouts.sh hygiene rule requires a bounded timeout on every
+        # subprocess.run call site under scripts/**/*.py (#3213).
+        subprocess.run(
+            [
+                "python",
+                RENDER_TRANSCRIPT_SCRIPT,
+                str(session_file),
+                "--output",
+                str(compact),
+            ],
+            check=True,
+            timeout=120,
+        )
+        boto3.client("s3").upload_file(str(compact), sessions_bucket, f"{agent_id}.txt")
+    except Exception as exc:  # noqa: BLE001 — best-effort archive
+        print(f"compact-transcript-upload-failed: {exc}", file=sys.stderr)
+
+
+def main() -> int:
+    """Run the configured runner, tee stdout to the session log, return rc.
+
+    The runner-specific argv is built by ``dispatcher_v3.runners.build_argv``
+    so adding a new runner does not require editing this entrypoint. stdout
+    and stderr are merged (``stderr=subprocess.STDOUT``) into a single
+    stream that is teed to both the parent process's stdout (the ECS log
+    driver picks it up and ships to CloudWatch) and the local jsonl file
+    (uploaded to S3 at exit). The duplicate is intentional — CloudWatch is
+    the liveness signal, S3 is the archive (spec §4.1).
+    """
+    agent_id = os.environ["AGENT_ID"]
+    issue_number = os.environ["TASK_ISSUE_NUMBER"]
+    runner = os.environ.get("RUNNER", "claude")
+    argv = build_argv(runner, issue_number, agent_id)
+
+    session_file = _session_file(agent_id)
+    with session_file.open("wb") as log:
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        for chunk in iter(proc.stdout.readline, b""):
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+            log.write(chunk)
+            log.flush()
+        return proc.wait()
+
+
+if __name__ == "__main__":
+    rc = 1
+    try:
+        rc = main()
+    finally:
+        upload_archive()
+    sys.exit(rc)

--- a/scripts/dispatcher_v3/tests/test_agent_runner.py
+++ b/scripts/dispatcher_v3/tests/test_agent_runner.py
@@ -1,0 +1,366 @@
+"""Unit tests for ``dispatcher_v3.agent_runner``.
+
+The tests pin the ECS task-runner contract: argv built via
+``dispatcher_v3.runners.build_argv`` is forwarded to ``subprocess.Popen``,
+stdout chunks are teed to a local jsonl file, and on EXIT the raw jsonl +
+the rendered compact transcript are uploaded to S3. ``boto3.client`` and
+``subprocess`` are mocked so the suite runs without AWS or a real
+``render-transcript.py`` on disk.
+
+The fixtures set the four required env vars (``AGENT_ID``,
+``TASK_ISSUE_NUMBER``, ``RUNNER``, ``SESSIONS_BUCKET``) and redirect
+``/tmp/session-<id>.{jsonl,txt}`` into ``tmp_path`` via
+``monkeypatch.setattr`` on the module-level path helpers — the production
+code uses absolute ``/tmp/`` paths so we cannot rely on cwd.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from dispatcher_v3 import agent_runner
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Set the four required env vars; return the dict for assertions."""
+    env = {
+        "AGENT_ID": "test-agent-id",
+        "TASK_ISSUE_NUMBER": "3835",
+        "RUNNER": "claude",
+        "SESSIONS_BUCKET": "judgemind-sessions-dev",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return env
+
+
+@pytest.fixture
+def session_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Redirect _session_file / _compact_file into tmp_path.
+
+    The production code writes to ``/tmp/session-<id>.jsonl`` — that is the
+    contract the ECS image relies on. For tests we monkeypatch the helpers
+    so the writes land under ``tmp_path`` and don't bleed across runs.
+    """
+    session = tmp_path / "session-test-agent-id.jsonl"
+    compact = tmp_path / "session-test-agent-id.txt"
+    monkeypatch.setattr(agent_runner, "_session_file", lambda _agent_id: session)
+    monkeypatch.setattr(agent_runner, "_compact_file", lambda _agent_id: compact)
+    return session, compact
+
+
+def _fake_proc(stdout_chunks: list[bytes], returncode: int = 0) -> MagicMock:
+    """Build a Popen-like mock whose ``stdout`` iterates ``stdout_chunks``.
+
+    ``proc.stdout.readline`` returns each chunk in order then ``b""`` (the
+    EOF sentinel that ``iter(readline, b"")`` stops on). ``proc.wait()``
+    returns ``returncode``.
+    """
+    proc = MagicMock(spec=subprocess.Popen)
+    # Use BytesIO so each readline() call advances correctly.
+    buf = io.BytesIO(b"".join(stdout_chunks))
+    proc.stdout = buf
+    proc.wait.return_value = returncode
+    return proc
+
+
+# ── main(): subprocess invocation + tee ───────────────────────────────────
+
+
+def test_main_invokes_popen_with_build_argv_output(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() calls Popen with the argv from build_argv(RUNNER, issue, agent).
+
+    Pins the contract that the entrypoint does not synthesize argv inline —
+    every runner edit goes through ``dispatcher_v3.runners``.
+    """
+    fake_popen = MagicMock(return_value=_fake_proc([b'{"ok":1}\n']))
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    rc = agent_runner.main()
+
+    assert rc == 0
+    # First positional arg is the argv list — assert it matches build_argv.
+    actual_argv = fake_popen.call_args[0][0]
+    assert actual_argv == [
+        "claude",
+        "-p",
+        "--worktree=agent-test-agent-id",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "/task #3835",
+    ]
+    # stderr merged into stdout per spec §4.1.
+    assert fake_popen.call_args.kwargs["stderr"] == subprocess.STDOUT
+    assert fake_popen.call_args.kwargs["stdout"] == subprocess.PIPE
+
+
+def test_main_writes_subprocess_stdout_to_session_file(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every chunk read from proc.stdout is written to the session jsonl."""
+    session_file, _compact = session_paths
+    chunks = [b'{"event":"start"}\n', b'{"event":"tool_use"}\n', b'{"event":"end"}\n']
+    monkeypatch.setattr(subprocess, "Popen", MagicMock(return_value=_fake_proc(chunks)))
+
+    agent_runner.main()
+
+    assert session_file.exists()
+    assert session_file.read_bytes() == b"".join(chunks)
+
+
+def test_main_propagates_subprocess_exit_code(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero subprocess returncode is the value main() returns."""
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        MagicMock(return_value=_fake_proc([b"{}\n"], returncode=42)),
+    )
+
+    rc = agent_runner.main()
+
+    assert rc == 42
+
+
+# ── upload_archive(): both files uploaded, render-transcript.py invoked ──
+
+
+def test_upload_archive_uploads_jsonl_and_compact_to_s3(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both uploads fire: jsonl and txt under <AGENT_ID>.<ext> keys."""
+    session_file, compact = session_paths
+    session_file.write_bytes(b'{"event":"start"}\n')
+
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+
+    # render-transcript.py is mocked — assume it produces the compact file.
+    def _render(cmd: list[str], **_kw: object) -> subprocess.CompletedProcess:
+        # Simulate the renderer writing its --output file.
+        compact.write_text("rendered transcript")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", _render)
+
+    agent_runner.upload_archive()
+
+    # Two upload_file calls — one for jsonl, one for txt.
+    assert fake_s3.upload_file.call_count == 2
+    fake_s3.upload_file.assert_has_calls(
+        [
+            call(
+                str(session_file),
+                "judgemind-sessions-dev",
+                "test-agent-id.jsonl",
+            ),
+            call(
+                str(compact),
+                "judgemind-sessions-dev",
+                "test-agent-id.txt",
+            ),
+        ]
+    )
+
+
+def test_upload_archive_invokes_render_transcript_script(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The renderer is invoked with the jsonl input + --output compact path.
+
+    Pins the contract that the entrypoint does not call any other transcript
+    tool, and uses the module-level ``RENDER_TRANSCRIPT_SCRIPT`` constant so
+    the Dockerfile path is the single source of truth.
+    """
+    session_file, compact = session_paths
+    session_file.write_bytes(b"{}\n")
+
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=MagicMock()))
+    fake_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    agent_runner.upload_archive()
+
+    fake_run.assert_called_once()
+    actual_argv = fake_run.call_args[0][0]
+    assert actual_argv == [
+        "python",
+        agent_runner.RENDER_TRANSCRIPT_SCRIPT,
+        str(session_file),
+        "--output",
+        str(compact),
+    ]
+    assert fake_run.call_args.kwargs.get("check") is True
+
+
+def test_upload_archive_returns_silently_when_session_file_missing(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the jsonl never got written (Popen failed before tee), no upload.
+
+    The ECS task may exit before main() opens the session file (e.g. the
+    image lacks the runner binary). upload_archive() must be safe to call
+    in that case.
+    """
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+    fake_run = MagicMock()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # Do not create session_file — the fixture already monkeypatched the
+    # path helper but did not write the file.
+    agent_runner.upload_archive()
+
+    fake_s3.upload_file.assert_not_called()
+    fake_run.assert_not_called()
+
+
+def test_upload_archive_swallows_jsonl_upload_failure(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A boto3 upload error on the jsonl prints to stderr and does not raise.
+
+    The compact-transcript step still runs after the jsonl failure.
+    """
+    session_file, compact = session_paths
+    session_file.write_bytes(b"{}\n")
+
+    fake_s3 = MagicMock()
+    fake_s3.upload_file.side_effect = [
+        RuntimeError("simulated S3 failure"),  # jsonl
+        None,  # compact
+    ]
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+
+    def _render(cmd: list[str], **_kw: object) -> subprocess.CompletedProcess:
+        compact.write_text("rendered")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", _render)
+
+    # No exception escapes.
+    agent_runner.upload_archive()
+
+    captured = capsys.readouterr()
+    assert "session-archive-upload-failed" in captured.err
+    # Compact upload still attempted.
+    assert fake_s3.upload_file.call_count == 2
+
+
+def test_upload_archive_swallows_render_transcript_failure(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A render-transcript failure prints to stderr and does not raise.
+
+    The jsonl upload still happens — the diagnoser can fall back to the raw
+    jsonl when the compact form is missing.
+    """
+    session_file, _compact = session_paths
+    session_file.write_bytes(b"{}\n")
+
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        MagicMock(side_effect=subprocess.CalledProcessError(1, "render")),
+    )
+
+    agent_runner.upload_archive()
+
+    captured = capsys.readouterr()
+    assert "compact-transcript-upload-failed" in captured.err
+    # Only the jsonl upload succeeded.
+    assert fake_s3.upload_file.call_count == 1
+
+
+# ── EXIT cleanup runs even when main() raises ────────────────────────────
+
+
+def test_module_main_block_runs_upload_archive_on_main_exception(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``if __name__ == '__main__':`` block calls upload_archive() in a
+    finally even when main() raises — exercise the same try/finally shape
+    against a fake main that raises, and assert the EXIT cleanup ran.
+    """
+    cleanup_calls = MagicMock()
+    monkeypatch.setattr(agent_runner, "upload_archive", cleanup_calls)
+
+    def _boom() -> int:
+        raise RuntimeError("simulated mid-run crash")
+
+    monkeypatch.setattr(agent_runner, "main", _boom)
+
+    # Replicate the if __name__ == "__main__" block. We cannot run the
+    # module under runpy because it calls sys.exit(); instead we mirror
+    # the try/finally shape, which is the contract under test.
+    rc = 1
+    raised: BaseException | None = None
+    try:
+        try:
+            rc = agent_runner.main()
+        finally:
+            agent_runner.upload_archive()
+    except RuntimeError as exc:
+        raised = exc
+
+    cleanup_calls.assert_called_once()
+    assert isinstance(raised, RuntimeError)
+    assert rc == 1  # initial value preserved when main() raised before returning
+
+
+# ── RUNNER env var defaulting ────────────────────────────────────────────
+
+
+def test_main_defaults_runner_to_claude_when_unset(
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``RUNNER`` is unset the entrypoint defaults to ``claude``."""
+    monkeypatch.setenv("AGENT_ID", "test-agent-id")
+    monkeypatch.setenv("TASK_ISSUE_NUMBER", "1")
+    monkeypatch.setenv("SESSIONS_BUCKET", "judgemind-sessions-dev")
+    monkeypatch.delenv("RUNNER", raising=False)
+
+    fake_popen = MagicMock(return_value=_fake_proc([b"{}\n"]))
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    agent_runner.main()
+
+    actual_argv = fake_popen.call_args[0][0]
+    # claude is the first token when the default runner kicks in.
+    assert actual_argv[0] == "claude"


### PR DESCRIPTION
## Summary

Adds the dispatcher-v3 task-runner ECS task entrypoint at `scripts/dispatcher_v3/agent_runner.py` per `docs/specs/dispatcher-v3-spec.md` §4.1. The Python entrypoint invokes `/task` via `dispatcher_v3.runners.build_argv` (the C1 module from #3905), tees stdout to a local jsonl file (and CloudWatch via the ECS log driver), and on EXIT uploads the raw jsonl + a rendered compact transcript to S3 — both best-effort, neither blocks the subprocess exit code.

Closes #3879

## Test plan

### Automated checks
- [ ] Lint passes (`ruff check`)
- [ ] Format check passes (`ruff format --check`)
- [ ] Tests pass (`pytest scripts/dispatcher_v3/tests/`)
- [ ] CI green
- [ ] `scripts/check-subprocess-timeouts.sh` clean (`subprocess.run` carries `timeout=120`)
- [ ] `scripts/check-markdown-links.sh` clean (spec edit)

### Post-deploy verification
- [ ] N/A — no deployed component (the agent-runner image's bundling of `/opt/judgemind-transcripts/render-transcript.py` and the v3 ECS task definition that uses this entrypoint land in F1 and the v3 launcher PRs respectively; this PR only adds the Python module + tests, both verified locally via `pytest -n auto` and an in-process mocked-AWS smoke test).
- [ ] Verification evidence posted on issue (see A.8)
