### PR TITLE
fix(dx): cleanup_governor_rulings_pollution.py remove cases delete to avoid FK rollback (#3840)

### DIFF
--- a/scripts/one_off/cleanup_governor_rulings_pollution.py
+++ b/scripts/one_off/cleanup_governor_rulings_pollution.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
 # one-off: true
-"""Delete derived.rulings and derived.cases rows created by the ca-governor-appointments
-scraper before the #3688 early-return fix was deployed.
+"""Delete derived.rulings rows created by the ca-governor-appointments scraper before
+the #3688 early-return fix was deployed.
 
 The scraper emits judge-bio press releases that share the CapturedDocument shape but
 are NOT rulings. Before #3688, the ingestion worker passed them through the LLM
 extractor, producing 178 rows with UNKNOWN-* case_numbers, empty case_titles, and a
 'Governor / Statewide' court entry in derived.rulings.
+
+Orphan derived.cases rows are intentionally left in place: the FK chain through
+derived.documents would require tearing down more rows than the user-facing pollution
+warrants, and the #2144 judge-bios pipeline may consume those case+document rows via
+the documents chain. The user-visible pollution is solely in derived.rulings.
 
 Surgical DELETE is used here rather than rebuild_db.py --county Statewide because
 rebuild would re-walk the same S3 press-release objects through the now-fixed scraper
@@ -20,6 +25,7 @@ Usage via ECS (dev DB is in a private VPC):
 The script is idempotent: re-running on a clean DB is a no-op (DELETE returns 0 rows).
 
 See: https://github.com/judgemind/judgemind/issues/3688
+     https://github.com/judgemind/judgemind/issues/3840
 """
 
 from __future__ import annotations
@@ -52,22 +58,6 @@ DELETE_RULINGS_SQL = """
     RETURNING r.id
 """
 
-# Delete orphaned derived.cases rows: cases with no remaining rulings that
-# were created for the Governor court and have an UNKNOWN-* case_number.
-DELETE_CASES_SQL = """
-    DELETE FROM derived.cases c
-    WHERE NOT EXISTS (
-        SELECT 1 FROM derived.rulings r WHERE r.case_id = c.id
-    )
-      AND c.case_number LIKE 'UNKNOWN-%'
-      AND c.court_id IN (
-          SELECT id FROM derived.courts
-          WHERE county = 'Statewide'
-            AND court_name ILIKE '%governor%'
-      )
-    RETURNING c.id
-"""
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -83,16 +73,10 @@ def main() -> None:
             deleted_rulings = cur.rowcount
             logger.info("Deleted %d derived.rulings rows", deleted_rulings)
 
-            logger.info("Deleting orphaned derived.cases rows")
-            cur.execute(DELETE_CASES_SQL)
-            deleted_cases = cur.rowcount
-            logger.info("Deleted %d derived.cases rows", deleted_cases)
-
         conn.commit()
         logger.info(
-            "Cleanup complete — rulings_deleted=%d cases_deleted=%d",
+            "Cleanup complete — rulings_deleted=%d",
             deleted_rulings,
-            deleted_cases,
         )
 
 

--- a/scripts/tests/test_cleanup_governor_rulings_pollution.py
+++ b/scripts/tests/test_cleanup_governor_rulings_pollution.py
@@ -1,0 +1,119 @@
+"""Tests for cleanup_governor_rulings_pollution script.
+
+Tests cover:
+- DELETE_RULINGS_SQL is defined with correct county/ILIKE predicates
+- DELETE_CASES_SQL is NOT defined (regression guard — cases delete was removed in #3840)
+- main() calls cur.execute() exactly once (rulings delete only)
+- main() calls conn.commit() exactly once after the rulings delete
+
+The script depends on psycopg, which may not be available in the lightweight
+CI scripts-tests environment. We mock it in sys.modules before importing the
+script under test, following the pattern in test_cleanup_legacy_date_partitioned_s3.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking — the script imports psycopg at module level,
+# which may not be installed in the CI scripts-tests environment.
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "one_off"))
+
+_mock_psycopg = MagicMock()
+
+_saved_modules: dict[str, object] = {}
+if "psycopg" in sys.modules:
+    _saved_modules["psycopg"] = sys.modules["psycopg"]
+sys.modules["psycopg"] = _mock_psycopg
+
+import cleanup_governor_rulings_pollution  # noqa: E402
+
+# Restore sys.modules so mock injection doesn't bleed into other test files.
+for _mod_name in ("psycopg",):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: DELETE_RULINGS_SQL is defined with correct predicates
+# ---------------------------------------------------------------------------
+
+
+def test_rulings_sql_contains_statewide_county() -> None:
+    """DELETE_RULINGS_SQL targets the 'Statewide' county."""
+    assert "Statewide" in cleanup_governor_rulings_pollution.DELETE_RULINGS_SQL
+
+
+def test_rulings_sql_contains_governor_ilike() -> None:
+    """DELETE_RULINGS_SQL filters court_name with '%governor%' ILIKE predicate."""
+    assert "%governor%" in cleanup_governor_rulings_pollution.DELETE_RULINGS_SQL
+
+
+# ---------------------------------------------------------------------------
+# Test 2: DELETE_CASES_SQL is NOT defined (regression guard for #3840 AC#2)
+# ---------------------------------------------------------------------------
+
+
+def test_cases_delete_constant_removed() -> None:
+    """DELETE_CASES_SQL must not exist on the module (cases delete was removed in #3840)."""
+    assert not hasattr(cleanup_governor_rulings_pollution, "DELETE_CASES_SQL")
+
+
+# ---------------------------------------------------------------------------
+# Test 3: main() calls cur.execute() exactly once (rulings delete only)
+# ---------------------------------------------------------------------------
+
+
+def test_main_executes_rulings_delete_only() -> None:
+    """main() calls cur.execute() exactly once with DELETE_RULINGS_SQL."""
+    mock_conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.rowcount = 178
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("cleanup_governor_rulings_pollution.psycopg") as mock_psycopg_mod:
+        mock_psycopg_mod.connect.return_value.__enter__ = MagicMock(
+            return_value=mock_conn
+        )
+        mock_psycopg_mod.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+            cleanup_governor_rulings_pollution.main()
+
+    assert cursor_mock.execute.call_count == 1
+    executed_sql = cursor_mock.execute.call_args[0][0]
+    assert "derived.rulings" in executed_sql
+    assert "derived.cases" not in executed_sql
+
+
+# ---------------------------------------------------------------------------
+# Test 4: main() calls conn.commit() exactly once
+# ---------------------------------------------------------------------------
+
+
+def test_main_commits_exactly_once() -> None:
+    """main() calls conn.commit() exactly once after the rulings delete."""
+    mock_conn = MagicMock()
+    cursor_mock = MagicMock()
+    cursor_mock.rowcount = 178
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("cleanup_governor_rulings_pollution.psycopg") as mock_psycopg_mod:
+        mock_psycopg_mod.connect.return_value.__enter__ = MagicMock(
+            return_value=mock_conn
+        )
+        mock_psycopg_mod.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+            cleanup_governor_rulings_pollution.main()
+
+    assert mock_conn.commit.call_count == 1


### PR DESCRIPTION
## Summary

Removed the `DELETE_CASES_SQL` constant from the cleanup script to fix a ForeignKeyViolation that was rolling back the entire transaction. The orphan cases are intentionally preserved for the #2144 judge-bios pipeline. Added comprehensive tests with regression guards.

Closes #3840

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/tests/test_cleanup_governor_rulings_pollution.py`)
- [x] CI green

### Post-deploy verification

- [ ] Run cleanup script on dev: `scripts/ecs-run-task.sh scripts/one_off/cleanup_governor_rulings_pollution.py`
- [ ] Verify rulings deleted: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.rulings r JOIN derived.cases ca ON ca.id = r.case_id JOIN derived.courts co ON co.id = ca.court_id WHERE co.county = 'Statewide';"` — expected: 0
- [ ] Verify spotcheck no longer samples governor pollution: run next-day `/spotcheck` and confirm Statewide rulings count is 0
- [ ] Verification evidence posted on #3840 (see /task-v2-verify output)