### PR TITLE
perf(scraping): switch backfill_llm_enrichment.py to keyset pagination (#3836)

### DIFF
--- a/packages/scraper-framework/tests/test_backfill_llm_enrichment.py
+++ b/packages/scraper-framework/tests/test_backfill_llm_enrichment.py
@@ -11,6 +11,7 @@ import importlib
 import os
 import sys
 import uuid
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -45,6 +46,7 @@ def _make_ruling(
     motion_type: str | None = None,
     outcome: str | None = None,
     case_title: str | None = None,
+    created_at: datetime | None = None,
 ) -> dict:
     return {
         "ruling_id": ruling_id,
@@ -54,6 +56,7 @@ def _make_ruling(
         "outcome": outcome,
         "case_title": case_title,
         "case_id_check": case_id,
+        "created_at": created_at or datetime(2024, 1, 1),
     }
 
 
@@ -384,9 +387,11 @@ class TestFetchRulingsBatch:
 
         backfill.fetch_rulings_batch(conn, "Riverside", force=False)
 
-        # The SQL should include the NULL field filter
+        # The SQL should include keyset pagination and the NULL field filter
         sql_arg = mock_cursor.execute.call_args[0][0]
         assert "motion_type IS NULL OR r.outcome IS NULL" in sql_arg
+        assert "(r.created_at, r.id) >" in sql_arg
+        assert "OFFSET" not in sql_arg
 
     def test_force_skips_null_filter(self) -> None:
         """With force=True, fetches all rulings with text."""
@@ -401,12 +406,64 @@ class TestFetchRulingsBatch:
 
         sql_arg = mock_cursor.execute.call_args[0][0]
         assert "motion_type IS NULL" not in sql_arg
+        assert "(r.created_at, r.id) >" in sql_arg
+        assert "OFFSET" not in sql_arg
 
-    def test_limit_caps_batch(self) -> None:
-        """When limit is reached, returns empty list."""
+    def test_cursor_advances_through_pages(self) -> None:
+        """Cursor-based pagination returns correct rows with no duplicates across pages."""
         conn = MagicMock()
-        result = backfill.fetch_rulings_batch(conn, "Riverside", force=False, limit=10, offset=15)
-        assert result == []
+        mock_cursor = MagicMock()
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Build 3 pages of 2 rows each — each row has a distinct (created_at, id)
+        ids = [str(uuid.uuid4()) for _ in range(6)]
+        timestamps = [datetime(2024, 1, d) for d in range(1, 7)]
+
+        # Each page is a list of tuples matching the columns order
+        cols = [
+            ("ruling_id", None),
+            ("case_id", None),
+            ("ruling_text", None),
+            ("motion_type", None),
+            ("outcome", None),
+            ("case_title", None),
+            ("case_id_check", None),
+            ("created_at", None),
+        ]
+        mock_cursor.description = cols
+
+        def _row(i: int) -> tuple:
+            return (ids[i], _CASE_ID_1, "text", None, None, None, _CASE_ID_1, timestamps[i])
+
+        pages = [
+            [_row(0), _row(1)],
+            [_row(2), _row(3)],
+            [_row(4), _row(5)],
+            [],
+        ]
+        mock_cursor.fetchall.side_effect = pages
+
+        all_results = []
+        cursor = None
+        for _ in range(4):
+            batch = backfill.fetch_rulings_batch(conn, "Riverside", force=False, cursor=cursor)
+            if not batch:
+                break
+            all_results.extend(batch)
+            cursor = (batch[-1]["created_at"], str(batch[-1]["ruling_id"]))
+
+        # All 6 rows retrieved, no duplicates
+        assert len(all_results) == 6
+        result_ids = [str(r["ruling_id"]) for r in all_results]
+        assert result_ids == ids
+        assert len(set(result_ids)) == 6
+
+        # Verify cursor params are passed correctly starting from page 2
+        second_call_params = mock_cursor.execute.call_args_list[1][0][1]
+        # params: [county, cursor[0], cursor[1], batch_size]
+        assert second_call_params[1] == timestamps[1]  # created_at of page-1 last row
+        assert second_call_params[2] == ids[1]  # id of page-1 last row
 
 
 # ---------------------------------------------------------------------------
@@ -546,6 +603,76 @@ class TestProcessCounty:
         assert county_stats.llm_api_failures == 1
         assert county_stats.no_extractable_data == 1
         assert county_stats.skipped_no_update == 0
+
+    @patch("backfill_llm_enrichment.apply_updates")
+    @patch("backfill_llm_enrichment.fetch_rulings_batch")
+    @patch("backfill_llm_enrichment.fetch_before_stats")
+    @patch("backfill_llm_enrichment.enrich_ruling")
+    def test_keyset_walks_all_pages_exactly_once(
+        self,
+        mock_enrich: MagicMock,
+        mock_before_stats: MagicMock,
+        mock_fetch_batch: MagicMock,
+        mock_apply: MagicMock,
+    ) -> None:
+        """Keyset pagination visits every ruling exactly once across ≥3 pages."""
+        mock_enrich.return_value = _make_enrichment_result()
+        mock_before_stats.return_value = {
+            "total": 8,
+            "null_motion_type": 8,
+            "null_outcome": 8,
+            "null_case_title": 8,
+        }
+
+        # 8 rulings spread across 3 pages (3+3+2) then empty sentinel
+        ruling_ids = [str(uuid.uuid4()) for _ in range(8)]
+        case_ids = [str(uuid.uuid4()) for _ in range(8)]
+        timestamps = [datetime(2024, 1, i + 1) for i in range(8)]
+
+        def _r(i: int) -> dict:
+            return _make_ruling(
+                ruling_id=ruling_ids[i],
+                case_id=case_ids[i],
+                created_at=timestamps[i],
+            )
+
+        page1 = [_r(0), _r(1), _r(2)]
+        page2 = [_r(3), _r(4), _r(5)]
+        page3 = [_r(6), _r(7)]
+        mock_fetch_batch.side_effect = [page1, page2, page3, []]
+
+        conn = MagicMock()
+        stats = backfill.BackfillStats(start_time=0)
+
+        backfill.process_county(
+            conn,
+            "Riverside",
+            stats,
+            provider="google",
+            model=None,
+            client=MagicMock(),
+            force=False,
+            dry_run=True,
+            batch_size=3,
+            concurrency=1,
+            limit=None,
+        )
+
+        # All 8 rulings processed, no duplicates
+        county_stats = stats.get_county("Riverside")
+        assert county_stats.processed == 8
+        assert mock_enrich.call_count == 8
+
+        # fetch_rulings_batch was called 4 times (3 pages + empty sentinel)
+        assert mock_fetch_batch.call_count == 4
+
+        # Verify cursor advanced: second call should pass cursor from end of page1
+        second_call_kwargs = mock_fetch_batch.call_args_list[1][1]
+        assert second_call_kwargs["cursor"] == (timestamps[2], ruling_ids[2])
+
+        # Third call cursor should match end of page2
+        third_call_kwargs = mock_fetch_batch.call_args_list[2][1]
+        assert third_call_kwargs["cursor"] == (timestamps[5], ruling_ids[5])
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_llm_enrichment.py
+++ b/scripts/backfill_llm_enrichment.py
@@ -39,6 +39,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 # Ensure the scraper-framework source is importable
@@ -60,6 +61,12 @@ from ingestion.llm_providers import create_client as create_llm_client  # noqa: 
 configure_structlog(contextvars=True)
 logger = structlog.get_logger()
 
+# ---------------------------------------------------------------------------
+# Keyset pagination sentinels
+# ---------------------------------------------------------------------------
+
+_CURSOR_MIN_TIMESTAMP = datetime(1970, 1, 1)
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
 
 # ---------------------------------------------------------------------------
 # Stats tracking
@@ -185,30 +192,35 @@ def fetch_rulings_batch(
     *,
     force: bool = False,
     batch_size: int = 50,
-    offset: int = 0,
-    limit: int | None = None,
+    cursor: tuple[datetime, str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch a batch of rulings for enrichment.
+    """Fetch a batch of rulings for enrichment using keyset pagination.
 
     Returns rulings joined with case and court info.  By default only
     fetches rulings where at least one enrichment field is missing.
     With ``force=True``, fetches all rulings with ruling_text.
+
+    The ``cursor`` parameter is a ``(created_at, id)`` pair that marks the
+    position of the last row returned by the previous page.  Pass ``None``
+    (or omit it) to start from the beginning.  After each call, advance the
+    cursor to ``(batch[-1]['created_at'], str(batch[-1]['ruling_id']))``.
     """
-    conditions = ["ct.county = %s", "r.ruling_text IS NOT NULL", "r.ruling_text != ''"]
-    params: list[Any] = [county]
+    if cursor is None:
+        cursor = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
+
+    conditions = [
+        "ct.county = %s",
+        "r.ruling_text IS NOT NULL",
+        "r.ruling_text != ''",
+        "(r.created_at, r.id) > (%s, %s)",
+    ]
+    params: list[Any] = [county, cursor[0], cursor[1]]
 
     if not force:
         conditions.append(
             "(r.motion_type IS NULL OR r.outcome IS NULL "
             "OR c.case_title IS NULL OR c.case_title = '')"
         )
-
-    effective_limit = batch_size
-    if limit is not None:
-        remaining = limit - offset
-        if remaining <= 0:
-            return []
-        effective_limit = min(batch_size, remaining)
 
     query = f"""
         SELECT
@@ -218,16 +230,16 @@ def fetch_rulings_batch(
             r.motion_type,
             r.outcome::text AS outcome,
             c.case_title,
-            c.id AS case_id_check
+            c.id AS case_id_check,
+            r.created_at AS created_at
         FROM rulings r
         JOIN cases c ON r.case_id = c.id
         JOIN courts ct ON c.court_id = ct.id
         WHERE {" AND ".join(conditions)}
-        ORDER BY r.created_at
-        OFFSET %s
+        ORDER BY r.created_at, r.id
         LIMIT %s
     """  # noqa: S608
-    params.extend([offset, effective_limit])
+    params.append(batch_size)
 
     with conn.cursor() as cur:
         cur.execute(query, params)
@@ -427,7 +439,7 @@ def process_county(
         logger.info("backfill.county_empty", county=county)
         return
 
-    offset = 0
+    cursor: tuple[datetime, str] = (_CURSOR_MIN_TIMESTAMP, _CURSOR_MIN_UUID)
     batch_num = 0
     total_processed = 0
 
@@ -437,8 +449,7 @@ def process_county(
             county,
             force=force,
             batch_size=batch_size,
-            offset=offset,
-            limit=limit,
+            cursor=cursor,
         )
 
         if not batch:
@@ -450,7 +461,6 @@ def process_county(
             county=county,
             batch=batch_num,
             size=len(batch),
-            offset=offset,
         )
 
         # Run LLM enrichment in parallel
@@ -510,7 +520,8 @@ def process_county(
                 updates=0,
             )
 
-        offset += len(batch)
+        # Advance keyset cursor to the last row of this batch
+        cursor = (batch[-1]["created_at"], str(batch[-1]["ruling_id"]))
 
         # Check limit
         if limit is not None and total_processed >= limit:


### PR DESCRIPTION
## Summary

Replaced O(n²) OFFSET-based pagination with O(n) keyset (cursor-based) pagination in `scripts/backfill_llm_enrichment.py`. This change reduces ECS task wall time for large-table backfills, directly cutting compute spend.

The keyset condition `(r.created_at, r.id) > (%s, %s)` ensures deterministic ordering and zero duplicates across pages. Caller advances the cursor to `(batch[-1]['created_at'], str(batch[-1]['ruling_id']))` after each batch.

Closes #3836

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 25 tests pass
- [x] CI green — pre-push hook passed cleanly (scraper-framework tests, coverage floor, filename collisions, one-off markers)

### Post-deploy verification

- [ ] Run backfill on a non-trivial table (≥10k rows) and measure wall time vs. OFFSET implementation (benchmark documentation required — see acceptance criteria #3)
- [ ] Verification evidence posted on #3836 (see /task-v2-verify output)

## Note

Acceptance criterion #3 requests benchmark or performance documentation. The implementation is complete and tested; the performance improvement is real (keyset is O(n) vs OFFSET's O(n²)), but a specific benchmark document was not included in this PR. Operator review flagged via needs_review.