### PR TITLE
fix(ci): retry docker push on ECR-creation race in deploy workflows (#3920)

### DIFF
--- a/.github/workflows/deploy-agent-runner.yml
+++ b/.github/workflows/deploy-agent-runner.yml
@@ -123,7 +123,20 @@ jobs:
               --build-arg "GIT_SHA=$SHA_TAG" \
               -f Dockerfile.dispatcher-agent-runner \
               "${TAGS[@]}" .
-          docker push "$IMAGE_BASE" --all-tags
+          # Retry once on ECR name-unknown race (issue #3920, ref #3886/#3915):
+          # A same-PR Terraform apply may create the ECR repo moments before this push runs.
+          PUSH_OUTPUT=$(docker push "$IMAGE_BASE" --all-tags 2>&1) && RC=0 || RC=$?
+          if [ $RC -ne 0 ]; then
+            if echo "$PUSH_OUTPUT" | grep -qE "name unknown|repository .+ does not exist"; then
+              echo "ECR repository not yet available; sleeping 60s before retry (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+              sleep 60
+              docker push "$IMAGE_BASE" --all-tags
+              echo "ECR retry succeeded — race condition resolved (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$PUSH_OUTPUT" >&2
+              exit $RC
+            fi
+          fi
 
           echo "image_uri=$IMAGE_BASE:$SHA_TAG" >> "$GITHUB_OUTPUT"
           echo "sha_tag=$SHA_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -87,7 +87,20 @@ jobs:
           fi
 
           docker build "${TAGS[@]}" -f packages/api/Dockerfile .
-          docker push "$IMAGE_BASE" --all-tags
+          # Retry once on ECR name-unknown race (issue #3920, ref #3886/#3915):
+          # A same-PR Terraform apply may create the ECR repo moments before this push runs.
+          PUSH_OUTPUT=$(docker push "$IMAGE_BASE" --all-tags 2>&1) && RC=0 || RC=$?
+          if [ $RC -ne 0 ]; then
+            if echo "$PUSH_OUTPUT" | grep -qE "name unknown|repository .+ does not exist"; then
+              echo "ECR repository not yet available; sleeping 60s before retry (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+              sleep 60
+              docker push "$IMAGE_BASE" --all-tags
+              echo "ECR retry succeeded — race condition resolved (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$PUSH_OUTPUT" >&2
+              exit $RC
+            fi
+          fi
 
           echo "image_uri=$IMAGE_BASE:$SHA_TAG" >> "$GITHUB_OUTPUT"
           echo "sha_tag=$SHA_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-dispatcher-v3.yml
+++ b/.github/workflows/deploy-dispatcher-v3.yml
@@ -121,7 +121,20 @@ jobs:
               --build-arg "GIT_SHA=$SHA_TAG" \
               -f Dockerfile.dispatcher-v3 \
               "${TAGS[@]}" .
-          docker push "$IMAGE_BASE" --all-tags
+          # Retry once on ECR name-unknown race (issue #3920, ref #3886/#3915):
+          # A same-PR Terraform apply may create the ECR repo moments before this push runs.
+          PUSH_OUTPUT=$(docker push "$IMAGE_BASE" --all-tags 2>&1) && RC=0 || RC=$?
+          if [ $RC -ne 0 ]; then
+            if echo "$PUSH_OUTPUT" | grep -qE "name unknown|repository .+ does not exist"; then
+              echo "ECR repository not yet available; sleeping 60s before retry (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+              sleep 60
+              docker push "$IMAGE_BASE" --all-tags
+              echo "ECR retry succeeded — race condition resolved (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$PUSH_OUTPUT" >&2
+              exit $RC
+            fi
+          fi
 
           echo "image_uri=$IMAGE_BASE:$SHA_TAG" >> "$GITHUB_OUTPUT"
           echo "sha_tag=$SHA_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-dispatcher.yml
+++ b/.github/workflows/deploy-dispatcher.yml
@@ -133,7 +133,20 @@ jobs:
               --build-arg "GIT_SHA=$SHA_TAG" \
               -f Dockerfile.dispatcher \
               "${TAGS[@]}" .
-          docker push "$IMAGE_BASE" --all-tags
+          # Retry once on ECR name-unknown race (issue #3920, ref #3886/#3915):
+          # A same-PR Terraform apply may create the ECR repo moments before this push runs.
+          PUSH_OUTPUT=$(docker push "$IMAGE_BASE" --all-tags 2>&1) && RC=0 || RC=$?
+          if [ $RC -ne 0 ]; then
+            if echo "$PUSH_OUTPUT" | grep -qE "name unknown|repository .+ does not exist"; then
+              echo "ECR repository not yet available; sleeping 60s before retry (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+              sleep 60
+              docker push "$IMAGE_BASE" --all-tags
+              echo "ECR retry succeeded — race condition resolved (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$PUSH_OUTPUT" >&2
+              exit $RC
+            fi
+          fi
 
           echo "image_uri=$IMAGE_BASE:$SHA_TAG" >> "$GITHUB_OUTPUT"
           echo "sha_tag=$SHA_TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -91,7 +91,20 @@ jobs:
           fi
 
           docker build "${TAGS[@]}" -f packages/scraper-framework/Dockerfile .
-          docker push "$IMAGE_BASE" --all-tags
+          # Retry once on ECR name-unknown race (issue #3920, ref #3886/#3915):
+          # A same-PR Terraform apply may create the ECR repo moments before this push runs.
+          PUSH_OUTPUT=$(docker push "$IMAGE_BASE" --all-tags 2>&1) && RC=0 || RC=$?
+          if [ $RC -ne 0 ]; then
+            if echo "$PUSH_OUTPUT" | grep -qE "name unknown|repository .+ does not exist"; then
+              echo "ECR repository not yet available; sleeping 60s before retry (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+              sleep 60
+              docker push "$IMAGE_BASE" --all-tags
+              echo "ECR retry succeeded — race condition resolved (issue #3920)" | tee -a "$GITHUB_STEP_SUMMARY"
+            else
+              echo "$PUSH_OUTPUT" >&2
+              exit $RC
+            fi
+          fi
 
           echo "image_uri=$IMAGE_BASE:$SHA_TAG" >> "$GITHUB_OUTPUT"
           echo "sha_tag=$SHA_TAG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Added a one-time retry-with-sleep mechanism to handle the race condition where a same-PR Terraform apply creates an ECR repository while deploy workflows attempt to push images. The retry fires only on `name unknown` or `repository does not exist` errors, waits 60s, and retries. Applied to all five active deploy workflows; deploy-production.yml is skipped since it only reads pre-existing images.

Closes #3920

## Test plan

### Automated checks

- [x] Lint passes — N/A, workflows only
- [x] Format check passes — N/A, workflows only
- [x] Tests pass — N/A, workflows only
- [x] CI green — Pre-push hook passed on first attempt

### Post-deploy verification

- [ ] Create a test PR that adds an ECR repository and matching deploy workflow; verify the deploy workflow retries when it encounters the race (or confirm no failure occurs if timing is fortunate)
- [ ] Verification evidence posted on #3920 (see /task-v2-verify output)