### PR TITLE
fix(dispatcher-v3): wire launcher env vars to unblock F4 service (#3939)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -461,6 +461,52 @@ module "dispatcher_v3_sessions" {
   # session_retention_days = 365
 }
 
+# ─── Dispatcher v3 agent-runner security group (#3939) ─────────────────────
+# Security group attached to every ECS task-runner ENI launched by the
+# v3 launcher via ecs:RunTask. Provisioned at the env layer (not inside
+# F2 or F4) to avoid a module-level cycle: F2 needs the SG ID to thread
+# into the launcher's AGENT_RUNNER_SECURITY_GROUP_ID env var, F4's ECS
+# service references F2's launcher task-def ARN -- so wiring the SG
+# inside F4 and reading it from F2 would cycle through F4 → F2 → F4.
+#
+# Egress profile mirrors F4's launcher SG: HTTPS for GitHub / Anthropic /
+# ECR / Secrets Manager / S3, Postgres for dispatcher.* writes, Redis
+# for the future event bus (spec §6). Same posture as v2's
+# dispatcher-agent-runner module's SG -- task-runners need outbound
+# HTTPS for `git clone`, `pip install`, `npm install`, etc.
+#
+# No inbound rules: task-runners are one-shot batch workloads, not
+# service endpoints.
+resource "aws_security_group" "dispatcher_v3_agent_runner" {
+  name        = "judgemind-dispatcher-v3-agent-runner-dev"
+  description = "Dispatcher v3 task-runner ECS task ENI -- outbound only (HTTPS, Postgres, Redis). #3939."
+  vpc_id      = module.networking.vpc_id
+
+  egress {
+    description = "HTTPS to GitHub, Anthropic, ECR, Secrets Manager, S3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL (dispatcher.* state writes from task-runner)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Redis (event bus, reserved for future phases)"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 # ─── Dispatcher v3 task-defs (F2, #3887) ────────────────────────────────────
 # Per `docs/specs/dispatcher-v3-spec.md` §4 + §6. Four ECS Fargate task
 # definitions baked from the F1 image (#3915, judgemind/dispatcher-v3)
@@ -522,6 +568,15 @@ module "dispatcher_v3_task_defs" {
   # Sessions bucket from #3891 — the task-runner entrypoint archives
   # session logs to s3://<bucket>/<agent_id>.jsonl on exit (spec §4.1).
   sessions_bucket_name = module.dispatcher_v3_sessions.bucket_id
+
+  # Launcher → task-runner network handoff (#3939). The launcher's
+  # `_build_launcher_from_env` reads these three values at boot to
+  # assemble each ecs:RunTask request. Subnets reuse the launcher
+  # service's own private subnets; the security group is provisioned
+  # above at env-layer (avoids the F2 ↔ F4 module cycle that would
+  # arise if F2 read it from F4's outputs).
+  agent_runner_subnet_ids        = module.networking.private_subnet_ids
+  agent_runner_security_group_id = aws_security_group.dispatcher_v3_agent_runner.id
 }
 
 # ─── Dispatcher v3 launcher ECS service (F4, #3889) ─────────────────────────

--- a/infra/terraform/modules/dispatcher-v3-task-defs/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-task-defs/main.tf
@@ -88,6 +88,27 @@ locals {
     var.sessions_bucket_name != "" ? [{ name = "SESSIONS_BUCKET", value = var.sessions_bucket_name }] : [],
   )
 
+  # Launcher-only environment block (#3939). The launcher's
+  # `_build_launcher_from_env` (scripts/dispatcher_v3/launcher.py:1496-1526)
+  # reads these three vars at boot to assemble an `ecs:RunTask` request
+  # for each claimed issue -- they're meaningless for the task-runner /
+  # diagnoser / scheduled-skill task-defs (those are the *callees*, not
+  # the caller). Concatenated onto `common_environment` for the launcher
+  # task-def only.
+  launcher_environment = concat(
+    local.common_environment,
+    [
+      # The launcher launches task-runners by family name -- ecs:RunTask
+      # accepts either a family name or a full ARN, and family-only lets
+      # revisions roll forward automatically (a fresh F2 apply registers
+      # a new revision, and the next launcher claim picks it up without
+      # an explicit env-var update).
+      { name = "TASK_RUNNER_TASK_DEFINITION", value = local.family_task_runner },
+      { name = "AGENT_RUNNER_SUBNET_IDS", value = join(",", var.agent_runner_subnet_ids) },
+      { name = "AGENT_RUNNER_SECURITY_GROUP_ID", value = var.agent_runner_security_group_id },
+    ],
+  )
+
   # Common secrets block -- agent task-defs (task-runner / diagnoser /
   # scheduled-skill) all read the same set. The launcher reads a
   # narrower subset (DATABASE_URL + TELEGRAM_BOT_TOKEN; no
@@ -190,7 +211,7 @@ resource "aws_ecs_task_definition" "launcher" {
       # final UPDATE.
       stopTimeout = 120
 
-      environment = local.common_environment
+      environment = local.launcher_environment
       secrets     = local.launcher_secrets
 
       logConfiguration = {
@@ -229,6 +250,26 @@ resource "aws_ecs_task_definition" "launcher" {
     postcondition {
       condition     = strcontains(self.container_definitions, "@sha256:")
       error_message = "dispatcher-v3-task-defs (launcher): rendered image reference is not digest-pinned. See #3754 image-staleness drift -- the v3 task-defs structurally prevent this by always referencing @sha256:<digest>."
+    }
+    # Launcher-only env vars (#3939). Same defense-in-depth pattern as
+    # the secret postconditions above: the launcher's
+    # `_build_launcher_from_env` raises KeyError on a missing
+    # TASK_RUNNER_TASK_DEFINITION / AGENT_RUNNER_SUBNET_IDS /
+    # AGENT_RUNNER_SECURITY_GROUP_ID at boot, so a regression that
+    # drops them from the rendered container_definitions would crashloop
+    # the launcher silently from terraform's perspective. These checks
+    # turn the failure into a plan-time error.
+    postcondition {
+      condition     = strcontains(self.container_definitions, "TASK_RUNNER_TASK_DEFINITION")
+      error_message = "dispatcher-v3-task-defs (launcher): rendered container_definitions is missing TASK_RUNNER_TASK_DEFINITION. The launcher's _build_launcher_from_env raises KeyError on this var at boot -- see #3939."
+    }
+    postcondition {
+      condition     = strcontains(self.container_definitions, "AGENT_RUNNER_SUBNET_IDS")
+      error_message = "dispatcher-v3-task-defs (launcher): rendered container_definitions is missing AGENT_RUNNER_SUBNET_IDS. The launcher needs this to assemble the ecs:RunTask awsvpcConfiguration -- see #3939."
+    }
+    postcondition {
+      condition     = strcontains(self.container_definitions, "AGENT_RUNNER_SECURITY_GROUP_ID")
+      error_message = "dispatcher-v3-task-defs (launcher): rendered container_definitions is missing AGENT_RUNNER_SECURITY_GROUP_ID. The launcher's _build_launcher_from_env raises KeyError on this var at boot -- see #3939."
     }
   }
 }

--- a/infra/terraform/modules/dispatcher-v3-task-defs/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-task-defs/variables.tf
@@ -157,7 +157,7 @@ variable "agent_runner_subnet_ids" {
 }
 
 variable "agent_runner_security_group_id" {
-  description = "Security group ID attached to every task-runner ENI launched via ecs:RunTask. Threaded into the launcher container as AGENT_RUNNER_SECURITY_GROUP_ID. Provisioned at the env layer to avoid an F2 ↔ F4 module cycle; egress profile mirrors F4's launcher SG (HTTPS / Postgres / Redis) so task-runners share the launcher's network posture."
+  description = "Security group ID attached to every task-runner ENI launched via ecs:RunTask. Threaded into the launcher container as AGENT_RUNNER_SECURITY_GROUP_ID. Provisioned at the env layer to avoid an F2 <-> F4 module cycle; egress profile mirrors F4's launcher SG (HTTPS / Postgres / Redis) so task-runners share the launcher's network posture."
   type        = string
 
   validation {

--- a/infra/terraform/modules/dispatcher-v3-task-defs/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-task-defs/variables.tf
@@ -118,6 +118,54 @@ variable "ecs_cluster_arn" {
   type        = string
 }
 
+# --- Launcher → task-runner network handoff (#3939) --------------------
+#
+# The launcher container's `_build_launcher_from_env` (scripts/dispatcher_v3/
+# launcher.py:1496-1526) reads three env vars at boot to build an
+# `ecs:RunTask` request for each claimed issue:
+#
+#   * TASK_RUNNER_TASK_DEFINITION  -- which task-def family to launch.
+#     Always the task-runner family this same module registers, so we
+#     wire `local.family_task_runner` directly into the launcher's
+#     environment block (no variable needed -- a self-reference would
+#     just propagate a value that's already locally available).
+#   * AGENT_RUNNER_SUBNET_IDS  -- comma-joined private-subnet IDs the
+#     RunTask network configuration places task-runner ENIs in.
+#   * AGENT_RUNNER_SECURITY_GROUP_ID  -- the security group to attach to
+#     each task-runner ENI. Provisioned at the env layer (not inside F2
+#     or F4) to avoid the F2 ↔ F4 module cycle that would arise if F2
+#     read it from F4's outputs while F4 already references F2's
+#     launcher task-def ARN. Egress profile mirrors F4's launcher SG
+#     (HTTPS / Postgres / Redis), so task-runners share the launcher's
+#     network posture. If task-runners ever need a different egress
+#     posture (e.g. tighter scoping to S3 + GitHub + Anthropic only),
+#     the env-layer SG can be tightened without changing this module.
+#
+# Both are required (no default empty-string) because the launcher
+# crashes loudly with KeyError on `os.environ["AGENT_RUNNER_SECURITY_GROUP_ID"]`
+# at boot if either is absent -- there's no "disabled" mode for a
+# launcher that can't actually launch task-runners.
+
+variable "agent_runner_subnet_ids" {
+  description = "Private-subnet IDs the launcher places each task-runner's ENI in via ecs:RunTask `awsvpcConfiguration.subnets`. Threaded into the launcher container as AGENT_RUNNER_SUBNET_IDS (comma-joined). Reuses the same private subnets as the launcher's own ECS service so dev/prod network scopes stay aligned."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.agent_runner_subnet_ids) > 0
+    error_message = "agent_runner_subnet_ids must contain at least one subnet ID -- the launcher's ecs:RunTask call requires a non-empty awsvpcConfiguration.subnets list."
+  }
+}
+
+variable "agent_runner_security_group_id" {
+  description = "Security group ID attached to every task-runner ENI launched via ecs:RunTask. Threaded into the launcher container as AGENT_RUNNER_SECURITY_GROUP_ID. Provisioned at the env layer to avoid an F2 ↔ F4 module cycle; egress profile mirrors F4's launcher SG (HTTPS / Postgres / Redis) so task-runners share the launcher's network posture."
+  type        = string
+
+  validation {
+    condition     = length(var.agent_runner_security_group_id) > 0
+    error_message = "agent_runner_security_group_id must be non-empty -- the launcher's _build_launcher_from_env raises KeyError on os.environ['AGENT_RUNNER_SECURITY_GROUP_ID'] at boot."
+  }
+}
+
 variable "sessions_bucket_name" {
   description = "Name of the v3 sessions S3 bucket (F6, #3893). Exposed to task-runner / diagnoser containers as SESSIONS_BUCKET so the entrypoint can archive session logs on exit. Empty disables -- the entrypoint's upload step short-circuits when SESSIONS_BUCKET is unset."
   type        = string


### PR DESCRIPTION
## Summary

The F2 launcher task-def was missing three env vars `_build_launcher_from_env` reads at boot (`scripts/dispatcher_v3/launcher.py:1496-1526`), which crashlooped F4's launcher service with `KeyError: 'TASK_RUNNER_TASK_DEFINITION'`. This wires `TASK_RUNNER_TASK_DEFINITION`, `AGENT_RUNNER_SUBNET_IDS`, and `AGENT_RUNNER_SECURITY_GROUP_ID` into the launcher task-def's `environment` block, with content-level postconditions following the #3764 defense-in-depth pattern. Scope kept narrow — task-runner / diagnoser / scheduled-skill task-defs untouched (#3940 handles their stopTimeout-cap issue separately).

The new agent-runner security group is provisioned at the env layer rather than inside F2 or F4 to avoid a module-level F2 <-> F4 dependency cycle (F4 already references F2's launcher task-def ARN).

Closes #3939

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (`terraform fmt -check -recursive` clean locally)
- [x] Tests pass (`terraform validate` clean locally on `environments/dev`)
- [x] CI green

### Post-deploy verification
- [ ] `aws logs tail /judgemind/dispatcher-v3/launcher --since 5m` shows tick / heartbeat lines (no `KeyError` Traceback) after dev-apply rolls out
- [ ] `SELECT count(*) FROM dispatcher.agents WHERE parent_run_id IN (SELECT run_id FROM dispatcher.runs WHERE dispatcher_version='v3')` returns 0 after the launcher ticks for 5 minutes (cap=0 holds)
- [ ] `SELECT run_id, dispatcher_version, started_at FROM dispatcher.runs WHERE dispatcher_version='v3' ORDER BY started_at DESC LIMIT 1` returns a fresh row tagged `'v3'`
- [ ] Verification evidence posted on issue (see A.8)
