### PR TITLE
feat(dispatcher-v3): wire launcher diagnoser invocation path (#3882)

### DIFF
--- a/scripts/dispatcher_v3/launcher.py
+++ b/scripts/dispatcher_v3/launcher.py
@@ -14,16 +14,26 @@ The single long-lived process for dispatcher-v3. Each tick (default 30s):
    the session log's ``lastEventTimestamp``; if the stream has not
    received an event in ``silent_hang_minutes`` (default 30), the task
    is killed via ``ecs:StopTask`` and the agent row is marked
-   ``failed`` with ``exit_reason='silent_hang'``. The diagnoser
-   invocation on STOPPED-non-zero (and silent-hang reap) is the
-   responsibility of issue #3882 (C5) and is marked TODO inline.
-4. **Recover partial claims** — rows with ``status='claiming'`` and
+   ``failed`` with ``exit_reason='silent_hang'``. On any non-success
+   terminal (STOPPED-non-zero or silent-hang kill) the launcher
+   inline-spawns a ``diagnoser`` ECS task (issue #3882, spec §4.2)
+   with ``AGENT_ID`` set, capping at 1 diagnoser per agent.
+4. **Watch in-flight diagnosers** — for every v3-owned row with
+   ``diagnoser_arn IS NOT NULL AND status='failed' AND outcome_summary
+   IS NULL`` (the in-flight diagnoser predicate), call
+   ``ecs:DescribeTasks`` against ``diagnoser_arn`` and resolve. STOPPED-0
+   is a no-op for the launcher — the diagnoser SKILL has written
+   ``outcome_summary`` itself; the launcher only writes a fallback
+   sentinel if it's still null (so the watch query stops matching).
+   STOPPED-non-zero / OOM / spot-reclaim → set ``status='needs_review'``
+   and emit a TODO marker for the C6 Telegram alert.
+5. **Recover partial claims** — rows with ``status='claiming'`` and
    ``task_arn IS NULL`` that have aged past
    :data:`PARTIAL_CLAIM_RECOVERY_AGE_SECONDS` are marked ``failed``
    with ``exit_reason='claim_abandoned'``. Belt-and-suspenders for the
    narrow window where a label flip or RunTask fails after the DB
    INSERT lands.
-5. **Claim if cap allows** — read ``dispatcher.config.concurrency_cap_v3``
+6. **Claim if cap allows** — read ``dispatcher.config.concurrency_cap_v3``
    (v3-scoped key — see issue #3880 notes — kept independent of v2's
    ``concurrency_cap`` so each daemon can ramp / kill-switch without
    touching the other), count v3 running agents, and for each ready
@@ -234,6 +244,7 @@ class Launcher:
         github_repo: str,
         ecs_cluster_arn: str,
         task_runner_task_definition: str,
+        diagnoser_task_definition: str,
         agent_runner_subnet_ids: list[str],
         agent_runner_security_group_id: str,
         sessions_bucket: str,
@@ -251,6 +262,7 @@ class Launcher:
         self._github_repo = github_repo
         self._ecs_cluster_arn = ecs_cluster_arn
         self._task_runner_task_definition = task_runner_task_definition
+        self._diagnoser_task_definition = diagnoser_task_definition
         self._agent_runner_subnet_ids = list(agent_runner_subnet_ids)
         self._agent_runner_security_group_id = agent_runner_security_group_id
         self._sessions_bucket = sessions_bucket
@@ -279,6 +291,8 @@ class Launcher:
             "heartbeat": False,
             "watched": 0,
             "transitions": [],
+            "diagnosers_watched": 0,
+            "diagnoser_transitions": [],
             "claims": [],
             "claim_skipped": [],
             "recovered": 0,
@@ -288,6 +302,9 @@ class Launcher:
         watched, transitions = self._watch_in_flight()
         summary["watched"] = watched
         summary["transitions"] = transitions
+        d_watched, d_transitions = self._watch_diagnosers()
+        summary["diagnosers_watched"] = d_watched
+        summary["diagnoser_transitions"] = d_transitions
         summary["recovered"] = self._recover_partial_claims()
         claims, skipped = self._claim_if_cap_allows()
         summary["claims"] = claims
@@ -427,34 +444,71 @@ class Launcher:
             )
 
     def _force_kill_agent(self, agent_id: str) -> None:
-        """Stop a running ECS task for *agent_id* (best-effort)."""
+        """Stop running ECS tasks for *agent_id* (best-effort).
+
+        Cascades to both ``task_arn`` and ``diagnoser_arn`` (spec §4.2):
+        the operator's force-kill must also stop an in-flight diagnoser
+        so we don't leave an orphan running after the operator has
+        already decided. The row predicate intentionally drops the
+        ``ended_at IS NULL`` filter when reading ``diagnoser_arn`` —
+        the agent's row may carry ``ended_at`` (the original task ended
+        and a diagnoser was spawned to inspect it) while the diagnoser
+        ECS task itself is still in flight.
+        """
         assert self._conn is not None
         with self._conn.cursor() as cur:
             cur.execute(
-                "SELECT task_arn FROM dispatcher.agents "
-                "WHERE agent_id = %s AND ended_at IS NULL",
+                "SELECT task_arn, diagnoser_arn, ended_at FROM dispatcher.agents "
+                "WHERE agent_id = %s",
                 (agent_id,),
             )
             row = cur.fetchone()
-        if row is None or row[0] is None:
+        if row is None:
             return
-        task_arn = str(row[0])
+        task_arn = row[0]
+        diagnoser_arn = row[1]
+        ended_at = row[2]
+        # The agent's task ARN is only "live" if the row hasn't ended.
+        # Once ended, the task has STOPPED and stop_task is a no-op
+        # (or fails); skip it. The diagnoser ARN is treated independently
+        # of ``ended_at`` — it may be set on a row whose original task
+        # already ended.
+        targets: list[tuple[str, str]] = []
+        if task_arn and ended_at is None:
+            targets.append(("task_arn", str(task_arn)))
+        if diagnoser_arn:
+            targets.append(("diagnoser_arn", str(diagnoser_arn)))
+        if not targets:
+            return
         try:
             client = self._get_ecs_client()
-            client.stop_task(
-                cluster=self._ecs_cluster_arn,
-                task=task_arn,
-                reason="force_kill",
-            )
         except Exception:
             log.exception(
-                "launcher.force_kill_failed",
+                "launcher.force_kill_client_init_failed",
                 extra={
-                    "event": "force_kill_failed",
+                    "event": "force_kill_client_init_failed",
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                 },
             )
+            return
+        for kind, arn in targets:
+            try:
+                client.stop_task(
+                    cluster=self._ecs_cluster_arn,
+                    task=arn,
+                    reason="force_kill",
+                )
+            except Exception:
+                log.exception(
+                    "launcher.force_kill_failed",
+                    extra={
+                        "event": "force_kill_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "arn_kind": kind,
+                    },
+                )
 
     # -- step 2: heartbeat -------------------------------------------------
 
@@ -497,11 +551,13 @@ class Launcher:
           wall-clock cap itself is enforced by ECS via the task-def's
           ``stopTimeout`` (F2's responsibility, not this method).
 
-        TODO(#3882 — diagnoser invocation): on STOPPED-non-zero AND on
-        silent-hang reap we mark the row failed but do not yet spawn
-        the diagnoser ECS task — that wiring lands in C5. The
+        On any non-success terminal — STOPPED-non-zero or silent-hang
+        reap — the launcher inline-spawns a ``diagnoser`` ECS task
+        (issue #3882, spec §4.2) with ``AGENT_ID`` set. The per-agent
+        cap of 1 diagnoser is enforced inside ``_launch_diagnoser`` via
+        a fresh re-read of the row's ``diagnoser_arn`` value, and the
         ``exit_reason`` field carries the kill class so the diagnoser
-        can branch on it when it reads the row.
+        SKILL can branch on it when it reads the row.
         """
         if self._conn is None:
             return 0, []
@@ -558,14 +614,22 @@ class Launcher:
                     exit_code=exit_code,
                     exit_reason=exit_reason,
                 )
-                transitions.append(
-                    {
-                        "agent_id": str(agent_id),
-                        "status": new_status,
-                        "exit_code": exit_code,
-                        "exit_reason": exit_reason,
-                    }
-                )
+                stopped_transition: dict[str, Any] = {
+                    "agent_id": str(agent_id),
+                    "status": new_status,
+                    "exit_code": exit_code,
+                    "exit_reason": exit_reason,
+                }
+                # On failure, inline-launch the diagnoser (cap of 1 per
+                # agent enforced inside _launch_diagnoser via re-read of
+                # the row).
+                if new_status == "failed":
+                    diagnoser_arn = self._launch_diagnoser(
+                        agent_id=str(agent_id)
+                    )
+                    if diagnoser_arn:
+                        stopped_transition["diagnoser_arn"] = diagnoser_arn
+                transitions.append(stopped_transition)
                 continue
 
             # RUNNING — check for silent hang. The detector is opt-in
@@ -606,14 +670,21 @@ class Launcher:
                     "threshold_seconds": silent_hang_seconds,
                 },
             )
-            transitions.append(
-                {
-                    "agent_id": str(agent_id),
-                    "status": "failed",
-                    "exit_code": None,
-                    "exit_reason": EXIT_REASON_SILENT_HANG,
-                }
+            silent_hang_transition: dict[str, Any] = {
+                "agent_id": str(agent_id),
+                "status": "failed",
+                "exit_code": None,
+                "exit_reason": EXIT_REASON_SILENT_HANG,
+            }
+            # Silent-hang reaped agents are non-success terminals; run
+            # the diagnoser (cap of 1 enforced inside _launch_diagnoser
+            # via re-read of the row's diagnoser_arn).
+            silent_hang_diagnoser_arn = self._launch_diagnoser(
+                agent_id=str(agent_id)
             )
+            if silent_hang_diagnoser_arn:
+                silent_hang_transition["diagnoser_arn"] = silent_hang_diagnoser_arn
+            transitions.append(silent_hang_transition)
         return len(rows), transitions
 
     @staticmethod
@@ -882,7 +953,400 @@ class Launcher:
         if issue_number:
             self._gh_remove_labels(issue_number, [LABEL_STATUS_IN_PROGRESS])
 
-    # -- step 4: recover partial claims -----------------------------------
+    # -- step 3b: diagnoser invocation (issue #3882, spec §4.2) -----------
+
+    def _launch_diagnoser(self, *, agent_id: str) -> Optional[str]:
+        """Launch a diagnoser ECS task for *agent_id*; return the task ARN.
+
+        Cap of 1 enforced by an atomic re-read inside this method: if
+        ``diagnoser_arn`` is already set on the row (any prior diagnoser
+        attempt — running or completed), no new diagnoser is launched
+        and the method returns None. Per spec §4.2: "if the diagnoser
+        exits non-zero, OOMs, or is reclaimed → status='needs_review';
+        the next claim of the same issue bypasses the diagnoser
+        entirely on its first failure — there's no recursion of
+        'diagnose the diagnoser.'"
+
+        The diagnoser task definition family name is taken from the
+        constructor's ``diagnoser_task_definition`` argument (env var
+        ``DIAGNOSER_TASK_DEFINITION`` in production). The diagnoser
+        container's entrypoint runs ``claude -p "/diagnose-failure
+        $AGENT_ID"`` against the same image as the task-runner; the
+        ``AGENT_ID`` env var is the only override the launcher passes.
+
+        Returns None on cap-of-1 short-circuit, on RunTask failure
+        (logged via :func:`log.exception`), or when no diagnoser
+        task-def is configured. The caller treats None as a benign
+        outcome — the row stays ``status='failed'`` without a diagnoser,
+        and a future re-attempt on the same issue will not loop on
+        diagnosis.
+        """
+        if self._conn is None:
+            return None
+        if not self._diagnoser_task_definition:
+            # Configuration sanity: no diagnoser task-def wired up.
+            # F2 (#3887) hasn't landed yet in the dev environment, or
+            # the operator has explicitly unset the env var. Log + skip.
+            log.warning(
+                "launcher.diagnoser_task_def_unset",
+                extra={
+                    "event": "diagnoser_task_def_unset",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            return None
+
+        # Cap-of-1 re-check: read the row's current diagnoser_arn and
+        # bail if any prior diagnoser exists. Done as a fresh SELECT
+        # rather than relying on the watch-loop's row data so a
+        # concurrent diagnoser launch from a hypothetical second tick
+        # cannot race past the gate.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT diagnoser_arn FROM dispatcher.agents "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "launcher.diagnoser_cap_check_failed",
+                extra={
+                    "event": "diagnoser_cap_check_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._safe_rollback()
+            return None
+        if row is not None and row[0] is not None:
+            log.info(
+                "launcher.diagnoser_skipped_capped",
+                extra={
+                    "event": "diagnoser_skipped_capped",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "existing_diagnoser_arn": str(row[0]),
+                },
+            )
+            return None
+
+        # ecs:RunTask the diagnoser. Same network configuration as the
+        # task-runner (private subnets, internal SG); the only env
+        # override is AGENT_ID — the diagnoser SKILL reads everything
+        # else from the DB row + S3 transcript.
+        try:
+            client = self._get_ecs_client()
+        except Exception:
+            log.exception(
+                "launcher.diagnoser_client_init_failed",
+                extra={
+                    "event": "diagnoser_client_init_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            return None
+
+        env_pairs = [
+            {"name": "AGENT_ID", "value": agent_id},
+        ]
+        overrides = {
+            "containerOverrides": [
+                {"name": "diagnoser", "environment": env_pairs}
+            ]
+        }
+        network_configuration = {
+            "awsvpcConfiguration": {
+                "subnets": list(self._agent_runner_subnet_ids),
+                "securityGroups": [self._agent_runner_security_group_id],
+                "assignPublicIp": "DISABLED",
+            }
+        }
+        tags = [
+            {"key": "agent_id", "value": agent_id},
+            {"key": "dispatcher_run_id", "value": self._run_id},
+            {"key": "dispatcher_version", "value": "v3"},
+            {"key": "kind", "value": "diagnoser"},
+        ]
+        try:
+            response = client.run_task(
+                cluster=self._ecs_cluster_arn,
+                taskDefinition=self._diagnoser_task_definition,
+                launchType="FARGATE",
+                count=1,
+                overrides=overrides,
+                networkConfiguration=network_configuration,
+                tags=tags,
+                propagateTags="TASK_DEFINITION",
+                enableExecuteCommand=True,
+            )
+        except Exception:
+            log.exception(
+                "launcher.diagnoser_run_task_raised",
+                extra={
+                    "event": "diagnoser_run_task_raised",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            return None
+        failures = response.get("failures") or []
+        if failures:
+            log.warning(
+                "launcher.diagnoser_run_task_failures",
+                extra={
+                    "event": "diagnoser_run_task_failures",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "failures": failures,
+                },
+            )
+            return None
+        tasks = response.get("tasks") or []
+        if not tasks:
+            return None
+        arn = tasks[0].get("taskArn")
+        if not arn:
+            return None
+        diagnoser_arn = str(arn)
+
+        # Persist the ARN. A failure here is logged; the row keeps
+        # status='failed' without diagnoser_arn — the diagnoser is
+        # already running but the launcher has no way to find it. The
+        # diagnoser will exit on its own (it doesn't need the launcher
+        # to operate).
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET diagnoser_arn = %s "
+                    "WHERE agent_id = %s",
+                    (diagnoser_arn, agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "launcher.diagnoser_arn_update_failed",
+                extra={
+                    "event": "diagnoser_arn_update_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "diagnoser_arn": diagnoser_arn,
+                },
+            )
+            self._safe_rollback()
+            # Fall through — the diagnoser is launched, just not tracked.
+
+        log.info(
+            "launcher.diagnoser_launched",
+            extra={
+                "event": "diagnoser_launched",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "diagnoser_arn": diagnoser_arn,
+            },
+        )
+        return diagnoser_arn
+
+    def _watch_diagnosers(self) -> tuple[int, list[dict[str, Any]]]:
+        """Resolve in-flight diagnoser tasks.
+
+        The watch predicate is ``diagnoser_arn IS NOT NULL AND
+        status = 'failed' AND outcome_summary IS NULL``:
+
+        - ``diagnoser_arn IS NOT NULL`` — there is (or was) a diagnoser
+          for this agent.
+        - ``status = 'failed'`` — the agent has not yet been bumped to
+          ``needs_review`` (the diagnoser-failed terminal). Once we
+          observe a non-zero diagnoser exit and bump status, the row
+          drops out of this scan.
+        - ``outcome_summary IS NULL`` — neither the diagnoser SKILL nor
+          our STOPPED-0 fallback has written a sentinel yet. Once a
+          sentinel is written, the row drops out of this scan even if
+          the diagnoser ECS task lingers in STOPPED state.
+
+        Together these gate-against re-scanning a row whose diagnoser
+        has already been resolved. STOPPED-0 path: the diagnoser SKILL
+        wrote ``outcome_summary`` itself before exiting cleanly — the
+        launcher writes a fallback sentinel iff the column is still
+        null, so the next tick's predicate excludes the row. STOPPED-
+        non-zero path: status flips to ``needs_review``, the predicate
+        excludes the row.
+        """
+        if self._conn is None:
+            return 0, []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT agent_id, diagnoser_arn FROM dispatcher.agents "
+                    "WHERE diagnoser_arn IS NOT NULL "
+                    "  AND status = 'failed' "
+                    "  AND outcome_summary IS NULL "
+                    f"  AND {V3_SCOPED_PARENT_RUN_FILTER}",
+                )
+                rows = list(cur.fetchall() or [])
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "launcher.diagnoser_watch_scan_failed",
+                extra={
+                    "event": "diagnoser_watch_scan_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            self._safe_rollback()
+            return 0, []
+
+        if not rows:
+            return 0, []
+
+        diagnoser_arns = [str(r[1]) for r in rows]
+        descriptions = self._describe_tasks(diagnoser_arns)
+        by_arn: dict[str, dict[str, Any]] = {}
+        for desc in descriptions:
+            arn = desc.get("taskArn")
+            if isinstance(arn, str):
+                by_arn[arn] = desc
+
+        transitions: list[dict[str, Any]] = []
+        for agent_id, diagnoser_arn in rows:
+            desc = by_arn.get(str(diagnoser_arn))
+            if desc is None:
+                continue
+            last_status = str(desc.get("lastStatus") or "")
+            if last_status != "STOPPED":
+                continue
+            exit_code, exit_reason = self._extract_exit_state(desc)
+            if exit_code == 0:
+                # Spec §4.2: "no further action — the diagnoser already
+                # wrote outcome_summary." Only write a fallback sentinel
+                # if the diagnoser somehow exited 0 without writing
+                # outcome_summary (defensive: stops the watch query
+                # from re-matching this row forever).
+                self._mark_diagnoser_succeeded(agent_id=str(agent_id))
+                transitions.append({
+                    "agent_id": str(agent_id),
+                    "diagnoser_status": "succeeded",
+                })
+            else:
+                # STOPPED-non-zero: bump agent to needs_review. The
+                # operator inspects from the cockpit; the per-issue
+                # claim budget governs whether a future ready-flip
+                # re-claims the issue. TODO(#3883 — C6): emit a
+                # Telegram alert here once the C6 wiring lands.
+                self._mark_agent_needs_review(
+                    agent_id=str(agent_id),
+                    diagnoser_exit_code=exit_code,
+                    diagnoser_exit_reason=exit_reason,
+                )
+                transitions.append({
+                    "agent_id": str(agent_id),
+                    "diagnoser_status": "failed",
+                    "diagnoser_exit_code": exit_code,
+                    "diagnoser_exit_reason": exit_reason,
+                })
+        return len(rows), transitions
+
+    def _mark_diagnoser_succeeded(self, *, agent_id: str) -> None:
+        """Write a fallback ``outcome_summary`` when diagnoser STOPPED-0.
+
+        Defensive only: under spec §4.2 the diagnoser SKILL writes its
+        own ``outcome_summary`` before exiting cleanly. If somehow the
+        diagnoser exited 0 without writing the column, this fallback
+        keeps the watch predicate (``outcome_summary IS NULL``) from
+        re-matching the row forever. We use ``COALESCE`` so a real
+        diagnoser write is never overwritten.
+        """
+        if self._conn is None:
+            return
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET outcome_summary = COALESCE(outcome_summary, %s) "
+                    "WHERE agent_id = %s",
+                    ("diagnoser_completed", agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "launcher.diagnoser_success_mark_failed",
+                extra={
+                    "event": "diagnoser_success_mark_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._safe_rollback()
+
+    def _mark_agent_needs_review(
+        self,
+        *,
+        agent_id: str,
+        diagnoser_exit_code: Optional[int],
+        diagnoser_exit_reason: str,
+    ) -> None:
+        """Bump agent status to ``needs_review`` after a diagnoser failure.
+
+        Records the diagnoser exit context in ``outcome_summary`` so the
+        cockpit can render a useful one-liner without further DB joins.
+        Per spec §4.2 the next claim of the same issue bypasses the
+        diagnoser entirely on its first failure — there's no recursion;
+        the per-issue claim budget is what governs further attempts.
+        """
+        if self._conn is None:
+            return
+        # Build a compact summary string. Truncate the raw stoppedReason
+        # so we don't blow past TEXT-column display widths in the cockpit.
+        reason_tail = (diagnoser_exit_reason or "").strip()[:160]
+        summary = (
+            f"diagnoser_failed: exit={diagnoser_exit_code} {reason_tail}"
+        ).strip()[:240]
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET status = 'needs_review', "
+                    "    outcome_summary = COALESCE(outcome_summary, %s) "
+                    "WHERE agent_id = %s",
+                    (summary, agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "launcher.needs_review_mark_failed",
+                extra={
+                    "event": "needs_review_mark_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._safe_rollback()
+            return
+        log.info(
+            "launcher.diagnoser_failed_needs_review",
+            extra={
+                "event": "diagnoser_failed_needs_review",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "diagnoser_exit_code": diagnoser_exit_code,
+            },
+        )
+        # TODO(#3883 — C6): once the Telegram-alert helper lands, emit
+        # an alert here so the operator sees the needs_review transition
+        # without polling the cockpit. The DB write above is the
+        # authoritative state; the alert is the human notification.
+
+    # -- step 4: watch in-flight diagnosers --------------------------------
+    # (defined above as part of step 3b's diagnoser-invocation block —
+    # ``_watch_diagnosers`` lives next to ``_launch_diagnoser`` because
+    # they share the cap-of-1 invariant.)
+
+    # -- step 5: recover partial claims -----------------------------------
 
     def _recover_partial_claims(self) -> int:
         """Mark stuck ``status='claiming' AND task_arn IS NULL`` rows failed."""
@@ -921,7 +1385,7 @@ class Launcher:
             )
         return int(rowcount or 0)
 
-    # -- step 5: claim if cap allows --------------------------------------
+    # -- step 6: claim if cap allows --------------------------------------
 
     def _claim_if_cap_allows(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         """Scan the queue and claim up to ``concurrency_cap_v3 - running`` issues."""
@@ -1505,6 +1969,14 @@ def _build_launcher_from_env() -> Launcher:
         github_repo=os.environ.get("GITHUB_REPO", "judgemind/judgemind"),
         ecs_cluster_arn=os.environ["ECS_CLUSTER_ARN"],
         task_runner_task_definition=os.environ["TASK_RUNNER_TASK_DEFINITION"],
+        # DIAGNOSER_TASK_DEFINITION is optional at boot — F2 (#3887) is in
+        # flight, and the cohabitation ramp tolerates a launcher that
+        # boots without diagnoser invocation wired (cap=0 means no
+        # failures fire either). When unset, ``_launch_diagnoser`` logs
+        # and skips; agents still mark ``failed`` correctly.
+        diagnoser_task_definition=os.environ.get(
+            "DIAGNOSER_TASK_DEFINITION", ""
+        ),
         agent_runner_subnet_ids=[
             s for s in os.environ.get("AGENT_RUNNER_SUBNET_IDS", "").split(",") if s
         ],

--- a/scripts/dispatcher_v3/tests/test_diagnoser_invocation.py
+++ b/scripts/dispatcher_v3/tests/test_diagnoser_invocation.py
@@ -1,0 +1,672 @@
+"""Unit tests for the launcher's diagnoser-invocation path (issue #3882).
+
+The launcher spawns a one-shot ``diagnoser`` ECS task whenever a
+task-runner ECS task exits non-zero (or is killed by silent-hang
+detection — that path lands in C4 / #3881). The diagnoser SKILL reads
+the agent's session log + the issue/PR state, performs side-effect
+decisions directly (close / re-add ``agent/ready`` / file follow-up /
+mark ``status/needs-human``), writes ``agents.outcome_summary``, and
+exits.
+
+This module pins the launcher-side invariants (spec §4.2):
+
+- **Failure → diagnoser task launched** with ``AGENT_ID`` env override on
+  the diagnoser container, ``diagnoser_arn`` persisted to the agent row.
+- **Cap of 1 per agent** — once ``diagnoser_arn IS NOT NULL`` the
+  launcher does not launch another diagnoser, even on subsequent ticks
+  while the first is still RUNNING. Spec language: "no recursion of
+  'diagnose the diagnoser.'"
+- **STOPPED-0 is a no-op.** The diagnoser SKILL has already written
+  ``outcome_summary`` and (optionally) re-added ``agent/ready``. The
+  launcher only writes a defensive fallback sentinel if the column is
+  still null, so the watch query stops re-matching the row.
+- **STOPPED-non-zero → status='needs_review'.** The diagnoser failed
+  itself (OOM / spot-reclaim / crash). The agent is bumped to
+  ``needs_review`` and a TODO marker for the C6 Telegram alert is in
+  place.
+- **Force-kill cascades.** ``force_kill <agent_id>`` calls
+  ``ecs:StopTask`` against both ``task_arn`` and ``diagnoser_arn`` if
+  non-null — prevents an orphan diagnoser running after the operator
+  has decided.
+
+Each test uses the same FakeConn + MagicMock-ECS plumbing as
+``test_launcher.py``; the shared helpers are duplicated here for
+locality (the v3 tests are < 200 LOC each, so the cost is small and
+the boundary is cleaner than re-exporting from another test module).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+# Inject a fake ``psycopg.errors`` module up front so the launcher's
+# lazy ``import psycopg`` finds something callable in environments
+# where the real wheel is not installed (CI test runner per
+# ``.github/workflows/ci.yml``). Same shim as test_launcher.py.
+if "psycopg" not in sys.modules:
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_errors = types.ModuleType("psycopg.errors")
+
+    class _FakeUniqueViolation(Exception):
+        pass
+
+    fake_errors.UniqueViolation = _FakeUniqueViolation
+    fake_psycopg.errors = fake_errors
+    sys.modules["psycopg"] = fake_psycopg
+    sys.modules["psycopg.errors"] = fake_errors
+
+
+from dispatcher_v3.launcher import Launcher  # noqa: E402 — must follow sys.modules patch
+
+
+# ---------------------------------------------------------------------------
+# Fakes — duplicated from test_launcher.py for locality. See module docstring.
+# ---------------------------------------------------------------------------
+
+
+class FakeCursor:
+    """Tiny in-memory cursor that records every executed SQL."""
+
+    def __init__(self, conn: "FakeConn") -> None:
+        self.conn = conn
+        self.rowcount = 0
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.conn.executed.append((sql, params or ()))
+        for predicate, handler in self.conn.handlers:
+            if predicate in sql:
+                handler(self, sql, params or ())
+                return
+        self._next_fetchone = None
+        self._next_fetchall: list[tuple[Any, ...]] = []
+        self.rowcount = 0
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return getattr(self, "_next_fetchone", None)
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return getattr(self, "_next_fetchall", []) or []
+
+
+class FakeConn:
+    """Fake psycopg connection that records executed SQL + commits."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.handlers: list[tuple[str, Any]] = []
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def install_handler(self, predicate: str, handler: Any) -> None:
+        self.handlers.append((predicate, handler))
+
+
+def make_launcher(
+    conn: FakeConn | None = None,
+    ecs_client: MagicMock | None = None,
+    diagnoser_task_definition: str = "judgemind-dispatcher-v3-diagnoser",
+) -> Launcher:
+    """Construct a :class:`Launcher` with diagnoser-test defaults."""
+    return Launcher(
+        run_id="run-test-uuid",
+        github_repo="judgemind/judgemind",
+        ecs_cluster_arn="arn:aws:ecs:us-west-2:0:cluster/jm",
+        task_runner_task_definition="judgemind-task-runner:7",
+        diagnoser_task_definition=diagnoser_task_definition,
+        agent_runner_subnet_ids=["subnet-a", "subnet-b"],
+        agent_runner_security_group_id="sg-aaa",
+        sessions_bucket="judgemind-sessions-dev",
+        conn=conn,
+        ecs_client=ecs_client,
+        subprocess_runner=lambda *a, **k: MagicMock(returncode=0, stdout="", stderr=""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Failure → diagnoser launch
+# ---------------------------------------------------------------------------
+
+
+def test_failure_launches_diagnoser_and_persists_arn() -> None:
+    """STOPPED-non-zero in _watch_in_flight launches the diagnoser inline.
+
+    The launcher reads the agent row, observes STOPPED with non-zero
+    exit, marks the agent ``failed``, and immediately calls
+    ``ecs:RunTask`` against the diagnoser task-def with ``AGENT_ID``
+    set. The returned task ARN is persisted to ``diagnoser_arn``.
+    """
+    conn = FakeConn()
+    # _watch_in_flight's SELECT returns one in-flight task.
+    conn.install_handler(
+        "SELECT agent_id, task_arn, issue_number FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchall", [("ag-1", "arn:task/run-1", 100)],
+        ),
+    )
+    # _launch_diagnoser's cap-check SELECT returns no prior diagnoser.
+    conn.install_handler(
+        "SELECT diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (None,)),
+    )
+
+    ecs = MagicMock()
+    # describe_tasks returns the failed task-runner.
+    ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:task/run-1",
+                "lastStatus": "STOPPED",
+                "containers": [{"exitCode": 7}],
+                "stoppedReason": "Container exited",
+            },
+        ],
+    }
+    # run_task returns the diagnoser task.
+    ecs.run_task.return_value = {
+        "tasks": [{"taskArn": "arn:task/diag-1"}],
+        "failures": [],
+    }
+
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    watched, transitions = launcher._watch_in_flight()
+
+    assert watched == 1
+    assert len(transitions) == 1
+    assert transitions[0]["agent_id"] == "ag-1"
+    assert transitions[0]["status"] == "failed"
+    assert transitions[0]["exit_code"] == 7
+    assert transitions[0]["diagnoser_arn"] == "arn:task/diag-1"
+
+    # ecs:RunTask was called once for the diagnoser (separate from the
+    # describe_tasks call). Inspect the call kwargs.
+    assert ecs.run_task.call_count == 1
+    kwargs = ecs.run_task.call_args.kwargs
+    assert kwargs["taskDefinition"] == "judgemind-dispatcher-v3-diagnoser"
+    assert kwargs["launchType"] == "FARGATE"
+    container_overrides = kwargs["overrides"]["containerOverrides"]
+    assert len(container_overrides) == 1
+    # The container name in the diagnoser task-def is "diagnoser" — the
+    # override must target it specifically.
+    assert container_overrides[0]["name"] == "diagnoser"
+    env_pairs = container_overrides[0]["environment"]
+    env_by_name = {p["name"]: p["value"] for p in env_pairs}
+    assert env_by_name == {"AGENT_ID": "ag-1"}, (
+        "AGENT_ID is the only env override the launcher must pass — the "
+        "diagnoser SKILL reads everything else from the DB row + S3 "
+        "transcript per spec §4.2."
+    )
+
+    # The DB UPDATE for diagnoser_arn fired with the returned ARN.
+    assert any(
+        sql.startswith("UPDATE dispatcher.agents")
+        and "SET diagnoser_arn = %s" in sql
+        and params[0] == "arn:task/diag-1"
+        and params[1] == "ag-1"
+        for sql, params in conn.executed
+    )
+
+
+def test_failure_with_no_diagnoser_taskdef_does_not_launch() -> None:
+    """Empty diagnoser_task_definition skips the launch (F2 not yet landed).
+
+    During the dispatcher-v3 buildout F2 (#3887) ships the diagnoser
+    task-def. Before it lands, the launcher boots with an empty env
+    var; failures still mark the agent ``failed`` correctly but no
+    diagnoser is spawned. The cohabitation cap=0 means failures are
+    rare in this window anyway.
+    """
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT agent_id, task_arn, issue_number FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchall", [("ag-1", "arn:task/run-1", 100)],
+        ),
+    )
+    ecs = MagicMock()
+    ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:task/run-1",
+                "lastStatus": "STOPPED",
+                "containers": [{"exitCode": 7}],
+                "stoppedReason": "Container exited",
+            },
+        ],
+    }
+    launcher = make_launcher(
+        conn=conn, ecs_client=ecs, diagnoser_task_definition=""
+    )
+    _, transitions = launcher._watch_in_flight()
+    # Status transition still fired — the agent is correctly marked failed.
+    assert len(transitions) == 1
+    assert transitions[0]["status"] == "failed"
+    # No diagnoser launched; no diagnoser_arn key on the transition.
+    assert "diagnoser_arn" not in transitions[0]
+    ecs.run_task.assert_not_called()
+
+
+def test_success_does_not_launch_diagnoser() -> None:
+    """STOPPED-exit-0 transitions to ``succeeded`` with no diagnoser launch."""
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT agent_id, task_arn, issue_number FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchall", [("ag-1", "arn:task/run-1", 100)],
+        ),
+    )
+    ecs = MagicMock()
+    ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:task/run-1",
+                "lastStatus": "STOPPED",
+                "containers": [{"exitCode": 0}],
+                "stoppedReason": "Essential container exited",
+            },
+        ],
+    }
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    _, transitions = launcher._watch_in_flight()
+    assert len(transitions) == 1
+    assert transitions[0]["status"] == "succeeded"
+    assert "diagnoser_arn" not in transitions[0]
+    ecs.run_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cap of 1 per agent
+# ---------------------------------------------------------------------------
+
+
+def test_cap_existing_diagnoser_arn_skips_relaunch() -> None:
+    """Calling _launch_diagnoser when diagnoser_arn is already set is a no-op.
+
+    Cap of 1 per agent (spec §4.2: "no recursion of 'diagnose the
+    diagnoser.'"). The cap-check SELECT inside _launch_diagnoser sees
+    a non-null diagnoser_arn and returns None without calling
+    ecs:RunTask.
+    """
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchone", ("arn:task/diag-existing",),
+        ),
+    )
+    ecs = MagicMock()
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    result = launcher._launch_diagnoser(agent_id="ag-1")
+    assert result is None
+    ecs.run_task.assert_not_called()
+
+
+def test_cap_holds_across_repeated_failure_observations() -> None:
+    """Two failure observations for the same agent only launch one diagnoser.
+
+    Simulates the launcher observing the same STOPPED-non-zero task on
+    two consecutive ticks (e.g. a clock-skew hiccup or a race in the
+    watch loop). The second observation's _launch_diagnoser sees the
+    diagnoser_arn that was persisted by the first call and short-circuits.
+    """
+    conn = FakeConn()
+
+    # The cap-check SELECT toggles between "no diagnoser" (first call) and
+    # "diagnoser exists" (subsequent calls) so we can simulate the second
+    # tick observing the same row after the first tick wrote diagnoser_arn.
+    cap_check_states = iter([(None,), ("arn:task/diag-1",)])
+
+    def cap_check_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        try:
+            cur._next_fetchone = next(cap_check_states)
+        except StopIteration:
+            cur._next_fetchone = ("arn:task/diag-1",)
+
+    conn.install_handler(
+        "SELECT diagnoser_arn FROM dispatcher.agents",
+        cap_check_handler,
+    )
+    ecs = MagicMock()
+    ecs.run_task.return_value = {
+        "tasks": [{"taskArn": "arn:task/diag-1"}],
+        "failures": [],
+    }
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+
+    first = launcher._launch_diagnoser(agent_id="ag-1")
+    second = launcher._launch_diagnoser(agent_id="ag-1")
+
+    assert first == "arn:task/diag-1"
+    assert second is None
+    # Only one ecs:RunTask call total.
+    assert ecs.run_task.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Diagnoser watch — STOPPED-0 path
+# ---------------------------------------------------------------------------
+
+
+def test_watch_diagnoser_stopped_zero_is_noop_for_status() -> None:
+    """STOPPED-0 leaves the agent's status='failed' alone.
+
+    Spec §4.2: "no further action — the diagnoser already wrote
+    outcome_summary." The launcher writes a defensive fallback sentinel
+    via COALESCE so that a future diagnoser write is never overwritten,
+    and the watch predicate (outcome_summary IS NULL) stops re-matching
+    the row.
+    """
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT agent_id, diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchall", [("ag-1", "arn:task/diag-1")],
+        ),
+    )
+    ecs = MagicMock()
+    ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:task/diag-1",
+                "lastStatus": "STOPPED",
+                "containers": [{"exitCode": 0}],
+                "stoppedReason": "Diagnoser ran cleanly",
+            },
+        ],
+    }
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    watched, transitions = launcher._watch_diagnosers()
+
+    assert watched == 1
+    assert len(transitions) == 1
+    assert transitions[0]["agent_id"] == "ag-1"
+    assert transitions[0]["diagnoser_status"] == "succeeded"
+    # No ``status='needs_review'`` transition fired.
+    assert not any(
+        sql.startswith("UPDATE dispatcher.agents")
+        and "status = 'needs_review'" in sql
+        for sql, _ in conn.executed
+    )
+    # The fallback sentinel was written via COALESCE so a real diagnoser
+    # outcome_summary is never overwritten.
+    matching = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("UPDATE dispatcher.agents")
+        and "outcome_summary = COALESCE(outcome_summary" in sql
+    ]
+    assert matching, (
+        "STOPPED-0 must write a fallback outcome_summary sentinel via "
+        "COALESCE so the watch query stops re-matching the row"
+    )
+    sql, params = matching[-1]
+    assert params == ("diagnoser_completed", "ag-1")
+
+
+def test_watch_diagnoser_running_is_noop() -> None:
+    """A diagnoser still RUNNING produces no transition."""
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT agent_id, diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchall", [("ag-1", "arn:task/diag-1")],
+        ),
+    )
+    ecs = MagicMock()
+    ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:task/diag-1",
+                "lastStatus": "RUNNING",
+                "containers": [{}],
+            },
+        ],
+    }
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    watched, transitions = launcher._watch_diagnosers()
+    assert watched == 1
+    assert transitions == []
+    # No status update fired.
+    assert not any(
+        sql.startswith("UPDATE dispatcher.agents") and "status =" in sql
+        for sql, _ in conn.executed
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diagnoser watch — STOPPED-non-zero → needs_review
+# ---------------------------------------------------------------------------
+
+
+def test_watch_diagnoser_failure_marks_needs_review() -> None:
+    """STOPPED-non-zero on the diagnoser flips agent to ``needs_review``.
+
+    Spec §4.2: "if the diagnoser exits non-zero, OOMs, or is reclaimed
+    → status='needs_review' and Telegram-alert." The launcher only
+    handles the DB transition here; the C6 Telegram alert lives behind
+    a TODO marker until #3883 lands.
+    """
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT agent_id, diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(
+            cur, "_next_fetchall", [("ag-1", "arn:task/diag-1")],
+        ),
+    )
+    ecs = MagicMock()
+    ecs.describe_tasks.return_value = {
+        "tasks": [
+            {
+                "taskArn": "arn:task/diag-1",
+                "lastStatus": "STOPPED",
+                "containers": [{"exitCode": 137}],  # SIGKILL / OOM
+                "stoppedReason": "OutOfMemoryError: Container killed",
+            },
+        ],
+    }
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    _, transitions = launcher._watch_diagnosers()
+
+    assert len(transitions) == 1
+    assert transitions[0]["agent_id"] == "ag-1"
+    assert transitions[0]["diagnoser_status"] == "failed"
+    assert transitions[0]["diagnoser_exit_code"] == 137
+    assert "OutOfMemoryError" in transitions[0]["diagnoser_exit_reason"]
+
+    # The UPDATE flips status to needs_review.
+    matching = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("UPDATE dispatcher.agents")
+        and "status = 'needs_review'" in sql
+    ]
+    assert matching, "diagnoser failure must flip status to needs_review"
+    sql, params = matching[-1]
+    # outcome_summary captures the failure context for the cockpit.
+    assert "outcome_summary = COALESCE(outcome_summary" in sql
+    assert params[0].startswith("diagnoser_failed: exit=137")
+    assert "OutOfMemoryError" in params[0]
+    assert params[1] == "ag-1"
+
+
+def test_diagnoser_watch_predicate_filters_completed_rows() -> None:
+    """The watch SELECT excludes rows whose diagnoser already resolved.
+
+    Predicate: ``diagnoser_arn IS NOT NULL AND status='failed' AND
+    outcome_summary IS NULL``. Once outcome_summary is non-null (the
+    diagnoser SKILL wrote it on success, or our fallback wrote
+    ``diagnoser_completed`` on STOPPED-0, or _mark_agent_needs_review
+    wrote a failure summary on STOPPED-non-zero), the row drops out of
+    the scan. Pinned because the predicate is the gate that prevents
+    forever-rescanning a STOPPED-0 diagnoser.
+    """
+    conn = FakeConn()
+    captured_sql: list[str] = []
+
+    def select_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        captured_sql.append(sql)
+        cur._next_fetchall = []
+
+    conn.install_handler(
+        "SELECT agent_id, diagnoser_arn FROM dispatcher.agents",
+        select_handler,
+    )
+    launcher = make_launcher(conn=conn, ecs_client=MagicMock())
+    launcher._watch_diagnosers()
+
+    assert captured_sql, "watch must execute the SELECT"
+    sql = captured_sql[-1]
+    assert "diagnoser_arn IS NOT NULL" in sql
+    assert "status = 'failed'" in sql
+    assert "outcome_summary IS NULL" in sql
+    # And it's scoped to v3 runs so a v2-owned row doesn't bleed in.
+    assert "dispatcher_version = 'v3'" in sql
+
+
+# ---------------------------------------------------------------------------
+# Force-kill cascade
+# ---------------------------------------------------------------------------
+
+
+def test_force_kill_cascades_to_both_arns() -> None:
+    """``force_kill`` calls ``ecs:StopTask`` against both task_arn AND diagnoser_arn.
+
+    Spec §4.2: "force-kill cascades to the diagnoser if one is running
+    (ecs:StopTask on both task_arn and diagnoser_arn). This prevents an
+    orphan diagnoser running after the operator has decided."
+
+    The agent row in this scenario carries ``ended_at IS NULL`` (the
+    task is still in flight) AND ``diagnoser_arn`` set (a diagnoser was
+    spawned, possibly from a hypothetical earlier transition the test
+    isn't simulating in detail). Force-kill must hit both.
+    """
+    conn = FakeConn()
+
+    def select_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        # Row: (task_arn, diagnoser_arn, ended_at)
+        cur._next_fetchone = ("arn:task/run-1", "arn:task/diag-1", None)
+
+    conn.install_handler(
+        "SELECT task_arn, diagnoser_arn, ended_at FROM dispatcher.agents",
+        select_handler,
+    )
+
+    ecs = MagicMock()
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    launcher._force_kill_agent("ag-1")
+
+    # Two stop_task calls — one per ARN.
+    assert ecs.stop_task.call_count == 2
+    targets = [c.kwargs["task"] for c in ecs.stop_task.call_args_list]
+    assert "arn:task/run-1" in targets
+    assert "arn:task/diag-1" in targets
+    # All calls share cluster + reason.
+    for call in ecs.stop_task.call_args_list:
+        assert call.kwargs["cluster"] == "arn:aws:ecs:us-west-2:0:cluster/jm"
+        assert call.kwargs["reason"] == "force_kill"
+
+
+def test_force_kill_only_diagnoser_when_task_already_ended() -> None:
+    """Once the task has ended (ended_at set), force-kill targets only diagnoser.
+
+    The agent's task-runner ECS task already STOPPED; firing StopTask
+    against a stopped task is a no-op or error. The diagnoser is the
+    only live target. This case fires when the operator force-kills an
+    agent whose task crashed and a diagnoser is now in flight.
+    """
+    conn = FakeConn()
+
+    def select_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        # (task_arn, diagnoser_arn, ended_at)  — ended_at non-null.
+        cur._next_fetchone = (
+            "arn:task/run-1",
+            "arn:task/diag-1",
+            "2026-05-02T04:30:00Z",
+        )
+
+    conn.install_handler(
+        "SELECT task_arn, diagnoser_arn, ended_at FROM dispatcher.agents",
+        select_handler,
+    )
+    ecs = MagicMock()
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    launcher._force_kill_agent("ag-1")
+    # Only the diagnoser ARN was stopped.
+    assert ecs.stop_task.call_count == 1
+    assert ecs.stop_task.call_args.kwargs["task"] == "arn:task/diag-1"
+
+
+def test_force_kill_no_arns_is_noop() -> None:
+    """No task_arn and no diagnoser_arn → force_kill is a clean no-op."""
+    conn = FakeConn()
+
+    def select_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        cur._next_fetchone = (None, None, None)
+
+    conn.install_handler(
+        "SELECT task_arn, diagnoser_arn, ended_at FROM dispatcher.agents",
+        select_handler,
+    )
+    ecs = MagicMock()
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    launcher._force_kill_agent("ag-1")
+    ecs.stop_task.assert_not_called()
+
+
+def test_force_kill_unknown_agent_is_noop() -> None:
+    """Force-kill against a missing agent_id is a clean no-op."""
+    conn = FakeConn()
+
+    def select_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        cur._next_fetchone = None  # no row
+
+    conn.install_handler(
+        "SELECT task_arn, diagnoser_arn, ended_at FROM dispatcher.agents",
+        select_handler,
+    )
+    ecs = MagicMock()
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+    launcher._force_kill_agent("ag-missing")
+    ecs.stop_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tick-level smoke — diagnoser watch is part of the standard tick
+# ---------------------------------------------------------------------------
+
+
+def test_tick_summary_includes_diagnoser_keys() -> None:
+    """``Launcher.tick`` populates the diagnoser-watch fields in its summary.
+
+    Pinned so a future "we forgot to wire _watch_diagnosers into the
+    tick" regression fails loudly. The summary is logged each tick
+    via CloudWatch Logs Insights for cockpit observability.
+    """
+    conn = FakeConn()
+    conn.install_handler(
+        "FROM dispatcher.config WHERE key = %s",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", ("0",)),
+    )
+    launcher = make_launcher(conn=conn, ecs_client=MagicMock())
+    summary = launcher.tick()
+    assert "diagnosers_watched" in summary
+    assert "diagnoser_transitions" in summary
+    assert summary["diagnosers_watched"] == 0
+    assert summary["diagnoser_transitions"] == []

--- a/scripts/dispatcher_v3/tests/test_launcher.py
+++ b/scripts/dispatcher_v3/tests/test_launcher.py
@@ -156,6 +156,7 @@ def make_launcher(
     runner_name: str = "claude",
     task_runner_log_group: str = "",
     task_runner_log_stream_prefix: str = DEFAULT_TASK_RUNNER_LOG_STREAM_PREFIX,
+    diagnoser_task_definition: str = "judgemind-dispatcher-v3-diagnoser",
 ) -> Launcher:
     """Construct a :class:`Launcher` with sane test defaults.
 
@@ -168,6 +169,7 @@ def make_launcher(
         github_repo="judgemind/judgemind",
         ecs_cluster_arn="arn:aws:ecs:us-west-2:0:cluster/jm",
         task_runner_task_definition="judgemind-task-runner:7",
+        diagnoser_task_definition=diagnoser_task_definition,
         agent_runner_subnet_ids=["subnet-a", "subnet-b"],
         agent_runner_security_group_id="sg-aaa",
         sessions_bucket="judgemind-sessions-dev",


### PR DESCRIPTION
## Summary

Wires the dispatcher-v3 launcher's diagnoser-invocation path (spec §4.2). On task-runner failure (STOPPED-non-zero or silent-hang reap from C4 #3927), the launcher spawns a one-shot `diagnoser` ECS task with `AGENT_ID` env override, persists the ARN to `agents.diagnoser_arn`, and watches the diagnoser. Cap is 1 per agent — STOPPED-0 is a no-op (the diagnoser SKILL writes `outcome_summary` itself); STOPPED-non-zero flips agent status to `needs_review` (Telegram alert TODO, lands in C6 #3883). `force_kill` cascades `ecs:StopTask` to both `task_arn` and `diagnoser_arn`.

Closes #3882

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (no ruff format check on `scripts/dispatcher_v3/` in CI; baseline files are also unformatted)
- [x] Tests pass (`scripts-tests (python)` includes `pytest scripts/dispatcher_v3/tests/` — 59 passed locally + on CI)
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component yet (cohabitation cap=0; F2 #3887 ships the diagnoser task-def). The launcher boots cleanly without `DIAGNOSER_TASK_DEFINITION` set; once F2 lands and the env var is wired, the next failure-induced agent termination will exercise the path. Verification at that point: CloudWatch Logs Insights query against `/judgemind/dispatcher-v3/launcher` for `event=diagnoser_launched`, then DescribeTasks against the resulting `diagnoser_arn` shows the diagnoser ECS task, and the agent row's `outcome_summary` reflects either the diagnoser's write (STOPPED-0) or the launcher's `diagnoser_failed: ...` summary (STOPPED-non-zero).

## Notes

- `DIAGNOSER_TASK_DEFINITION` env var is optional at boot — when unset (pre-F2 #3887), `_launch_diagnoser` logs `diagnoser_task_def_unset` and skips the launch. The agent is still correctly marked `failed`. The empty-string short-circuit is exercised by `test_failure_with_no_diagnoser_taskdef_does_not_launch`.
- Watch predicate gates on `outcome_summary IS NULL` so STOPPED-0 diagnoser ECS tasks don't get re-described forever. A defensive `COALESCE(outcome_summary, 'diagnoser_completed')` write covers the edge case where the diagnoser somehow exits 0 without writing the column.
- Telegram alert TODO sits inline in `_mark_agent_needs_review` for #3883.
- Issue intentionally has no `agent/ready` label per the parent dispatch.
- Diagnoser invocation fires on BOTH STOPPED-non-zero and silent-hang reap paths (C4 #3927 merged in flight; rebase resolved cleanly).
