### PR TITLE
fix(scraping): prefer LLM spelling for judge canonical, roster as alias (#3858)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1439,6 +1439,10 @@ def resolve_judge(
         # snapshot for a fuzzy match against official judge names (#2140).
         # This catches typos, initial placement variants, and partial names
         # that steps 2-3 miss.
+        # When the roster name differs from the incoming canonical, we store it
+        # as an alias after creation rather than overwriting canonical (#3858).
+        pending_roster_alias: str | None = None
+        pending_roster_alias_confidence: float | None = None
         roster_names = _get_roster_names(conn, court_id)
         if roster_names:
             roster_match = fuzzy_match_roster_name(canonical, roster_names)
@@ -1523,14 +1527,19 @@ def resolve_judge(
                         )
                         return judge_id
                     else:
-                        # No existing judge with the roster name — use roster name
-                        # as the canonical name instead of the raw-derived name.
-                        canonical = roster_normalized
+                        # No existing judge with the roster name — preserve the
+                        # incoming (LLM-extracted) spelling as canonical (#3858).
+                        # The roster name is stored as a roster_match alias after
+                        # creation so future ingests with the roster spelling
+                        # still resolve to the same judge.
+                        if roster_normalized.lower() != canonical.lower():
+                            pending_roster_alias = roster_normalized
+                            pending_roster_alias_confidence = confidence
                         logger.info(
-                            "resolve_judge: using roster canonical name %r "
-                            "instead of %r (confidence=%.2f)",
+                            "resolve_judge: preserving incoming canonical %r "
+                            "over roster %r as alias (confidence=%.2f)",
+                            canonical,
                             roster_normalized,
-                            normalize_judge_name(raw_name),
                             confidence,
                         )
 
@@ -1561,6 +1570,24 @@ def resolve_judge(
             """,
             (judge_id, raw_name),
         )
+
+        # If a roster name differed from the incoming canonical, insert it as a
+        # roster_match alias so future ingests with the roster spelling resolve
+        # to this judge (#3858).
+        if pending_roster_alias is not None:
+            cur.execute(
+                """
+                INSERT INTO judge_aliases (judge_id, raw_name, source, confidence, is_verified)
+                VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
+                ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
+                """,
+                (judge_id, pending_roster_alias, pending_roster_alias_confidence),
+            )
+            logger.debug(
+                "resolve_judge: stored roster alias %r for new judge %s",
+                pending_roster_alias,
+                judge_id,
+            )
 
         logger.debug("resolve_judge: created new judge %s for %r", judge_id, raw_name)
         return judge_id

--- a/packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py
+++ b/packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py
@@ -522,3 +522,164 @@ class TestStep1Deterministic:
 
         assert sql1 == sql2, f"Step-1 SQL differed between calls:\nCall 1: {sql1}\nCall 2: {sql2}"
         assert "ORDER BY" in sql1, f"Expected Step-1 SQL to contain ORDER BY, got:\n{sql1}"
+
+
+class TestStep3bBootstrapPrefersIncomingSpelling:
+    """Tests for Step 3b bootstrap behavior: incoming spelling wins over roster (#3858).
+
+    When no existing judge is found with the roster name, the judge should be
+    created with the LLM-extracted (incoming) spelling as canonical, not the
+    roster name. The roster name (if it differs by case-insensitive comparison)
+    is stored only as an alias for future lookups.
+    """
+
+    def test_no_existing_judge_uses_incoming_not_roster_canonical(self) -> None:
+        """When no judge exists with roster name, canonical uses incoming not roster.
+
+        Scenario:
+        - Court roster has 'Mattew C. Braner' (typo).
+        - Incoming raw name is 'MATTHEW C. BRANER' (source='sd_calendar').
+        - No existing judge found at any step.
+        - Assert: INSERT INTO judges uses 'Matthew C. Braner' (normalized incoming),
+          NOT 'Mattew C. Braner' (roster typo).
+        - Assert: a roster_match alias IS inserted for 'Mattew C. Braner'.
+        """
+        mock_conn, mock_cur = _make_mock_conn()
+
+        clear_roster_cache("court-uuid-bootstrap-1")
+
+        # fetchone sequence:
+        # Step 1: no alias for 'MATTHEW C. BRANER'
+        # Step 2: no exact canonical 'Matthew C. Braner'
+        # _get_roster_names: court_code lookup
+        # _get_roster_names: snapshot lookup
+        # Step 3b: no judge with 'Mattew C. Braner' (the roster name)
+        # Step 4: INSERT INTO judges RETURNING id
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            ("ca-san_diego",),  # _get_roster_names: court_code
+            ({"D1": "Mattew C. Braner"},),  # _get_roster_names: snapshot
+            None,  # Step 3b: no judge with roster name exists
+            ("new-judge-uuid",),  # Step 4: INSERT INTO judges RETURNING id
+        ]
+        mock_cur.fetchall.side_effect = [
+            [],  # Step 3: no near-duplicates
+        ]
+
+        result = resolve_judge(
+            mock_conn, "MATTHEW C. BRANER", "court-uuid-bootstrap-1", source="sd_calendar"
+        )
+
+        assert result == "new-judge-uuid"
+
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+
+        # The INSERT INTO judges must use the incoming spelling, not the roster typo
+        insert_judge_calls = [c for c in all_sql_calls if "INSERT INTO judges" in c]
+        assert len(insert_judge_calls) == 1, (
+            f"Expected 1 INSERT INTO judges call, got: {insert_judge_calls}"
+        )
+        assert "Matthew C. Braner" in insert_judge_calls[0], (
+            f"Expected INSERT to use incoming 'Matthew C. Braner', got: {insert_judge_calls[0]}"
+        )
+        assert "Mattew C. Braner" not in insert_judge_calls[0], (
+            "Expected INSERT to NOT use roster typo 'Mattew C. Braner', "
+            f"got: {insert_judge_calls[0]}"
+        )
+
+        # A roster_match alias must be inserted for the roster typo
+        alias_inserts = [c for c in all_sql_calls if "INSERT INTO judge_aliases" in c]
+        assert any("roster_match" in c for c in alias_inserts), (
+            f"Expected a roster_match alias INSERT for 'Mattew C. Braner', got: {alias_inserts}"
+        )
+        assert any("Mattew C. Braner" in c for c in alias_inserts), (
+            f"Expected alias INSERT containing 'Mattew C. Braner', got: {alias_inserts}"
+        )
+
+    def test_no_existing_judge_no_roster_alias_when_incoming_equals_roster(self) -> None:
+        """When incoming and roster names only differ by case, no second alias is inserted.
+
+        If normalize_judge_name(roster) == canonical (case-insensitive), the
+        roster name is not meaningfully different — no extra alias INSERT.
+        """
+        mock_conn, mock_cur = _make_mock_conn()
+
+        clear_roster_cache("court-uuid-bootstrap-2")
+
+        # Roster name matches incoming (same letters, different case only)
+        # roster='Matthew C. Braner', incoming='MATTHEW C. BRANER' ->
+        # both normalize to 'Matthew C. Braner'
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            ("ca-san_diego",),  # _get_roster_names: court_code
+            ({"D1": "Matthew C. Braner"},),  # _get_roster_names: snapshot (correct spelling)
+            None,  # Step 3b: no judge with roster name exists
+            ("new-judge-uuid-2",),  # Step 4: INSERT INTO judges RETURNING id
+        ]
+        mock_cur.fetchall.side_effect = [
+            [],  # Step 3: no near-duplicates
+        ]
+
+        result = resolve_judge(
+            mock_conn, "MATTHEW C. BRANER", "court-uuid-bootstrap-2", source="sd_calendar"
+        )
+
+        assert result == "new-judge-uuid-2"
+
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+
+        # The INSERT INTO judges must use 'Matthew C. Braner'
+        insert_judge_calls = [c for c in all_sql_calls if "INSERT INTO judges" in c]
+        assert len(insert_judge_calls) == 1
+        assert "Matthew C. Braner" in insert_judge_calls[0]
+
+        # No roster_match alias should be inserted (canonical == roster_normalized)
+        alias_inserts = [c for c in all_sql_calls if "INSERT INTO judge_aliases" in c]
+        roster_match_inserts = [c for c in alias_inserts if "roster_match" in c]
+        assert len(roster_match_inserts) == 0, (
+            f"Expected no roster_match alias when incoming==roster (case-insensitive), "
+            f"got: {roster_match_inserts}"
+        )
+
+    def test_no_existing_judge_no_source_still_creates_with_incoming_canonical(self) -> None:
+        """With source=None, incoming spelling still wins as canonical.
+
+        When no source is provided, the fix still applies: the judge is created
+        with the LLM-extracted (incoming) spelling, not the roster name.
+        """
+        mock_conn, mock_cur = _make_mock_conn()
+
+        clear_roster_cache("court-uuid-bootstrap-3")
+
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            ("ca-san_diego",),  # _get_roster_names: court_code
+            ({"D1": "Mattew C. Braner"},),  # _get_roster_names: snapshot (typo)
+            None,  # Step 3b: no judge with roster name exists
+            ("new-judge-uuid-3",),  # Step 4: INSERT INTO judges RETURNING id
+        ]
+        mock_cur.fetchall.side_effect = [
+            [],  # Step 3: no near-duplicates
+        ]
+
+        result = resolve_judge(
+            mock_conn, "MATTHEW C. BRANER", "court-uuid-bootstrap-3", source=None
+        )
+
+        assert result == "new-judge-uuid-3"
+
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+
+        # The INSERT INTO judges must use the incoming spelling
+        insert_judge_calls = [c for c in all_sql_calls if "INSERT INTO judges" in c]
+        assert len(insert_judge_calls) == 1
+        assert "Matthew C. Braner" in insert_judge_calls[0], (
+            f"Expected INSERT to use incoming 'Matthew C. Braner', got: {insert_judge_calls[0]}"
+        )
+        assert "Mattew C. Braner" not in insert_judge_calls[0], (
+            "Expected INSERT to NOT use roster typo 'Mattew C. Braner', "
+            f"got: {insert_judge_calls[0]}"
+        )

--- a/packages/scraper-framework/tests/test_judge_dedup.py
+++ b/packages/scraper-framework/tests/test_judge_dedup.py
@@ -492,8 +492,8 @@ class TestResolveJudgeRosterIntegration:
         all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
         assert "roster_match" in all_sql
 
-    def test_roster_match_no_existing_judge_uses_roster_name(self) -> None:
-        """When roster match found but no existing judge, uses roster canonical name."""
+    def test_roster_match_no_existing_judge_uses_incoming_canonical(self) -> None:
+        """When roster match found but no existing judge, incoming spelling wins (#3858)."""
         mock_conn, mock_cur = self._make_mock_conn()
 
         mock_cur.fetchone.side_effect = [
@@ -512,13 +512,18 @@ class TestResolveJudgeRosterIntegration:
         result = resolve_judge(mock_conn, "Jennifer Mccarthey", "court-uuid-1")
 
         assert result == "new-judge-uuid"
-        # The INSERT should use the roster-normalized name, not "Jennifer Mccarthey"
+        # INSERT INTO judges must use incoming canonical, not the roster typo
         insert_calls = [
             c for c in mock_cur.execute.call_args_list if "INSERT INTO judges" in str(c)
         ]
         assert len(insert_calls) == 1
         insert_sql = str(insert_calls[0])
-        assert "Jennifer Mccartney" in insert_sql
+        assert "Jennifer Mccarthey" in insert_sql
+        assert "Jennifer Mccartney" not in insert_sql
+        # Roster typo stored as roster_match alias, not as canonical
+        all_sql = " ".join(str(c) for c in mock_cur.execute.call_args_list)
+        assert "roster_match" in all_sql
+        assert "Jennifer Mccartney" in all_sql
 
     def test_no_roster_falls_through_to_create(self) -> None:
         """When no roster data exists, falls through to creating a new judge."""

--- a/scripts/backfill_braner_canonical_typo_3858.py
+++ b/scripts/backfill_braner_canonical_typo_3858.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Backfill Braner judge canonical-name typo (#3858).
+
+Fixes the canonical_name for judge bafa63e4-6a93-4d97-b00e-92e446857c7c from
+the roster typo 'Mattew C. Braner' to the correct spelling 'Matthew C. Braner',
+and inserts the typo as a roster_match alias so historical lookups still resolve.
+
+This is safe: the judge UUID is preserved, so all 30 attached rulings remain
+linked.  The alias insertion uses ON CONFLICT DO NOTHING to be idempotent.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- scripts/run-py.sh scripts/backfill_braner_canonical_typo_3858.py
+
+Options:
+    --dry-run    Print what would be changed without writing to the database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+_JUDGE_UUID = "bafa63e4-6a93-4d97-b00e-92e446857c7c"
+_OLD_CANONICAL = "Mattew C. Braner"
+_NEW_CANONICAL = "Matthew C. Braner"
+
+UPDATE_QUERY = """
+    UPDATE derived.judges
+    SET canonical_name = %s,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+      AND canonical_name = %s
+"""
+
+ALIAS_QUERY = """
+    INSERT INTO derived.judge_aliases (judge_id, raw_name, source, confidence, is_verified)
+    VALUES (%s::uuid, %s, 'roster_match', 0.85, FALSE)
+    ON CONFLICT DO NOTHING
+"""
+
+
+def run_backfill(dsn: str, *, dry_run: bool = False) -> dict[str, int]:
+    """Apply the canonical-name fix and alias insertion.
+
+    Returns a dict with 'rows_updated' and 'aliases_inserted'.
+    """
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_QUERY, (_NEW_CANONICAL, _JUDGE_UUID, _OLD_CANONICAL))
+            rows_updated = cur.rowcount
+
+            cur.execute(ALIAS_QUERY, (_JUDGE_UUID, _OLD_CANONICAL))
+            aliases_inserted = cur.rowcount
+
+        if dry_run:
+            conn.rollback()
+            logger.info(
+                "DRY RUN: would update %d judge row(s), insert %d alias row(s) [rolled back]",
+                rows_updated,
+                aliases_inserted,
+            )
+        else:
+            conn.commit()
+            logger.info(
+                "Committed: updated %d judge row(s), inserted %d alias row(s)",
+                rows_updated,
+                aliases_inserted,
+            )
+
+    return {"rows_updated": rows_updated, "aliases_inserted": aliases_inserted}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fix Braner judge canonical-name typo (#3858).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be changed without writing to the database.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(dsn, dry_run=args.dry_run)
+
+    logger.info(
+        "Backfill complete: %d row(s) updated, %d alias row(s) inserted",
+        stats["rows_updated"],
+        stats["aliases_inserted"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-sql-conflicts.py
+++ b/scripts/check-sql-conflicts.py
@@ -423,7 +423,13 @@ def _validate_conflict(
     cols: frozenset[str] | None,
 ) -> str | None:
     """Return an error message if the ON CONFLICT target is invalid, else None."""
-    constraints = UNIQUE_CONSTRAINTS.get(table)
+    # Strip schema prefix to match how UNIQUE_CONSTRAINTS is keyed (same logic as _add).
+    normalized = table
+    for prefix in ("public.", "derived.", "telemetry."):
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+            break
+    constraints = UNIQUE_CONSTRAINTS.get(normalized)
     if constraints is None:
         return f"unknown table '{table}' (not in schema reference)"
 


### PR DESCRIPTION
## Summary

Fixed resolve_judge Step 3b bootstrap to prefer the LLM-extracted spelling for judge canonicals when it differs from the roster spelling (e.g., 'Matthew' vs 'Mattew'). The roster spelling is stored only as a roster_match alias, preventing roster typos from locking in on first ingest. Implemented with TDD: three test methods validate the new behavior.

Closes #3858

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — three new test methods all passing
- [x] CI green

### Post-deploy verification

- [ ] Backfill script executed: `scripts/with-secret.sh -e DATABASE_URL=judgemind/dev/db/connection:.url -- scripts/run-py.sh scripts/backfill_braner_canonical_typo_3858.py`
- [ ] Judge canonical verified: `SELECT canonical_name FROM derived.judges WHERE id='bafa63e4-6a93-4d97-b00e-92e446857c7c';` returns 'Matthew C. Braner'
- [ ] Alias retained for backward compatibility: `SELECT raw_name FROM derived.judge_aliases WHERE judge_id='bafa63e4-6a93-4d97-b00e-92e446857c7c' ORDER BY raw_name;` includes both 'Matthew C. Braner' and 'Mattew C. Braner'
- [ ] Rulings preserved: `SELECT COUNT(*) FROM derived.rulings WHERE judge_id='bafa63e4-6a93-4d97-b00e-92e446857c7c';` returns 30 (or current count)
- [ ] Verification evidence posted on #3858 (see /task-v2-verify output)