### PR TITLE
feat(dispatcher-v3): add S3 sessions bucket + lifecycle (#3891)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -102,6 +102,15 @@ jobs:
       - name: dispatcher-v3-iam policy-shape check
         run: bash infra/terraform/modules/dispatcher-v3-iam/tests/policy-checks/check.sh
 
+      # Policy-shape regression test for dispatcher-v3-sessions-bucket
+      # (#3891). Static analysis of the rendered HCL — no AWS
+      # credentials needed. Asserts the spec §4.1 invariants (bucket is
+      # private, lifecycle uses GLACIER_IR not deep Glacier, bucket
+      # policy is scoped to the agent_task_role and grants only
+      # PutObject + GetObject).
+      - name: dispatcher-v3-sessions-bucket policy-shape check
+        run: bash infra/terraform/modules/dispatcher-v3-sessions-bucket/tests/policy-checks/check.sh
+
       # Plan requires AWS credentials (stored as GitHub Actions secrets).
       # The plan confirms the module is deployable and shows exactly what
       # resources will be created or modified.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -429,6 +429,28 @@ module "dispatcher_v3_iam" {
   github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
 }
 
+# ─── Dispatcher v3 sessions bucket (F-this-issue, #3891) ────────────────────
+# Per `docs/specs/dispatcher-v3-spec.md` §4.1 session capture. Stores
+# per-agent session logs (raw stream-json jsonl + compact transcript)
+# emitted by the v3 task-runner and diagnoser. Private bucket, IAM-only
+# access from the v3 agent_task_role, lifecycle Standard for 30 days
+# then Glacier-IR with a configurable expiration (default 365 days).
+#
+# The bucket policy grants only s3:PutObject and s3:GetObject to the
+# agent_task_role; ListBucket is intentionally omitted (the diagnoser
+# reads by exact key from the agents table, never enumerates).
+module "dispatcher_v3_sessions" {
+  source = "../../modules/dispatcher-v3-sessions-bucket"
+
+  environment         = "dev"
+  bucket_name         = "judgemind-dispatcher-v3-sessions"
+  agent_task_role_arn = module.dispatcher_v3_iam.agent_task_role_arn
+
+  # Default 365 days. Operators can override here if a future incident
+  # review needs an extended audit window without changing the module.
+  # session_retention_days = 365
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url
@@ -725,4 +747,14 @@ output "dispatcher_v3_agent_task_role_arn" {
 output "dispatcher_v3_execution_role_arn" {
   description = "Dev dispatcher-v3 shared task-execution role ARN (used by every v3 task definition for ECR pull + secret injection + log writes)"
   value       = module.dispatcher_v3_iam.execution_role_arn
+}
+
+output "dispatcher_v3_sessions_bucket" {
+  description = "Dev dispatcher-v3 sessions bucket name. Wired into F2 task definitions as the SESSIONS_BUCKET env var (per spec section 4.1)."
+  value       = module.dispatcher_v3_sessions.bucket_id
+}
+
+output "dispatcher_v3_sessions_bucket_arn" {
+  description = "Dev dispatcher-v3 sessions bucket ARN. Useful for `aws iam simulate-principal-policy` regression checks against the agent_task_role policies."
+  value       = module.dispatcher_v3_sessions.bucket_arn
 }

--- a/infra/terraform/modules/dispatcher-v3-sessions-bucket/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-sessions-bucket/main.tf
@@ -1,0 +1,149 @@
+# Dispatcher v3 sessions bucket.
+#
+# Stores per-agent session logs (raw stream-json jsonl + compact transcript)
+# written by the v3 task-runner and diagnoser. Per `docs/specs/dispatcher-v3-spec.md`
+# section 4.1, the launcher reads `lastEventTimestamp` from CloudWatch Logs
+# for silent-hang detection and the diagnoser reads the full session
+# transcript from this bucket as input context.
+#
+# Sensitivity: session logs may contain operator commands and tool-call
+# outputs that incidentally include secrets if a skill prints them. The
+# bucket is private by construction: no public access, IAM-only writes
+# from the dispatcher-v3 agent_task_role (F3, #3921), versioning enabled
+# for accidental-overwrite recovery, SSE-S3 at rest.
+#
+# Lifecycle: Standard storage for the first 30 days (covers the diagnoser
+# read window plus a few weeks of incident-replay headroom), then transition
+# to Glacier Instant Retrieval (~80% cheaper, millisecond retrieval), and
+# finally expire at `var.session_retention_days` (default 365 days). The
+# retention is configurable via Terraform variable so operators can extend
+# or shorten without changing the module.
+
+resource "aws_s3_bucket" "sessions" {
+  bucket = var.bucket_name
+}
+
+# Block all public access. Sessions are read only by the diagnoser
+# (agent_task_role) via IAM-authenticated GetObject, never via a
+# pre-signed URL or public read.
+resource "aws_s3_bucket_public_access_block" "sessions" {
+  bucket = aws_s3_bucket.sessions.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Versioning enabled so an accidental overwrite (rare; agent_id is a
+# UUID so collisions are negligible) leaves the prior version
+# recoverable for a noncurrent-version retention window. Lifecycle
+# below expires noncurrent versions after 30 days.
+resource "aws_s3_bucket_versioning" "sessions" {
+  bucket = aws_s3_bucket.sessions.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# SSE-S3 (AES256). Same handling as the document-archive bucket; see
+# `modules/storage/main.tf` for the rationale (no key-management
+# overhead, free, sufficient for non-compliance workloads).
+resource "aws_s3_bucket_server_side_encryption_configuration" "sessions" {
+  bucket = aws_s3_bucket.sessions.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# Lifecycle: 30 days Standard, then Glacier-IR, expire at
+# `var.session_retention_days`. Glacier-IR (Instant Retrieval) keeps
+# millisecond retrieval latency for the diagnoser at ~1/5 the price of
+# Standard. Noncurrent versions follow a shorter schedule because they
+# exist only as accidental-overwrite safety nets.
+resource "aws_s3_bucket_lifecycle_configuration" "sessions" {
+  bucket = aws_s3_bucket.sessions.id
+
+  # Versioning must be enabled before noncurrent_version rules take effect.
+  depends_on = [aws_s3_bucket_versioning.sessions]
+
+  rule {
+    id     = "sessions-tiered-storage"
+    status = "Enabled"
+
+    filter {}
+
+    # Glacier Instant Retrieval at 30 days. Diagnosers read recent
+    # sessions during the active investigation window; older sessions
+    # are read by humans during retros and audits, where cost matters
+    # more than latency.
+    transition {
+      days          = 30
+      storage_class = "GLACIER_IR"
+    }
+
+    expiration {
+      days = var.session_retention_days
+    }
+
+    # Noncurrent (overwritten) versions: drop to Glacier-IR after 7
+    # days, expire after 30. Operators rarely need to recover an
+    # accidentally-overwritten session log; the short window covers
+    # genuine accidents without long-term cost.
+    noncurrent_version_transition {
+      noncurrent_days = 7
+      storage_class   = "GLACIER_IR"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# Bucket policy: only the dispatcher-v3 agent_task_role may PutObject
+# or GetObject. Every other principal is implicitly denied (no
+# matching Allow statement plus the public-access-block above). This
+# is the IAM-side counterpart to the v3 spec section 10 invariant
+# that v3 ECS tasks are the only writers and readers.
+#
+# We grant only the two actions the spec actually needs:
+#   - s3:PutObject       -- task-runner writes session log on EXIT.
+#   - s3:GetObject       -- diagnoser reads session log on entry.
+#
+# We deliberately do NOT grant s3:ListBucket here. The diagnoser knows
+# the exact key (`<agent_id>.jsonl`) from the agents table; bucket
+# enumeration is unnecessary and would expose the full session history
+# to any role with the bucket-level policy. ListBucket can be added
+# later via a follow-up if a future skill needs to discover sessions.
+resource "aws_s3_bucket_policy" "sessions" {
+  bucket = aws_s3_bucket.sessions.id
+
+  # The public-access-block must apply first so the bucket policy
+  # cannot accidentally grant cross-account public access during a
+  # racy create.
+  depends_on = [aws_s3_bucket_public_access_block.sessions]
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAgentTaskRoleReadWrite"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.agent_task_role_arn
+        }
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+        ]
+        Resource = "${aws_s3_bucket.sessions.arn}/*"
+      },
+    ]
+  })
+}

--- a/infra/terraform/modules/dispatcher-v3-sessions-bucket/outputs.tf
+++ b/infra/terraform/modules/dispatcher-v3-sessions-bucket/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "Name/ID of the dispatcher-v3 sessions bucket. Wired into F2 task definitions as the SESSIONS_BUCKET env var."
+  value       = aws_s3_bucket.sessions.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the dispatcher-v3 sessions bucket. Useful for `aws iam simulate-principal-policy` regression checks against the agent_task_role policies."
+  value       = aws_s3_bucket.sessions.arn
+}
+
+output "bucket_regional_domain_name" {
+  description = "Regional domain name of the sessions bucket. Use for direct S3 endpoint construction inside the dev VPC if a future component needs path-style addressing."
+  value       = aws_s3_bucket.sessions.bucket_regional_domain_name
+}

--- a/infra/terraform/modules/dispatcher-v3-sessions-bucket/tests/policy-checks/check.sh
+++ b/infra/terraform/modules/dispatcher-v3-sessions-bucket/tests/policy-checks/check.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Policy-shape regression test for the dispatcher-v3-sessions-bucket module.
+#
+# Asserts the spec section 4.1 / section 10 invariants that are easy to
+# break with a stray edit and hard to spot in code review:
+#
+#   1. The bucket policy grants ONLY s3:PutObject and s3:GetObject. No
+#      s3:ListBucket, no s3:DeleteObject, no s3:* wildcard. Adding
+#      another action would silently widen scope.
+#   2. The bucket policy Principal is `var.agent_task_role_arn` only;
+#      no cross-account principal, no wildcard, no IAM-user principal.
+#   3. The public access block sets all four flags to true. Any flag
+#      flipping to false would silently expose the bucket.
+#   4. Versioning is enabled. SSE is configured.
+#   5. The lifecycle rule transitions to GLACIER_IR at exactly 30 days
+#      and expires at `var.session_retention_days`. A typo like
+#      `STANDARD_IA` or `GLACIER` (deep archive) would silently
+#      change cost or retrieval characteristics.
+#
+# This script runs against the rendered HCL only, no AWS credentials
+# are needed and no actual resources are created. It is a static lint
+# of the module's main.tf to defend against the regression class
+# where a future edit accidentally widens the bucket policy or
+# disables a public-access-block flag.
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$FIXTURE_DIR/../.."
+
+main_tf="$MODULE_DIR/main.tf"
+variables_tf="$MODULE_DIR/variables.tf"
+
+if [ ! -f "$main_tf" ]; then
+    echo "FAIL: $main_tf not found" >&2
+    exit 2
+fi
+
+if [ ! -f "$variables_tf" ]; then
+    echo "FAIL: $variables_tf not found" >&2
+    exit 2
+fi
+
+failures=0
+
+check() {
+    local description="$1"
+    local condition_result="$2"
+    if [ "$condition_result" = "0" ]; then
+        echo "PASS: $description"
+    else
+        echo "FAIL: $description" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# 1. Bucket policy actions: ONLY PutObject + GetObject.
+grep -q '"s3:PutObject"' "$main_tf" && pp=0 || pp=1
+check "bucket policy grants s3:PutObject" "$pp"
+
+grep -q '"s3:GetObject"' "$main_tf" && gp=0 || gp=1
+check "bucket policy grants s3:GetObject" "$gp"
+
+# Reject any other s3:Action verb in the bucket policy. We use a tight
+# allowlist instead of a denylist so future S3 actions are caught by
+# default. The policy block is the `aws_s3_bucket_policy` resource;
+# scan its action list.
+disallowed=$(grep -oE '"s3:[A-Za-z]+"' "$main_tf" | sort -u | grep -vE '^"(s3:PutObject|s3:GetObject)"$' || true)
+if [ -z "$disallowed" ]; then
+    check "bucket policy has no actions beyond PutObject + GetObject" 0
+else
+    echo "FAIL: bucket policy contains disallowed s3 actions: $disallowed" >&2
+    failures=$((failures + 1))
+fi
+
+# 2. Principal scoping: must be var.agent_task_role_arn, not a wildcard.
+grep -q 'AWS = var.agent_task_role_arn' "$main_tf" && pa=0 || pa=1
+check "bucket policy Principal scoped to var.agent_task_role_arn" "$pa"
+
+# Defensive: no Principal = "*" anywhere in the file.
+if grep -qE 'Principal[[:space:]]*=[[:space:]]*"\*"' "$main_tf"; then
+    echo "FAIL: bucket policy contains wildcard Principal" >&2
+    failures=$((failures + 1))
+else
+    check "no wildcard Principal in bucket policy" 0
+fi
+
+# 3. Public access block: all four flags must be true.
+for flag in block_public_acls block_public_policy ignore_public_acls restrict_public_buckets; do
+    if grep -qE "${flag}[[:space:]]+= true" "$main_tf"; then
+        check "public access block: $flag = true" 0
+    else
+        echo "FAIL: public access block: $flag is not set to true" >&2
+        failures=$((failures + 1))
+    fi
+done
+
+# 4. Versioning enabled, SSE configured.
+grep -qE 'status[[:space:]]+= "Enabled"' "$main_tf" && ve=0 || ve=1
+check "versioning enabled" "$ve"
+
+grep -q 'sse_algorithm = "AES256"' "$main_tf" && se=0 || se=1
+check "SSE-S3 (AES256) configured" "$se"
+
+# 5. Lifecycle: GLACIER_IR transition at 30 days.
+if grep -qE 'storage_class[[:space:]]+= "GLACIER_IR"' "$main_tf"; then
+    check "lifecycle transition uses GLACIER_IR" 0
+else
+    echo "FAIL: lifecycle transition does not reference GLACIER_IR" >&2
+    failures=$((failures + 1))
+fi
+
+# Reject GLACIER (deep archive) and DEEP_ARCHIVE -- accidental
+# substitution would change retrieval latency dramatically.
+if grep -qE 'storage_class[[:space:]]+= "GLACIER"[^_]' "$main_tf"; then
+    echo "FAIL: lifecycle uses GLACIER (deep archive) instead of GLACIER_IR" >&2
+    failures=$((failures + 1))
+else
+    check "lifecycle does not use GLACIER (deep archive)" 0
+fi
+
+if grep -qE 'storage_class[[:space:]]+= "DEEP_ARCHIVE"' "$main_tf"; then
+    echo "FAIL: lifecycle uses DEEP_ARCHIVE instead of GLACIER_IR" >&2
+    failures=$((failures + 1))
+else
+    check "lifecycle does not use DEEP_ARCHIVE" 0
+fi
+
+# Verify the 30-day transition floor is preserved. A future edit that
+# bumps this to 7d (or drops it to 90d) would change the diagnoser's
+# read-window cost characteristics; pin the value.
+if grep -qE 'days[[:space:]]+= 30' "$main_tf"; then
+    check "lifecycle transition pinned at 30 days" 0
+else
+    echo "FAIL: lifecycle transition is not pinned at 30 days" >&2
+    failures=$((failures + 1))
+fi
+
+# 6. session_retention_days variable: default 365, lower bound > 30.
+if grep -qE 'default[[:space:]]+= 365' "$variables_tf"; then
+    check "session_retention_days default is 365" 0
+else
+    echo "FAIL: session_retention_days default is not 365" >&2
+    failures=$((failures + 1))
+fi
+
+if grep -qE 'session_retention_days[[:space:]]+>=[[:space:]]+31' "$variables_tf"; then
+    check "session_retention_days lower-bound validation enforces >= 31" 0
+else
+    echo "FAIL: session_retention_days lower bound is not enforced (must be >= 31)" >&2
+    failures=$((failures + 1))
+fi
+
+# 7. ASCII-only descriptions (the AWS provider rejects non-ASCII bytes
+# in description fields per #3321 / #3923). The repo-level check
+# (scripts/check-no-nonascii-tf-descriptions.sh) is the source of
+# truth -- this module-local check is a fast smoke test so a developer
+# editing the module catches a stray em-dash before pushing.
+if LC_ALL=C grep -P '[^\x00-\x7F]' "$main_tf" "$variables_tf" "$MODULE_DIR/outputs.tf" >/dev/null 2>&1; then
+    echo "FAIL: module contains non-ASCII bytes" >&2
+    failures=$((failures + 1))
+else
+    check "module is ASCII-only" 0
+fi
+
+if [ "$failures" -gt 0 ]; then
+    echo "" >&2
+    echo "$failures policy-shape check(s) failed." >&2
+    exit 1
+fi
+
+echo ""
+echo "All policy-shape checks passed."

--- a/infra/terraform/modules/dispatcher-v3-sessions-bucket/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-sessions-bucket/variables.tf
@@ -1,0 +1,45 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket for dispatcher-v3 session logs. Must be globally unique. Production-style name lives in dev only because v3 has no production footprint."
+  type        = string
+  default     = "judgemind-dispatcher-v3-sessions"
+}
+
+variable "environment" {
+  description = "Deployment environment. v3 is dev-only by spec section 10; the variable exists so future tooling can grep for environment scope but production is not a supported value."
+  type        = string
+
+  validation {
+    condition     = contains(["dev"], var.environment)
+    error_message = "environment must be 'dev'. Dispatcher v3 has no production footprint per spec section 10."
+  }
+}
+
+variable "agent_task_role_arn" {
+  description = "ARN of the dispatcher-v3 agent_task_role (F3, #3921). Wired into the bucket policy as the only principal allowed to PutObject and GetObject. Coming from module.dispatcher_v3_iam.agent_task_role_arn."
+  type        = string
+
+  validation {
+    # Reject empty strings early. A blank ARN would render the bucket
+    # policy as `Principal.AWS = ""` which IAM accepts but resolves to
+    # 'no principal' so the entire Allow statement becomes a no-op,
+    # leaving the bucket effectively read-only-from-public-access-block
+    # and write-only via the implicit owner. Better to fail at plan time.
+    condition     = length(var.agent_task_role_arn) > 0
+    error_message = "agent_task_role_arn must be a non-empty IAM role ARN."
+  }
+}
+
+variable "session_retention_days" {
+  description = "Number of days to retain session log objects before expiration. Default 365 (1 year). Operators can extend (e.g. 730 for two-year audit horizon) without changing the module. Per spec section 12.1, raw stream-json transcripts can be 50-200 MB so the lifecycle rule moves them to Glacier-IR at 30 days regardless of this value."
+  type        = number
+  default     = 365
+
+  validation {
+    # Lower bound guards against an accidental 0 (which would expire
+    # objects on creation day, before the diagnoser can even read
+    # them). Upper bound is generous; operators who need a true
+    # archive can layer their own retention rule outside this module.
+    condition     = var.session_retention_days >= 31 && var.session_retention_days <= 3650
+    error_message = "session_retention_days must be between 31 and 3650 (10 years). The lifecycle rule transitions to Glacier-IR at day 30 so retention must exceed that floor."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the `judgemind-dispatcher-v3-sessions` S3 bucket per `docs/specs/dispatcher-v3-spec.md` section 4.1 — private, IAM-only access from the dispatcher-v3 `agent_task_role` (F3 #3921), versioned, SSE-S3, with a tiered lifecycle (Standard for 30 days, then Glacier-IR, expire at 365 days by default; retention is configurable). Wires the new module into `environments/dev/main.tf` and adds a static policy-shape regression test.

Closes #3891

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (`terraform fmt -check -recursive`)
- [x] `scripts/check-no-nonascii-tf-descriptions.sh` clean
- [x] `dispatcher-v3-sessions-bucket` policy-shape check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `aws s3api head-bucket --bucket judgemind-dispatcher-v3-sessions` returns 200
- [x] `aws s3api get-public-access-block --bucket judgemind-dispatcher-v3-sessions` shows all four blocks set to true
- [x] `aws s3api get-bucket-lifecycle-configuration --bucket judgemind-dispatcher-v3-sessions` shows the `sessions-tiered-storage` rule (GLACIER_IR transition at 30 days, expiration at 365)
- [x] `aws s3api get-bucket-policy --bucket judgemind-dispatcher-v3-sessions` shows agent_task_role-only policy with PutObject + GetObject
- [x] `aws s3api get-bucket-versioning --bucket judgemind-dispatcher-v3-sessions` shows `Status: Enabled`
- [x] Verification evidence posted on issue #3891
