### PR TITLE
fix(dispatcher): scope _housekeeping_tick query to v2 (regression from #3875)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -26440,10 +26440,13 @@ class DispatcherDaemon:
             with self._conn.cursor() as cur:
                 # exec-mode-agnostic (#3158): reads succeeded+merged rows for GH-side
                 # cleanup only; execution_mode has no bearing on whether a PR merged.
+                # v2-scoped: housekeeping cleanup only operates on v2-owned rows;
+                # v3 closes its own issues via the diagnoser path.
                 cur.execute(
                     "SELECT issue_number, pr_number FROM dispatcher.agents "
                     "WHERE status = 'succeeded' "
-                    "  AND merged_at IS NOT NULL",
+                    "  AND merged_at IS NOT NULL "
+                    f"  AND {V2_SCOPED_PARENT_RUN_FILTER}",
                 )
                 rows = list(cur.fetchall())
             self._conn.commit()


### PR DESCRIPTION
## Summary

`_housekeeping_tick` reads `dispatcher.agents WHERE status='succeeded' AND merged_at IS NOT NULL` for GH-side cleanup. PR #3902 (#3875) added a CI guard requiring every `dispatcher.agents` query to be v2-scoped during cohabitation; this site was missed in that audit.

The CI guard correctly caught it on PR #3909 (#3879). Fix-forward: add the standard `V2_SCOPED_PARENT_RUN_FILTER` filter + marker comment.

## Test plan

- [x] Local diff matches the existing pattern at daemon.py:4571 / 4619.
- [x] Marker comment present so the `test_agent_query_scoping.py` walker accepts it.
- [ ] CI's `scripts-tests (python)` shard passes — verify on this PR's run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
