### PR TITLE
fix(dx): add ECS exec-agent readiness polling to dev-db-query.sh and ecs-run.sh (#3896)

### DIFF
--- a/scripts/_ecs_exec_lib.sh
+++ b/scripts/_ecs_exec_lib.sh
@@ -1,0 +1,98 @@
+# _ecs_exec_lib.sh — sourceable helper for ECS Exec agent readiness polling.
+#
+# Defines wait_for_exec_agent_ready <cluster> <task_arn> <container> <region>
+# [timeout_secs].
+#
+# This file has no shebang and no `set -e` so it can be sourced safely by
+# scripts that already have their own error-handling settings.
+#
+# Naming convention: leading underscore marks this as a sourceable helper (not
+# an executable test), consistent with scripts/dispatcher/helpers/_query_lib.sh
+# and scripts/tests/_guard_self_match_helpers.sh.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/_ecs_exec_lib.sh"
+#   wait_for_exec_agent_ready "$CLUSTER" "$task_arn" "$CONTAINER" "$REGION" || exit 1
+
+# wait_for_exec_agent_ready <cluster> <task_arn> <container> <region> [timeout_secs]
+#
+# Polls `aws ecs execute-command` with a harmless `bash -c 'true'` probe until
+# the ECS Exec agent on the target task is ready. This bridges the gap between
+# `list-tasks` returning a running ARN and the execute-command agent actually
+# being reachable — which can be 30-90 s after a rolling deploy.
+#
+# Arguments:
+#   cluster       — ECS cluster name
+#   task_arn      — full task ARN (arn:aws:ecs:...)
+#   container     — container name
+#   region        — AWS region
+#   timeout_secs  — polling deadline in seconds (default: $EXEC_AGENT_POLL_TIMEOUT_SECS
+#                   or 120 if unset)
+#
+# Exit codes:
+#   0 — exec agent responded successfully (exit-0 probe)
+#   1 — terminal failure (non-retryable AWS error) or deadline exhausted
+wait_for_exec_agent_ready() {
+    local cluster="$1"
+    local task_arn="$2"
+    local container="$3"
+    local region="$4"
+    local timeout_secs="${5:-${EXEC_AGENT_POLL_TIMEOUT_SECS:-120}}"
+
+    local _start
+    _start=$(date +%s)
+    local _deadline
+    _deadline=$((_start + timeout_secs))
+
+    while true; do
+        local _probe_stderr
+        local _probe_rc=0
+        # Capture stderr so we can distinguish retryable from terminal errors.
+        # Use a temp file because bash <() process substitution is not allowed
+        # by the preflight hook, and we need both exit-code and stderr.
+        local _stderr_file
+        _stderr_file=$(mktemp)
+        aws ecs execute-command \
+            --cluster "$cluster" \
+            --task "$task_arn" \
+            --container "$container" \
+            --interactive \
+            --region "$region" \
+            --command "bash -c 'true'" \
+            >/dev/null 2>"$_stderr_file" || _probe_rc=$?
+
+        _probe_stderr=$(cat "$_stderr_file")
+        rm -f "$_stderr_file"
+
+        if [[ $_probe_rc -eq 0 ]]; then
+            # Exec agent responded — we're clear to run the real command.
+            return 0
+        fi
+
+        # Retryable only when the error is InvalidParameterException with the
+        # specific "execute command agent" not-running message.  The AWS CLI
+        # uses "is not running" (not the contraction "isn't running"), but
+        # match both to be forward-compatible.
+        if printf '%s' "$_probe_stderr" | grep -q "InvalidParameterException" \
+            && printf '%s' "$_probe_stderr" | grep -qE "execute command agent (isn't|is not) running"; then
+            local _now
+            _now=$(date +%s)
+            if [[ "$_now" -ge "$_deadline" ]]; then
+                local _elapsed
+                _elapsed=$((_now - _start))
+                printf 'ECS exec agent on task %s did not come up within %ds — task definition may not have ECS Exec enabled, or the rollout is still stabilizing. Retry in ~1 minute or run '"'"'aws ecs describe-tasks'"'"' to inspect.\n' \
+                    "$task_arn" "$_elapsed" >&2
+                return 1
+            fi
+            local _elapsed
+            _elapsed=$((_now - _start))
+            printf 'exec agent on %s not ready (%ds elapsed), retrying in 5s...\n' \
+                "$task_arn" "$_elapsed" >&2
+            sleep 5
+        else
+            # Terminal failure (permissions, throttling, wrong cluster, etc.)
+            printf '%s\n' "$_probe_stderr" >&2
+            return 1
+        fi
+    done
+}

--- a/scripts/dev-db-query.sh
+++ b/scripts/dev-db-query.sh
@@ -177,6 +177,19 @@ while true; do
     sleep 3
 done
 
+# ─── Wait for ECS Exec agent to be ready ────────────────────────────────────
+# Even when list-tasks returns a running ARN the execute-command agent inside
+# the container may not be accepting connections yet (common during a rolling
+# deploy). Poll with a harmless probe before running the real query so the
+# user sees clear retry progress instead of the raw AWS error.
+
+# shellcheck source=scripts/_ecs_exec_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_ecs_exec_lib.sh"
+
+if ! wait_for_exec_agent_ready "$CLUSTER" "$task_arn" "$CONTAINER" "$REGION"; then
+    exit 1
+fi
+
 # ─── Build the command ───────────────────────────────────────────────────────
 
 echo "Running query on dev database via ECS Exec..." >&2

--- a/scripts/ecs-run.sh
+++ b/scripts/ecs-run.sh
@@ -165,6 +165,17 @@ fi
 echo "Task: $task_arn" >&2
 echo "" >&2
 
+# ─── Wait for ECS Exec agent to be ready ─────────────────────────────────────
+# Poll with a harmless probe before running the real command so the user sees
+# clear retry progress instead of the raw "execute command was not enabled" error.
+
+# shellcheck source=scripts/_ecs_exec_lib.sh
+source "$SCRIPT_DIR/_ecs_exec_lib.sh"
+
+if ! wait_for_exec_agent_ready "$CLUSTER" "$task_arn" "$CONTAINER" "$REGION"; then
+    exit 1
+fi
+
 # ─── Build and execute the command ─────────────────────────────────────────
 
 if [[ -n "$SCRIPT_PATH" ]]; then

--- a/scripts/tests/test_dev_db_query.sh
+++ b/scripts/tests/test_dev_db_query.sh
@@ -539,6 +539,129 @@ test_polls_then_gives_up_with_clear_error() {
     fi
 }
 
+# ── Exec-agent readiness probe tests (#3896) ──────────────────────────────
+
+# Mock aws that returns a task ARN on list-tasks, and for execute-command
+# either exits 0 immediately (success) or fails with the retryable
+# InvalidParameterException message N times before succeeding (or always fails
+# to test deadline).
+#
+# Args:
+#   $1 — number of execute-command calls that return the retryable error
+#        (0 = succeed immediately; -1 = always fail / deadline)
+#   $2 — (optional) tmpdir base; if omitted a new one is created
+#
+# Prints the mock_bin path.
+setup_mock_aws_exec_agent() {
+    local retryable_calls="$1"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local mock_bin="$tmpdir/bin"
+    local state_file="$tmpdir/exec_call_count"
+    mkdir -p "$mock_bin"
+    echo "0" > "$state_file"
+
+    # Write a separate retryable-error payload file so the mock script can
+    # cat it without needing inline heredocs (which are blocked by the
+    # preflight hook in interactive Bash calls but are fine in written files).
+    local err_file="$tmpdir/exec_err.txt"
+    printf 'An error occurred (InvalidParameterException) when calling the ExecuteCommand operation: The execute command agent is not running. Please wait until the exec agent on your task is ready.\n' \
+        > "$err_file"
+
+    cat > "$mock_bin/aws" << MOCK_AWS
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "ecs" && "\${2:-}" == "list-tasks" ]]; then
+    echo "arn:aws:ecs:us-west-2:000000000000:task/fake-cluster/fake-exec-task"
+    exit 0
+fi
+if [[ "\${1:-}" == "ecs" && "\${2:-}" == "execute-command" ]]; then
+    count=\$(cat "$state_file")
+    count=\$((count + 1))
+    echo "\$count" > "$state_file"
+    # retryable_calls == -1 means always fail
+    if [[ $retryable_calls -eq -1 || \$count -le $retryable_calls ]]; then
+        cat "$err_file" >&2
+        exit 1
+    fi
+    echo "[]"
+    exit 0
+fi
+echo "Mock aws: unexpected command: \$*" >&2
+exit 1
+MOCK_AWS
+    chmod +x "$mock_bin/aws"
+    echo "$mock_bin"
+}
+
+test_exec_agent_probe_success() {
+    # Probe exits 0 on first call — no retry messages, real query reached.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_exec_agent 0)
+    local output rc=0
+    output=$(LIST_TASKS_POLL_TIMEOUT_SECS=10 EXEC_AGENT_POLL_TIMEOUT_SECS=10 \
+        run_script "$mock_bin" "SELECT 1" 2>&1) || rc=$?
+
+    if [[ "$output" == *"exec agent"*"not ready"* ]]; then
+        fail "exec_agent_probe_success: no retry message expected" "got: $output"
+        return
+    fi
+    # Script should have reached execute-command (rc=0 or probe stage passed).
+    # The mock execute-command returns "[]" which after SSM strip is empty
+    # (or passes through) — either way the script must NOT have exited from
+    # the probe-failure path.
+    if [[ "$output" == *"ECS exec agent on task"*"did not come up"* ]]; then
+        fail "exec_agent_probe_success: must not emit deadline message" "got: $output"
+        return
+    fi
+    pass "exec_agent_probe_success: probe succeeds immediately, no retry noise"
+}
+
+test_exec_agent_probe_retries() {
+    # Probe returns retryable error on calls 1–2, succeeds on call 3.
+    # Must emit retry messages and then proceed (not exit non-zero).
+    local mock_bin
+    mock_bin=$(setup_mock_aws_exec_agent 2)
+    local output rc=0
+    output=$(LIST_TASKS_POLL_TIMEOUT_SECS=10 EXEC_AGENT_POLL_TIMEOUT_SECS=20 \
+        run_script "$mock_bin" "SELECT 1" 2>&1) || rc=$?
+
+    if [[ "$output" != *"exec agent"*"not ready"* ]]; then
+        fail "exec_agent_probe_retries: expected retry message in output" "got: $output"
+        return
+    fi
+    if [[ "$output" == *"ECS exec agent on task"*"did not come up"* ]]; then
+        fail "exec_agent_probe_retries: must not emit deadline message when probe eventually succeeds" \
+            "got: $output"
+        return
+    fi
+    pass "exec_agent_probe_retries: retry messages printed, script proceeds after agent ready"
+}
+
+test_exec_agent_probe_deadline_msg() {
+    # Probe always returns the retryable error. With a very short timeout the
+    # script must exit non-zero and emit the specific deadline message — NOT the
+    # raw "execute command was not enabled" text alone.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_exec_agent -1)
+    local output rc=0
+    output=$(LIST_TASKS_POLL_TIMEOUT_SECS=10 EXEC_AGENT_POLL_TIMEOUT_SECS=2 \
+        run_script "$mock_bin" "SELECT 1" 2>&1) || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        fail "exec_agent_probe_deadline_msg: must exit non-zero on deadline" "got: $output"
+        return
+    fi
+    if [[ "$output" != *"ECS exec agent on task"*"did not come up"* ]]; then
+        fail "exec_agent_probe_deadline_msg: must print specific deadline message" "got: $output"
+        return
+    fi
+    # The raw AWS message must not be the only error shown (it should be wrapped
+    # or replaced by the specific deadline message).
+    # We allow the raw message to appear in addition (it may be in retry lines),
+    # but the final-failure path must emit our friendly message.
+    pass "exec_agent_probe_deadline_msg: exits non-zero with specific deadline message"
+}
+
 # ── Run all ────────────────────────────────────────────────────────────────
 
 test_no_args_shows_usage
@@ -560,6 +683,9 @@ test_strips_own_line_cannot_perform
 test_empty_output_after_strip_is_ok
 test_polls_until_task_appears
 test_polls_then_gives_up_with_clear_error
+test_exec_agent_probe_success
+test_exec_agent_probe_retries
+test_exec_agent_probe_deadline_msg
 
 echo ""
 echo "────────────────────────────────────────────────"

--- a/scripts/tests/test_ecs_run.sh
+++ b/scripts/tests/test_ecs_run.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# test_ecs_run.sh — Tests for ecs-run.sh exec-agent readiness probe (#3896).
+#
+# Validates that ecs-run.sh sources _ecs_exec_lib.sh and calls
+# wait_for_exec_agent_ready before executing the user command.
+#
+# The mock aws returns a fake task ARN for list-tasks and simulates three
+# probe scenarios for execute-command:
+#   1. Probe succeeds immediately — no retry messages, command runs.
+#   2. Probe is retryable N times then succeeds — retry messages printed.
+#   3. Probe always retryable — deadline exceeded, script exits non-zero.
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ECS_RUN="$SCRIPT_DIR/ecs-run.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# setup_mock_aws_exec_agent <retryable_calls>
+#
+# Creates a mock aws CLI that:
+#   - Returns a fake task ARN for `aws ecs list-tasks`
+#   - For `aws ecs execute-command`:
+#       * returns the retryable InvalidParameterException error for the first
+#         <retryable_calls> calls (or always if retryable_calls == -1)
+#       * exits 0 on subsequent calls
+#
+# Prints the mock_bin path.
+setup_mock_aws_exec_agent() {
+    local retryable_calls="$1"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local mock_bin="$tmpdir/bin"
+    local state_file="$tmpdir/exec_call_count"
+    mkdir -p "$mock_bin"
+    echo "0" > "$state_file"
+
+    local err_file="$tmpdir/exec_err.txt"
+    printf 'An error occurred (InvalidParameterException) when calling the ExecuteCommand operation: The execute command agent is not running. Please wait until the exec agent on your task is ready.\n' \
+        > "$err_file"
+
+    cat > "$mock_bin/aws" << MOCK_AWS
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "ecs" && "\${2:-}" == "list-tasks" ]]; then
+    echo "arn:aws:ecs:us-west-2:000000000000:task/fake-cluster/fake-ecs-run-task"
+    exit 0
+fi
+if [[ "\${1:-}" == "ecs" && "\${2:-}" == "execute-command" ]]; then
+    count=\$(cat "$state_file")
+    count=\$((count + 1))
+    echo "\$count" > "$state_file"
+    if [[ $retryable_calls -eq -1 || \$count -le $retryable_calls ]]; then
+        cat "$err_file" >&2
+        exit 1
+    fi
+    # Simulate a successful execute-command (user command reached).
+    echo "Session Manager plugin ran successfully"
+    exit 0
+fi
+echo "Mock aws: unexpected command: \$*" >&2
+exit 1
+MOCK_AWS
+    chmod +x "$mock_bin/aws"
+    echo "$mock_bin"
+}
+
+run_script() {
+    # Args: <mock_bin> <extra env vars as VAR=val...> -- <ecs-run.sh args>
+    local mock_bin="$1"
+    shift
+    PATH="$mock_bin:$PATH" "$ECS_RUN" "$@" 2>&1
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+test_exec_agent_probe_success() {
+    # Probe exits 0 on first execute-command call. No retry messages should
+    # appear, and the script should proceed to run the user command (not exit
+    # from the probe-failure path).
+    local mock_bin
+    mock_bin=$(setup_mock_aws_exec_agent 0)
+    local output rc=0
+    output=$(EXEC_AGENT_POLL_TIMEOUT_SECS=10 \
+        run_script "$mock_bin" "true" 2>&1) || rc=$?
+
+    if [[ "$output" == *"exec agent"*"not ready"* ]]; then
+        fail "exec_agent_probe_success: no retry message expected" "got: $output"
+        return
+    fi
+    if [[ "$output" == *"ECS exec agent on task"*"did not come up"* ]]; then
+        fail "exec_agent_probe_success: must not emit deadline message" "got: $output"
+        return
+    fi
+    # The user command was reached (mock prints success string).
+    if [[ "$output" != *"Session Manager plugin ran successfully"* ]]; then
+        fail "exec_agent_probe_success: user command should have been reached" "got: $output"
+        return
+    fi
+    pass "exec_agent_probe_success: probe succeeds immediately, user command runs"
+}
+
+test_exec_agent_probe_retries() {
+    # Probe fails with retryable error on calls 1–2, succeeds on call 3.
+    # Script should emit retry messages and eventually reach the user command.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_exec_agent 2)
+    local output rc=0
+    output=$(EXEC_AGENT_POLL_TIMEOUT_SECS=20 \
+        run_script "$mock_bin" "true" 2>&1) || rc=$?
+
+    if [[ "$output" != *"exec agent"*"not ready"* ]]; then
+        fail "exec_agent_probe_retries: expected retry message in output" "got: $output"
+        return
+    fi
+    if [[ "$output" == *"ECS exec agent on task"*"did not come up"* ]]; then
+        fail "exec_agent_probe_retries: must not emit deadline message when probe eventually succeeds" \
+            "got: $output"
+        return
+    fi
+    # User command must have been reached after the probe succeeded.
+    if [[ "$output" != *"Session Manager plugin ran successfully"* ]]; then
+        fail "exec_agent_probe_retries: user command should have been reached after retries" \
+            "got: $output"
+        return
+    fi
+    pass "exec_agent_probe_retries: retry messages printed, user command runs after agent ready"
+}
+
+test_exec_agent_probe_deadline_msg() {
+    # Probe always returns retryable error. Script must exit non-zero and print
+    # the specific deadline message. The user command must NOT be reached.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_exec_agent -1)
+    local output rc=0
+    output=$(EXEC_AGENT_POLL_TIMEOUT_SECS=2 \
+        run_script "$mock_bin" "true" 2>&1) || rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        fail "exec_agent_probe_deadline_msg: must exit non-zero on deadline" "got: $output"
+        return
+    fi
+    if [[ "$output" != *"ECS exec agent on task"*"did not come up"* ]]; then
+        fail "exec_agent_probe_deadline_msg: must print specific deadline message" "got: $output"
+        return
+    fi
+    if [[ "$output" == *"Session Manager plugin ran successfully"* ]]; then
+        fail "exec_agent_probe_deadline_msg: user command must NOT be reached on probe failure" \
+            "got: $output"
+        return
+    fi
+    pass "exec_agent_probe_deadline_msg: exits non-zero with specific deadline message, user command not reached"
+}
+
+# ── Run all ────────────────────────────────────────────────────────────────
+
+test_exec_agent_probe_success
+test_exec_agent_probe_retries
+test_exec_agent_probe_deadline_msg
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Ran $TESTS tests, $FAILURES failed"
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

ECS tasks transition through a race condition during rolling deploys: `list-tasks` returns the task ARN while it's RUNNING, but the SSM exec agent inside the container hasn't finished initializing yet (30-90s). Scripts that immediately try `execute-command` hit an `InvalidParameterException` mentioning "execute command agent isn't running," which is misleading because the issue isn't configuration—it's just timing.

This PR adds `scripts/_ecs_exec_lib.sh`, a sourceable polling helper that bridges this gap. Both `scripts/dev-db-query.sh` and `scripts/ecs-run.sh` now source it after task ARN resolution, probe for readiness with a harmless `bash -c 'true'` command, retry on the specific retryable error, and emit a clear deadline message if the agent doesn't come up within ~120s.

Closes #3896

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` on scripts/tests/) — 6 new test cases cover probe success, retries, and deadline scenarios
- [x] CI green (pre-push hook validated)

### Post-deploy verification

- [ ] Force a rolling deploy on the dev ingestion-worker service: `aws ecs update-service --cluster judgemind-api-dev --service judgemind-ingestion-worker-dev --force-new-deployment`
- [ ] Run `scripts/dev-db-query.sh "SELECT 1"` immediately (within ~10s). Script should emit retry messages ("exec agent on... not ready, retrying in 5s") as the agent initializes, then succeed. If agent takes >120s, script exits with specific deadline message.
- [ ] Verify the same behavior with `scripts/ecs-run.sh` — the helper is sourced and used identically in both.
- [ ] Verification evidence posted on #3896 (see /task-v2-verify output)