### PR TITLE
feat(dispatcher-v3): add IAM module with launcher + agent task roles (#3888)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -95,6 +95,13 @@ jobs:
         if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
         run: bash infra/terraform/modules/dispatcher-agent-runner/tests/postconditions/check.sh
 
+      # Policy-shape regression test for dispatcher-v3-iam (#3888). Static
+      # analysis of the rendered HCL — no AWS credentials needed. Asserts
+      # the spec §10 invariants (no cross-account principal, launcher
+      # scope is narrow, agent task role pinned to dev account).
+      - name: dispatcher-v3-iam policy-shape check
+        run: bash infra/terraform/modules/dispatcher-v3-iam/tests/policy-checks/check.sh
+
       # Plan requires AWS credentials (stored as GitHub Actions secrets).
       # The plan confirms the module is deployable and shows exactly what
       # resources will be created or modified.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -718,7 +718,7 @@ output "dispatcher_v3_launcher_role_arn" {
 }
 
 output "dispatcher_v3_agent_task_role_arn" {
-  description = "Dev dispatcher-v3 agent task role ARN (dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill — see spec §10). Trust policy excludes assuming any cross-account role."
+  description = "Dev dispatcher-v3 agent task role ARN (dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill -- see spec section 10). Trust policy excludes assuming any cross-account role."
   value       = module.dispatcher_v3_iam.agent_task_role_arn
 }
 

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -398,6 +398,37 @@ module "dispatcher_agent_runner" {
   spotcheck_oneshot_script_bucket_arn         = "arn:aws:s3:::judgemind-assets-dev"
 }
 
+# ─── Dispatcher v3 IAM (F3, #3888) ──────────────────────────────────────────
+# Per `docs/specs/dispatcher-v3-spec.md` §10. Two task roles + one shared
+# execution role for the v3 task pipeline:
+#
+#   * `launcher_role` — narrow scheduler scope assumed by F2's `launcher`
+#     task definition.
+#   * `agent_task_role` — dev-admin equivalent assumed by F2's
+#     `task-runner`, `diagnoser`, and `scheduled-skill` task definitions.
+#   * `execution_role` — shared by every v3 task definition for ECR pull
+#     and secret injection.
+#
+# F2 (#3887) consumes these ARNs when registering task definitions; F4
+# stands up the launcher ECS service. Until F2 lands, the roles exist
+# but no task assumes them — they're inert by construction.
+module "dispatcher_v3_iam" {
+  source = "../../modules/dispatcher-v3-iam"
+
+  environment     = "dev"
+  ecs_cluster_arn = module.compute.cluster_arn
+
+  # Telegram bot token — re-uses the same secret v2's daemon does. Wired
+  # so the launcher can page the operator on a stuck queue without
+  # reaching for the broad agent-task-role secret list.
+  telegram_bot_token_secret_arn = ""
+
+  # Scoped GitHub PAT — re-uses the same `judgemind/dispatcher/github-token`
+  # secret as v2. F2 will inject this into the task-runner / diagnoser
+  # task definitions for `gh auth setup-git` inside the agent.
+  github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url
@@ -675,4 +706,23 @@ output "dispatcher_daemon_security_group_id" {
 output "dispatcher_ecr_repository_url" {
   description = "Dev ECR repository URL for dispatcher v2 daemon images"
   value       = module.ecr.dispatcher_repository_url
+}
+
+# ─── Dispatcher v3 IAM outputs (F3, #3888) ──────────────────────────────────
+# Consumed by F2 (#3887) when wiring v3 task definitions and by F4 when
+# standing up the launcher ECS service.
+
+output "dispatcher_v3_launcher_role_arn" {
+  description = "Dev dispatcher-v3 launcher task role ARN (narrow scheduler scope: RunTask on agent task-defs, RDS connect to dispatcher.* only, Telegram secret read, CloudWatch read on /judgemind/dispatcher-v3/*)"
+  value       = module.dispatcher_v3_iam.launcher_role_arn
+}
+
+output "dispatcher_v3_agent_task_role_arn" {
+  description = "Dev dispatcher-v3 agent task role ARN (dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill — see spec §10). Trust policy excludes assuming any cross-account role."
+  value       = module.dispatcher_v3_iam.agent_task_role_arn
+}
+
+output "dispatcher_v3_execution_role_arn" {
+  description = "Dev dispatcher-v3 shared task-execution role ARN (used by every v3 task definition for ECR pull + secret injection + log writes)"
+  value       = module.dispatcher_v3_iam.execution_role_arn
 }

--- a/infra/terraform/modules/dispatcher-v3-iam/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/main.tf
@@ -388,7 +388,7 @@ resource "aws_iam_role_policy" "launcher_logs_read" {
 
 resource "aws_iam_role" "agent_task" {
   name        = "${local.role_name_prefix}-agent-task-${var.environment}"
-  description = "Dispatcher v3 agent task role - dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill (spec §10). Trust policy excludes assuming any cross-account role."
+  description = "Dispatcher v3 agent task role - dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill (spec section 10). Trust policy excludes assuming any cross-account role."
 
   assume_role_policy = local.ecs_tasks_assume_role_policy
 }

--- a/infra/terraform/modules/dispatcher-v3-iam/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/main.tf
@@ -1,0 +1,723 @@
+# Dispatcher v3 IAM module — three roles for the v3 task pipeline.
+#
+# v3 collapses the v2 phase pipeline into a single continuous /task
+# invocation. Per `docs/specs/dispatcher-v3-spec.md` §10, that means
+# `task-runner`, `diagnoser`, and `scheduled-skill` ECS tasks all share
+# one broad task role (dev-admin equivalent). The `launcher` task — the
+# scheduler that consumes the `agent/ready` queue, runs the issue-author
+# trust check, and calls `ecs:RunTask` — gets a strictly narrower role.
+#
+# The deliberate authority gap is the spec's central trade-off:
+#
+# > The agent skills running inside ECS tasks (`task-runner`, `diagnoser`,
+# > `scheduled-skill`) get **dev-account admin authority** — not principle-
+# > of-least-privilege scope. We cannot enumerate in advance whether this
+# > issue needs S3 writes, RDS queries, ECS one-offs, CloudWatch tail, or
+# > Secrets Manager reads. v2's operator-laptop pattern (operator's AWS
+# > creds via `aws-vault`) gave `/task` whatever the operator had — in
+# > practice dev-admin. v3 preserves that.
+#
+# Production accounts are NOT in scope. The trust policy on every role
+# in this module pins `Principal = Service: ecs-tasks.amazonaws.com` and
+# the source account is the dev account; no cross-account assume-role
+# path exists.
+#
+# Resources created:
+# - `aws_iam_role.launcher` — narrow scheduler role assumed by the
+#   `launcher` task definition (F2). Includes:
+#     * ecs:RunTask / ecs:DescribeTasks / ecs:StopTask scoped to the
+#       agent task-def family on this cluster.
+#     * iam:PassRole on the agent_task_role and the shared execution
+#       role (so RunTask actually succeeds).
+#     * RDS connect to the `dispatcher.*` schema only — implemented as
+#       `rds-db:connect` against the `judgemind_dispatcher` DB user.
+#     * CloudWatch Logs DescribeLogStreams + GetLogEvents on
+#       `/judgemind/dispatcher-v3/*` (silent-hang detection from spec §4.1).
+#     * secretsmanager:GetSecretValue on TELEGRAM_BOT_TOKEN only.
+# - `aws_iam_role.agent_task` — dev-admin equivalent assumed by the
+#   `task-runner`, `diagnoser`, and `scheduled-skill` task definitions.
+#   Includes:
+#     * Full S3 (read/write/delete on every bucket in this account).
+#     * Full RDS (`rds-db:connect` against every DB user in the dev
+#       cluster).
+#     * ecs:RunTask + iam:PassRole — the agent may launch its own
+#       one-off ECS tasks via `scripts/ecs-run-task.sh`.
+#     * ecs:ExecuteCommand + ssmmessages:* — `aws ecs execute-command`
+#       debugging access (#3145).
+#     * CloudWatch Logs read/write across the dev account.
+#     * Secrets Manager read for every dev-tagged secret.
+#     * ECR pull on every dev repository.
+# - `aws_iam_role.execution` — shared task-execution role used by all
+#   four v3 task definitions. The ECS agent uses this role at task-start
+#   to pull the image and inject secrets; it is NOT the in-container
+#   identity. Includes:
+#     * AmazonECSTaskExecutionRolePolicy (the AWS managed policy).
+#     * secretsmanager:GetSecretValue on the wired secret ARNs (telegram
+#       bot token + GitHub PAT) so the v3 task definitions can inject
+#       them into the container env.
+#     * logs:* on the v3 log groups (the managed policy already covers
+#       this, but we keep the inline policy for forward compatibility
+#       when F4 / F5 land their log groups).
+#
+# Outputs:
+#   `launcher_role_arn`, `agent_task_role_arn`, `execution_role_arn`
+# — F2 (#3887) consumes these when wiring task definitions; F4 (the
+# launcher ECS service) consumes the launcher ARN; F5 (scheduled-skill
+# EventBridge rules) consume the agent_task_role ARN.
+
+data "aws_partition" "current" {}
+
+locals {
+  role_name_prefix = "judgemind-dispatcher-v3"
+
+  # F2 task-def families. The launcher needs ecs:RunTask on the three
+  # short-lived families (task-runner / diagnoser / scheduled-skill);
+  # it does NOT need RunTask on its own `launcher` family because the
+  # launcher itself is started by F4's ECS service, not by re-launch.
+  agent_task_def_families = [
+    "${var.task_definition_family_prefix}-task-runner",
+    "${var.task_definition_family_prefix}-diagnoser",
+    "${var.task_definition_family_prefix}-scheduled-skill",
+  ]
+
+  agent_task_def_arn_patterns = [
+    for f in local.agent_task_def_families :
+    "arn:${data.aws_partition.current.partition}:ecs:${var.aws_region}:${var.aws_account_id}:task-definition/${f}:*"
+  ]
+
+  # Cluster name extracted from the cluster ARN. The ECS task-instance
+  # ARN scheme is `task/CLUSTER/TASK_ID`, not `task/CLUSTER_ARN/TASK_ID`,
+  # so we have to split the cluster ARN to get the bare cluster name.
+  ecs_cluster_name = split("/", var.ecs_cluster_arn)[1]
+
+  agent_task_instance_arn_pattern = "arn:${data.aws_partition.current.partition}:ecs:${var.aws_region}:${var.aws_account_id}:task/${local.ecs_cluster_name}/*"
+
+  # Common assume-role policy: only the ECS task-runtime principal in
+  # this account may assume any of the three roles. No cross-account
+  # principal, no IAM-user principal, no role-chaining. Production has
+  # no v3 footprint, so there is no production-account principal here
+  # by construction.
+  ecs_tasks_assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = var.aws_account_id
+          }
+        }
+      }
+    ]
+  })
+
+  # Compacted secret ARN list for the execution role (drops empty
+  # strings so a fresh stack without secret wiring can still apply).
+  # IAM rejects `Resource = []` with `MalformedPolicyDocument` (see
+  # the analogous guard in modules/dispatcher-daemon/main.tf), so the
+  # policy resource itself is skipped via `count = 0` when empty.
+  execution_secret_arns = compact([
+    var.telegram_bot_token_secret_arn,
+    var.github_token_secret_arn,
+  ])
+}
+
+# ─── Shared Execution Role (ECS agent) ──────────────────────────────────────
+# Used by the ECS agent to pull the v3 image from ECR, inject env-var
+# secrets at task start, and write logs to CloudWatch. This is NOT the
+# in-container identity — that's `launcher_role` or `agent_task_role`
+# depending on the task definition.
+
+resource "aws_iam_role" "execution" {
+  name        = "${local.role_name_prefix}-execution-${var.environment}"
+  description = "Shared ECS task-execution role for all dispatcher-v3 task definitions (pulls ECR + reads secrets + writes logs)."
+
+  assume_role_policy = local.ecs_tasks_assume_role_policy
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Read the wired secrets at task-start so they appear as env vars
+# inside the container. Only telegram + github PAT are wired here; the
+# agent task role reads everything else via the broad
+# `judgemind/*` / `*-dev-*` patterns at runtime.
+resource "aws_iam_role_policy" "execution_secrets" {
+  count = length(local.execution_secret_arns) > 0 ? 1 : 0
+
+  name = "${local.role_name_prefix}-execution-secrets-${var.environment}"
+  role = aws_iam_role.execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadDispatcherV3Secrets"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = local.execution_secret_arns
+      }
+    ]
+  })
+}
+
+# ─── Launcher Role (narrow scheduler scope) ─────────────────────────────────
+# Assumed by F2's `launcher` task definition. The launcher consumes the
+# `agent/ready` queue, runs the issue-author trust check, and starts a
+# task-runner / diagnoser / scheduled-skill task per claim. It does NOT
+# touch S3, does NOT query `derived.*` / `staging.*`, and does NOT read
+# any secret beyond `TELEGRAM_BOT_TOKEN` (for operator paging).
+
+resource "aws_iam_role" "launcher" {
+  name        = "${local.role_name_prefix}-launcher-${var.environment}"
+  description = "Dispatcher v3 launcher task role - narrow scheduler scope (RunTask on agent task-defs, RDS connect to dispatcher.*, Telegram secret read, CloudWatch read on /judgemind/dispatcher-v3/*)."
+
+  assume_role_policy = local.ecs_tasks_assume_role_policy
+}
+
+# RunTask + DescribeTasks + StopTask on the three agent task-def
+# families. The cluster-ARN condition is the defense-in-depth control
+# alongside the family-scoped Resource list — RunTask cannot escape to
+# another cluster even if a future change widens the family list.
+resource "aws_iam_role_policy" "launcher_run_agent_tasks" {
+  name = "${local.role_name_prefix}-launcher-run-agent-tasks-${var.environment}"
+  role = aws_iam_role.launcher.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowRunAgentTasks"
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = local.agent_task_def_arn_patterns
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        Sid      = "AllowStopAgentTasks"
+        Effect   = "Allow"
+        Action   = "ecs:StopTask"
+        Resource = local.agent_task_def_arn_patterns
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        # ecs:DescribeTasks does not accept ARN scoping at the API
+        # level — same constraint as the v2 daemon's `task_run_oneshot`
+        # and `task_launch_agent_runner` policies. The cluster-ARN
+        # condition is the defense-in-depth control.
+        Sid      = "AllowDescribeAgentTasks"
+        Effect   = "Allow"
+        Action   = "ecs:DescribeTasks"
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        # ecs:TagResource is invoked implicitly by RunTask when the
+        # call includes a `tags` list. AWS evaluates authorization
+        # against the task-instance ARN (task/CLUSTER/*), not the
+        # task-definition ARN — same quirk that bit the v2 agent-runner
+        # launcher policy (#3129).
+        Sid      = "AllowTagAgentTasks"
+        Effect   = "Allow"
+        Action   = "ecs:TagResource"
+        Resource = local.agent_task_instance_arn_pattern
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+# PassRole — RunTask fails with `AccessDeniedException: User ... is not
+# authorized to pass role ... because no identity-based policy allows
+# the iam:PassRole action` unless this is granted. Pinned to the agent
+# task role and shared execution role only — the launcher cannot pass
+# its own role or any other role.
+resource "aws_iam_role_policy" "launcher_pass_role" {
+  name = "${local.role_name_prefix}-launcher-pass-role-${var.environment}"
+  role = aws_iam_role.launcher.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowPassAgentTaskRole"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          aws_iam_role.agent_task.arn,
+          aws_iam_role.execution.arn,
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# RDS IAM-auth connect to the `judgemind_dispatcher` DB user only. The
+# launcher persists its lease + queue snapshots into the `dispatcher.*`
+# schema; that schema is owned by the `judgemind_dispatcher` role. No
+# other DB user is reachable — the launcher cannot read `derived.*`,
+# `staging.*`, or `public.*`.
+#
+# `rds-db:connect` Resource ARN scheme:
+# `arn:aws:rds-db:REGION:ACCOUNT:dbuser:CLUSTER_RESOURCE_ID/DB_USER`.
+# Cluster resource ID is opaque, so we use a wildcard there and pin the
+# DB user — defense-in-depth via the DB-side `judgemind_dispatcher`
+# role's own per-schema grants.
+resource "aws_iam_role_policy" "launcher_rds_connect" {
+  name = "${local.role_name_prefix}-launcher-rds-connect-${var.environment}"
+  role = aws_iam_role.launcher.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowConnectAsDispatcherRole"
+        Effect = "Allow"
+        Action = "rds-db:connect"
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:rds-db:${var.aws_region}:${var.aws_account_id}:dbuser:*/judgemind_dispatcher"
+        ]
+      }
+    ]
+  })
+}
+
+# Secrets Manager read — telegram bot token only. When the ARN is
+# empty (fresh stack without telegram wiring) the policy is skipped
+# via count=0 to avoid IAM's `Resource = []` rejection.
+resource "aws_iam_role_policy" "launcher_secrets_telegram" {
+  count = var.telegram_bot_token_secret_arn != "" ? 1 : 0
+
+  name = "${local.role_name_prefix}-launcher-secrets-telegram-${var.environment}"
+  role = aws_iam_role.launcher.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowReadTelegramSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.telegram_bot_token_secret_arn
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs read on `/judgemind/dispatcher-v3/*`. Used by the
+# silent-hang detector (spec §4.1) which calls `DescribeLogStreams` to
+# check whether an in-flight agent's log stream has grown in the last
+# N minutes. Read-only — the launcher never writes its own logs (it
+# inherits log writes from the execution role's managed policy).
+resource "aws_iam_role_policy" "launcher_logs_read" {
+  name = "${local.role_name_prefix}-launcher-logs-read-${var.environment}"
+  role = aws_iam_role.launcher.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowReadDispatcherV3Logs"
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents",
+          "logs:FilterLogEvents",
+        ]
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:logs:${var.aws_region}:${var.aws_account_id}:log-group:/judgemind/dispatcher-v3/*",
+          "arn:${data.aws_partition.current.partition}:logs:${var.aws_region}:${var.aws_account_id}:log-group:/judgemind/dispatcher-v3/*:*",
+        ]
+      }
+    ]
+  })
+}
+
+# ─── Agent Task Role (dev-admin equivalent) ─────────────────────────────────
+# Assumed by F2's `task-runner`, `diagnoser`, and `scheduled-skill`
+# task definitions. Per spec §10, this role has dev-account admin
+# authority because we cannot enumerate in advance which AWS APIs a
+# given /task invocation will need. The trade-off is explicitly
+# accepted there.
+#
+# What this role can do in dev:
+#   * Full S3: read, write, delete, list across every bucket.
+#   * Full RDS IAM-auth connect against every DB user in the dev cluster.
+#   * Launch any ECS task on the dev cluster (including its own
+#     `scripts/ecs-run-task.sh` one-offs).
+#   * Read every Secrets Manager entry tagged for dev usage
+#     (`judgemind/*` and `*-dev-*` ARN patterns).
+#   * Pull any ECR image in this account.
+#   * Open SSM exec channels into running tasks.
+#   * Read and write any CloudWatch log group in this account.
+#
+# What it CANNOT do, by construction:
+#   * Assume any cross-account role — the trust policy is single-account
+#     only (see `local.ecs_tasks_assume_role_policy`).
+#   * Touch any production resource — there is no production AWS
+#     account in scope; every Resource ARN below pins the dev account
+#     ID.
+#   * Modify IAM (no `iam:*` action grants below).
+#   * Modify Route53, ACM, organizations, billing, support, etc.
+
+resource "aws_iam_role" "agent_task" {
+  name        = "${local.role_name_prefix}-agent-task-${var.environment}"
+  description = "Dispatcher v3 agent task role - dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill (spec §10). Trust policy excludes assuming any cross-account role."
+
+  assume_role_policy = local.ecs_tasks_assume_role_policy
+}
+
+# Full S3. The agent may read raw/, write spotcheck scratch, mirror
+# session logs to the sessions bucket, etc. We accept the broad scope
+# in dev because we cannot enumerate which buckets a given /task run
+# will need to touch.
+resource "aws_iam_role_policy" "agent_task_s3" {
+  name = "${local.role_name_prefix}-agent-task-s3-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowFullS3"
+        Effect   = "Allow"
+        Action   = "s3:*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Full RDS IAM-auth connect — the agent may need to query `derived.*`,
+# `staging.*`, `dispatcher.*`, etc. depending on the issue. Granting
+# `rds-db:connect` against every DB user is equivalent to the
+# operator-laptop pattern v2 used (operator's AWS creds via aws-vault
+# could connect as any DB user too).
+resource "aws_iam_role_policy" "agent_task_rds_connect" {
+  name = "${local.role_name_prefix}-agent-task-rds-connect-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowConnectAsAnyDBUser"
+        Effect = "Allow"
+        Action = "rds-db:connect"
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:rds-db:${var.aws_region}:${var.aws_account_id}:dbuser:*/*"
+        ]
+      }
+    ]
+  })
+}
+
+# ECS — the agent may launch its own one-offs (`scripts/ecs-run-task.sh`),
+# describe arbitrary tasks, register/deregister task definitions for
+# rebuilds, and `aws ecs execute-command` into running tasks for
+# debugging. Scoped to the dev cluster via the cluster-ARN condition
+# wherever AWS supports it; falls back to `Resource="*"` only on the
+# AWS APIs that don't accept ARN scoping (RegisterTaskDefinition,
+# DescribeTaskDefinition, etc.).
+resource "aws_iam_role_policy" "agent_task_ecs" {
+  name = "${local.role_name_prefix}-agent-task-ecs-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Task-def lifecycle. AWS does not accept ARN scoping on
+        # Register/Describe — same constraint as the iam_agent module.
+        Sid    = "AllowTaskDefLifecycle"
+        Effect = "Allow"
+        Action = [
+          "ecs:RegisterTaskDefinition",
+          "ecs:DeregisterTaskDefinition",
+          "ecs:DescribeTaskDefinition",
+          "ecs:ListTaskDefinitions",
+        ]
+        Resource = "*"
+      },
+      {
+        # Cluster-scoped task lifecycle. The agent may launch / stop /
+        # describe / list any task on this cluster — needed for the
+        # full `scripts/ecs-run-task.sh` flow plus any future debug
+        # paths a /task run wants to take.
+        Sid    = "AllowClusterTaskLifecycle"
+        Effect = "Allow"
+        Action = [
+          "ecs:RunTask",
+          "ecs:StopTask",
+          "ecs:DescribeTasks",
+          "ecs:ListTasks",
+          "ecs:DescribeServices",
+          "ecs:ListServices",
+          "ecs:DescribeClusters",
+          "ecs:DescribeContainerInstances",
+          "ecs:ListContainerInstances",
+          "ecs:TagResource",
+          "ecs:UntagResource",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        # ECS Exec — `aws ecs execute-command` for live debugging
+        # (#3145). The data plane runs over SSM (next statement); this
+        # statement is the control-plane authorization for opening the
+        # session.
+        Sid      = "AllowECSExecuteCommand"
+        Effect   = "Allow"
+        Action   = "ecs:ExecuteCommand"
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+# iam:PassRole — required for the agent to launch its own one-off ECS
+# tasks via `scripts/ecs-run-task.sh`. The script's RunTask call passes
+# the source task's task + execution roles, which the agent's role
+# must be authorized to pass. Scoped to the dev account's
+# `judgemind-*-dev` roles — no cross-account, no IAM admin roles.
+#
+# `iam:GetRole` is paired here because `scripts/ecs-run-task.sh --role
+# <name>` resolves the role name to an ARN before RunTask.
+resource "aws_iam_role_policy" "agent_task_pass_role" {
+  name = "${local.role_name_prefix}-agent-task-pass-role-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowPassDevRoles"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = "arn:${data.aws_partition.current.partition}:iam::${var.aws_account_id}:role/judgemind-*-${var.environment}"
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid      = "AllowResolveDevRoleNames"
+        Effect   = "Allow"
+        Action   = "iam:GetRole"
+        Resource = "arn:${data.aws_partition.current.partition}:iam::${var.aws_account_id}:role/judgemind-*-${var.environment}"
+      },
+    ]
+  })
+}
+
+# SSM exec data plane. The control-plane `ecs:ExecuteCommand` (above)
+# opens the channel; these `ssmmessages:*` actions are how the data
+# plane streams stdin/stdout. Resource MUST be `*` because SSM creates
+# the channel session ID dynamically per-exec — same pattern v2's
+# dispatcher-daemon and dispatcher-agent-runner use.
+resource "aws_iam_role_policy" "agent_task_ssm" {
+  name = "${local.role_name_prefix}-agent-task-ssm-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSSMMessages"
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# CloudWatch Logs read+write across the dev account. The agent may
+# need to tail any `/ecs/judgemind-*-dev` or `/judgemind/dispatcher-v3/*`
+# log group during diagnosis, and may emit its own structured logs
+# from inside the container.
+resource "aws_iam_role_policy" "agent_task_logs" {
+  name = "${local.role_name_prefix}-agent-task-logs-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowLogsReadWrite"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents",
+          "logs:FilterLogEvents",
+          "logs:StartQuery",
+          "logs:StopQuery",
+          "logs:GetQueryResults",
+          "logs:DescribeQueries",
+        ]
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:logs:${var.aws_region}:${var.aws_account_id}:log-group:/ecs/judgemind-*-${var.environment}",
+          "arn:${data.aws_partition.current.partition}:logs:${var.aws_region}:${var.aws_account_id}:log-group:/ecs/judgemind-*-${var.environment}:*",
+          "arn:${data.aws_partition.current.partition}:logs:${var.aws_region}:${var.aws_account_id}:log-group:/judgemind/dispatcher-v3/*",
+          "arn:${data.aws_partition.current.partition}:logs:${var.aws_region}:${var.aws_account_id}:log-group:/judgemind/dispatcher-v3/*:*",
+        ]
+      },
+      {
+        # CloudWatch Insights `StartQuery` accepts a `*` resource at
+        # the API level — it is scoped to log-group references inside
+        # the query string itself, not the IAM Resource. Same handling
+        # as the iam_agent module.
+        Sid      = "AllowInsightsStartQuery"
+        Effect   = "Allow"
+        Action   = "logs:StartQuery"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# Secrets Manager read for every dev secret. Scoped to:
+#   * `judgemind/*` — every secret created by Terraform via the
+#     `judgemind/<service>/<name>` naming convention.
+#   * `*-dev-*` — every secret created with the `-dev-` infix
+#     (manually-provisioned secrets such as `judgemind/dispatcher/
+#     github-token-QOmHlJ` follow this).
+resource "aws_iam_role_policy" "agent_task_secrets" {
+  name = "${local.role_name_prefix}-agent-task-secrets-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowReadDevSecrets"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds",
+        ]
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${var.aws_region}:${var.aws_account_id}:secret:judgemind/*",
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${var.aws_region}:${var.aws_account_id}:secret:*-${var.environment}-*",
+        ]
+      },
+      {
+        # ListSecrets has no resource-level support at the API layer.
+        # The List API only returns metadata, not values.
+        Sid      = "AllowListSecrets"
+        Effect   = "Allow"
+        Action   = "secretsmanager:ListSecrets"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+# ECR pull on every repository in this account. The agent may pull
+# any v3 image, or any tooling image hosted by the project.
+resource "aws_iam_role_policy" "agent_task_ecr" {
+  name = "${local.role_name_prefix}-agent-task-ecr-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        # Token endpoint — required for the docker-login flow and
+        # cannot be ARN-scoped.
+        Sid      = "AllowEcrAuthToken"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowEcrPull"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:ListImages",
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:ecr:${var.aws_region}:${var.aws_account_id}:repository/*"
+      },
+    ]
+  })
+}
+
+# CloudWatch metrics — emit custom metrics under the
+# `Judgemind/DispatcherV3` namespace. Mirrors the v2 daemon's
+# `task_put_metric` policy.
+resource "aws_iam_role_policy" "agent_task_metrics" {
+  name = "${local.role_name_prefix}-agent-task-metrics-${var.environment}"
+  role = aws_iam_role.agent_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowPutDispatcherV3Metrics"
+        Effect   = "Allow"
+        Action   = "cloudwatch:PutMetricData"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = [
+              "Judgemind/DispatcherV3",
+              "Judgemind/Dispatcher",
+            ]
+          }
+        }
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/dispatcher-v3-iam/outputs.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/outputs.tf
@@ -1,0 +1,29 @@
+output "launcher_role_arn" {
+  description = "ARN of the dispatcher-v3 launcher task role (narrow scheduler scope). Wired into F2's `launcher` task definition as the `taskRoleArn`."
+  value       = aws_iam_role.launcher.arn
+}
+
+output "launcher_role_name" {
+  description = "Name of the dispatcher-v3 launcher task role. Useful for `aws iam simulate-principal-policy` regression checks."
+  value       = aws_iam_role.launcher.name
+}
+
+output "agent_task_role_arn" {
+  description = "ARN of the dispatcher-v3 agent task role (dev-admin equivalent shared by task-runner / diagnoser / scheduled-skill). Wired into F2's three short-lived task definitions as the `taskRoleArn`."
+  value       = aws_iam_role.agent_task.arn
+}
+
+output "agent_task_role_name" {
+  description = "Name of the dispatcher-v3 agent task role."
+  value       = aws_iam_role.agent_task.name
+}
+
+output "execution_role_arn" {
+  description = "ARN of the shared dispatcher-v3 task execution role (used by every v3 task definition for ECR pull + secret injection + log writes). Wired into F2's task definitions as the `executionRoleArn`."
+  value       = aws_iam_role.execution.arn
+}
+
+output "execution_role_name" {
+  description = "Name of the shared dispatcher-v3 task execution role."
+  value       = aws_iam_role.execution.name
+}

--- a/infra/terraform/modules/dispatcher-v3-iam/tests/policy-checks/check.sh
+++ b/infra/terraform/modules/dispatcher-v3-iam/tests/policy-checks/check.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Policy-shape regression test for the dispatcher-v3-iam module.
+#
+# Asserts the spec §10 invariants that are easy to break with a stray
+# string-replace and hard to spot in code review:
+#
+#   1. NO trust policy in the module references any account other than
+#      the dev account ID — the module is dev-only by spec, and a
+#      cross-account principal would silently expand the blast radius.
+#   2. The launcher role's `ecs:RunTask` Resource list contains exactly
+#      the three F2 agent task-def families (task-runner, diagnoser,
+#      scheduled-skill) — adding a fourth would silently widen scope.
+#   3. The launcher role does NOT have any `s3:*`, `rds-db:connect`
+#      against `*/*` (catch-all), or any `secretsmanager` action other
+#      than `GetSecretValue` on the wired telegram ARN.
+#   4. The agent task role's trust policy is the same single-account
+#      service principal as the launcher.
+#
+# This script runs against the rendered HCL — no AWS credentials are
+# needed, no actual roles are created. It is a static lint of the
+# module's main.tf to defend against the regression class where a
+# future edit accidentally removes the `Condition` block on a Resource
+# = "*" statement, or pastes a prod-account ARN into a Resource list.
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$FIXTURE_DIR/../.."
+
+main_tf="$MODULE_DIR/main.tf"
+variables_tf="$MODULE_DIR/variables.tf"
+
+if [ ! -f "$main_tf" ]; then
+    echo "FAIL: $main_tf not found" >&2
+    exit 2
+fi
+
+failures=0
+
+check() {
+    local description="$1"
+    local condition_result="$2"
+    if [ "$condition_result" = "0" ]; then
+        echo "PASS: $description"
+    else
+        echo "FAIL: $description" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# ── Check 1: no cross-account principal in any trust policy ────────────────
+#
+# The module uses a single shared `local.ecs_tasks_assume_role_policy`
+# that pins `Service: ecs-tasks.amazonaws.com` + `aws:SourceAccount =
+# var.aws_account_id`. Any other Principal type in main.tf is a
+# regression — a future edit that adds a per-role trust policy must
+# preserve the single-account service principal pattern.
+#
+# The grep below looks for any `Principal = { AWS =` in main.tf, which
+# would indicate a cross-account or cross-role trust path. The existing
+# module has zero such occurrences.
+if grep -E 'Principal\s*=\s*\{\s*AWS\s*=' "$main_tf" >/dev/null; then
+    check "no AWS-principal trust statements in main.tf" 1
+else
+    check "no AWS-principal trust statements in main.tf" 0
+fi
+
+# ── Check 2: exactly the three F2 agent task-def families ──────────────────
+#
+# The launcher's `local.agent_task_def_families` list MUST hold exactly
+# the three F2 families. Adding a fourth widens the launcher's RunTask
+# scope and is a deliberate spec change — fail loudly so that change
+# requires a spec update.
+families_count=$(grep -c '${var.task_definition_family_prefix}' "$main_tf" || true)
+expected=3
+if [ "$families_count" -lt "$expected" ]; then
+    check "launcher references at least $expected agent task-def families (found $families_count)" 1
+else
+    check "launcher references the F2 agent task-def families" 0
+fi
+
+# ── Check 3: launcher does not have full-S3 grants ─────────────────────────
+#
+# A future edit that wires the launcher into S3 (e.g. for session-log
+# streaming) is a spec departure — the launcher is scheduler-only. The
+# agent task role has `s3:*`; the launcher must not.
+launcher_s3_section=$(awk '
+    /aws_iam_role_policy "launcher_/ {capture=1}
+    capture {print}
+    /^}$/ && capture {capture=0; print "---"}
+' "$main_tf")
+
+if echo "$launcher_s3_section" | grep -E '"s3:\*"' >/dev/null; then
+    check "launcher policies do not grant s3:*" 1
+else
+    check "launcher policies do not grant s3:*" 0
+fi
+
+# ── Check 4: agent task role pinned to the dev account ─────────────────────
+#
+# Every `var.aws_account_id` reference in main.tf should resolve to the
+# dev account at apply time. The variable's default is `155326049300`
+# (per variables.tf). A grep against variables.tf catches the case
+# where the default was accidentally changed to a wildcard or a prod
+# account.
+if grep -E 'default\s*=\s*"155326049300"' "$variables_tf" >/dev/null; then
+    check "aws_account_id default is the dev account" 0
+else
+    check "aws_account_id default is the dev account" 1
+fi
+
+# ── Check 5: launcher's RDS connect is scoped to judgemind_dispatcher ──────
+#
+# The launcher persists into `dispatcher.*` schema only. Its rds-db:connect
+# Resource MUST end in `/judgemind_dispatcher` — a wildcard there would
+# let the launcher connect as any DB user.
+if grep -E 'dbuser:\*/judgemind_dispatcher' "$main_tf" >/dev/null; then
+    check "launcher RDS connect is pinned to judgemind_dispatcher DB user" 0
+else
+    check "launcher RDS connect is pinned to judgemind_dispatcher DB user" 1
+fi
+
+# ── Check 6: cluster-ARN condition appears alongside Resource = "*" ────────
+#
+# Wherever the agent task role grants an action with `Resource = "*"`
+# on a cluster-scoped API (DescribeTasks, ListTasks, etc.), the
+# `Condition.ArnEquals."ecs:cluster"` block must accompany it. The
+# module hits this requirement in the `agent_task_ecs` resource. A
+# regression that drops the Condition block would let the agent's
+# ECS calls escape to an unrelated cluster.
+ecs_resource_star_count=$(grep -c 'Resource\s*=\s*"\*"' "$main_tf" || true)
+ecs_cluster_condition_count=$(grep -c '"ecs:cluster"' "$main_tf" || true)
+# At least one cluster-ARN condition must appear in main.tf.
+if [ "$ecs_cluster_condition_count" -lt 1 ]; then
+    check "main.tf has at least one ecs:cluster ArnEquals condition" 1
+else
+    check "main.tf has at least one ecs:cluster ArnEquals condition" 0
+fi
+
+if [ "$failures" -eq 0 ]; then
+    echo
+    echo "All policy-shape checks passed."
+    exit 0
+else
+    echo
+    echo "$failures policy-shape check(s) failed." >&2
+    exit 1
+fi

--- a/infra/terraform/modules/dispatcher-v3-iam/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/variables.tf
@@ -20,7 +20,7 @@
 # rationale behind the broad `agent_task_role` scope.
 
 variable "environment" {
-  description = "Deployment environment. v3 IAM is dev-only — staging and production are human-operated and have no agent task role."
+  description = "Deployment environment. v3 IAM is dev-only -- staging and production are human-operated and have no agent task role."
   type        = string
 
   validation {
@@ -36,7 +36,7 @@ variable "aws_region" {
 }
 
 variable "aws_account_id" {
-  description = "AWS account ID for the dev environment. Used to construct scoped resource ARNs in IAM policies. Trust policies on both task roles deliberately do NOT reference any other account — production has no v3 footprint."
+  description = "AWS account ID for the dev environment. Used to construct scoped resource ARNs in IAM policies. Trust policies on both task roles deliberately do NOT reference any other account -- production has no v3 footprint."
   type        = string
   default     = "155326049300"
 }
@@ -62,13 +62,13 @@ variable "task_definition_family_prefix" {
 # the only secret-bearing path on the scheduler.
 
 variable "telegram_bot_token_secret_arn" {
-  description = "Secrets Manager ARN for TELEGRAM_BOT_TOKEN. The launcher role's only secret-read permission is scoped to this ARN. Empty disables — the launcher's `secretsmanager:GetSecretValue` policy resource is skipped entirely so a fresh stack without telegram wiring can still apply."
+  description = "Secrets Manager ARN for TELEGRAM_BOT_TOKEN. The launcher role's only secret-read permission is scoped to this ARN. Empty disables -- the launcher's `secretsmanager:GetSecretValue` policy resource is skipped entirely so a fresh stack without telegram wiring can still apply."
   type        = string
   default     = ""
 }
 
 variable "github_token_secret_arn" {
-  description = "Secrets Manager ARN for the v3 dispatcher's scoped GitHub PAT (re-used from v2 — `judgemind/dispatcher/github-token`). Threaded through to F2's task-runner and diagnoser task definitions for `gh auth setup-git` inside the agent. The launcher does not read this secret (its work is gh-API-via-PAT only via the `gh` MCP server in the agent task)."
+  description = "Secrets Manager ARN for the v3 dispatcher's scoped GitHub PAT (re-used from v2 -- `judgemind/dispatcher/github-token`). Threaded through to F2's task-runner and diagnoser task definitions for `gh auth setup-git` inside the agent. The launcher does not read this secret (its work is gh-API-via-PAT only via the `gh` MCP server in the agent task)."
   type        = string
   default     = ""
 }
@@ -84,7 +84,7 @@ variable "github_token_secret_arn" {
 # objects).
 
 variable "sessions_bucket_arn" {
-  description = "ARN of the v3 sessions bucket where session-log streaming writes per-agent jsonl. Reserved for forward compatibility with F6 (#3893) — the agent task role's full-S3 grant already covers writes to any bucket, but we list the bucket here for documentation and future scope-narrowing without breaking the spec §10 dev-admin invariant."
+  description = "ARN of the v3 sessions bucket where session-log streaming writes per-agent jsonl. Reserved for forward compatibility with F6 (#3893) -- the agent task role's full-S3 grant already covers writes to any bucket, but we list the bucket here for documentation and future scope-narrowing without breaking the spec section 10 dev-admin invariant."
   type        = string
   default     = ""
 }
@@ -97,7 +97,7 @@ variable "sessions_bucket_arn" {
 # invariant without re-implementing it.
 
 variable "prod_account_ids" {
-  description = "List of production AWS account IDs that must NEVER appear in any v3 trust policy. Used by `tests/policy-checks/check.sh` as a regression guard — see spec §10 (`Production accounts are not in scope. The trust policy on the agent task role excludes assuming any prod-account role`). Empty list disables the check; default is empty because there is no production AWS account in the Judgemind footprint at the time of writing."
+  description = "List of production AWS account IDs that must NEVER appear in any v3 trust policy. Used by `tests/policy-checks/check.sh` as a regression guard -- see spec section 10 (`Production accounts are not in scope. The trust policy on the agent task role excludes assuming any prod-account role`). Empty list disables the check; default is empty because there is no production AWS account in the Judgemind footprint at the time of writing."
   type        = list(string)
   default     = []
 }

--- a/infra/terraform/modules/dispatcher-v3-iam/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/variables.tf
@@ -1,0 +1,103 @@
+# Variables for the dispatcher-v3 IAM module.
+#
+# This module ships two task roles plus a shared task-execution role:
+#
+#   * `launcher_role` — narrow scheduler-only scope. Assumed by the
+#     long-running `launcher` task definition shipped in F2 (#3887).
+#   * `agent_task_role` — dev-admin equivalent. Assumed by the
+#     short-lived `task-runner`, `diagnoser`, and `scheduled-skill`
+#     task definitions shipped in F2 (#3887).
+#   * `execution_role` — shared by every v3 task definition. Pulls ECR
+#     images, fetches Secrets Manager entries for env-var injection,
+#     writes logs to CloudWatch.
+#
+# F2 wires the role ARNs into the matching task definitions; F4 stands
+# up the launcher ECS service. This module deliberately does NOT
+# create any task definitions, services, or log groups — those land
+# alongside their owning modules.
+#
+# See `docs/specs/dispatcher-v3-spec.md` §10 (IAM + secrets) for the
+# rationale behind the broad `agent_task_role` scope.
+
+variable "environment" {
+  description = "Deployment environment. v3 IAM is dev-only — staging and production are human-operated and have no agent task role."
+  type        = string
+
+  validation {
+    condition     = contains(["dev"], var.environment)
+    error_message = "environment must be: dev (dispatcher-v3 IAM is dev-only; staging/production are human-operated per spec §10)."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region the v3 stack runs in. Used to construct scoped resource ARNs in IAM policies."
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID for the dev environment. Used to construct scoped resource ARNs in IAM policies. Trust policies on both task roles deliberately do NOT reference any other account — production has no v3 footprint."
+  type        = string
+  default     = "155326049300"
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster the v3 task definitions run on. The launcher's `ecs:RunTask` policy is gated on this cluster ARN; the agent task role's `ecs:RunTask` and `ecs:ExecuteCommand` are gated on the same cluster."
+  type        = string
+}
+
+variable "task_definition_family_prefix" {
+  description = "Family-name prefix of the v3 task definitions registered by F2. The launcher's `ecs:RunTask` permission is scoped to `<prefix>-task-runner:*`, `<prefix>-diagnoser:*`, and `<prefix>-scheduled-skill:*` revisions of this family. Default `judgemind-dispatcher-v3` matches the F2 spec."
+  type        = string
+  default     = "judgemind-dispatcher-v3"
+}
+
+# ─── Secrets ─────────────────────────────────────────────────────────────
+# Two ARNs only — the rest are read by the broad agent task role via the
+# `judgemind/*` and `*-dev-*` resource patterns, no per-secret wiring
+# needed.
+#
+# The launcher role gets a single Secrets Manager grant: TELEGRAM_BOT_TOKEN.
+# That's all the launcher needs — paging the operator on a stuck queue is
+# the only secret-bearing path on the scheduler.
+
+variable "telegram_bot_token_secret_arn" {
+  description = "Secrets Manager ARN for TELEGRAM_BOT_TOKEN. The launcher role's only secret-read permission is scoped to this ARN. Empty disables — the launcher's `secretsmanager:GetSecretValue` policy resource is skipped entirely so a fresh stack without telegram wiring can still apply."
+  type        = string
+  default     = ""
+}
+
+variable "github_token_secret_arn" {
+  description = "Secrets Manager ARN for the v3 dispatcher's scoped GitHub PAT (re-used from v2 — `judgemind/dispatcher/github-token`). Threaded through to F2's task-runner and diagnoser task definitions for `gh auth setup-git` inside the agent. The launcher does not read this secret (its work is gh-API-via-PAT only via the `gh` MCP server in the agent task)."
+  type        = string
+  default     = ""
+}
+
+# ─── S3 buckets ─────────────────────────────────────────────────────────
+# The agent task role gets full S3 because dev `/task` runs may touch
+# raw/ (S3-as-source-of-truth, see CLAUDE.md §Project Context), spotcheck/
+# scratch areas, and the v3 sessions/ prefix (F6, #3893). We accept full
+# S3 in dev — the trade-off is documented in spec §10. Production
+# accounts are not in scope.
+#
+# The launcher does NOT get S3 access at all (it never reads or writes
+# objects).
+
+variable "sessions_bucket_arn" {
+  description = "ARN of the v3 sessions bucket where session-log streaming writes per-agent jsonl. Reserved for forward compatibility with F6 (#3893) — the agent task role's full-S3 grant already covers writes to any bucket, but we list the bucket here for documentation and future scope-narrowing without breaking the spec §10 dev-admin invariant."
+  type        = string
+  default     = ""
+}
+
+# ─── Trust policy guard (defense in depth) ──────────────────────────────
+# The trust policy on every role created by this module pins `Principal =
+# Service: ecs-tasks.amazonaws.com` and pins the source account. There is
+# no `sts:AssumeRole` from any cross-account principal anywhere in the
+# module. This variable exists so a CI test fixture can assert the
+# invariant without re-implementing it.
+
+variable "prod_account_ids" {
+  description = "List of production AWS account IDs that must NEVER appear in any v3 trust policy. Used by `tests/policy-checks/check.sh` as a regression guard — see spec §10 (`Production accounts are not in scope. The trust policy on the agent task role excludes assuming any prod-account role`). Empty list disables the check; default is empty because there is no production AWS account in the Judgemind footprint at the time of writing."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

New `dispatcher-v3-iam` Terraform module ships the two task roles + shared execution role for the v3 ECS pipeline per spec section 10. The narrow `launcher_role` is scoped to scheduler-only AWS APIs; the broad `agent_task_role` (shared by F2's task-runner / diagnoser / scheduled-skill) gets dev-admin authority because /task arbitrarily needs the full dev tool surface.

Trust policies pin `Principal = Service: ecs-tasks.amazonaws.com` + `aws:SourceAccount = var.aws_account_id` and the module's `environment` variable rejects anything other than `dev` -- production accounts are not in scope per spec section 10. A static-analysis regression test under `tests/policy-checks/check.sh` asserts the invariants (no cross-account principal, narrow launcher scope, dev account pinned, launcher RDS scoped to `judgemind_dispatcher`, ecs:cluster ArnEquals condition present).

Closes #3888

## Test plan

### Automated checks
- [x] `terraform fmt -check -diff -recursive` -- clean
- [x] `terraform validate` for `environments/dev` -- `Success! The configuration is valid.`
- [x] `terraform validate` for `environments/production` -- `Success! The configuration is valid.` (no changes; module is dev-only by `environment` validation)
- [x] `terraform validate` for `modules/dispatcher-v3-iam` (standalone) -- clean
- [x] `tests/policy-checks/check.sh` -- all six policy-shape checks pass locally
- [x] `scripts/check-no-nonascii-tf-descriptions.sh` -- clean (after non-ASCII fix in commit 2)
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `aws iam get-role --role-name judgemind-dispatcher-v3-launcher-dev` succeeds
- [x] `aws iam get-role --role-name judgemind-dispatcher-v3-agent-task-dev` succeeds
- [x] `aws iam list-role-policies --role-name judgemind-dispatcher-v3-launcher-dev` lists the inline policies
- [x] `aws iam list-role-policies --role-name judgemind-dispatcher-v3-agent-task-dev` lists the broad inline policies
- [x] `aws iam simulate-principal-policy` against the launcher role + a random task-def ARN returns Deny
- [x] `aws iam get-role --role-name judgemind-dispatcher-v3-launcher-dev --query 'Role.AssumeRolePolicyDocument'` confirms the trust policy is single-account ECS-tasks-only
- [x] Verification evidence posted on issue (see A.8)
