### PR TITLE
feat(infra): land dispatcher-v3 launcher ECS service idle alongside v2 (#3889)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -924,7 +924,7 @@ output "dispatcher_v3_scheduled_skill_log_group" {
 # rollout after a fresh image push.
 
 output "dispatcher_v3_service_name" {
-  description = "Dev dispatcher-v3 launcher ECS service name (`judgemind-dispatcher-v3-dev`). Use with `aws ecs describe-services --cluster judgemind-dev --services <service_name>` to inspect runningCount / deployment status. Spec §6."
+  description = "Dev dispatcher-v3 launcher ECS service name (`judgemind-dispatcher-v3-dev`). Use with `aws ecs describe-services --cluster judgemind-dev --services <service_name>` to inspect runningCount / deployment status. Spec section 6."
   value       = module.dispatcher_v3_service.service_name
 }
 

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -514,6 +514,49 @@ module "dispatcher_v3_task_defs" {
   sessions_bucket_name = module.dispatcher_v3_sessions.bucket_id
 }
 
+# ─── Dispatcher v3 launcher ECS service (F4, #3889) ─────────────────────────
+# Per `docs/specs/dispatcher-v3-spec.md` §6 + §9 step 2. Single-replica
+# ECS Fargate service that runs the v3 launcher loop alongside v2's
+# dispatcher daemon. Deploys at desired_count=1 with the launcher
+# observing the queue but claiming nothing — `dispatcher.config.
+# concurrency_cap_v3=0` (seeded by migration 58) keeps it idle until
+# the operator manually flips the cap.
+#
+# References F2's `launcher_task_definition_arn` directly (revision-
+# pinned). Subsequent F2 reapplies that resolve a fresh image digest
+# register a new task-def revision, but the service's
+# `lifecycle.ignore_changes = [task_definition]` block keeps Terraform
+# from churning the service on every apply — operator-driven redeploys
+# go through `aws ecs update-service --force-new-deployment` exactly
+# like v2's dispatcher-daemon.
+#
+# Why a separate service vs piggy-backing on v2's dispatcher-daemon:
+# spec §8.1 explicitly separates the two ECS services so cohabitation
+# stays clean — independent log groups, independent breakers, independent
+# concurrency caps. Wiring v3 onto the v2 service would couple the two
+# rollout knobs (cap=0 means BOTH off) and lose the gradual ramp pattern
+# in §9 step 4 (raise v3 cap by 2, decrease v2 cap by 2).
+module "dispatcher_v3_service" {
+  source = "../../modules/dispatcher-v3-service"
+
+  environment        = "dev"
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_cluster_arn    = module.compute.cluster_arn
+
+  # F2 (#3887) launcher task-def. Revision-pinned -- Terraform reapplies
+  # after a deploy-dispatcher-v3.yml push will resolve a fresh digest in
+  # F2 and register a new revision; the service ignores those revisions
+  # via lifecycle.ignore_changes = [task_definition] so the operator
+  # controls rollout timing via `update-service --force-new-deployment`.
+  task_definition_arn = module.dispatcher_v3_task_defs.launcher_task_definition_arn
+
+  # Default desired_count=1 -- launcher is RUNNING but idle (cap=0
+  # blocks claims). Operator can scale to 0 as a kill-switch
+  # (rollback button per spec §9 step 4).
+  # desired_count = 1
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url
@@ -873,4 +916,24 @@ output "dispatcher_v3_diagnoser_log_group" {
 output "dispatcher_v3_scheduled_skill_log_group" {
   description = "Dev CloudWatch log group for the dispatcher-v3 scheduled-skill task (/judgemind/dispatcher-v3/scheduled-skill)."
   value       = module.dispatcher_v3_task_defs.scheduled_skill_log_group_name
+}
+
+# ─── Dispatcher v3 launcher service outputs (F4, #3889) ─────────────────────
+# Consumed by operators to drive `aws ecs describe-services` /
+# `update-service` flows and by the v3 deploy workflow when forcing a
+# rollout after a fresh image push.
+
+output "dispatcher_v3_service_name" {
+  description = "Dev dispatcher-v3 launcher ECS service name (`judgemind-dispatcher-v3-dev`). Use with `aws ecs describe-services --cluster judgemind-dev --services <service_name>` to inspect runningCount / deployment status. Spec §6."
+  value       = module.dispatcher_v3_service.service_name
+}
+
+output "dispatcher_v3_service_arn" {
+  description = "Dev dispatcher-v3 launcher ECS service ARN."
+  value       = module.dispatcher_v3_service.service_arn
+}
+
+output "dispatcher_v3_service_security_group_id" {
+  description = "Dev dispatcher-v3 launcher security group ID (outbound HTTPS + Postgres + Redis only). Reference from any module that needs to allow ingress from the launcher (e.g. RDS / Redis security groups)."
+  value       = module.dispatcher_v3_service.security_group_id
 }

--- a/infra/terraform/modules/dispatcher-v3-service/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-service/main.tf
@@ -1,0 +1,189 @@
+# Dispatcher v3 launcher ECS service module (F4, #3889).
+#
+# Stands up the long-running ECS Fargate service that runs the v3
+# launcher loop. The service references the launcher task definition
+# from F2 (#3887, modules/dispatcher-v3-task-defs); the IAM roles
+# (launcher_role, agent_task_role, execution_role) come from F3 (#3921,
+# modules/dispatcher-v3-iam) via the task definition itself.
+#
+# Why this module exists separately from F2:
+#
+#   * F2 registers the four v3 task definitions (launcher, task-runner,
+#     diagnoser, scheduled-skill). Three of those four are one-shot
+#     (launched by the launcher via `ecs:RunTask` per claim or per
+#     EventBridge cron). The launcher is the only one that needs an
+#     ECS service to keep it running 24/7 -- standing it up alongside
+#     F2 would have implied F2 is "the launcher module" when it's
+#     really the multi-task-def module.
+#   * F4 lands AFTER F1, F2, F3 in the dependency chain. The image
+#     (#3915), task definitions (#3887), and IAM roles (#3888) all
+#     have to exist before the service can start a task.
+#
+# Cohabitation with v2 (spec section 8):
+#
+#   * The launcher's container reads `dispatcher.config.concurrency_cap_v3`
+#     (a v3-specific config key, distinct from v2's `concurrency_cap`)
+#     so v2 and v3 have independent caps during cohabitation. F4
+#     deploys with `desired_count=1` AND the seed migration writes
+#     `concurrency_cap_v3=0`, so the launcher boots, writes a heartbeat
+#     `dispatcher.runs` row tagged `dispatcher_version='v3'`, observes
+#     the queue, and claims nothing. Operator flips the cap manually
+#     (spec section 9 step 3) when ready to smoke v3 at cap=1.
+#   * The cross-daemon claim race is handled by the `status/in-progress`
+#     label interlock (spec section 8.1) -- both daemons add the label
+#     atomically before stripping `agent/ready`, so whichever wins the
+#     label flip owns the issue.
+#
+# Why a single-replica service rather than `desired_count=0` + manual
+# RunTask:
+#
+#   * The launcher needs to be running 24/7 to consume the queue. ECS
+#     services give us ECS-managed restart on container exit, plus the
+#     deployment workflow (push image -> register task-def revision ->
+#     `update-service --force-new-deployment`) that v2's daemon already
+#     uses. A `desired_count=0` service with manual RunTask launches
+#     would re-implement that loop in operator runbooks.
+#   * A standalone Fargate task launched by `aws ecs run-task` has no
+#     restart-on-exit behaviour and no health-check integration, so a
+#     single SIGKILL'd container leaves the queue unobserved until
+#     someone notices.
+#
+# Cap > 1 is not allowed: the launcher is a singleton, the same way
+# v2's dispatcher-daemon is. Overlapping replicas would each scan the
+# queue and both call `ecs:RunTask` for the same `agent/ready` issue
+# (the GitHub-side `status/in-progress` label race only protects
+# against cross-daemon collisions, not v3-vs-v3).
+#
+# Resources created:
+#
+#   * `aws_security_group.launcher` -- egress-only. Mirrors the
+#     dispatcher-daemon module's security-group ports (HTTPS for
+#     GitHub/Anthropic/ECR/Secrets Manager/Telegram, Postgres for the
+#     `dispatcher.*` writes, Redis for forward compat with future
+#     event-bus subscriptions). No inbound -- the launcher is a queue
+#     consumer, not a service endpoint.
+#   * `aws_ecs_service.launcher` -- single-replica Fargate service
+#     pinned to `var.task_definition_arn` (an immutable revision ARN
+#     from F2). `lifecycle.ignore_changes = [task_definition]` lets
+#     operator-driven redeploys (`update-service --force-new-deployment`)
+#     bump the revision without Terraform churning every apply.
+#
+# Resources NOT created here (deliberately):
+#
+#   * Task definition -- registered by F2 (modules/dispatcher-v3-task-defs).
+#   * Log group `/judgemind/dispatcher-v3/launcher` -- created by F2
+#     alongside the task definition because the awslogs driver options
+#     in the task-def JSON reference it.
+#   * IAM roles -- shipped by F3 (modules/dispatcher-v3-iam) and
+#     consumed by F2's task-def directly via `executionRoleArn` /
+#     `taskRoleArn`. F4 never sees them.
+#   * Heartbeat / circuit-breaker alarms -- a follow-up. The v2 daemon
+#     module ships extensive CloudWatch alarms (`heartbeat_stale`,
+#     `stuck_timeout_repeated`, supervisor-tick swallow alarms). v3
+#     needs equivalents (`HeartbeatAge` for v3 will live under a
+#     distinct dimension or namespace), but F4's scope is intentionally
+#     narrow to land the singleton-running invariant first; alarms come
+#     in a follow-up issue.
+
+locals {
+  service_name = var.service_name != "" ? var.service_name : "judgemind-dispatcher-v3-${var.environment}"
+}
+
+# --- Security group ---------------------------------------------------
+# Mirrors modules/dispatcher-daemon/main.tf's security group ports. The
+# launcher needs:
+#
+#   * HTTPS (443) -- GitHub API (issue queue + status/in-progress flips),
+#     Anthropic (none today; the launcher does not invoke claude itself
+#     -- only task-runner and diagnoser tasks do, and those tasks have
+#     their own security group via the F2 task-def's networkMode), ECR
+#     (image pull is via the execution role, not the task ENI -- but
+#     keeping the egress rule aligns with v2 for forward compat),
+#     Secrets Manager (TELEGRAM_BOT_TOKEN read via execution role at
+#     task start; the runtime read goes via the data-plane IAM action,
+#     not the task ENI -- but again, kept for v2 alignment), Telegram
+#     Bot API (operator paging on stuck queues, spec section 6).
+#   * Postgres (5432) -- writes to `dispatcher.runs`,
+#     `dispatcher.agents`, `dispatcher.queue_snapshots`. The DB sits
+#     in private subnets behind its own security group; the launcher's
+#     egress allows the connection out, the DB's ingress allows it in.
+#   * Redis (6379) -- reserved for forward compat with the event bus
+#     (spec section 6 "EventBridge cron rules" mentions only the
+#     EventBridge wiring, but a Redis subscriber pattern is on the
+#     roadmap). Mirrors v2's port list verbatim.
+
+resource "aws_security_group" "launcher" {
+  name        = local.service_name
+  description = "Dispatcher v3 launcher ECS task - outbound only (HTTPS, Postgres, Redis). No inbound -- the launcher is a queue consumer, not a service endpoint."
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "HTTPS to GitHub, Anthropic, ECR, Secrets Manager, Telegram, S3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL (dispatcher.* state)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Redis (event bus, reserved for future phases)"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# --- ECS Service ------------------------------------------------------
+# Single-replica Fargate service pinned to the F2 launcher task
+# definition's revision ARN. `lifecycle.ignore_changes = [task_definition]`
+# is the same pattern v2's dispatcher-daemon uses: the deploy workflow
+# pushes a new image tag, F2's data.aws_ecr_image resolves a fresh
+# digest, F2 registers a new task-def revision -- and an explicit
+# `aws ecs update-service --force-new-deployment` (or operator-driven
+# `update-service --task-definition`) is what actually rolls the
+# service. Without this lifecycle block, every F2 apply would force
+# Terraform to issue an update-service call, which is awkward when the
+# operator wants to control rollout timing.
+
+resource "aws_ecs_service" "launcher" {
+  name            = local.service_name
+  cluster         = var.ecs_cluster_arn
+  task_definition = var.task_definition_arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  # Enable ECS Exec so operators can attach an interactive shell to
+  # the running launcher for ad-hoc psql / log inspection. The agent
+  # task role's SSM permissions (F3) make the data plane work; this
+  # flag wires the control plane.
+  enable_execute_command = var.enable_execute_command
+
+  # Singleton invariant: overlapping deploys would briefly run two
+  # launchers, which would each scan the queue and call ecs:RunTask
+  # for the same agent/ready issue. The 0/100 pair lets ECS start the
+  # new task before stopping the old, but caps the window at one extra
+  # task -- a momentary singleton violation we accept (vs the alternative
+  # of a 0/0 pair which would leave the queue unobserved during the
+  # entire deploy swap).
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.launcher.id]
+    assign_public_ip = false
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}

--- a/infra/terraform/modules/dispatcher-v3-service/outputs.tf
+++ b/infra/terraform/modules/dispatcher-v3-service/outputs.tf
@@ -1,0 +1,28 @@
+# Outputs from the dispatcher-v3 launcher ECS service module.
+#
+# Consumed by:
+#   * `environments/dev/main.tf` for top-level outputs (operators query
+#     `terraform output dispatcher_v3_launcher_service_name` to drive
+#     `aws ecs describe-services` / `update-service` commands).
+#   * Future heartbeat / circuit-breaker alarm modules that target the
+#     service by name in CloudWatch dimensions.
+
+output "service_name" {
+  description = "Name of the dispatcher-v3 launcher ECS service (default `judgemind-dispatcher-v3-<environment>`, e.g. `judgemind-dispatcher-v3-dev`). Use with `aws ecs describe-services --cluster <cluster> --services <service_name>` to inspect runningCount / desiredCount / deployment status."
+  value       = aws_ecs_service.launcher.name
+}
+
+output "service_arn" {
+  description = "ARN of the dispatcher-v3 launcher ECS service. Useful for scoping CloudWatch alarms or IAM resource conditions."
+  value       = aws_ecs_service.launcher.id
+}
+
+output "security_group_id" {
+  description = "Security group ID attached to the launcher's task ENI. Outbound HTTPS + Postgres + Redis only -- no inbound rules. Reference this from any other module (e.g. RDS / Redis security group) that needs to allow ingress from the launcher."
+  value       = aws_security_group.launcher.id
+}
+
+output "security_group_arn" {
+  description = "ARN of the launcher security group. Useful for IAM resource conditions or cross-module references."
+  value       = aws_security_group.launcher.arn
+}

--- a/infra/terraform/modules/dispatcher-v3-service/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-service/variables.tf
@@ -1,0 +1,94 @@
+# Variables for the dispatcher-v3 launcher ECS service module (F4, #3889).
+#
+# This module stands up the long-running ECS Fargate service that runs
+# the v3 launcher loop. It deliberately does NOT create the task
+# definition, IAM roles, ECR repo, log group, or sessions bucket --
+# those land in F1 (#3915), F2 (#3887), F3 (#3921), and F6 (#3891)
+# respectively. F4's only job is the service + the security group it
+# attaches to.
+#
+# See `docs/specs/dispatcher-v3-spec.md` section 6 for the architecture
+# overview and section 9 (cutover step 2) for the deploy-at-cap=0
+# rationale: the ECS service deploys with desired_count=1 so the
+# launcher container is RUNNING and writing heartbeat ticks, but the
+# `dispatcher.config.concurrency_cap_v3` value is 0 -- the launcher
+# observes the queue without claiming any issue. The operator manually
+# flips the cap to 1+ to start v3 work (spec section 9 step 3).
+
+variable "environment" {
+  description = "Deployment environment. v3 is dev-only at first land -- staging and production are human-operated and have no v3 footprint (spec section 10). The default service name is `judgemind-dispatcher-v3-<environment>`."
+  type        = string
+
+  validation {
+    condition     = contains(["dev"], var.environment)
+    error_message = "environment must be: dev (dispatcher-v3 service is dev-only at first land)."
+  }
+}
+
+variable "service_name" {
+  description = "Name of the ECS service. Default empty string -- the module substitutes `judgemind-dispatcher-v3-<environment>` which matches the spec section 6 service name (`judgemind-dispatcher-v3-dev`) referenced by #3754's image-staleness defense and the cohabitation log filters. Override only if a non-default name is needed for migration or testing."
+  type        = string
+  default     = ""
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC the launcher task runs in. Same VPC as v2's dispatcher daemon -- same egress-only access requirements (HTTPS to GitHub / Anthropic / ECR / Secrets Manager / Telegram, Postgres for dispatcher.* state). No inbound."
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for the Fargate task ENI. Same subnets as v2's dispatcher daemon -- both daemons need NAT egress for GitHub/Anthropic/Telegram and Postgres connectivity."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_ids) > 0
+    error_message = "private_subnet_ids must be non-empty -- the launcher needs at least one subnet to schedule its task ENI."
+  }
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster the launcher service runs in. Same cluster as v2's dispatcher daemon (`judgemind-dev`) so the launcher's `ecs:RunTask` calls (gated on this cluster ARN by F3's launcher_role policy) target the correct cluster."
+  type        = string
+}
+
+# --- Task definition (from F2, #3887) ---------------------------------
+
+variable "task_definition_arn" {
+  description = "Full ARN (with revision) of the v3 launcher task definition exported by F2 as `launcher_task_definition_arn`. Used at apply time only -- the service's `lifecycle.ignore_changes = [task_definition]` block keeps later F2 reapplies (which register fresh revisions whenever the image digest changes) from forcing a service-level redeploy. Operator-driven redeploys go through `aws ecs update-service --force-new-deployment` instead."
+  type        = string
+}
+
+# --- Service sizing ----------------------------------------------------
+
+variable "desired_count" {
+  description = "Number of launcher task replicas. v3 is a singleton -- one replica only. Default 1 (deploy at cap=0 means the launcher is RUNNING and writing heartbeats, but the in-container cap read keeps it from claiming any issue until the operator flips dispatcher.config.concurrency_cap_v3)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.desired_count >= 0 && var.desired_count <= 1
+    error_message = "desired_count must be 0 or 1 -- the launcher is a singleton; overlapping replicas would double-claim issues."
+  }
+}
+
+# --- ECS Exec ---------------------------------------------------------
+
+variable "enable_execute_command" {
+  description = "Whether to enable `aws ecs execute-command` on the launcher service for ad-hoc operator debugging (psql, log tail, etc.). The agent task role (F3) carries the SSM exec permissions; the service-level flag is what wires them together. Default true to mirror v2 dispatcher-daemon."
+  type        = bool
+  default     = true
+}
+
+# --- Deployment behaviour ---------------------------------------------
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Min healthy percent during deploys. The launcher is a singleton; overlapping deploys would briefly double-claim. Default 0 means the old task may stop before the new one is healthy -- pairs with deployment_maximum_percent=100 (so a new task can start, but only one runs at a time during the swap window)."
+  type        = number
+  default     = 0
+}
+
+variable "deployment_maximum_percent" {
+  description = "Max percent during deploys. Default 100 means the new task starts before the old one stops (then ECS drains the old). The 0/100 pair gives ECS a momentary singleton invariant violation only during the swap; without ignore_changes on task_definition this would constantly trigger swaps on every F2 reapply."
+  type        = number
+  default     = 100
+}

--- a/packages/api/migrations/58_dispatcher-config-concurrency-cap-v3.sql
+++ b/packages/api/migrations/58_dispatcher-config-concurrency-cap-v3.sql
@@ -1,0 +1,69 @@
+-- Up Migration
+--
+-- Dispatcher v3 buildout — seed `dispatcher.config.concurrency_cap_v3 = 0`.
+-- Issue #3889 (F4 launcher ECS service AC).
+--
+-- Why
+-- ---
+-- The v3 launcher (modules/dispatcher-v3-service, F4) deploys at
+-- `desired_count=1` so the container is RUNNING and writing heartbeat
+-- ticks to ``dispatcher.runs`` immediately on apply. Per spec section 9
+-- step 2, the launcher must observe the queue WITHOUT claiming any
+-- issue until the operator manually flips the cap to 1+ for the
+-- cap=1 smoke test (spec section 9 step 3).
+--
+-- v3 reads its own cap key — ``concurrency_cap_v3`` — distinct from
+-- v2's ``concurrency_cap``. Per spec section 8.1, v2 and v3 have
+-- independent concurrency caps during cohabitation so the operator
+-- can ramp v3 up while ramping v2 down in lockstep without coupling
+-- the two daemons through a single config row.
+--
+-- Without this seed, ``scripts/dispatcher_v3/launcher.py``'s
+-- ``_read_concurrency_cap_v3`` falls back to its in-code default
+-- (``DEFAULT_CONCURRENCY_CAP_V3 = 0``) for any row that does not
+-- exist. So the launcher would still observe-but-not-claim — but the
+-- AC requires the row to exist after deploy so the operator can flip
+-- it via a ``dispatcher.commands`` write or a direct
+-- ``UPDATE dispatcher.config`` without first having to INSERT the row.
+--
+-- Design notes
+-- ------------
+-- * ``ON CONFLICT (key) DO NOTHING`` makes the migration idempotent.
+--   If an operator (or a future migration) has already inserted
+--   ``concurrency_cap_v3`` with a non-zero value, this migration does
+--   not clobber it. That matters for replays and for the case where
+--   F4's PR lands AFTER an operator has manually seeded the row to
+--   smoke v3.
+-- * ``value`` is stored as a JSONB integer (``'0'::jsonb``) — same
+--   shape as v2's ``concurrency_cap`` row from migration 21. The
+--   launcher reads it as ``SELECT value FROM dispatcher.config
+--   WHERE key = 'concurrency_cap_v3'`` and casts via ``int()``;
+--   ``dispatcher.commands`` writes set the value via
+--   ``set_config(key, jsonb_value)`` which accepts the same JSONB
+--   integer shape.
+-- * ``updated_by = 'init'`` matches the seed convention from
+--   migration 21 (live-editable keys whose initial value came from a
+--   migration, not an operator edit). The admin page and audit query
+--   already filter on this value to distinguish migration seeds from
+--   subsequent operator flips.
+--
+-- Verify (per the issue body's AC)
+-- --------------------------------
+--   ``scripts/dev-db-query.sh "SELECT value FROM dispatcher.config
+--   WHERE key='concurrency_cap_v3'"`` must return ``0``.
+
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('concurrency_cap_v3', '0'::jsonb, 'init')
+ON CONFLICT (key) DO NOTHING;
+
+
+-- Down Migration
+--
+-- Drop the row. If an operator has flipped the cap to a non-zero
+-- value (e.g. cap=1 for the smoke test), DELETE here removes that
+-- value too — the launcher's fallback default of 0 keeps it idle
+-- after the rollback, so the down migration is non-destructive in
+-- effect (the launcher behaves the same way it would with the
+-- pre-migration empty-row state).
+
+DELETE FROM dispatcher.config WHERE key = 'concurrency_cap_v3';


### PR DESCRIPTION
## Summary

F4 of the dispatcher-v3 buildout — the milestone PR that brings v3 RUNNING (idle) alongside v2. Adds:

- **`infra/terraform/modules/dispatcher-v3-service/`** — single-replica ECS Fargate service `judgemind-dispatcher-v3-dev` referencing F2's `launcher` task-def (revision-pinned, `ignore_changes` on the attribute so post-deploy revision bumps don't churn). Egress-only security group (HTTPS / Postgres / Redis). ECS Exec enabled.
- **Migration 58** — seeds `dispatcher.config.concurrency_cap_v3 = 0` so the launcher boots, writes heartbeats tagged `dispatcher_version='v3'`, but claims zero issues until the operator manually flips the cap.
- **`environments/dev/main.tf`** — instantiates the new module, adds three top-level outputs.

Spec references: `docs/specs/dispatcher-v3-spec.md` section 6 (architecture), section 9 step 2 (deploy at cap=0), section 8.1 (cohabitation — separate ECS services + caps).

Closes #3889

## Test plan

### Automated checks
- [x] `terraform fmt -check` passes
- [x] `terraform validate` passes (dev + production)
- [x] Migration files / collision checks pass
- [x] CI green

### Post-deploy verification
- [ ] `aws ecs describe-services --cluster judgemind-dev --services judgemind-dispatcher-v3-dev` shows `runningCount=1`, `status=ACTIVE` (AC #1)
- [ ] `taskDefinition` resolves to the `judgemind-dispatcher-v3-launcher` family (AC #2)
- [ ] `scripts/dev-db-query.sh "SELECT value FROM dispatcher.config WHERE key='concurrency_cap_v3'"` returns `0` (AC #3)
- [ ] `aws logs tail /judgemind/dispatcher-v3/launcher --since 5m` shows heartbeat tick lines (AC #4)
- [ ] `SELECT count(*) FROM dispatcher.agents WHERE parent_run_id IN (SELECT run_id FROM dispatcher.runs WHERE dispatcher_version='v3')` returns 0 after deploy + 5 minutes (AC #5)
- [ ] Verification evidence comment posted on #3889
