### PR TITLE
fix(infra): add ANTHROPIC_API_KEY + DATABASE_URL to v3 execution-role secret read (#3934)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -427,6 +427,16 @@ module "dispatcher_v3_iam" {
   # secret as v2. F2 will inject this into the task-runner / diagnoser
   # task definitions for `gh auth setup-git` inside the agent.
   github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
+
+  # Anthropic + DB secrets — F2's task-defs pass these to ECS as
+  # `secrets[]` entries, which means the EXECUTION role (not the agent
+  # task role) is the principal that performs `secretsmanager:GetSecretValue`
+  # at task-start. The execution role's secret-read policy compacts both
+  # ARNs into its Resource list. Without these, the launcher task fails
+  # with `ResourceInitializationError: AccessDeniedException` -- the
+  # exact failure mode F4 (#3889) hit on first deploy.
+  anthropic_api_key_secret_arn = data.aws_secretsmanager_secret.anthropic_api_key.arn
+  db_connection_secret_arn     = module.database.db_connection_secret_arn
 }
 
 # ─── Dispatcher v3 sessions bucket (#3891) ──────────────────────────────────

--- a/infra/terraform/modules/dispatcher-v3-iam/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/main.tf
@@ -118,9 +118,24 @@ locals {
   # IAM rejects `Resource = []` with `MalformedPolicyDocument` (see
   # the analogous guard in modules/dispatcher-daemon/main.tf), so the
   # policy resource itself is skipped via `count = 0` when empty.
+  #
+  # Why every secret threaded through F2's task-defs MUST appear here:
+  # ECS injects `secrets[].valueFrom` entries at task-start time using
+  # the execution role -- NOT the task role. So even though the agent
+  # task role has broad Secrets Manager read in dev (for runtime reads
+  # like `scripts/with-secret.sh`), the task itself fails to even
+  # start with `ResourceInitializationError: AccessDeniedException` if
+  # the execution role lacks GetSecretValue on the per-task-def
+  # secret list. F4 (#3889) surfaced this with the launcher task
+  # failing to pull DATABASE_URL despite the launcher role having
+  # rds-db:connect to judgemind_dispatcher. The fix is to compact
+  # every secret ARN F2's `agent_secrets` and `launcher_secrets`
+  # blocks reference, here.
   execution_secret_arns = compact([
     var.telegram_bot_token_secret_arn,
     var.github_token_secret_arn,
+    var.anthropic_api_key_secret_arn,
+    var.db_connection_secret_arn,
   ])
 }
 

--- a/infra/terraform/modules/dispatcher-v3-iam/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-iam/variables.tf
@@ -73,6 +73,18 @@ variable "github_token_secret_arn" {
   default     = ""
 }
 
+variable "anthropic_api_key_secret_arn" {
+  description = "Secrets Manager ARN for ANTHROPIC_API_KEY. Wired into F2's task-runner / diagnoser / scheduled-skill task definitions as a `secrets[]` entry, which means the **execution role** (not the agent task role) is the principal that actually fetches the secret value at task-start time. Without this in `execution_secret_arns` below, ECS RunTask fails with `ResourceInitializationError: AccessDeniedException: User ... is not authorized to perform: secretsmanager:GetSecretValue` and the task never starts. F4 (#3889) surfaced this gap when the launcher task started failing to pull DATABASE_URL even though the launcher task role had RDS connect via judgemind_dispatcher. Same pattern as the v2 dispatcher-daemon's `execution_secrets` policy. Empty disables -- the task-def's `secrets` block omits the entry entirely when this is empty (see F2's `agent_secrets` concat)."
+  type        = string
+  default     = ""
+}
+
+variable "db_connection_secret_arn" {
+  description = "Secrets Manager ARN for the dispatcher-role DATABASE_URL JSON secret (key `url`). Wired into F2's launcher task-def (and the agent task-defs) as a `secrets[]` entry, so the execution role -- not the launcher role -- fetches the secret at task-start time. Without this in `execution_secret_arns` below, ECS RunTask fails with `ResourceInitializationError: AccessDeniedException` and the launcher task never starts. F4 (#3889) surfaced this gap. Empty disables."
+  type        = string
+  default     = ""
+}
+
 # ─── S3 buckets ─────────────────────────────────────────────────────────
 # The agent task role gets full S3 because dev `/task` runs may touch
 # raw/ (S3-as-source-of-truth, see CLAUDE.md §Project Context), spotcheck/


### PR DESCRIPTION
## Summary

Fix follow-up to #3889 (F4 launcher ECS service). The launcher service deployed cleanly but the launcher container failed to start with `ResourceInitializationError: AccessDeniedException` because F3's execution role (`judgemind-dispatcher-v3-execution-dev`) only had GetSecretValue on the telegram + github PAT secret ARNs -- the DATABASE_URL and ANTHROPIC_API_KEY ARNs that F2's task definitions reference via `secrets[]` were missing.

ECS injects `secrets[].valueFrom` at task-start using the **execution role** (not the task role), so even though F3's broad agent task role has Secrets Manager read for everything in dev, the task itself never reaches the in-container identity transition.

Adds the two missing ARNs as F3 module variables, compacts them into `local.execution_secret_arns`, and wires them from `environments/dev/main.tf`.

Closes #3934

## Test plan

### Automated checks
- [ ] `terraform fmt -check` passes
- [ ] `terraform validate` passes (dev + production)
- [ ] CI green

### Post-deploy verification
- [ ] `aws ecs describe-services --cluster judgemind-dev --services judgemind-dispatcher-v3-dev` shows `runningCount=1`
- [ ] `aws iam get-role-policy --role-name judgemind-dispatcher-v3-execution-dev --policy-name judgemind-dispatcher-v3-execution-secrets-dev` lists 3 ARNs (github, anthropic, db; telegram empty by design)
- [ ] `aws logs tail /judgemind/dispatcher-v3/launcher --since 5m` shows heartbeat lines
- [ ] Verification evidence comment posted on #3934 AND on the parent #3889
