### PR TITLE
fix(ingestion): handle OpenSearch startup errors gracefully (#3917)

### DIFF
--- a/packages/scraper-framework/src/framework/search/indexer.py
+++ b/packages/scraper-framework/src/framework/search/indexer.py
@@ -35,7 +35,7 @@ from typing import TYPE_CHECKING, Any
 
 from opensearchpy import helpers
 from opensearchpy.exceptions import ConnectionError as OSConnectionError
-from opensearchpy.exceptions import ConnectionTimeout
+from opensearchpy.exceptions import ConnectionTimeout, TransportError
 
 from .mapping import TENTATIVE_RULINGS_ALIAS, create_index
 
@@ -73,7 +73,19 @@ class IndexingConsumer:
         self._index = index_name
 
         if ensure_index:
-            create_index(self._os)
+            try:
+                create_index(self._os)
+            except (TransportError, OSConnectionError) as exc:
+                # OpenSearch is best-effort and fully derivable from derived.*.
+                # A transient or auth error at startup must never prevent the
+                # ingestion worker from starting.  Log a warning and continue —
+                # per-document indexing errors are handled separately in
+                # index_document().  See #3917.
+                logger.warning(
+                    "OpenSearch ensure_index failed at startup — worker will start "
+                    "without index pre-check; indexing may degrade until resolved. %s",
+                    exc,
+                )
 
     # ------------------------------------------------------------------
     # Direct indexing interface

--- a/packages/scraper-framework/src/ingestion/__main__.py
+++ b/packages/scraper-framework/src/ingestion/__main__.py
@@ -29,6 +29,12 @@ from framework.s3_cache import make_s3_client
 
 from .worker import InfrastructureError, IngestionWorker
 
+# Early-flush print before structlog is configured so that any pre-logging
+# failures (import errors, configure_structlog crash) are visible in CloudWatch
+# as plain text rather than silence.  This is intentionally a bare print()
+# because structlog is not yet configured.  See #3917.
+print("ingestion-worker starting", flush=True)
+
 # Configure structlog for its own loggers (structlog.get_logger()) AND route
 # standard-library logging (logging.getLogger()) through structlog.
 # json=True forces JSON output regardless of terminal — the ingestion worker

--- a/packages/scraper-framework/tests/test_search_indexer.py
+++ b/packages/scraper-framework/tests/test_search_indexer.py
@@ -7,8 +7,8 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opensearchpy.exceptions import AuthorizationException, ConnectionTimeout, TransportError
 from opensearchpy.exceptions import ConnectionError as OSConnectionError
-from opensearchpy.exceptions import ConnectionTimeout
 
 from framework.search.indexer import (
     CONSUMER_GROUP,
@@ -607,6 +607,94 @@ class TestStreamConsumer:
         call_kwargs = mock_opensearch.index.call_args.kwargs
         assert call_kwargs["id"] == "doc-str"
         mock_redis.xack.assert_called_once()
+
+
+class TestEnsureIndexStartup:
+    """Regression tests for #3917 — IndexingConsumer.__init__ must not raise
+    when OpenSearch returns a 403 (AuthorizationException) or other transport
+    errors on startup.  OpenSearch is best-effort and fully derivable from
+    derived.*; a transient or auth error at startup must never prevent the
+    ingestion worker from starting.
+    """
+
+    def test_authorization_exception_during_ensure_index_does_not_raise(self) -> None:
+        """AuthorizationException(403) from create_index is swallowed at startup.
+
+        Reproduces the exact crash loop seen in dev: the OpenSearch endpoint
+        returned 403 on the HEAD /tentative_rulings_v1 call inside create_index,
+        propagating up through IngestionWorker.__init__ and causing sys.exit(1).
+        """
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        # Simulate the 403 that dev was returning
+        mock_os.indices.exists.side_effect = AuthorizationException(403, "")
+
+        # Must NOT raise — worker should start and log a warning
+        consumer = IndexingConsumer(
+            opensearch_client=mock_os,
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            ensure_index=True,
+        )
+        assert consumer is not None
+
+    def test_transport_error_during_ensure_index_does_not_raise(self) -> None:
+        """Any TransportError from create_index is swallowed at startup."""
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        mock_os.indices.exists.side_effect = TransportError(503, "Service Unavailable", {})
+
+        consumer = IndexingConsumer(
+            opensearch_client=mock_os,
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            ensure_index=True,
+        )
+        assert consumer is not None
+
+    def test_connection_error_during_ensure_index_does_not_raise(self) -> None:
+        """OSConnectionError from create_index is swallowed at startup."""
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        mock_os.indices.exists.side_effect = OSConnectionError("N/A", "Connection refused", None)
+
+        consumer = IndexingConsumer(
+            opensearch_client=mock_os,
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            ensure_index=True,
+        )
+        assert consumer is not None
+
+    def test_ensure_index_false_skips_create_index(self) -> None:
+        """When ensure_index=False, create_index is never called."""
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+
+        IndexingConsumer(
+            opensearch_client=mock_os,
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            ensure_index=False,
+        )
+
+        mock_os.indices.exists.assert_not_called()
+
+    def test_successful_ensure_index_still_works(self) -> None:
+        """Normal path: index does not exist, create_index runs without error."""
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        mock_os.indices.exists.return_value = False  # index doesn't exist yet
+
+        consumer = IndexingConsumer(
+            opensearch_client=mock_os,
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            ensure_index=True,
+        )
+
+        assert consumer is not None
+        mock_os.indices.create.assert_called_once()
 
 
 class TestFetchTextError:


### PR DESCRIPTION
## Summary

Fixed a crash loop in judgemind-ingestion-worker-dev where IndexingConsumer.__init__ raised an unhandled AuthorizationException(403) when OpenSearch rejected the startup index-existence check, causing every container to exit immediately.

Wrapped create_index() in try/except to catch TransportError and OSConnectionError, log a warning, and continue—OpenSearch is best-effort and fully derivable from derived.*. Added early print() for pre-logging failure visibility. Five regression tests cover the 403 reproducer, other transport errors, connection errors, ensure_index=False, and normal path.

Closes #3917

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 333 tests pass; diff coverage ≥90%)
- [x] CI green

### Post-deploy verification

- [ ] `aws ecs describe-services --cluster judgemind-dev --services judgemind-ingestion-worker-dev --query 'services[0].events[0:5]'` shows no `started 1 tasks` events for ≥5 minutes after merge
- [ ] `scripts/dev-db-query.sh "SELECT 1"` succeeds without `InvalidParameterException`, returns `{"ping": 1}`
- [ ] Verification evidence posted on #3917 (see /task-v2-verify output)