### PR TITLE
fix(docs): clean up CLAUDE.md hygiene issues (#3834)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, 
 - Watch CI to completion (`gh run watch`) before doing anything else after pushing.
 - Create a PR immediately after your first push to a branch.
 - Re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed.
-- Set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, `scripts/ecs-run-task.sh`, `scripts/ecs-run.sh --script`, `scripts/rebuild_db.sh`, any data-processing script.
+- Set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, `scripts/ecs-run-task.sh`, `scripts/rebuild_db.sh`, any data-processing script.
 
 ## Enforced Rules — Automated Checks
 
@@ -49,6 +49,8 @@ scripts/preflight/branch-fresh.sh      # Fail if behind origin/main (pass --fetc
 scripts/preflight/venv-local.sh        # Fail if .venv is missing or is a symlink
 scripts/preflight/no-duplicate-pr.sh N # Check if open PR already exists for issue #N
 scripts/preflight/rate-budget.sh       # Warn if GitHub API rate budget < 100 remaining
+scripts/preflight/no-forbidden-syntax.sh CMD  # Check command string for $(), heredocs, python -c
+scripts/preflight/tf-not-root.sh              # Fail if running terraform from infra/terraform/ root
 ```
 
 `scripts/preflight.sh` is the umbrella runner / sourceable function library; the per-check wrappers under `scripts/preflight/` (in-worktree.sh, not-on-main.sh, etc.) each invoke one library function for use under permission rules that block `source ... && fn`.
@@ -266,7 +268,7 @@ When one of these tags arrives and you have a **pending question**: do not treat
 
 ### Telegram Integration (optional)
 
-Telegram integration (optional, opt-in) is delivered via the `plugin:telegram` MCP plugin when installed. Agents never invoke `/telegram:access` or edit `.claude/telegram/`.
+Telegram integration is delivered via the `plugin:telegram` MCP plugin when installed.
 
 When the user asks to pick up work, invoke `/task` as a background subagent. To enable continuous autonomous work queue management, invoke `/dispatcher`.
 


### PR DESCRIPTION
## Summary

Removed contradictory reference to `scripts/ecs-run.sh --script` from the 20-minute timeout list (it's already prohibited on line 247 for script use), replaced stale Telegram integration documentation, and added two missing preflight wrapper scripts to the documented block.

Closes #3834

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green
- [x] Markdown link check passed

### Post-deploy verification

- [x] N/A — no deployed component (CLAUDE.md documentation only)

### Verification of acceptance criteria (pre-merge)

- [x] AC 1: `grep -n "ecs-run.sh --script" CLAUDE.md` returns no match
- [x] AC 2: `grep -n ".claude/telegram/" CLAUDE.md` returns no match
- [x] AC 3: `grep -n "no-forbidden-syntax.sh\|tf-not-root.sh" CLAUDE.md` returns matches on lines 52-53