### PR TITLE
fix(ci): add missing jobs to ci-passed aggregator, prevent false-green merges (#3919)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1573,10 +1573,22 @@ jobs:
       - name: Verify dispatcher image meets minimum runtime version requirements
         run: scripts/check-dispatcher-image-versions.sh --build Dockerfile.dispatcher
 
+  # ---------------------------------------------------------------
+  # ci-passed coverage guard: assert every top-level job appears in
+  # ci-passed.needs: so gaps like #3919 are caught before merge.
+  # ---------------------------------------------------------------
+  ci-passed-coverage-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assert every CI job is listed in ci-passed needs array
+        run: python3 scripts/check-ci-passed-coverage.py
+
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1586,6 +1598,10 @@ jobs:
           echo "Job results: $results"
           if echo "$results" | grep -q '"result": "failure"'; then
             echo "One or more jobs failed."
+            exit 1
+          fi
+          if echo "$results" | grep -q '"result": "cancelled"'; then
+            echo "One or more jobs were cancelled."
             exit 1
           fi
           echo "All jobs passed or were skipped."

--- a/scripts/check-ci-passed-coverage.py
+++ b/scripts/check-ci-passed-coverage.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check-ci-passed-coverage.py — Assert every top-level CI job appears in the
+`ci-passed.needs:` array so missing entries (like the #3919 gap) are caught
+before merge.
+
+Motivation (#3919): The `ci-passed` aggregator job is the sole required
+status check for branch protection. If a job is defined in ci.yml but absent
+from `ci-passed.needs:`, CI can be green on a PR even when that job fails,
+giving a false green signal.
+
+This script:
+1. Parses `.github/workflows/ci.yml` (simple line-oriented parser).
+2. Enumerates every top-level job name.
+3. Reads the `ci-passed.needs:` array.
+4. Asserts every job (excluding an explicit allow-list) is present.
+
+Allow-list (jobs that legitimately do not need to be in ci-passed.needs:):
+  - detect-changes       (orchestrator; always succeeds)
+  - ci-passed            (the aggregator itself)
+  - migration-notice     (informational PR comment; no gate)
+
+Note: ci-passed-coverage-check (this guard) is NOT in the allow-list — it IS
+wired into ci-passed.needs: by design, so it is covered by the check itself.
+
+Usage:
+    scripts/check-ci-passed-coverage.py                  # Use repo-root ci.yml
+    scripts/check-ci-passed-coverage.py --ci-yml PATH    # Override ci.yml location
+    scripts/check-ci-passed-coverage.py --help
+
+Exit codes:
+    0 — Every top-level job is covered by ci-passed.needs:.
+    1 — One or more jobs are missing from ci-passed.needs:.
+    2 — Script error (cannot parse ci.yml, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+# Jobs that are intentionally excluded from the ci-passed.needs: requirement.
+ALLOW_LIST: frozenset[str] = frozenset(
+    [
+        "detect-changes",  # orchestrator; always succeeds, not a gate
+        "ci-passed",  # the aggregator itself
+        "migration-notice",  # informational PR comment; no gate
+    ]
+)
+
+
+def find_repo_root() -> Path:
+    """Auto-detect the repo root via git."""
+    try:
+        r = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        return Path(r.stdout.strip())
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise RuntimeError(f"cannot determine repo root: {exc}") from exc
+
+
+def parse_job_names(lines: list[str]) -> list[str]:
+    """Return all top-level job names from the jobs: block."""
+    jobs_start: int | None = None
+    for i, line in enumerate(lines):
+        if re.match(r"^jobs:\s*$", line):
+            jobs_start = i + 1
+            break
+    if jobs_start is None:
+        raise ValueError("Could not find 'jobs:' block in ci.yml")
+
+    job_header_re = re.compile(r"^  ([A-Za-z0-9_\-]+):\s*$")
+    job_names: list[str] = []
+    for line in lines[jobs_start:]:
+        if not line.strip():
+            continue
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+        m = job_header_re.match(line)
+        if m:
+            job_names.append(m.group(1))
+    return job_names
+
+
+def parse_ci_passed_needs(lines: list[str]) -> list[str]:
+    """Return the list of job names in ci-passed.needs:."""
+    # Find the ci-passed: job header.
+    ci_passed_line: int | None = None
+    for i, line in enumerate(lines):
+        if re.match(r"^  ci-passed:\s*$", line):
+            ci_passed_line = i
+            break
+    if ci_passed_line is None:
+        raise ValueError("Could not find 'ci-passed:' job in ci.yml")
+
+    # Look for `needs: [...]` within the next ~5 lines of the job body.
+    needs_re = re.compile(r"^\s+needs:\s*\[(.+)\]")
+    for line in lines[ci_passed_line + 1 : ci_passed_line + 10]:
+        m = needs_re.match(line)
+        if m:
+            raw = m.group(1)
+            return [name.strip() for name in raw.split(",")]
+    raise ValueError("Could not find 'needs: [...]' in ci-passed job body")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Assert every top-level CI job is listed in ci-passed.needs:."
+    )
+    ap.add_argument(
+        "--ci-yml",
+        default=None,
+        help="Path to ci.yml (absolute or relative to cwd). Default: auto-detect.",
+    )
+    args = ap.parse_args()
+
+    if args.ci_yml:
+        ci_yml_path = Path(args.ci_yml).resolve()
+    else:
+        try:
+            repo_root = find_repo_root()
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        ci_yml_path = repo_root / ".github" / "workflows" / "ci.yml"
+
+    if not ci_yml_path.is_file():
+        print(f"ERROR: ci.yml not found at {ci_yml_path}", file=sys.stderr)
+        return 2
+
+    lines = ci_yml_path.read_text(encoding="utf-8").splitlines()
+
+    try:
+        all_jobs = parse_job_names(lines)
+    except ValueError as exc:
+        print(f"ERROR: failed to parse job names: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        needs = parse_ci_passed_needs(lines)
+    except ValueError as exc:
+        print(f"ERROR: failed to parse ci-passed.needs: {exc}", file=sys.stderr)
+        return 2
+
+    needs_set = set(needs)
+    missing: list[str] = []
+    for job in all_jobs:
+        if job in ALLOW_LIST:
+            continue
+        if job not in needs_set:
+            missing.append(job)
+
+    if not missing:
+        print(f"check-ci-passed-coverage: all {len(all_jobs)} jobs covered.")
+        return 0
+
+    print(
+        "check-ci-passed-coverage: the following jobs are NOT listed in "
+        "ci-passed.needs: and will not block merge if they fail:",
+        file=sys.stderr,
+    )
+    for name in missing:
+        print(f"  - {name}", file=sys.stderr)
+    print(
+        "\nFix: add the missing job name(s) to the ci-passed.needs: array in "
+        ".github/workflows/ci.yml.",
+        file=sys.stderr,
+    )
+    print(
+        "\nSee https://github.com/judgemind/judgemind/issues/3919 for background.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-ci-passed-coverage.sh
+++ b/scripts/check-ci-passed-coverage.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# check-ci-passed-coverage.sh — Thin wrapper for check-ci-passed-coverage.py
+#
+# Asserts every top-level CI job is listed in ci-passed.needs: so missing
+# entries (like the #3919 gap) are caught before merge.
+#
+# Passes all args through to the Python script — see that file for flags
+# and exit codes (#3919).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-ci-passed-coverage.py" "$@"

--- a/scripts/tests/test_check_ci_passed_coverage.sh
+++ b/scripts/tests/test_check_ci_passed_coverage.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# test_check_ci_passed_coverage.sh — Integration test for check-ci-passed-coverage.py (#3919)
+#
+# Runs the check against two synthetic ci.yml fixtures:
+#   Fixture A — has a job missing from ci-passed.needs:  → must exit 1
+#   Fixture B — all jobs covered                         → must exit 0
+#
+# Usage:
+#   scripts/tests/test_check_ci_passed_coverage.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-ci-passed-coverage.py"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR_TEST/.github/workflows"
+
+# Fixture A — extra-job is defined but NOT in ci-passed.needs:
+write_fixture_missing() {
+    cat > "$TMPDIR_TEST/.github/workflows/ci.yml" <<'EOF'
+name: CI
+on:
+  push:
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo detecting
+
+  scripts-tests:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+
+  extra-job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo extra
+
+  ci-passed:
+    needs: [scripts-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs passed or were skipped
+        run: echo ok
+EOF
+}
+
+# Fixture B — all jobs (except allow-listed) are in ci-passed.needs:
+write_fixture_complete() {
+    cat > "$TMPDIR_TEST/.github/workflows/ci.yml" <<'EOF'
+name: CI
+on:
+  push:
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo detecting
+
+  scripts-tests:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+
+  extra-job:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo extra
+
+  ci-passed:
+    needs: [scripts-tests, extra-job]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs passed or were skipped
+        run: echo ok
+EOF
+}
+
+run_check() {
+    python3 "$CHECK_SCRIPT" --ci-yml "$TMPDIR_TEST/.github/workflows/ci.yml"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    local out
+    local rc
+    out=$(run_check 2>&1)
+    rc=$?
+    if [[ "$rc" -ne 1 ]]; then
+        echo "FAIL: $desc (expected exit 1, got $rc)"
+        echo "  output: $out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    local out
+    local rc
+    out=$(run_check 2>&1)
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "FAIL: $desc (expected exit 0, got $rc)"
+        echo "  output: $out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: job missing from ci-passed.needs: is flagged ────────────────────
+write_fixture_missing
+assert_fails "extra-job missing from ci-passed.needs: is flagged"
+
+# ─── Test 2: all jobs present in ci-passed.needs: passes ─────────────────────
+write_fixture_complete
+assert_passes "all jobs listed in ci-passed.needs: passes"
+
+# ─── Test 3: help flag works ──────────────────────────────────────────────────
+TESTS=$((TESTS + 1))
+if python3 "$CHECK_SCRIPT" --help 2>&1 | grep -q "ci-passed"; then
+    echo "PASS: --help describes the script"
+else
+    echo "FAIL: --help output does not include expected description"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixed silent false-green merges where required CI jobs were missing from the `ci-passed` aggregator's `needs:` array. This happened when a job was defined in `.github/workflows/ci.yml` but forgotten in the `ci-passed.needs:` list — GitHub would report CI green even when that job failed.

The fix adds the 8 missing jobs (including `dispatcher-integration-tests`), strengthens the aggregator to catch cancelled jobs, and adds a proactive automated guard to prevent future gaps.

Closes #3919

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`scripts/tests/test_check_ci_passed_coverage.sh`)
- [x] CI green (aggregator now correctly requires all jobs)
- [x] New `ci-passed-coverage-check` job validates aggregator coverage

### Post-deploy verification

- [ ] Open a test PR that intentionally fails one required job (e.g., a scripts-tests python test) and confirm the merge button is disabled until CI is green
- [ ] Verify that a new top-level CI job, if added to ci.yml in the future, will fail the `ci-passed-coverage-check` guard until added to the aggregator's needs: array
- [ ] Verification evidence posted on #3919 (see /task-v2-verify output)