### PR TITLE
refactor(dispatcher): extract _watch_in_flight branch helpers (#3943)

### DIFF
--- a/scripts/dispatcher_v3/launcher.py
+++ b/scripts/dispatcher_v3/launcher.py
@@ -577,115 +577,131 @@ class Launcher:
             )
             self._safe_rollback()
             return 0, []
-
         if not rows:
             return 0, []
-
-        task_arns = [str(r[1]) for r in rows]
-        descriptions = self._describe_tasks(task_arns)
-        # Index ECS results by ARN for O(1) lookup.
-        by_arn: dict[str, dict[str, Any]] = {}
-        for desc in descriptions:
-            arn = desc.get("taskArn")
-            if isinstance(arn, str):
-                by_arn[arn] = desc
-
-        # Read silent-hang threshold once per tick — `dispatcher.config`
-        # writes are rare so the value is stable across a tick.
+        descriptions = self._describe_tasks([str(r[1]) for r in rows])
+        by_arn = {
+            d["taskArn"]: d for d in descriptions if isinstance(d.get("taskArn"), str)
+        }
         silent_hang_seconds = self._read_silent_hang_minutes() * 60
-
         transitions: list[dict[str, Any]] = []
         for agent_id, task_arn, issue_number in rows:
             desc = by_arn.get(str(task_arn))
             if desc is None:
-                # Task missing from ECS response (very stale ARN). Leave
-                # in place — the next tick will re-check. No-op here so
-                # a transient API blip does not flip an active agent to
-                # failed.
-                continue
-            last_status = str(desc.get("lastStatus") or "")
-            if last_status == "STOPPED":
-                exit_code, exit_reason = self._extract_exit_state(desc)
-                new_status = "succeeded" if exit_code == 0 else "failed"
-                self._mark_agent_terminal(
-                    agent_id=str(agent_id),
-                    issue_number=int(issue_number) if issue_number is not None else 0,
-                    status=new_status,
-                    exit_code=exit_code,
-                    exit_reason=exit_reason,
-                )
-                stopped_transition: dict[str, Any] = {
-                    "agent_id": str(agent_id),
-                    "status": new_status,
-                    "exit_code": exit_code,
-                    "exit_reason": exit_reason,
-                }
-                # On failure, inline-launch the diagnoser (cap of 1 per
-                # agent enforced inside _launch_diagnoser via re-read of
-                # the row).
-                if new_status == "failed":
-                    diagnoser_arn = self._launch_diagnoser(
-                        agent_id=str(agent_id)
+                continue  # transient API blip — re-check next tick
+            issue_num = int(issue_number) if issue_number is not None else 0
+            if str(desc.get("lastStatus") or "") == "STOPPED":
+                transitions.append(
+                    self._resolve_stopped_task(
+                        agent_id=str(agent_id),
+                        task_arn=str(task_arn),
+                        issue_number=issue_num,
+                        desc=desc,
                     )
-                    if diagnoser_arn:
-                        stopped_transition["diagnoser_arn"] = diagnoser_arn
-                transitions.append(stopped_transition)
-                continue
-
-            # RUNNING — check for silent hang. The detector is opt-in
-            # via the log-group config; if ``task_runner_log_group`` is
-            # empty we skip the check entirely (graceful degradation
-            # for environments where F2 has not landed the log group
-            # yet — wall-clock cap is the only liveness signal).
-            if not self._task_runner_log_group:
-                continue
-            stale = self._task_session_is_silent(
-                task_arn=str(task_arn),
-                threshold_seconds=silent_hang_seconds,
-            )
-            if not stale:
-                continue
-            # Stale: stop the task and mark the agent failed.
-            self._stop_task_for_silent_hang(
-                agent_id=str(agent_id),
-                task_arn=str(task_arn),
-            )
-            self._mark_agent_terminal(
-                agent_id=str(agent_id),
-                issue_number=int(issue_number) if issue_number is not None else 0,
-                status="failed",
-                exit_code=None,
-                exit_reason=EXIT_REASON_SILENT_HANG,
-            )
-            log.warning(
-                "launcher.silent_hang_reaped",
-                extra={
-                    "event": "silent_hang_reaped",
-                    "run_id": self._run_id,
-                    "agent_id": str(agent_id),
-                    "issue_number": int(issue_number)
-                    if issue_number is not None
-                    else 0,
-                    "task_arn": str(task_arn),
-                    "threshold_seconds": silent_hang_seconds,
-                },
-            )
-            silent_hang_transition: dict[str, Any] = {
-                "agent_id": str(agent_id),
-                "status": "failed",
-                "exit_code": None,
-                "exit_reason": EXIT_REASON_SILENT_HANG,
-            }
-            # Silent-hang reaped agents are non-success terminals; run
-            # the diagnoser (cap of 1 enforced inside _launch_diagnoser
-            # via re-read of the row's diagnoser_arn).
-            silent_hang_diagnoser_arn = self._launch_diagnoser(
-                agent_id=str(agent_id)
-            )
-            if silent_hang_diagnoser_arn:
-                silent_hang_transition["diagnoser_arn"] = silent_hang_diagnoser_arn
-            transitions.append(silent_hang_transition)
+                )
+            else:
+                result = self._maybe_reap_silent_hang(
+                    agent_id=str(agent_id),
+                    task_arn=str(task_arn),
+                    issue_number=issue_num,
+                    threshold_seconds=silent_hang_seconds,
+                )
+                if result is not None:
+                    transitions.append(result)
         return len(rows), transitions
+
+    def _resolve_stopped_task(
+        self,
+        *,
+        agent_id: str,
+        task_arn: str,
+        issue_number: int,
+        desc: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve a STOPPED ECS task to a terminal agent status.
+
+        Extracts exit state from the ECS task description, marks the agent
+        row terminal, and (on failure) inline-spawns the diagnoser. Returns
+        the transition dict to be appended to the tick's transition list.
+        """
+        exit_code, exit_reason = self._extract_exit_state(desc)
+        new_status = "succeeded" if exit_code == 0 else "failed"
+        self._mark_agent_terminal(
+            agent_id=agent_id,
+            issue_number=issue_number,
+            status=new_status,
+            exit_code=exit_code,
+            exit_reason=exit_reason,
+        )
+        transition: dict[str, Any] = {
+            "agent_id": agent_id,
+            "status": new_status,
+            "exit_code": exit_code,
+            "exit_reason": exit_reason,
+        }
+        # On failure, inline-launch the diagnoser (cap of 1 per agent
+        # enforced inside _launch_diagnoser via re-read of the row).
+        if new_status == "failed":
+            diagnoser_arn = self._launch_diagnoser(agent_id=agent_id)
+            if diagnoser_arn:
+                transition["diagnoser_arn"] = diagnoser_arn
+        return transition
+
+    def _maybe_reap_silent_hang(
+        self,
+        *,
+        agent_id: str,
+        task_arn: str,
+        issue_number: int,
+        threshold_seconds: float,
+    ) -> Optional[dict[str, Any]]:
+        """Reap a RUNNING task if its CloudWatch log stream has gone silent.
+
+        Returns ``None`` if the silent-hang detector is disabled (no log
+        group configured) or the task is not yet stale. Returns the
+        transition dict when the task is reaped.
+        """
+        if not self._task_runner_log_group:
+            return None
+        stale = self._task_session_is_silent(
+            task_arn=task_arn,
+            threshold_seconds=threshold_seconds,
+        )
+        if not stale:
+            return None
+        # Stale: stop the task and mark the agent failed.
+        self._stop_task_for_silent_hang(agent_id=agent_id, task_arn=task_arn)
+        self._mark_agent_terminal(
+            agent_id=agent_id,
+            issue_number=issue_number,
+            status="failed",
+            exit_code=None,
+            exit_reason=EXIT_REASON_SILENT_HANG,
+        )
+        log.warning(
+            "launcher.silent_hang_reaped",
+            extra={
+                "event": "silent_hang_reaped",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "task_arn": task_arn,
+                "threshold_seconds": threshold_seconds,
+            },
+        )
+        transition: dict[str, Any] = {
+            "agent_id": agent_id,
+            "status": "failed",
+            "exit_code": None,
+            "exit_reason": EXIT_REASON_SILENT_HANG,
+        }
+        # Silent-hang reaped agents are non-success terminals; run the
+        # diagnoser (cap of 1 enforced inside _launch_diagnoser via
+        # re-read of the row's diagnoser_arn).
+        diagnoser_arn = self._launch_diagnoser(agent_id=agent_id)
+        if diagnoser_arn:
+            transition["diagnoser_arn"] = diagnoser_arn
+        return transition
 
     @staticmethod
     def _extract_exit_state(desc: dict[str, Any]) -> tuple[Optional[int], str]:
@@ -1005,8 +1021,7 @@ class Launcher:
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
-                    "SELECT diagnoser_arn FROM dispatcher.agents "
-                    "WHERE agent_id = %s",
+                    "SELECT diagnoser_arn FROM dispatcher.agents WHERE agent_id = %s",
                     (agent_id,),
                 )
                 row = cur.fetchone()
@@ -1055,9 +1070,7 @@ class Launcher:
             {"name": "AGENT_ID", "value": agent_id},
         ]
         overrides = {
-            "containerOverrides": [
-                {"name": "diagnoser", "environment": env_pairs}
-            ]
+            "containerOverrides": [{"name": "diagnoser", "environment": env_pairs}]
         }
         network_configuration = {
             "awsvpcConfiguration": {
@@ -1228,10 +1241,12 @@ class Launcher:
                 # outcome_summary (defensive: stops the watch query
                 # from re-matching this row forever).
                 self._mark_diagnoser_succeeded(agent_id=str(agent_id))
-                transitions.append({
-                    "agent_id": str(agent_id),
-                    "diagnoser_status": "succeeded",
-                })
+                transitions.append(
+                    {
+                        "agent_id": str(agent_id),
+                        "diagnoser_status": "succeeded",
+                    }
+                )
             else:
                 # STOPPED-non-zero: bump agent to needs_review. The
                 # operator inspects from the cockpit; the per-issue
@@ -1243,12 +1258,14 @@ class Launcher:
                     diagnoser_exit_code=exit_code,
                     diagnoser_exit_reason=exit_reason,
                 )
-                transitions.append({
-                    "agent_id": str(agent_id),
-                    "diagnoser_status": "failed",
-                    "diagnoser_exit_code": exit_code,
-                    "diagnoser_exit_reason": exit_reason,
-                })
+                transitions.append(
+                    {
+                        "agent_id": str(agent_id),
+                        "diagnoser_status": "failed",
+                        "diagnoser_exit_code": exit_code,
+                        "diagnoser_exit_reason": exit_reason,
+                    }
+                )
         return len(rows), transitions
 
     def _mark_diagnoser_succeeded(self, *, agent_id: str) -> None:
@@ -1974,9 +1991,7 @@ def _build_launcher_from_env() -> Launcher:
         # boots without diagnoser invocation wired (cap=0 means no
         # failures fire either). When unset, ``_launch_diagnoser`` logs
         # and skips; agents still mark ``failed`` correctly.
-        diagnoser_task_definition=os.environ.get(
-            "DIAGNOSER_TASK_DEFINITION", ""
-        ),
+        diagnoser_task_definition=os.environ.get("DIAGNOSER_TASK_DEFINITION", ""),
         agent_runner_subnet_ids=[
             s for s in os.environ.get("AGENT_RUNNER_SUBNET_IDS", "").split(",") if s
         ],

--- a/scripts/dispatcher_v3/tests/test_watch_helpers.py
+++ b/scripts/dispatcher_v3/tests/test_watch_helpers.py
@@ -1,0 +1,356 @@
+"""Unit tests for the extracted _watch_in_flight branch helpers (issue #3943).
+
+Exercises ``_resolve_stopped_task`` and ``_maybe_reap_silent_hang`` in
+isolation so each helper can be tested without the full DescribeTasks shim
+that the end-to-end ``_watch_in_flight`` integration tests in
+``test_launcher.py`` require.
+
+Each test constructs a :class:`Launcher` with minimal stubs and calls the
+helper directly, asserting the returned transition dict and side-effect
+calls. The helpers share the same psycopg shim as the other test modules.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+# Inject a fake ``psycopg.errors`` module so the launcher's lazy import
+# finds something callable in environments where the real wheel is not
+# installed. Matches the shim in test_launcher.py and test_diagnoser_invocation.py.
+if "psycopg" not in sys.modules:
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_errors = types.ModuleType("psycopg.errors")
+
+    class _FakeUniqueViolation(Exception):
+        pass
+
+    fake_errors.UniqueViolation = _FakeUniqueViolation
+    fake_psycopg.errors = fake_errors
+    sys.modules["psycopg"] = fake_psycopg
+    sys.modules["psycopg.errors"] = fake_errors
+
+
+from dispatcher_v3.launcher import (  # noqa: E402 — must follow sys.modules patch
+    EXIT_REASON_SILENT_HANG,
+    Launcher,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fakes — enough to exercise the helpers without a full DB loop
+# ---------------------------------------------------------------------------
+
+
+class FakeCursor:
+    """Minimal cursor stub."""
+
+    def __init__(self, conn: "FakeConn") -> None:
+        self.conn = conn
+        self.rowcount = 0
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.conn.executed.append((sql, params or ()))
+        for predicate, handler in self.conn.handlers:
+            if predicate in sql:
+                handler(self, sql, params or ())
+                return
+        self._next_fetchone = None
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return getattr(self, "_next_fetchone", None)
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return getattr(self, "_next_fetchall", []) or []
+
+
+class FakeConn:
+    """Minimal connection stub that records executed SQL."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.handlers: list[tuple[str, Any]] = []
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def install_handler(self, predicate: str, handler: Any) -> None:
+        self.handlers.append((predicate, handler))
+
+
+def make_launcher(
+    conn: FakeConn | None = None,
+    ecs_client: MagicMock | None = None,
+    cloudwatch_logs_client: MagicMock | None = None,
+    task_runner_log_group: str = "",
+    diagnoser_task_definition: str = "judgemind-dispatcher-v3-diagnoser",
+) -> Launcher:
+    """Construct a Launcher wired for helper-level unit tests."""
+    return Launcher(
+        run_id="run-test-uuid",
+        github_repo="judgemind/judgemind",
+        ecs_cluster_arn="arn:aws:ecs:us-west-2:0:cluster/jm",
+        task_runner_task_definition="judgemind-task-runner:7",
+        diagnoser_task_definition=diagnoser_task_definition,
+        agent_runner_subnet_ids=["subnet-a"],
+        agent_runner_security_group_id="sg-aaa",
+        sessions_bucket="judgemind-sessions-dev",
+        task_runner_log_group=task_runner_log_group,
+        conn=conn,
+        ecs_client=ecs_client,
+        cloudwatch_logs_client=cloudwatch_logs_client,
+        subprocess_runner=lambda *a, **k: MagicMock(returncode=0, stdout="", stderr=""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_stopped_task
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_stopped_task_success_no_diagnoser() -> None:
+    """exit_code=0 → status='succeeded', no diagnoser invoked, no diagnoser_arn."""
+    conn = FakeConn()
+    ecs = MagicMock()
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+
+    desc = {
+        "taskArn": "arn:task/1",
+        "lastStatus": "STOPPED",
+        "containers": [{"exitCode": 0}],
+        "stoppedReason": "Essential container exited",
+    }
+    result = launcher._resolve_stopped_task(
+        agent_id="ag-1",
+        task_arn="arn:task/1",
+        issue_number=42,
+        desc=desc,
+    )
+
+    assert result["agent_id"] == "ag-1"
+    assert result["status"] == "succeeded"
+    assert result["exit_code"] == 0
+    assert "diagnoser_arn" not in result
+    # No ECS RunTask (diagnoser launch) for a success transition.
+    ecs.run_task.assert_not_called()
+    # DB UPDATE for status='succeeded' fired.
+    assert any(
+        sql.startswith("UPDATE dispatcher.agents")
+        and "SET status = %s" in sql
+        and params[0] == "succeeded"
+        for sql, params in conn.executed
+    )
+
+
+def test_resolve_stopped_task_failure_invokes_diagnoser() -> None:
+    """exit_code=1 → status='failed', _launch_diagnoser called, diagnoser_arn populated."""
+    conn = FakeConn()
+    # _launch_diagnoser's cap-check SELECT returns no prior diagnoser.
+    conn.install_handler(
+        "SELECT diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (None,)),
+    )
+    ecs = MagicMock()
+    ecs.run_task.return_value = {
+        "tasks": [{"taskArn": "arn:task/diag-1"}],
+        "failures": [],
+    }
+    launcher = make_launcher(conn=conn, ecs_client=ecs)
+
+    desc = {
+        "taskArn": "arn:task/1",
+        "lastStatus": "STOPPED",
+        "containers": [{"exitCode": 1}],
+        "stoppedReason": "Error: something went wrong",
+    }
+    result = launcher._resolve_stopped_task(
+        agent_id="ag-1",
+        task_arn="arn:task/1",
+        issue_number=42,
+        desc=desc,
+    )
+
+    assert result["status"] == "failed"
+    assert result["exit_code"] == 1
+    assert result["diagnoser_arn"] == "arn:task/diag-1"
+    # _launch_diagnoser called exactly once.
+    ecs.run_task.assert_called_once()
+    kwargs = ecs.run_task.call_args.kwargs
+    assert kwargs["taskDefinition"] == "judgemind-dispatcher-v3-diagnoser"
+    env_pairs = kwargs["overrides"]["containerOverrides"][0]["environment"]
+    env = {p["name"]: p["value"] for p in env_pairs}
+    assert env == {"AGENT_ID": "ag-1"}
+
+
+def test_resolve_stopped_task_failure_no_diagnoser_arn_when_disabled() -> None:
+    """_launch_diagnoser returns None (disabled) → no diagnoser_arn key in result."""
+    conn = FakeConn()
+    ecs = MagicMock()
+    # Empty diagnoser task-def disables the launch.
+    launcher = make_launcher(conn=conn, ecs_client=ecs, diagnoser_task_definition="")
+
+    desc = {
+        "taskArn": "arn:task/1",
+        "lastStatus": "STOPPED",
+        "containers": [{"exitCode": 7}],
+        "stoppedReason": "OOM",
+    }
+    result = launcher._resolve_stopped_task(
+        agent_id="ag-1",
+        task_arn="arn:task/1",
+        issue_number=42,
+        desc=desc,
+    )
+
+    assert result["status"] == "failed"
+    assert "diagnoser_arn" not in result
+    ecs.run_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _maybe_reap_silent_hang
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_reap_silent_hang_returns_none_without_log_group() -> None:
+    """Empty task_runner_log_group → detector OFF, returns None immediately."""
+    conn = FakeConn()
+    cw = MagicMock()
+    # task_runner_log_group="" (the default) disables the detector.
+    launcher = make_launcher(
+        conn=conn, cloudwatch_logs_client=cw, task_runner_log_group=""
+    )
+
+    result = launcher._maybe_reap_silent_hang(
+        agent_id="ag-1",
+        task_arn="arn:task/1",
+        issue_number=42,
+        threshold_seconds=1800.0,
+    )
+
+    assert result is None
+    cw.describe_log_streams.assert_not_called()
+
+
+def test_maybe_reap_silent_hang_returns_none_when_not_stale() -> None:
+    """A fresh log stream is not stale — returns None, no stop/mark/diagnoser."""
+    import time as _time
+
+    conn = FakeConn()
+    ecs = MagicMock()
+    cw = MagicMock()
+    fresh_ms = int((_time.time() - 5) * 1000)  # 5 seconds ago
+    cw.describe_log_streams.return_value = {
+        "logStreams": [
+            {
+                "logStreamName": "task-runner/task-runner/abc123",
+                "lastEventTimestamp": fresh_ms,
+            }
+        ]
+    }
+    launcher = make_launcher(
+        conn=conn,
+        ecs_client=ecs,
+        cloudwatch_logs_client=cw,
+        task_runner_log_group="/ecs/judgemind-task-runner-dev",
+    )
+
+    result = launcher._maybe_reap_silent_hang(
+        agent_id="ag-1",
+        task_arn="arn:aws:ecs:us-west-2:0:task/jm/abc123",
+        issue_number=42,
+        threshold_seconds=1800.0,  # 30 min — stream is only 5s old
+    )
+
+    assert result is None
+    ecs.stop_task.assert_not_called()
+    assert not any(
+        sql.startswith("UPDATE dispatcher.agents") and "SET status = %s" in sql
+        for sql, _ in conn.executed
+    )
+
+
+def test_maybe_reap_silent_hang_stale_stops_marks_logs_and_diagnoses() -> None:
+    """Stale log stream → StopTask, mark failed, emit warning, return transition."""
+    import time as _time
+
+    conn = FakeConn()
+    # _launch_diagnoser cap-check sees no prior diagnoser.
+    conn.install_handler(
+        "SELECT diagnoser_arn FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (None,)),
+    )
+    ecs = MagicMock()
+    ecs.stop_task.return_value = {}
+    ecs.run_task.return_value = {
+        "tasks": [{"taskArn": "arn:task/diag-1"}],
+        "failures": [],
+    }
+    cw = MagicMock()
+    stale_ms = int((_time.time() - (45 * 60)) * 1000)  # 45 min ago
+    cw.describe_log_streams.return_value = {
+        "logStreams": [
+            {
+                "logStreamName": "task-runner/task-runner/abc123",
+                "lastEventTimestamp": stale_ms,
+            }
+        ]
+    }
+    launcher = make_launcher(
+        conn=conn,
+        ecs_client=ecs,
+        cloudwatch_logs_client=cw,
+        task_runner_log_group="/ecs/judgemind-task-runner-dev",
+    )
+
+    result = launcher._maybe_reap_silent_hang(
+        agent_id="ag-1",
+        task_arn="arn:aws:ecs:us-west-2:0:task/jm/abc123",
+        issue_number=42,
+        threshold_seconds=1800.0,  # 30 min — stream is 45 min old → stale
+    )
+
+    # Returned transition reflects the reap.
+    assert result is not None
+    assert result["agent_id"] == "ag-1"
+    assert result["status"] == "failed"
+    assert result["exit_code"] is None
+    assert result["exit_reason"] == EXIT_REASON_SILENT_HANG
+    assert result["diagnoser_arn"] == "arn:task/diag-1"
+
+    # ecs:StopTask called with the right ARN.
+    assert ecs.stop_task.call_count == 1
+    assert (
+        ecs.stop_task.call_args.kwargs["task"]
+        == "arn:aws:ecs:us-west-2:0:task/jm/abc123"
+    )
+
+    # DB UPDATE marks agent failed with exit_reason='silent_hang'.
+    matching = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("UPDATE dispatcher.agents") and "SET status = %s" in sql
+    ]
+    assert matching
+    _, params = matching[-1]
+    assert params[0] == "failed"
+    assert params[2] == EXIT_REASON_SILENT_HANG
+
+    # Diagnoser launched once.
+    ecs.run_task.assert_called_once()


### PR DESCRIPTION
## Summary

Refactored `Launcher._watch_in_flight` to extract two private helpers: `_resolve_stopped_task` (handles STOPPED task resolution and failure-triggered diagnoser launch) and `_maybe_reap_silent_hang` (handles RUNNING/silent-hang detection and reaping). The orchestrator dispatch loop is now ~20 lines vs. the original 116, reducing merge friction across parallel dispatcher-v3 features (#3881, #3882). Each helper is independently unit-testable; new test file adds 6 isolated unit tests covering both success and failure paths, diagnoser enable/disable, and stale-task detection.

Closes #3943

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher_v3/tests/test_launcher.py scripts/dispatcher_v3/tests/test_diagnoser_invocation.py` — 47 tests; plus new unit tests in `test_watch_helpers.py`)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (pure refactor of private launcher methods)