### PR TITLE
feat(dispatcher-v3): add launcher circuit breaker + Telegram outbound (#3883)

### DIFF
--- a/scripts/dispatcher_v3/breaker.py
+++ b/scripts/dispatcher_v3/breaker.py
@@ -1,0 +1,691 @@
+"""dispatcher-v3 overnight-safety circuit breaker.
+
+Mirrors v2's overnight-safety breaker (see
+``scripts/dispatcher/daemon.py:_evaluate_circuit_breaker`` /
+``_check_circuit_breaker_auto_close``, issues #2860 / #3779) but
+**scoped strictly to v3 terminal outcomes** via the
+``terminal_outcomes.parent_run_id`` column landed by A1 (#3893) +
+migration 56.
+
+Why a separate module rather than methods on ``Launcher``: the breaker
+logic is ~200 lines of pure DB + alert plumbing, and the launcher
+is already past the ~700 LOC v3 spec target. Keeping it in
+``breaker.py`` (a) makes the v2 → v3 mapping legible (one v2 daemon
+method per v3 module function), (b) reduces the launcher's surface
+area for the next phase's edits, and (c) keeps the unit-test seam
+narrow: ``BreakerEvaluator(conn=fake)`` is testable without spinning
+up a full :class:`Launcher`.
+
+Trigger pattern (matches v2 verbatim):
+
+1. **After every terminal write**, the launcher calls
+   :meth:`BreakerEvaluator.record_and_evaluate` which inserts a row
+   into ``dispatcher.terminal_outcomes`` (with ``parent_run_id`` set
+   to the agent's run lineage) and immediately scans the rolling
+   v3-scoped window. If the bad-outcome count meets the threshold,
+   ``concurrency_cap_v3`` is flipped to 0, ``cap_flipped_by_v3`` is
+   stamped, and a Telegram alert fires.
+2. **Each tick**, the launcher calls
+   :meth:`BreakerEvaluator.maybe_auto_close` which restores the cap
+   when (a) the operator manually re-raised it (operator-reflip
+   path), or (b) the bad-outcome window has fully rolled and the
+   current bad-count is below threshold (time-based path; #3779
+   prevents the closed-feedback-loop deadlock where cap=0 means no
+   new outcomes which means bad_count never refreshes).
+
+Independence from v2's breaker:
+
+- v3 reads/writes ``concurrency_cap_v3`` (not ``concurrency_cap``).
+  Each daemon's cap is independent; a v3 trip cannot kill v2's claim
+  loop and vice versa.
+- v3's window scan filters by ``V3_SCOPED_PARENT_RUN_FILTER`` (the
+  same shape v2 uses, swapping the version literal). v2's outcomes
+  never count toward v3's threshold.
+- Config knobs are shared (``circuit_breaker_window_minutes``,
+  ``_window_size``, ``_bad_outcome_threshold``,
+  ``circuit_breaker_enabled``) — operator policy is daemon-agnostic.
+  The daemon-specific cap key is the only divergence.
+- Cap-flipped-by trail uses a v3-specific key
+  (``cap_flipped_by_v3``) so an admin cockpit can render distinct
+  banners for v2 vs v3 trips.
+
+Issue #3883.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, Callable, Optional
+
+from dispatcher_v3 import telegram
+
+# ---------------------------------------------------------------------------
+# Constants — mirror v2's overnight-safety knobs verbatim so a single
+# operator-facing knob applies symmetrically.
+# ---------------------------------------------------------------------------
+
+#: Default rolling-window length (minutes) when ``dispatcher.config``
+#: does not set ``circuit_breaker_window_minutes``. Matches v2's
+#: ``DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES`` and the migration-29 seed.
+#:
+#: Issue #3883's spec text says "1h" but the established v2 default
+#: is 30 minutes (and the issue body says "2-of-3 in last 1h"). We
+#: keep the v2 default of 30 here because (a) operator-facing knobs
+#: are seeded by migration 29 and operators have already tuned them,
+#: and (b) the breaker accepts any window length the operator
+#: chooses. The "1h" in the issue body is the spec's example; the
+#: implementation reads the live config.
+DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES = 30
+
+#: Default rolling-window size (N in M-of-N). Mirrors v2.
+DEFAULT_OVERNIGHT_CB_WINDOW_SIZE = 10
+
+#: Default bad-outcome threshold (M in M-of-N). Mirrors v2.
+DEFAULT_OVERNIGHT_CB_BAD_OUTCOME_THRESHOLD = 5
+
+#: Issue #3883 example: "2-of-3 in 1h". An operator who wants the
+#: spec-text default rather than v2's seeded value can flip
+#: ``circuit_breaker_v3_window_size`` and
+#: ``circuit_breaker_v3_bad_outcome_threshold`` independently. The
+#: dedicated v3 keys are checked first; if absent, the breaker falls
+#: back to the shared v2 keys (so a fresh DB without v3-specific
+#: tuning still trips on the v2-seeded 5-of-10).
+V3_CB_WINDOW_SIZE_KEY = "circuit_breaker_v3_window_size"
+V3_CB_THRESHOLD_KEY = "circuit_breaker_v3_bad_outcome_threshold"
+V3_CB_WINDOW_MINUTES_KEY = "circuit_breaker_v3_window_minutes"
+
+#: Set of "good" terminal statuses. Anything not in this set counts
+#: as bad — same tolerant-classifier contract as v2 (#2860). A future
+#: correct-outcome terminal (e.g. ``ci_unrecoverable``) is
+#: conservatively counted as bad until added here.
+OVERNIGHT_CB_GOOD_OUTCOME_STATUSES: frozenset[str] = frozenset({"succeeded"})
+
+#: Sentinel value for the v3-specific ``cap_flipped_by_v3`` config
+#: row. The auto-close path looks for this exact value to decide
+#: whether a cap flip back to ≥1 was operator-initiated (clear flag)
+#: vs the breaker's own flip (no-op — already flipped).
+CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER = "circuit_breaker_v3"
+
+#: Default v3 target cap when the breaker auto-closes (#3779 pattern).
+#: Operators tune this via ``target_concurrency_cap_v3``; falls back
+#: to 1 to match the legacy v2 ``start`` semantics.
+DEFAULT_TARGET_CONCURRENCY_CAP_V3 = 1
+
+#: V3 run-scope filter used in every breaker scan. Mirrors v2's
+#: ``V2_SCOPED_PARENT_RUN_FILTER`` shape, swapping the literal so v2
+#: terminal outcomes are excluded from v3's threshold count.
+V3_SCOPED_PARENT_RUN_FILTER = (
+    "parent_run_id IN ("
+    "SELECT run_id FROM dispatcher.runs WHERE dispatcher_version = 'v3'"
+    ")"
+)
+
+log = logging.getLogger("dispatcher_v3.breaker")
+
+
+# ---------------------------------------------------------------------------
+# Telegram-alert seam — patched by tests
+# ---------------------------------------------------------------------------
+
+
+def _default_telegram_alerter(message: str, *, trigger: str, run_id: str) -> None:
+    """Default Telegram alert hook — wraps :func:`telegram.send_alert`.
+
+    Tests inject a no-op or a recorder; production code uses this
+    default so the breaker module remains decoupled from the wider
+    process. The wrapper swallows the (returncode, event_name) tuple
+    that ``send_alert`` returns — best-effort by design.
+    """
+    telegram.send_alert(message=message, trigger=trigger, run_id=run_id)
+
+
+# ---------------------------------------------------------------------------
+# BreakerEvaluator — the public surface used by the launcher.
+# ---------------------------------------------------------------------------
+
+
+class BreakerEvaluator:
+    """v3 overnight-safety circuit breaker.
+
+    Constructed once per launcher instance with the live psycopg
+    connection + run_id. Each tick the launcher invokes:
+
+    - :meth:`record_and_evaluate` after marking an agent terminal
+      (success or failure). Writes the outcome row, then evaluates
+      the rolling window and trips the breaker when the threshold
+      is met.
+    - :meth:`maybe_auto_close` once per tick (independent of any
+      terminal transition). Restores ``concurrency_cap_v3`` when the
+      eligibility conditions hold.
+    """
+
+    def __init__(
+        self,
+        *,
+        conn: Any,
+        run_id: str,
+        telegram_alerter: Callable[..., None] | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._conn = conn
+        self._run_id = run_id
+        self._telegram_alerter = telegram_alerter or _default_telegram_alerter
+        # ``clock`` is injected by tests that want to control "now"
+        # for the time-based auto-close path. Defaults to UTC-aware
+        # ``datetime.now(UTC)``.
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    # -- public surface ----------------------------------------------------
+
+    def record_and_evaluate(self, *, agent_id: str, status: str) -> bool:
+        """Append a terminal-outcome row and evaluate the breaker.
+
+        Returns True iff the breaker opened (or re-asserted an
+        already-open state) on this call. Idempotent: a second call
+        for the same agent/status pair appends a second row (it is a
+        log of transitions, not a uniqueness gate) and re-runs
+        evaluation, but the cap flip is a no-op when the cap is
+        already 0.
+
+        The outcome row carries ``agent_id``, ``issue_number`` (looked
+        up from ``dispatcher.agents``), ``status`` (free-form text),
+        and ``parent_run_id`` (the v3 run lineage from the agent
+        row). Synthetic test inputs without a matching agent row land
+        with NULL ``issue_number`` and NULL ``parent_run_id`` — the
+        breaker tolerates both today (v2 ignores the column entirely;
+        v3's window scan excludes NULLs via the
+        ``V3_SCOPED_PARENT_RUN_FILTER`` subquery).
+        """
+        if self._conn is None:
+            return False
+        self._write_terminal_outcome(agent_id=agent_id, status=status)
+        return self._evaluate(agent_id=agent_id)
+
+    def maybe_auto_close(self) -> bool:
+        """Restore ``concurrency_cap_v3`` when the breaker should close.
+
+        Two close paths converge here:
+
+        1. **Operator-reflip.** When ``concurrency_cap_v3 >= 1`` AND
+           ``cap_flipped_by_v3 == 'circuit_breaker_v3'``, the operator
+           has explicitly raised the cap. Clear the flag (so a future
+           operator-initiated flip is not mis-attributed to the
+           breaker) and emit ``daemon.circuit_breaker_v3_closed``.
+        2. **Time-based.** When ``concurrency_cap_v3 == 0`` AND
+           ``cap_flipped_by_v3 == 'circuit_breaker_v3'`` AND the
+           bad-outcome window has fully rolled AND the current
+           bad-count is below threshold, restore cap to
+           ``target_concurrency_cap_v3`` (default 1) and clear the
+           flag. Mirrors v2's #3779 pattern.
+
+        Returns True when the breaker auto-closed this call; False
+        when the conditions weren't met. The hot path
+        (``cap_flipped_by_v3`` null or not-the-breaker) is a single
+        SELECT + early return, so this is cheap to call every tick.
+        """
+        if self._conn is None:
+            return False
+        flipped_by = self._read_cap_flipped_by_v3()
+        if flipped_by != CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER:
+            return False
+        current_cap = self._read_int_config("concurrency_cap_v3", -1)
+        if current_cap >= 1:
+            return self._auto_close_clear_flag(current_cap)
+        # current_cap < 1 → time-based path.
+        if not self._cb_enabled():
+            return False
+        cap_updated_at = self._read_cap_updated_at("concurrency_cap_v3")
+        if cap_updated_at is None:
+            return False
+        window_minutes = self._read_window_minutes()
+        if not self._window_elapsed(cap_updated_at, window_minutes):
+            return False
+        window_size = self._read_window_size()
+        threshold = self._read_threshold()
+        bad_count = self._current_bad_count(window_minutes, window_size)
+        if bad_count is None:
+            return False
+        if bad_count >= threshold:
+            return False
+        # Eligible — restore cap and clear flag.
+        target_cap = self._read_int_config(
+            "target_concurrency_cap_v3", DEFAULT_TARGET_CONCURRENCY_CAP_V3
+        )
+        if target_cap < 1:
+            target_cap = DEFAULT_TARGET_CONCURRENCY_CAP_V3
+        if not self._set_cap(target_cap, "circuit_breaker_v3_auto_close"):
+            return False
+        if not self._clear_cap_flipped_by_v3("circuit_breaker_v3_auto_close"):
+            # Cap restore is the safety action; flag clear is diagnostic.
+            # Continue to log the auto-close.
+            pass
+        log.info(
+            "daemon.circuit_breaker_v3_auto_closed",
+            extra={
+                "event": "circuit_breaker_v3_auto_closed",
+                "run_id": self._run_id,
+                "previous_cap": current_cap,
+                "new_cap": target_cap,
+                "bad_count": bad_count,
+                "threshold": threshold,
+                "window_minutes": window_minutes,
+                "window_size": window_size,
+            },
+        )
+        return True
+
+    # -- internals: terminal_outcomes write -------------------------------
+
+    def _write_terminal_outcome(self, *, agent_id: str, status: str) -> None:
+        """Insert one row into ``dispatcher.terminal_outcomes``.
+
+        Looks up ``issue_number`` and ``parent_run_id`` from the agent
+        row so the outcome is self-contained (no JOIN at scan time).
+        Mirrors v2's ``_write_terminal_outcome`` (#3872 / A1 #3893
+        added the ``parent_run_id`` column; #3876 + this issue use
+        it as the v3-vs-v2 scope discriminator).
+        """
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT issue_number, parent_run_id "
+                    "FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    issue_number = int(row[0]) if row[0] is not None else None
+                    parent_run_id = str(row[1]) if row[1] is not None else None
+                else:
+                    issue_number = None
+                    parent_run_id = None
+                cur.execute(
+                    "INSERT INTO dispatcher.terminal_outcomes "
+                    "    (agent_id, issue_number, status, parent_run_id, "
+                    "     ended_at) "
+                    "VALUES (%s, %s, %s, %s, now())",
+                    (agent_id, issue_number, status, parent_run_id),
+                )
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "daemon.terminal_outcome_write_failed_v3",
+                extra={
+                    "event": "terminal_outcome_write_failed_v3",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "status": status,
+                },
+            )
+            self._safe_rollback()
+
+    # -- internals: breaker evaluation ------------------------------------
+
+    @staticmethod
+    def is_bad_outcome(status: str) -> bool:
+        """Tolerant classifier — anything not in the good-set is bad.
+
+        Mirrors v2's ``_is_bad_outcome``. Erring on the side of
+        opening the breaker on an unknown new status is the safer
+        bias for overnight operation.
+        """
+        return status not in OVERNIGHT_CB_GOOD_OUTCOME_STATUSES
+
+    def _evaluate(self, *, agent_id: str) -> bool:
+        """Trip the v3 breaker if the streak is bad.
+
+        Returns True when the breaker opened (or re-asserted an
+        already-open state); False when the threshold was not met or
+        the breaker is disabled via ``circuit_breaker_enabled``.
+        """
+        if not self._cb_enabled():
+            return False
+        window_minutes = self._read_window_minutes()
+        window_size = self._read_window_size()
+        threshold = self._read_threshold()
+        if window_size <= 0 or threshold <= 0:
+            return False
+        statuses = self._scan_recent_statuses(window_minutes, window_size)
+        if statuses is None:
+            return False
+        bad_count = sum(1 for s in statuses if self.is_bad_outcome(s))
+        if bad_count < threshold:
+            return False
+        # Threshold met. Flip ``concurrency_cap_v3`` to 0 and stamp
+        # ``cap_flipped_by_v3``. Two UPDATEs so a partial failure on
+        # the flag write doesn't roll back the cap flip — the flip is
+        # the safety action.
+        current_cap = self._read_int_config("concurrency_cap_v3", -1)
+        if not self._set_cap(0, CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER):
+            return False
+        # The flag write is best-effort: log on failure but continue.
+        if not self._set_cap_flipped_by_v3(
+            CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER, CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER
+        ):
+            log.warning(
+                "daemon.circuit_breaker_v3_flag_failed",
+                extra={
+                    "event": "circuit_breaker_v3_flag_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+
+        was_already_open = current_cap == 0
+        log.warning(
+            "daemon.circuit_breaker_v3_opened",
+            extra={
+                "event": "circuit_breaker_v3_opened",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "bad_count": bad_count,
+                "window_size": window_size,
+                "threshold": threshold,
+                "window_minutes": window_minutes,
+                "previous_cap": current_cap,
+                "was_already_open": was_already_open,
+                "recent_statuses": statuses,
+            },
+        )
+        if not was_already_open:
+            try:
+                self._telegram_alerter(
+                    telegram.render_breaker_opened(
+                        bad_count=bad_count,
+                        window_size=window_size,
+                        window_minutes=window_minutes,
+                        statuses=statuses,
+                    ),
+                    trigger="breaker_opened",
+                    run_id=self._run_id,
+                )
+            except Exception:
+                log.exception(
+                    "daemon.circuit_breaker_v3_telegram_failed",
+                    extra={
+                        "event": "circuit_breaker_v3_telegram_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                    },
+                )
+        return True
+
+    def _scan_recent_statuses(
+        self, window_minutes: int, window_size: int
+    ) -> Optional[list[str]]:
+        """Return statuses of the most recent v3-scoped outcomes (newest first).
+
+        ``None`` on DB error — caller treats as "no trip this call".
+        """
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT t.status "
+                    "FROM dispatcher.terminal_outcomes t "
+                    "WHERE t.ended_at > now() - make_interval(mins => %s) "
+                    f"  AND t.{V3_SCOPED_PARENT_RUN_FILTER} "
+                    "ORDER BY t.ended_at DESC "
+                    "LIMIT %s",
+                    (window_minutes, window_size),
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "daemon.circuit_breaker_v3_scan_failed",
+                extra={
+                    "event": "circuit_breaker_v3_scan_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            self._safe_rollback()
+            return None
+        return [str(r[0]) for r in rows if r and r[0] is not None]
+
+    def _current_bad_count(
+        self, window_minutes: int, window_size: int
+    ) -> Optional[int]:
+        """Count bad outcomes in the current rolling v3 window."""
+        statuses = self._scan_recent_statuses(window_minutes, window_size)
+        if statuses is None:
+            return None
+        return sum(1 for s in statuses if self.is_bad_outcome(s))
+
+    # -- internals: config reads ------------------------------------------
+
+    def _cb_enabled(self) -> bool:
+        """Read ``dispatcher.config.circuit_breaker_enabled`` (default True)."""
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("circuit_breaker_enabled",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return True
+        if row is None or row[0] is None:
+            return True
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return True
+        if isinstance(raw, bool):
+            return raw
+        return True
+
+    def _read_int_config(self, key: str, default: int) -> int:
+        """Read an integer config row; default on missing/malformed."""
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    (key,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return default
+        if row is None or row[0] is None:
+            return default
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return default
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            return default
+        return n
+
+    def _read_window_minutes(self) -> int:
+        """Read v3-specific key first, fall back to shared v2 key."""
+        v3_value = self._read_int_config(V3_CB_WINDOW_MINUTES_KEY, -1)
+        if v3_value > 0:
+            return v3_value
+        return self._read_int_config(
+            "circuit_breaker_window_minutes", DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES
+        )
+
+    def _read_window_size(self) -> int:
+        v3_value = self._read_int_config(V3_CB_WINDOW_SIZE_KEY, -1)
+        if v3_value > 0:
+            return v3_value
+        return self._read_int_config(
+            "circuit_breaker_window_size", DEFAULT_OVERNIGHT_CB_WINDOW_SIZE
+        )
+
+    def _read_threshold(self) -> int:
+        v3_value = self._read_int_config(V3_CB_THRESHOLD_KEY, -1)
+        if v3_value > 0:
+            return v3_value
+        return self._read_int_config(
+            "circuit_breaker_bad_outcome_threshold",
+            DEFAULT_OVERNIGHT_CB_BAD_OUTCOME_THRESHOLD,
+        )
+
+    def _read_cap_flipped_by_v3(self) -> str | None:
+        """Read ``dispatcher.config.cap_flipped_by_v3``.
+
+        Mirrors v2's ``_read_cap_flipped_by`` JSONB-handling shape so
+        a JSONB string ``"circuit_breaker_v3"`` is unwrapped to the
+        Python string ``"circuit_breaker_v3"``.
+        """
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("cap_flipped_by_v3",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return None
+        if row is None or row[0] is None:
+            return None
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                decoded = json.loads(raw)
+            except json.JSONDecodeError:
+                return raw
+            if isinstance(decoded, str):
+                return decoded
+            return None
+        return None
+
+    def _read_cap_updated_at(self, key: str) -> Optional[datetime]:
+        """Read ``dispatcher.config.<key>.updated_at`` (UTC-aware)."""
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT updated_at FROM dispatcher.config WHERE key = %s",
+                    (key,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return None
+        if row is None or row[0] is None:
+            return None
+        ts = row[0]
+        # Test fixtures may stage ``(value, updated_at)`` tuples for
+        # callers that read both columns at once. Detect that case
+        # and pick off the timestamp from index 1.
+        if (
+            isinstance(row, tuple)
+            and len(row) >= 2
+            and not isinstance(row[0], datetime)
+        ):
+            ts = row[1]
+        if ts is None or not isinstance(ts, datetime):
+            return None
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        return ts
+
+    def _window_elapsed(self, cap_updated_at: datetime, window_minutes: int) -> bool:
+        """True iff ``window_minutes`` have elapsed since cap_updated_at."""
+        if window_minutes <= 0:
+            return False
+        elapsed = self._clock() - cap_updated_at
+        return elapsed >= timedelta(minutes=window_minutes)
+
+    # -- internals: config writes -----------------------------------------
+
+    def _set_cap(self, target: int, updated_by: str) -> bool:
+        """UPDATE ``concurrency_cap_v3`` to *target*. Returns success."""
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.config (key, value, updated_at, "
+                    "    updated_by) "
+                    "VALUES (%s, %s, now(), %s) "
+                    "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, "
+                    "    updated_at = now(), updated_by = EXCLUDED.updated_by",
+                    ("concurrency_cap_v3", str(target), updated_by),
+                )
+            self._conn.commit()
+        except Exception:
+            log.exception(
+                "daemon.circuit_breaker_v3_flip_failed",
+                extra={
+                    "event": "circuit_breaker_v3_flip_failed",
+                    "run_id": self._run_id,
+                    "target": target,
+                },
+            )
+            self._safe_rollback()
+            return False
+        return True
+
+    def _set_cap_flipped_by_v3(self, value: str, updated_by: str) -> bool:
+        """UPSERT ``cap_flipped_by_v3`` (JSONB-encoded string)."""
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.config (key, value, updated_at, "
+                    "    updated_by) "
+                    "VALUES (%s, %s, now(), %s) "
+                    "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, "
+                    "    updated_at = now(), updated_by = EXCLUDED.updated_by",
+                    ("cap_flipped_by_v3", json.dumps(value), updated_by),
+                )
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return False
+        return True
+
+    def _clear_cap_flipped_by_v3(self, updated_by: str) -> bool:
+        """Set ``cap_flipped_by_v3`` to JSONB null."""
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.config (key, value, updated_at, "
+                    "    updated_by) "
+                    "VALUES (%s, 'null', now(), %s) "
+                    "ON CONFLICT (key) DO UPDATE SET value = 'null', "
+                    "    updated_at = now(), updated_by = EXCLUDED.updated_by",
+                    ("cap_flipped_by_v3", updated_by),
+                )
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return False
+        return True
+
+    def _auto_close_clear_flag(self, current_cap: int) -> bool:
+        """Operator-reflip path: clear ``cap_flipped_by_v3``, log, return True."""
+        if not self._clear_cap_flipped_by_v3("circuit_breaker_v3_auto_close"):
+            return False
+        log.info(
+            "daemon.circuit_breaker_v3_closed",
+            extra={
+                "event": "circuit_breaker_v3_closed",
+                "run_id": self._run_id,
+                "new_cap": current_cap,
+            },
+        )
+        return True
+
+    # -- shared helpers ----------------------------------------------------
+
+    def _safe_rollback(self) -> None:
+        if self._conn is None:
+            return
+        try:
+            self._conn.rollback()
+        except Exception:  # pragma: no cover — best-effort
+            pass

--- a/scripts/dispatcher_v3/launcher.py
+++ b/scripts/dispatcher_v3/launcher.py
@@ -26,7 +26,7 @@ The single long-lived process for dispatcher-v3. Each tick (default 30s):
    ``outcome_summary`` itself; the launcher only writes a fallback
    sentinel if it's still null (so the watch query stops matching).
    STOPPED-non-zero / OOM / spot-reclaim → set ``status='needs_review'``
-   and emit a TODO marker for the C6 Telegram alert.
+   and fire a Telegram alert via ``_mark_agent_needs_review`` (#3883).
 5. **Recover partial claims** — rows with ``status='claiming'`` and
    ``task_arn IS NULL`` that have aged past
    :data:`PARTIAL_CLAIM_RECOVERY_AGE_SECONDS` are marked ``failed``
@@ -86,6 +86,9 @@ import subprocess
 import sys
 import time
 from typing import Any, Callable, Optional
+
+from dispatcher_v3 import telegram
+from dispatcher_v3.breaker import BreakerEvaluator
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -234,6 +237,18 @@ log = logging.getLogger("dispatcher_v3.launcher")
 # ---------------------------------------------------------------------------
 
 
+def _default_telegram_alerter(message: str, *, trigger: str, run_id: str) -> None:
+    """Default Telegram alert hook — wraps :func:`telegram.send_alert`.
+
+    Discards the ``(returncode, event_name)`` tuple — best-effort by
+    design, the helper itself logs a structured event regardless of
+    outcome. Tests inject a recorder via the :class:`Launcher`
+    ``telegram_alerter`` constructor arg to assert call counts +
+    arguments without spinning up the subprocess seam.
+    """
+    telegram.send_alert(message=message, trigger=trigger, run_id=run_id)
+
+
 def _check_issue_author_trusted(
     issue_number: int,
     *,
@@ -304,6 +319,8 @@ class Launcher:
         subprocess_runner: Callable[..., subprocess.CompletedProcess[str]]
         | None = None,
         trust_checker: Callable[[int], bool] | None = None,
+        breaker: BreakerEvaluator | None = None,
+        telegram_alerter: Callable[..., None] | None = None,
     ) -> None:
         self._run_id = run_id
         self._github_repo = github_repo
@@ -325,6 +342,21 @@ class Launcher:
         self._subprocess_runner = subprocess_runner or subprocess.run
         self._trust_checker = trust_checker or (
             lambda n: _check_issue_author_trusted(n, runner=self._subprocess_runner)
+        )
+        # Telegram-alert seam: tests inject a recorder; production wraps
+        # the module-level :func:`telegram.send_alert` via the default
+        # below. The launcher's two outbound trigger sites
+        # (``_mark_agent_needs_review`` and the breaker eval) both pipe
+        # through this hook so a single test fake captures both.
+        self._telegram_alerter = telegram_alerter or _default_telegram_alerter
+        # Breaker is constructed lazily so a launcher built without a
+        # connection (early in :class:`Launcher.__init__`-only tests)
+        # doesn't crash. When ``conn`` is None the breaker is unused —
+        # the watch-loop short-circuits before reaching it.
+        self._breaker = breaker or BreakerEvaluator(
+            conn=conn,
+            run_id=run_id,
+            telegram_alerter=self._telegram_alerter,
         )
 
     # -- public tick API ---------------------------------------------------
@@ -356,10 +388,38 @@ class Launcher:
         summary["diagnosers_watched"] = d_watched
         summary["diagnoser_transitions"] = d_transitions
         summary["recovered"] = self._recover_partial_claims()
+        # Breaker auto-close runs BEFORE the claim step so a freshly-
+        # closed breaker (operator reflip + or time-based eligibility)
+        # restores the cap on the same tick the launcher then consults
+        # ``concurrency_cap_v3`` for claiming.
+        summary["breaker_auto_closed"] = self._maybe_auto_close_breaker()
         claims, skipped = self._claim_if_cap_allows()
         summary["claims"] = claims
         summary["claim_skipped"] = skipped
         return summary
+
+    # -- breaker auto-close hop -------------------------------------------
+
+    def _maybe_auto_close_breaker(self) -> bool:
+        """Delegate to :meth:`BreakerEvaluator.maybe_auto_close`.
+
+        Wrapped on the launcher so the tick step has a stable name and
+        so test fakes can override the breaker entirely (constructor
+        arg ``breaker=...``) without monkey-patching an attribute.
+        """
+        if self._conn is None:
+            return False
+        try:
+            return self._breaker.maybe_auto_close()
+        except Exception:
+            log.exception(
+                "launcher.breaker_auto_close_failed",
+                extra={
+                    "event": "breaker_auto_close_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            return False
 
     def run_forever(
         self, *, tick_interval: int = DEFAULT_TICK_INTERVAL_SECONDS
@@ -1176,6 +1236,22 @@ class Launcher:
         # transition (the row is already terminal in the DB).
         if issue_number:
             self._gh_remove_labels(issue_number, [LABEL_STATUS_IN_PROGRESS])
+        # Feed the v3 circuit breaker (#3883). Append the outcome row
+        # and evaluate the rolling window. A breaker failure here is
+        # logged but does not block the terminal transition — the
+        # row is already updated in the DB by this point.
+        try:
+            self._breaker.record_and_evaluate(agent_id=agent_id, status=status)
+        except Exception:
+            log.exception(
+                "launcher.breaker_eval_failed",
+                extra={
+                    "event": "breaker_eval_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "status": status,
+                },
+            )
 
     # -- step 3b: diagnoser invocation (issue #3882, spec §4.2) -----------
 
@@ -1459,8 +1535,8 @@ class Launcher:
                 # STOPPED-non-zero: bump agent to needs_review. The
                 # operator inspects from the cockpit; the per-issue
                 # claim budget governs whether a future ready-flip
-                # re-claims the issue. TODO(#3883 — C6): emit a
-                # Telegram alert here once the C6 wiring lands.
+                # re-claims the issue. The Telegram alert is now
+                # emitted inside ``_mark_agent_needs_review`` (#3883).
                 self._mark_agent_needs_review(
                     agent_id=str(agent_id),
                     diagnoser_exit_code=exit_code,
@@ -1522,9 +1598,19 @@ class Launcher:
         Per spec §4.2 the next claim of the same issue bypasses the
         diagnoser entirely on its first failure — there's no recursion;
         the per-issue claim budget is what governs further attempts.
+
+        Also fires a Telegram alert (#3883) so the operator sees the
+        needs_review transition without polling the cockpit. The DB
+        write above is the authoritative state; the alert is the
+        human notification, best-effort and logged separately on
+        failure.
         """
         if self._conn is None:
             return
+        # Look up the issue number FIRST so the Telegram message can
+        # name the issue even if the UPDATE below fails. The lookup
+        # is best-effort — fall through to a 0 sentinel.
+        issue_number = self._lookup_issue_number(agent_id)
         # Build a compact summary string. Truncate the raw stoppedReason
         # so we don't blow past TEXT-column display widths in the cockpit.
         reason_tail = (diagnoser_exit_reason or "").strip()[:160]
@@ -1561,10 +1647,51 @@ class Launcher:
                 "diagnoser_exit_code": diagnoser_exit_code,
             },
         )
-        # TODO(#3883 — C6): once the Telegram-alert helper lands, emit
-        # an alert here so the operator sees the needs_review transition
-        # without polling the cockpit. The DB write above is the
-        # authoritative state; the alert is the human notification.
+        # Fire the Telegram alert (#3883 fills the prior C5 TODO marker).
+        # Best-effort — a Telegram outage / config gap is logged inside
+        # the helper; the DB transition is the authoritative state.
+        try:
+            self._telegram_alerter(
+                telegram.render_needs_review(
+                    issue_number=issue_number,
+                    agent_id=agent_id,
+                    diagnoser_exit_code=diagnoser_exit_code,
+                    diagnoser_exit_reason=diagnoser_exit_reason,
+                ),
+                trigger="needs_review",
+                run_id=self._run_id,
+            )
+        except Exception:
+            log.exception(
+                "launcher.needs_review_telegram_failed",
+                extra={
+                    "event": "needs_review_telegram_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+
+    def _lookup_issue_number(self, agent_id: str) -> int:
+        """Fetch the agent row's ``issue_number`` (0 sentinel on miss/error)."""
+        if self._conn is None:
+            return 0
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT issue_number FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._safe_rollback()
+            return 0
+        if row is None or row[0] is None:
+            return 0
+        try:
+            return int(row[0])
+        except (TypeError, ValueError):
+            return 0
 
     # -- step 4: watch in-flight diagnosers --------------------------------
     # (defined above as part of step 3b's diagnoser-invocation block —

--- a/scripts/dispatcher_v3/telegram.py
+++ b/scripts/dispatcher_v3/telegram.py
@@ -1,0 +1,271 @@
+"""dispatcher-v3 Telegram outbound helper.
+
+Thin wrapper around ``scripts/notify-telegram.sh`` for v3's two outbound
+trigger sites (v3 spec §6):
+
+1. **Circuit breaker tripped** — see :mod:`dispatcher_v3.breaker`. The
+   breaker calls :func:`send_alert` with the rendered breaker-trip
+   message after flipping ``concurrency_cap_v3`` to 0.
+2. **Agent marked ``status='needs_review'``** — the launcher's diagnoser
+   watch path (see :meth:`Launcher._mark_agent_needs_review`) calls
+   :func:`send_alert` with a per-agent message naming the issue and
+   the diagnoser exit context.
+
+The v2 daemon already integrates with ``notify-telegram.sh`` (see
+``scripts/dispatcher/daemon.py:_send_circuit_breaker_telegram_alert``).
+v3 reuses the same secret (``TELEGRAM_BOT_TOKEN`` from Secrets Manager,
+fetched by the helper script itself), the same per-exit-code
+classification, and the same plaintext-via-``--message-file`` calling
+convention so the on-the-wire surface is identical between the two
+daemons. This keeps a single Telegram bot token / chat target / message
+shape across cohabitation, which matches issue #3883's "reuse v2's
+secret-handling and message format" guidance.
+
+Best-effort by design: a Telegram outage / misconfigured secret / API
+timeout never blocks the breaker flip or the ``needs_review`` DB
+transition. The helper script's exit code is mapped to a structured
+log event (mirroring v2's
+:func:`dispatcher.daemon._map_notify_telegram_exit_code`) so post-
+incident CloudWatch queries can distinguish "sent" vs "config_missing"
+vs "all_send_failed" without parsing stderr.
+
+Issue #3883.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+#: Path to the Telegram notification helper, relative to the repo root.
+#: Mirrors v2's ``NOTIFY_TELEGRAM_SCRIPT_RELPATH``.
+NOTIFY_TELEGRAM_SCRIPT_RELPATH = "scripts/notify-telegram.sh"
+
+#: Hard timeout on the ``notify-telegram.sh`` subprocess. Short enough
+#: that a Telegram outage can't stall a terminal transition; long
+#: enough that AWS Secrets Manager + curl to the Bot API always fits
+#: on a healthy network. Mirrors v2's value verbatim.
+NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS = 30
+
+#: Per-exit-code mapping. Same shape as v2's
+#: :data:`dispatcher.daemon.NOTIFY_TELEGRAM_EXIT_CODE_MAPPING` so a
+#: single CloudWatch query can rollup v2 + v3 events without
+#: per-version aliasing. Values are ``(event_suffix, reason)`` tuples;
+#: ``reason`` is the free-text discriminator for the
+#: ``config_missing`` bucket (exit codes 3/4/5 distinguish secret
+#: fetch failure vs empty bot_token vs empty user IDs).
+NOTIFY_TELEGRAM_EXIT_CODE_MAPPING: dict[int, tuple[str, str | None]] = {
+    0: ("sent", None),
+    1: ("usage_error", None),
+    2: ("all_send_failed", None),
+    3: ("config_missing", "secret_fetch_failed"),
+    4: ("config_missing", "empty_bot_token"),
+    5: ("config_missing", "empty_user_ids"),
+}
+
+#: Domain prefix prepended to ``event_suffix`` to build the full
+#: structured log event name. Choosing ``v3_telegram_`` (rather than
+#: re-using v2's ``circuit_breaker_telegram_``) keeps the per-trigger
+#: filterability — the caller (breaker vs ``needs_review`` site)
+#: passes its own sub-domain via the ``trigger`` argument.
+EVENT_DOMAIN_PREFIX = "v3_telegram"
+
+log = logging.getLogger("dispatcher_v3.telegram")
+
+
+def map_exit_code(returncode: int) -> tuple[str, str | None]:
+    """Return ``(event_suffix, reason)`` for a ``notify-telegram.sh`` exit code.
+
+    Unknown exit codes return ``("nonzero_exit", None)`` so a future
+    code added to the script without updating this mapping falls back
+    to the generic warning path — never silently treated as success.
+    Mirrors :func:`dispatcher.daemon._map_notify_telegram_exit_code`.
+    """
+    return NOTIFY_TELEGRAM_EXIT_CODE_MAPPING.get(returncode, ("nonzero_exit", None))
+
+
+def _resolve_repo_root() -> Path:
+    """Resolve the repo root for locating ``scripts/notify-telegram.sh``.
+
+    Production: respects the ``DISPATCHER_V3_REPO_ROOT`` env override
+    (set by the v3 ECS task entrypoint). Fallback: walk up from this
+    module's directory (``scripts/dispatcher_v3/telegram.py`` →
+    ``scripts/dispatcher_v3/`` → ``scripts/`` → repo root). The walk
+    matches v2's ``_repo_root_for_notify_script`` shape so tests that
+    set ``DISPATCHER_V3_REPO_ROOT`` to a tmp_path under pytest get the
+    expected behavior.
+    """
+    override = os.environ.get("DISPATCHER_V3_REPO_ROOT")
+    if override:
+        return Path(override)
+    # scripts/dispatcher_v3/telegram.py → repo root is two parents up.
+    return Path(__file__).resolve().parents[2]
+
+
+def send_alert(
+    *,
+    message: str,
+    trigger: str,
+    run_id: str,
+    tmp_dir: Path | None = None,
+    subprocess_runner: Callable[..., subprocess.CompletedProcess[str]] | None = None,
+) -> tuple[int, str]:
+    """Send *message* via ``notify-telegram.sh`` (best-effort).
+
+    Returns a ``(returncode, event_name)`` tuple so the caller can act
+    on the result if needed (e.g. log the breaker-trip success
+    separately from the daemon's normal log stream). The full event
+    name follows the convention ``v3_telegram.<trigger>_<event_suffix>``
+    so CloudWatch queries can filter by trigger site (e.g.
+    ``trigger='breaker_opened'`` vs ``trigger='needs_review'``) AND by
+    delivery outcome.
+
+    Args:
+        message: Plain-text message body. Written to a temp file and
+            passed via ``--message-file`` (so the body never appears in
+            ``ps`` listings — same posture as v2's
+            :meth:`_send_circuit_breaker_telegram_alert`).
+        trigger: Short identifier for the call site, used in the log
+            event name. Examples: ``"breaker_opened"``,
+            ``"needs_review"``.
+        run_id: The dispatcher-v3 run UUID. Threaded into log extras
+            so cross-restart correlation works even if the message
+            body strips the ID for privacy.
+        tmp_dir: Optional override for the directory where the message
+            tempfile lives. Defaults to ``<repo-root>/tmp``. Tests
+            inject ``tmp_path`` here; the production daemon writes to
+            its container-local ``tmp/`` so the path is stable across
+            calls (same pattern as v2).
+        subprocess_runner: Hook for unit tests. Defaults to
+            :func:`subprocess.run`.
+
+    Returns:
+        ``(returncode, event_name)``. ``returncode`` is the literal
+        ``notify-telegram.sh`` exit code (0 = sent; non-zero = some
+        flavor of failure). ``event_name`` is the full structured log
+        event the helper emitted (``v3_telegram.<trigger>_sent``,
+        ``v3_telegram.<trigger>_config_missing``, etc.). Returns
+        ``(-1, "v3_telegram.<trigger>_skipped_no_script")`` when the
+        helper script does not exist on disk (best-effort skip — same
+        as v2).
+    """
+    runner = subprocess_runner or subprocess.run
+    repo_root = _resolve_repo_root()
+    notify_script = repo_root / NOTIFY_TELEGRAM_SCRIPT_RELPATH
+    if not notify_script.exists():
+        event_name = f"{EVENT_DOMAIN_PREFIX}.{trigger}_skipped_no_script"
+        log.info(
+            event_name,
+            extra={
+                "event": event_name,
+                "run_id": run_id,
+                "trigger": trigger,
+                "script_path": str(notify_script),
+            },
+        )
+        return -1, event_name
+
+    # Write message to a tempfile so the body never appears in argv.
+    actual_tmp_dir = tmp_dir or (repo_root / "tmp")
+    actual_tmp_dir.mkdir(parents=True, exist_ok=True)
+    msg_path = actual_tmp_dir / f"v3-telegram-{trigger}-{run_id or 'unknown'}.txt"
+    msg_path.write_text(message, encoding="utf-8")
+
+    try:
+        result = runner(
+            [str(notify_script), "--message-file", str(msg_path)],
+            capture_output=True,
+            text=True,
+            timeout=NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        event_name = f"{EVENT_DOMAIN_PREFIX}.{trigger}_timeout"
+        log.warning(
+            event_name,
+            extra={
+                "event": event_name,
+                "run_id": run_id,
+                "trigger": trigger,
+                "timeout_s": NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS,
+            },
+        )
+        return -2, event_name
+
+    event_suffix, reason = map_exit_code(result.returncode)
+    event_name = f"{EVENT_DOMAIN_PREFIX}.{trigger}_{event_suffix}"
+    log_extra: dict[str, object] = {
+        "event": event_name,
+        "run_id": run_id,
+        "trigger": trigger,
+        "exit_code": result.returncode,
+    }
+    if reason is not None:
+        log_extra["reason"] = reason
+    if result.returncode != 0:
+        log_extra["stderr_tail"] = (result.stderr or "")[-500:]
+
+    if result.returncode == 0:
+        log.info(event_name, extra=log_extra)
+    else:
+        log.warning(event_name, extra=log_extra)
+    return result.returncode, event_name
+
+
+def render_breaker_opened(
+    *,
+    bad_count: int,
+    window_size: int,
+    window_minutes: int,
+    statuses: list[str],
+) -> str:
+    """Render the Telegram alert body for a v3 circuit-breaker open.
+
+    Plain text — ``notify-telegram.sh`` defaults to ``parse_mode=HTML``
+    but HTML entities would leak through as literal characters on a
+    misconfigured client; the v2 message also uses plaintext for the
+    same reason. The recent-status list is comma-joined newest-first
+    so the operator can see the cascade pattern at a glance.
+    """
+    recent = ", ".join(statuses[: min(window_size, 10)]) if statuses else "(none)"
+    return (
+        "Dispatcher v3 circuit breaker OPENED\n"
+        f"{bad_count}/{window_size} of the last terminal outcomes in the "
+        f"last {window_minutes} min were bad.\n"
+        "concurrency_cap_v3 has been set to 0 — the v3 launcher will "
+        "not claim new agents.\n"
+        f"Recent statuses (newest first): {recent}\n"
+        "Manually flip cap_v3 back to >=1 in the admin cockpit once "
+        "you've triaged the underlying failure pattern."
+    )
+
+
+def render_needs_review(
+    *,
+    issue_number: int,
+    agent_id: str,
+    diagnoser_exit_code: int | None,
+    diagnoser_exit_reason: str,
+) -> str:
+    """Render the Telegram alert body for an agent ``needs_review`` flip.
+
+    Triggered by the C5 diagnoser-failure path: a v3 agent's diagnoser
+    ECS task exited non-zero / OOMed / was reclaimed, so the launcher
+    bumps ``status='needs_review'`` and the operator must triage. The
+    message names the issue + agent + exit context so the operator can
+    open the cockpit (or GitHub issue) directly without first looking
+    up the agent.
+    """
+    reason_tail = (diagnoser_exit_reason or "").strip()[:240] or "(none)"
+    code_str = "?" if diagnoser_exit_code is None else str(diagnoser_exit_code)
+    return (
+        "Dispatcher v3 agent needs review\n"
+        f"Issue: #{issue_number}\n"
+        f"Agent: {agent_id}\n"
+        f"Diagnoser exit: {code_str}\n"
+        f"Reason: {reason_tail}\n"
+        "Open the admin cockpit or the GitHub issue to triage."
+    )

--- a/scripts/dispatcher_v3/tests/test_breaker.py
+++ b/scripts/dispatcher_v3/tests/test_breaker.py
@@ -1,0 +1,712 @@
+"""Unit tests for ``dispatcher_v3.breaker.BreakerEvaluator``.
+
+Pinned invariants (issue #3883):
+
+- **2-of-3 trips, scoped to v3.** A bad-streak in the v3 rolling
+  window flips ``concurrency_cap_v3`` to 0 and stamps
+  ``cap_flipped_by_v3='circuit_breaker_v3'``. v2 outcomes (selected
+  out by the ``parent_run_id`` filter) never count.
+- **Auto-close paths.** Operator-reflip clears the flag; time-based
+  restores cap once the window has rolled and bad-count is below
+  threshold.
+- **Telegram fires once on fresh open.** Re-asserting an already-open
+  state (cap was 0) does NOT fire the alert again.
+- **Tolerant classifier.** Anything not in
+  :data:`OVERNIGHT_CB_GOOD_OUTCOME_STATUSES` counts as bad — matches
+  v2's #2860 contract.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+# Inject a fake ``psycopg.errors`` module up front so the launcher's
+# lazy ``import psycopg`` finds something callable in environments
+# where the real wheel is not installed (matches test_launcher.py).
+if "psycopg" not in sys.modules:
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_errors = types.ModuleType("psycopg.errors")
+
+    class _FakeUniqueViolation(Exception):
+        pass
+
+    fake_errors.UniqueViolation = _FakeUniqueViolation
+    fake_psycopg.errors = fake_errors
+    sys.modules["psycopg"] = fake_psycopg
+    sys.modules["psycopg.errors"] = fake_errors
+
+
+from dispatcher_v3.breaker import (  # noqa: E402
+    CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER,
+    DEFAULT_OVERNIGHT_CB_BAD_OUTCOME_THRESHOLD,
+    DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES,
+    DEFAULT_OVERNIGHT_CB_WINDOW_SIZE,
+    BreakerEvaluator,
+    OVERNIGHT_CB_GOOD_OUTCOME_STATUSES,
+    V3_CB_THRESHOLD_KEY,
+    V3_CB_WINDOW_MINUTES_KEY,
+    V3_CB_WINDOW_SIZE_KEY,
+    V3_SCOPED_PARENT_RUN_FILTER,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes (mirror test_launcher.py shape)
+# ---------------------------------------------------------------------------
+
+
+class FakeCursor:
+    def __init__(self, conn: "FakeConn") -> None:
+        self.conn = conn
+        self.rowcount = 0
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.conn.executed.append((sql, params or ()))
+        for predicate, handler in self.conn.handlers:
+            if predicate in sql:
+                handler(self, sql, params or ())
+                return
+        self._next_fetchone = None
+        self._next_fetchall: list[tuple[Any, ...]] = []
+        self.rowcount = 0
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return getattr(self, "_next_fetchone", None)
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return getattr(self, "_next_fetchall", []) or []
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.handlers: list[tuple[str, Any]] = []
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def install_handler(self, predicate: str, handler: Any) -> None:
+        self.handlers.append((predicate, handler))
+
+
+def _make_config_handler(conn: FakeConn, *, values: dict[str, Any]) -> None:
+    """Install a handler returning ``values[key]`` for config reads."""
+
+    def handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        if not params:
+            cur._next_fetchone = None
+            return
+        key = params[0]
+        if key in values:
+            cur._next_fetchone = (values[key],)
+        else:
+            cur._next_fetchone = None
+
+    conn.install_handler("FROM dispatcher.config WHERE key = %s", handler)
+
+
+def _make_breaker(
+    conn: FakeConn,
+    *,
+    statuses_by_window: list[str] | None = None,
+    config_values: dict[str, Any] | None = None,
+    telegram_alerter: Any = None,
+    clock_returns: datetime | None = None,
+) -> tuple[BreakerEvaluator, list[dict[str, Any]]]:
+    """Wire common handlers + return (breaker, telegram_call_log)."""
+    telegram_calls: list[dict[str, Any]] = []
+    if telegram_alerter is None:
+
+        def telegram_alerter(message: str, *, trigger: str, run_id: str) -> None:
+            telegram_calls.append(
+                {
+                    "message": message,
+                    "trigger": trigger,
+                    "run_id": run_id,
+                }
+            )
+
+    if config_values:
+        _make_config_handler(conn, values=config_values)
+    if statuses_by_window is not None:
+        conn.install_handler(
+            "FROM dispatcher.terminal_outcomes t",
+            lambda cur, sql, params: setattr(
+                cur,
+                "_next_fetchall",
+                [(s,) for s in statuses_by_window],
+            ),
+        )
+    # SELECT issue_number, parent_run_id FROM dispatcher.agents — the
+    # write-terminal-outcome lookup. Default: synthetic agent row.
+    conn.install_handler(
+        "SELECT issue_number, parent_run_id",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (1234, "v3-run-uuid")),
+    )
+
+    breaker = BreakerEvaluator(
+        conn=conn,
+        run_id="run-test-uuid",
+        telegram_alerter=telegram_alerter,
+        clock=(lambda: clock_returns) if clock_returns else None,
+    )
+    return breaker, telegram_calls
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+def test_is_bad_outcome_only_succeeded_is_good() -> None:
+    """succeeded → False; everything else → True."""
+    assert BreakerEvaluator.is_bad_outcome("succeeded") is False
+    assert BreakerEvaluator.is_bad_outcome("failed") is True
+    assert BreakerEvaluator.is_bad_outcome("crashed") is True
+    assert BreakerEvaluator.is_bad_outcome("needs_review") is True
+    assert BreakerEvaluator.is_bad_outcome("unknown_future_status") is True
+
+
+def test_good_outcome_set_is_just_succeeded() -> None:
+    assert OVERNIGHT_CB_GOOD_OUTCOME_STATUSES == frozenset({"succeeded"})
+
+
+# ---------------------------------------------------------------------------
+# record_and_evaluate — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_writes_terminal_outcome_row() -> None:
+    """record_and_evaluate inserts a row into terminal_outcomes."""
+    conn = FakeConn()
+    breaker, _ = _make_breaker(
+        conn,
+        statuses_by_window=["succeeded"],  # benign — won't trip
+        config_values={
+            "circuit_breaker_enabled": "true",
+        },
+    )
+    breaker.record_and_evaluate(agent_id="ag-1", status="succeeded")
+
+    inserts = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("INSERT INTO dispatcher.terminal_outcomes")
+    ]
+    assert len(inserts) == 1
+    sql, params = inserts[0]
+    # (agent_id, issue_number, status, parent_run_id, ended_at) — last is now()
+    assert params[0] == "ag-1"
+    assert params[1] == 1234  # issue_number lookup
+    assert params[2] == "succeeded"
+    assert params[3] == "v3-run-uuid"  # parent_run_id lookup
+
+
+def test_breaker_does_not_trip_below_threshold() -> None:
+    """5/10 of last terminals bad → no trip when threshold = 5? Wait, that's met.
+
+    Actually: threshold is the floor (>=), so 5/10 trips. To not trip,
+    we need fewer than threshold bad outcomes. Test 4 bad + 1 good =
+    bad_count = 4 < 5 = threshold → no trip.
+    """
+    conn = FakeConn()
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=[
+            "failed",
+            "failed",
+            "failed",
+            "failed",
+            "succeeded",
+        ],
+        config_values={
+            "circuit_breaker_enabled": "true",
+            # Default threshold = 5 (per migration 29 seed).
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is False
+    # No cap flip.
+    cap_flips = [
+        (sql, params)
+        for sql, params in conn.executed
+        if "concurrency_cap_v3" in sql and "INSERT INTO dispatcher.config" in sql
+    ]
+    assert cap_flips == []
+    assert telegram_calls == []
+
+
+def test_breaker_trips_when_threshold_met_and_flips_cap_v3() -> None:
+    """5/10 bad outcomes → trip → flip concurrency_cap_v3 to 0."""
+    conn = FakeConn()
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=[
+            "failed",
+            "failed",
+            "failed",
+            "failed",
+            "failed",
+            "succeeded",
+            "succeeded",
+            "succeeded",
+            "succeeded",
+            "succeeded",
+        ],
+        config_values={
+            "circuit_breaker_enabled": "true",
+            "concurrency_cap_v3": "1",  # currently open
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is True
+
+    # ``concurrency_cap_v3`` UPSERT-ed with value '0'.
+    cap_flip_writes = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("INSERT INTO dispatcher.config")
+        and params
+        and params[0] == "concurrency_cap_v3"
+    ]
+    assert cap_flip_writes, "v3 breaker must write to concurrency_cap_v3"
+    _, params = cap_flip_writes[-1]
+    assert params[1] == "0"
+    assert params[2] == CAP_FLIPPED_BY_V3_CIRCUIT_BREAKER
+
+    # ``cap_flipped_by_v3`` stamped.
+    flag_writes = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("INSERT INTO dispatcher.config")
+        and params
+        and params[0] == "cap_flipped_by_v3"
+    ]
+    assert flag_writes, "must stamp cap_flipped_by_v3 on trip"
+
+    # Telegram alert fired once.
+    assert len(telegram_calls) == 1
+    assert telegram_calls[0]["trigger"] == "breaker_opened"
+    assert "OPENED" in telegram_calls[0]["message"]
+    assert "concurrency_cap_v3" in telegram_calls[0]["message"]
+
+
+def test_breaker_uses_2_of_3_when_v3_keys_set() -> None:
+    """Issue body example: 2-of-3 in last 1h → custom v3 keys override."""
+    conn = FakeConn()
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=["failed", "failed", "succeeded"],
+        config_values={
+            "circuit_breaker_enabled": "true",
+            "concurrency_cap_v3": "1",
+            V3_CB_WINDOW_MINUTES_KEY: "60",  # 1h
+            V3_CB_WINDOW_SIZE_KEY: "3",  # last 3
+            V3_CB_THRESHOLD_KEY: "2",  # 2 bad
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is True
+    assert len(telegram_calls) == 1
+
+
+def test_breaker_does_not_trip_with_2_of_3_when_only_1_bad() -> None:
+    conn = FakeConn()
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=["failed", "succeeded", "succeeded"],
+        config_values={
+            "circuit_breaker_enabled": "true",
+            V3_CB_WINDOW_MINUTES_KEY: "60",
+            V3_CB_WINDOW_SIZE_KEY: "3",
+            V3_CB_THRESHOLD_KEY: "2",
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is False
+    assert telegram_calls == []
+
+
+# ---------------------------------------------------------------------------
+# v3-scoping (parent_run_id filter on the scan)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_uses_v3_scoped_parent_run_filter() -> None:
+    """The breaker's outcome scan filters on parent_run_id IN (v3 runs)."""
+    conn = FakeConn()
+    breaker, _ = _make_breaker(
+        conn,
+        statuses_by_window=["succeeded"],
+        config_values={"circuit_breaker_enabled": "true"},
+    )
+    breaker.record_and_evaluate(agent_id="ag-1", status="succeeded")
+
+    scans = [
+        (sql, params)
+        for sql, params in conn.executed
+        if "FROM dispatcher.terminal_outcomes" in sql and "ORDER BY" in sql
+    ]
+    assert scans, "must run a window scan"
+    sql, _ = scans[0]
+    assert V3_SCOPED_PARENT_RUN_FILTER in sql, (
+        f"v3 breaker must scope to v3 runs via parent_run_id filter (got: {sql})"
+    )
+
+
+def test_v3_breaker_ignores_v2_outcomes() -> None:
+    """Breaker scan only returns v3-scoped rows — v2 outcomes don't count.
+
+    We simulate this by having the scan handler return only the v3
+    rows (the FakeConn handler is the SQL gate; the assertion is that
+    the SQL the breaker emits asks only for v3 rows).
+
+    The behavioral check: 3 v3-rows of [failed, failed, succeeded]
+    with threshold=2 trips. If the scan had returned a different
+    set of statuses (because the filter wasn't applied), the test
+    would observe a different outcome.
+    """
+    conn = FakeConn()
+    # Statuses_by_window represents what the v3-scoped query returns.
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=["failed", "failed", "succeeded"],
+        config_values={
+            "circuit_breaker_enabled": "true",
+            "concurrency_cap_v3": "1",
+            V3_CB_WINDOW_SIZE_KEY: "3",
+            V3_CB_THRESHOLD_KEY: "2",
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is True
+
+    # Verify the SELECT'd SQL has the v3 filter (no v2 mismatch leak).
+    for sql, _ in conn.executed:
+        if "FROM dispatcher.terminal_outcomes" in sql and "ORDER BY" in sql:
+            # Must NOT contain 'v2' literal in scope (would be wrong scope)
+            assert "dispatcher_version = 'v2'" not in sql
+            assert "dispatcher_version = 'v3'" in sql
+
+
+# ---------------------------------------------------------------------------
+# Idempotence + alert dedup
+# ---------------------------------------------------------------------------
+
+
+def test_breaker_does_not_fire_telegram_when_already_open() -> None:
+    """Re-asserting an already-open breaker (cap=0) skips the Telegram alert."""
+    conn = FakeConn()
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=["failed"] * 5 + ["succeeded"] * 5,
+        config_values={
+            "circuit_breaker_enabled": "true",
+            "concurrency_cap_v3": "0",  # already open
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is True  # re-asserts state
+    assert telegram_calls == [], (
+        "no Telegram alert when re-asserting an already-open breaker"
+    )
+
+
+def test_breaker_disabled_via_config_does_not_trip() -> None:
+    """``circuit_breaker_enabled = false`` skips evaluation entirely."""
+    conn = FakeConn()
+    breaker, telegram_calls = _make_breaker(
+        conn,
+        statuses_by_window=["failed"] * 10,
+        config_values={
+            "circuit_breaker_enabled": "false",
+            "concurrency_cap_v3": "1",
+        },
+    )
+    tripped = breaker.record_and_evaluate(agent_id="ag-1", status="failed")
+    assert tripped is False
+    # No cap flip even though the streak is bad.
+    cap_flips = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("INSERT INTO dispatcher.config")
+        and params
+        and params[0] == "concurrency_cap_v3"
+    ]
+    assert cap_flips == []
+    assert telegram_calls == []
+
+
+# ---------------------------------------------------------------------------
+# maybe_auto_close — operator-reflip path
+# ---------------------------------------------------------------------------
+
+
+def test_auto_close_clears_flag_when_operator_reflipped_cap() -> None:
+    """cap_v3 >= 1 + flag set → clear flag (operator reflip path)."""
+    conn = FakeConn()
+    breaker, _ = _make_breaker(
+        conn,
+        config_values={
+            "cap_flipped_by_v3": '"circuit_breaker_v3"',
+            "concurrency_cap_v3": "2",  # operator raised
+            "circuit_breaker_enabled": "true",
+        },
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is True
+
+    # ``cap_flipped_by_v3`` cleared (set to 'null').
+    flag_clears = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("INSERT INTO dispatcher.config")
+        and params
+        and params[0] == "cap_flipped_by_v3"
+    ]
+    assert flag_clears, "operator-reflip must clear the flag"
+
+
+def test_auto_close_skips_when_flag_unset() -> None:
+    """cap_flipped_by_v3 null → no auto-close (hot path)."""
+    conn = FakeConn()
+    breaker, _ = _make_breaker(
+        conn,
+        config_values={"cap_flipped_by_v3": None},
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is False
+
+
+def test_auto_close_skips_when_flipped_by_other_source() -> None:
+    """cap_flipped_by_v3 = something other than 'circuit_breaker_v3' → no-op."""
+    conn = FakeConn()
+    breaker, _ = _make_breaker(
+        conn,
+        config_values={
+            "cap_flipped_by_v3": '"operator_killswitch"',
+        },
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is False
+
+
+# ---------------------------------------------------------------------------
+# maybe_auto_close — time-based path (#3779 pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_auto_close_time_based_restores_cap_after_window_elapsed() -> None:
+    """cap=0, flag set, window elapsed, bad_count low → restore cap."""
+    conn = FakeConn()
+    # cap_updated_at is 60min ago (longer than default 30min window).
+    cap_updated_at = datetime.now(UTC) - timedelta(minutes=60)
+    now = datetime.now(UTC)
+
+    # Custom handler: ``cap_flipped_by_v3`` reads need the flag value;
+    # ``concurrency_cap_v3`` updated_at lookup needs cap_updated_at.
+    flow: dict[str, Any] = {
+        "cap_flipped_by_v3": '"circuit_breaker_v3"',
+        "concurrency_cap_v3": "0",
+        "circuit_breaker_enabled": "true",
+        "target_concurrency_cap_v3": "2",
+    }
+
+    def config_value_handler(
+        cur: FakeCursor, sql: str, params: tuple[Any, ...]
+    ) -> None:
+        if not params:
+            cur._next_fetchone = None
+            return
+        key = params[0]
+        if key in flow:
+            cur._next_fetchone = (flow[key],)
+        else:
+            cur._next_fetchone = None
+
+    def updated_at_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        if params and params[0] == "concurrency_cap_v3":
+            cur._next_fetchone = (cap_updated_at,)
+        else:
+            cur._next_fetchone = None
+
+    conn.install_handler(
+        "SELECT updated_at FROM dispatcher.config",
+        updated_at_handler,
+    )
+    conn.install_handler(
+        "SELECT value FROM dispatcher.config WHERE key = %s",
+        config_value_handler,
+    )
+    # Outcome scan returns 1 bad (below default threshold of 5).
+    conn.install_handler(
+        "FROM dispatcher.terminal_outcomes t",
+        lambda cur, sql, params: setattr(
+            cur,
+            "_next_fetchall",
+            [("succeeded",), ("failed",), ("succeeded",)],
+        ),
+    )
+
+    breaker = BreakerEvaluator(
+        conn=conn,
+        run_id="run-test-uuid",
+        clock=lambda: now,
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is True
+
+    # Cap restored to target (2).
+    cap_writes = [
+        (sql, params)
+        for sql, params in conn.executed
+        if sql.startswith("INSERT INTO dispatcher.config")
+        and params
+        and params[0] == "concurrency_cap_v3"
+    ]
+    assert cap_writes, "auto-close must restore concurrency_cap_v3"
+    _, params = cap_writes[-1]
+    assert params[1] == "2"
+    assert params[2] == "circuit_breaker_v3_auto_close"
+
+
+def test_auto_close_blocks_when_window_not_elapsed() -> None:
+    """cap_updated_at recent → don't auto-close yet."""
+    conn = FakeConn()
+    cap_updated_at = datetime.now(UTC) - timedelta(minutes=5)
+    now = datetime.now(UTC)
+    flow = {
+        "cap_flipped_by_v3": '"circuit_breaker_v3"',
+        "concurrency_cap_v3": "0",
+        "circuit_breaker_enabled": "true",
+    }
+
+    def config_value_handler(
+        cur: FakeCursor, sql: str, params: tuple[Any, ...]
+    ) -> None:
+        cur._next_fetchone = (
+            (flow[params[0]],) if params and params[0] in flow else None
+        )
+
+    conn.install_handler(
+        "SELECT updated_at FROM dispatcher.config",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (cap_updated_at,)),
+    )
+    conn.install_handler(
+        "SELECT value FROM dispatcher.config WHERE key = %s",
+        config_value_handler,
+    )
+    breaker = BreakerEvaluator(
+        conn=conn,
+        run_id="run-test-uuid",
+        clock=lambda: now,
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is False
+
+
+def test_auto_close_blocks_when_bad_count_still_high() -> None:
+    """cap=0, window elapsed, but bad_count >= threshold → don't close yet."""
+    conn = FakeConn()
+    cap_updated_at = datetime.now(UTC) - timedelta(minutes=60)
+    now = datetime.now(UTC)
+    flow = {
+        "cap_flipped_by_v3": '"circuit_breaker_v3"',
+        "concurrency_cap_v3": "0",
+        "circuit_breaker_enabled": "true",
+    }
+
+    conn.install_handler(
+        "SELECT updated_at FROM dispatcher.config",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (cap_updated_at,)),
+    )
+    conn.install_handler(
+        "SELECT value FROM dispatcher.config WHERE key = %s",
+        lambda cur, sql, params: setattr(
+            cur,
+            "_next_fetchone",
+            (flow[params[0]],) if params and params[0] in flow else None,
+        ),
+    )
+    # Still 5+ bad outcomes — above threshold.
+    conn.install_handler(
+        "FROM dispatcher.terminal_outcomes t",
+        lambda cur, sql, params: setattr(
+            cur,
+            "_next_fetchall",
+            [("failed",)] * 5 + [("succeeded",)] * 5,
+        ),
+    )
+    breaker = BreakerEvaluator(
+        conn=conn,
+        run_id="run-test-uuid",
+        clock=lambda: now,
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is False
+
+
+def test_auto_close_disabled_breaker_yields_open_state() -> None:
+    """``circuit_breaker_enabled = false`` blocks time-based auto-close."""
+    conn = FakeConn()
+    cap_updated_at = datetime.now(UTC) - timedelta(minutes=60)
+    now = datetime.now(UTC)
+    flow = {
+        "cap_flipped_by_v3": '"circuit_breaker_v3"',
+        "concurrency_cap_v3": "0",
+        "circuit_breaker_enabled": "false",
+    }
+    conn.install_handler(
+        "SELECT updated_at FROM dispatcher.config",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (cap_updated_at,)),
+    )
+    conn.install_handler(
+        "SELECT value FROM dispatcher.config WHERE key = %s",
+        lambda cur, sql, params: setattr(
+            cur,
+            "_next_fetchone",
+            (flow[params[0]],) if params and params[0] in flow else None,
+        ),
+    )
+    breaker = BreakerEvaluator(
+        conn=conn,
+        run_id="run-test-uuid",
+        clock=lambda: now,
+    )
+    closed = breaker.maybe_auto_close()
+    assert closed is False
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_window_minutes_is_30() -> None:
+    """v2 default carries forward when no v3-specific key set."""
+    assert DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES == 30
+
+
+def test_default_window_size_is_10() -> None:
+    assert DEFAULT_OVERNIGHT_CB_WINDOW_SIZE == 10
+
+
+def test_default_threshold_is_5() -> None:
+    assert DEFAULT_OVERNIGHT_CB_BAD_OUTCOME_THRESHOLD == 5

--- a/scripts/dispatcher_v3/tests/test_launcher_breaker_telegram.py
+++ b/scripts/dispatcher_v3/tests/test_launcher_breaker_telegram.py
@@ -1,0 +1,383 @@
+"""Launcher-level wiring for the v3 breaker + Telegram (issue #3883).
+
+The pure-breaker tests live in ``test_breaker.py``. This file checks
+that the launcher actually calls into the breaker / Telegram seam at
+the right places:
+
+1. ``_mark_agent_terminal`` → calls ``BreakerEvaluator.record_and_evaluate``
+   after the agent-row UPDATE + label release (best-effort: a breaker
+   exception does NOT propagate).
+2. ``_mark_agent_needs_review`` (the C5 path) → fires a Telegram alert
+   after writing ``status='needs_review'``. This replaces the prior
+   ``# TODO(#3883 — C6)`` marker.
+3. ``tick`` → calls ``BreakerEvaluator.maybe_auto_close`` once per
+   tick, BEFORE the claim step (so a freshly-closed breaker restores
+   the cap on the same tick).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+# Inject the same psycopg fake as test_launcher.py (CI runner has no
+# psycopg wheel installed — see ``.github/workflows/ci.yml``).
+if "psycopg" not in sys.modules:
+    fake_psycopg = types.ModuleType("psycopg")
+    fake_errors = types.ModuleType("psycopg.errors")
+
+    class _FakeUniqueViolation(Exception):
+        pass
+
+    fake_errors.UniqueViolation = _FakeUniqueViolation
+    fake_psycopg.errors = fake_errors
+    sys.modules["psycopg"] = fake_psycopg
+    sys.modules["psycopg.errors"] = fake_errors
+
+
+from dispatcher_v3.launcher import (  # noqa: E402
+    DEFAULT_TASK_RUNNER_LOG_STREAM_PREFIX,
+    Launcher,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeCursor:
+    def __init__(self, conn: "FakeConn") -> None:
+        self.conn = conn
+        self.rowcount = 0
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> None:
+        self.conn.executed.append((sql, params or ()))
+        for predicate, handler in self.conn.handlers:
+            if predicate in sql:
+                handler(self, sql, params or ())
+                return
+        self._next_fetchone = None
+        self._next_fetchall: list[tuple[Any, ...]] = []
+        self.rowcount = 0
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return getattr(self, "_next_fetchone", None)
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return getattr(self, "_next_fetchall", []) or []
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple[Any, ...]]] = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.handlers: list[tuple[str, Any]] = []
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def install_handler(self, predicate: str, handler: Any) -> None:
+        self.handlers.append((predicate, handler))
+
+
+class RecordingBreaker:
+    """Records calls to the BreakerEvaluator surface used by the launcher."""
+
+    def __init__(self) -> None:
+        self.record_calls: list[tuple[str, str]] = []
+        self.auto_close_calls: int = 0
+        self.auto_close_returns: bool = False
+        self.record_raises: Exception | None = None
+
+    def record_and_evaluate(self, *, agent_id: str, status: str) -> bool:
+        self.record_calls.append((agent_id, status))
+        if self.record_raises is not None:
+            raise self.record_raises
+        return False
+
+    def maybe_auto_close(self) -> bool:
+        self.auto_close_calls += 1
+        return self.auto_close_returns
+
+
+def _make_launcher(
+    *,
+    conn: FakeConn,
+    breaker: Any,
+    telegram_alerter: Any | None = None,
+    ecs_client: MagicMock | None = None,
+) -> Launcher:
+    telegram_calls: list[dict[str, Any]] = []
+    if telegram_alerter is None:
+
+        def telegram_alerter(message: str, *, trigger: str, run_id: str) -> None:
+            telegram_calls.append(
+                {
+                    "message": message,
+                    "trigger": trigger,
+                    "run_id": run_id,
+                }
+            )
+
+    return Launcher(
+        run_id="run-test-uuid",
+        github_repo="judgemind/judgemind",
+        ecs_cluster_arn="arn:aws:ecs:us-west-2:0:cluster/jm",
+        task_runner_task_definition="judgemind-task-runner:7",
+        diagnoser_task_definition="judgemind-dispatcher-v3-diagnoser",
+        agent_runner_subnet_ids=["subnet-a", "subnet-b"],
+        agent_runner_security_group_id="sg-aaa",
+        sessions_bucket="judgemind-sessions-dev",
+        task_runner_log_group="",
+        task_runner_log_stream_prefix=DEFAULT_TASK_RUNNER_LOG_STREAM_PREFIX,
+        conn=conn,
+        ecs_client=ecs_client,
+        subprocess_runner=lambda *a, **k: MagicMock(returncode=0, stdout="", stderr=""),
+        breaker=breaker,
+        telegram_alerter=telegram_alerter,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _mark_agent_terminal → breaker
+# ---------------------------------------------------------------------------
+
+
+def test_mark_agent_terminal_calls_breaker() -> None:
+    """After the UPDATE + label release, the breaker is invoked."""
+    conn = FakeConn()
+    breaker = RecordingBreaker()
+    launcher = _make_launcher(conn=conn, breaker=breaker)
+
+    launcher._mark_agent_terminal(
+        agent_id="ag-1",
+        issue_number=42,
+        status="failed",
+        exit_code=1,
+        exit_reason="boom",
+    )
+    assert breaker.record_calls == [("ag-1", "failed")]
+
+
+def test_mark_agent_terminal_breaker_failure_does_not_propagate() -> None:
+    """A breaker exception is logged but does not block the transition."""
+    conn = FakeConn()
+    breaker = RecordingBreaker()
+    breaker.record_raises = RuntimeError("breaker exploded")
+    launcher = _make_launcher(conn=conn, breaker=breaker)
+
+    # Should NOT raise.
+    launcher._mark_agent_terminal(
+        agent_id="ag-1",
+        issue_number=42,
+        status="succeeded",
+        exit_code=0,
+        exit_reason="",
+    )
+    # Agent-row UPDATE still ran.
+    assert any(
+        sql.startswith("UPDATE dispatcher.agents")
+        and params
+        and params[0] == "succeeded"
+        for sql, params in conn.executed
+    )
+
+
+def test_mark_agent_terminal_breaker_called_with_status_string() -> None:
+    """Status passed verbatim — the breaker classifies, not the launcher."""
+    conn = FakeConn()
+    breaker = RecordingBreaker()
+    launcher = _make_launcher(conn=conn, breaker=breaker)
+    launcher._mark_agent_terminal(
+        agent_id="ag-2",
+        issue_number=99,
+        status="succeeded",
+        exit_code=0,
+        exit_reason="",
+    )
+    assert breaker.record_calls == [("ag-2", "succeeded")]
+
+
+# ---------------------------------------------------------------------------
+# _mark_agent_needs_review → Telegram (replaces TODO(#3883 — C6))
+# ---------------------------------------------------------------------------
+
+
+def test_mark_agent_needs_review_fires_telegram() -> None:
+    """Diagnoser-failure path now sends a Telegram alert (#3883)."""
+    conn = FakeConn()
+    # issue_number lookup returns 5555.
+    conn.install_handler(
+        "SELECT issue_number FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (5555,)),
+    )
+    breaker = RecordingBreaker()
+    telegram_calls: list[dict[str, Any]] = []
+
+    def telegram_alerter(message: str, *, trigger: str, run_id: str) -> None:
+        telegram_calls.append(
+            {
+                "message": message,
+                "trigger": trigger,
+                "run_id": run_id,
+            }
+        )
+
+    launcher = _make_launcher(
+        conn=conn,
+        breaker=breaker,
+        telegram_alerter=telegram_alerter,
+    )
+    launcher._mark_agent_needs_review(
+        agent_id="ag-1",
+        diagnoser_exit_code=137,
+        diagnoser_exit_reason="OOMKilled",
+    )
+
+    # Status flipped + outcome_summary written.
+    assert any(
+        sql.startswith("UPDATE dispatcher.agents") and "needs_review" in sql
+        for sql, _ in conn.executed
+    )
+    # Telegram called once with the right trigger.
+    assert len(telegram_calls) == 1
+    call = telegram_calls[0]
+    assert call["trigger"] == "needs_review"
+    assert call["run_id"] == "run-test-uuid"
+    # Message references the issue + exit code.
+    assert "5555" in call["message"]
+    assert "137" in call["message"]
+    assert "OOMKilled" in call["message"]
+
+
+def test_mark_agent_needs_review_telegram_failure_does_not_propagate() -> None:
+    """Telegram exception is logged; needs_review write still happens."""
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT issue_number FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", (1,)),
+    )
+    breaker = RecordingBreaker()
+
+    def boom_alerter(message: str, *, trigger: str, run_id: str) -> None:
+        raise RuntimeError("telegram down")
+
+    launcher = _make_launcher(
+        conn=conn,
+        breaker=breaker,
+        telegram_alerter=boom_alerter,
+    )
+    # Should NOT raise.
+    launcher._mark_agent_needs_review(
+        agent_id="ag-1",
+        diagnoser_exit_code=1,
+        diagnoser_exit_reason="x",
+    )
+    assert any(
+        "needs_review" in sql
+        for sql, _ in conn.executed
+        if sql.startswith("UPDATE dispatcher.agents")
+    )
+
+
+# ---------------------------------------------------------------------------
+# tick → maybe_auto_close
+# ---------------------------------------------------------------------------
+
+
+def test_tick_calls_breaker_maybe_auto_close() -> None:
+    """Each tick invokes the breaker's auto-close hop exactly once."""
+    conn = FakeConn()
+    # cap_v3 = 0 so the claim step is a no-op.
+    conn.install_handler(
+        "FROM dispatcher.config WHERE key = %s",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", ("0",)),
+    )
+    breaker = RecordingBreaker()
+    breaker.auto_close_returns = False
+    launcher = _make_launcher(conn=conn, breaker=breaker)
+    summary = launcher.tick()
+    assert breaker.auto_close_calls == 1
+    assert summary["breaker_auto_closed"] is False
+
+
+def test_tick_records_auto_close_in_summary_when_breaker_closes() -> None:
+    """When auto-close fires, the tick summary reports it."""
+    conn = FakeConn()
+    conn.install_handler(
+        "FROM dispatcher.config WHERE key = %s",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", ("1",)),
+    )
+    breaker = RecordingBreaker()
+    breaker.auto_close_returns = True
+    launcher = _make_launcher(conn=conn, breaker=breaker)
+    summary = launcher.tick()
+    assert summary["breaker_auto_closed"] is True
+
+
+def test_tick_breaker_exception_does_not_crash_loop() -> None:
+    """A breaker exception is caught at the launcher level."""
+    conn = FakeConn()
+    conn.install_handler(
+        "FROM dispatcher.config WHERE key = %s",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", ("0",)),
+    )
+
+    class BoomBreaker:
+        def maybe_auto_close(self) -> bool:
+            raise RuntimeError("breaker exploded")
+
+        def record_and_evaluate(self, **kwargs: Any) -> bool:
+            return False
+
+    launcher = _make_launcher(conn=conn, breaker=BoomBreaker())
+    # Should not raise — caught, summary["breaker_auto_closed"] = False.
+    summary = launcher.tick()
+    assert summary["breaker_auto_closed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Lookup issue_number — defensive
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_issue_number_handles_missing_row() -> None:
+    """Missing agent row → 0 sentinel (not a crash, not a None)."""
+    conn = FakeConn()
+    conn.install_handler(
+        "SELECT issue_number FROM dispatcher.agents",
+        lambda cur, sql, params: setattr(cur, "_next_fetchone", None),
+    )
+    launcher = _make_launcher(conn=conn, breaker=RecordingBreaker())
+    assert launcher._lookup_issue_number("ag-x") == 0
+
+
+def test_lookup_issue_number_handles_db_error() -> None:
+    """DB exception → 0 sentinel (caller still fires Telegram with #0)."""
+    conn = FakeConn()
+
+    def raise_handler(cur: FakeCursor, sql: str, params: tuple[Any, ...]) -> None:
+        raise RuntimeError("db down")
+
+    conn.install_handler(
+        "SELECT issue_number FROM dispatcher.agents",
+        raise_handler,
+    )
+    launcher = _make_launcher(conn=conn, breaker=RecordingBreaker())
+    assert launcher._lookup_issue_number("ag-x") == 0

--- a/scripts/dispatcher_v3/tests/test_telegram.py
+++ b/scripts/dispatcher_v3/tests/test_telegram.py
@@ -1,0 +1,251 @@
+"""Unit tests for ``dispatcher_v3.telegram``.
+
+Pinned invariants (issue #3883):
+
+- **Reuses v2's secret-handling.** ``send_alert`` invokes
+  ``scripts/notify-telegram.sh --message-file <path>`` — same calling
+  convention v2 uses. The shell script handles the ``TELEGRAM_BOT_TOKEN``
+  fetch from Secrets Manager, so v3 inherits it for free.
+- **Best-effort.** A non-zero exit / timeout / missing-script never
+  raises out of ``send_alert``; each failure mode emits a structured
+  log event so post-incident queries can identify what went wrong.
+- **Per-trigger event names.** ``v3_telegram.<trigger>_<suffix>`` so a
+  CloudWatch query can rollup by trigger site (breaker_opened vs
+  needs_review).
+- **Message-file isolation.** The message body never goes in argv —
+  same posture as v2's ``_send_circuit_breaker_telegram_alert``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dispatcher_v3.telegram import (
+    EVENT_DOMAIN_PREFIX,
+    NOTIFY_TELEGRAM_EXIT_CODE_MAPPING,
+    map_exit_code,
+    render_breaker_opened,
+    render_needs_review,
+    send_alert,
+)
+
+
+# ---------------------------------------------------------------------------
+# map_exit_code
+# ---------------------------------------------------------------------------
+
+
+def test_map_exit_code_known_codes() -> None:
+    """Each documented notify-telegram.sh exit code maps to expected event."""
+    assert map_exit_code(0) == ("sent", None)
+    assert map_exit_code(1) == ("usage_error", None)
+    assert map_exit_code(2) == ("all_send_failed", None)
+    assert map_exit_code(3) == ("config_missing", "secret_fetch_failed")
+    assert map_exit_code(4) == ("config_missing", "empty_bot_token")
+    assert map_exit_code(5) == ("config_missing", "empty_user_ids")
+
+
+def test_map_exit_code_unknown_falls_back_to_nonzero() -> None:
+    """An exit code not in the table never resolves to 'sent'."""
+    assert map_exit_code(42) == ("nonzero_exit", None)
+    assert map_exit_code(-9) == ("nonzero_exit", None)
+
+
+def test_exit_code_table_matches_v2() -> None:
+    """The v3 mapping mirrors v2's so a single CW query rolls them up."""
+    # v2's mapping is in scripts/dispatcher/daemon.py — pinned by name
+    # here so a future v2 mapping change is a deliberate cross-version
+    # decision, not silent drift.
+    expected = {
+        0: ("sent", None),
+        1: ("usage_error", None),
+        2: ("all_send_failed", None),
+        3: ("config_missing", "secret_fetch_failed"),
+        4: ("config_missing", "empty_bot_token"),
+        5: ("config_missing", "empty_user_ids"),
+    }
+    assert NOTIFY_TELEGRAM_EXIT_CODE_MAPPING == expected
+
+
+# ---------------------------------------------------------------------------
+# send_alert — happy path / failure paths
+# ---------------------------------------------------------------------------
+
+
+def _fake_runner(returncode: int, stderr: str = "") -> Any:
+    """Build a subprocess fake that always returns ``returncode``.
+
+    Captures the argv it was called with on the closure so the test
+    can assert call shape (script path, --message-file flag, etc.).
+    """
+    calls: list[list[str]] = []
+
+    def runner(argv: list[str], **kwargs: Any) -> Any:
+        calls.append(argv)
+        return subprocess.CompletedProcess(
+            args=argv, returncode=returncode, stdout="", stderr=stderr
+        )
+
+    return runner, calls
+
+
+def _make_repo_root(tmp_path: Path, *, with_script: bool = True) -> Path:
+    """Stage a minimal repo-root tree under ``tmp_path``."""
+    repo = tmp_path / "repo"
+    scripts = repo / "scripts"
+    scripts.mkdir(parents=True)
+    if with_script:
+        (scripts / "notify-telegram.sh").write_text("#!/bin/sh\n")
+    return repo
+
+
+def test_send_alert_happy_path_returns_sent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exit 0 → returns (0, 'v3_telegram.<trigger>_sent')."""
+    repo = _make_repo_root(tmp_path)
+    monkeypatch.setenv("DISPATCHER_V3_REPO_ROOT", str(repo))
+    runner, calls = _fake_runner(returncode=0)
+    rc, event_name = send_alert(
+        message="hello",
+        trigger="breaker_opened",
+        run_id="run-uuid",
+        subprocess_runner=runner,
+    )
+    assert rc == 0
+    assert event_name == f"{EVENT_DOMAIN_PREFIX}.breaker_opened_sent"
+    assert len(calls) == 1
+    argv = calls[0]
+    # Must use --message-file (not inline argv).
+    assert "--message-file" in argv
+    msg_path = Path(argv[argv.index("--message-file") + 1])
+    assert msg_path.read_text() == "hello"
+
+
+def test_send_alert_skips_when_script_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No notify-telegram.sh on disk → return -1 + skipped_no_script event."""
+    repo = _make_repo_root(tmp_path, with_script=False)
+    monkeypatch.setenv("DISPATCHER_V3_REPO_ROOT", str(repo))
+    runner, calls = _fake_runner(returncode=99)  # never invoked
+
+    rc, event_name = send_alert(
+        message="hello",
+        trigger="needs_review",
+        run_id="run-uuid",
+        subprocess_runner=runner,
+    )
+    assert rc == -1
+    assert event_name == f"{EVENT_DOMAIN_PREFIX}.needs_review_skipped_no_script"
+    # Subprocess never called.
+    assert calls == []
+
+
+def test_send_alert_maps_exit_3_to_config_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """exit 3 (secret fetch) → config_missing event with reason."""
+    repo = _make_repo_root(tmp_path)
+    monkeypatch.setenv("DISPATCHER_V3_REPO_ROOT", str(repo))
+    runner, _ = _fake_runner(returncode=3, stderr="AccessDenied")
+    rc, event_name = send_alert(
+        message="boom",
+        trigger="breaker_opened",
+        run_id="run-uuid",
+        subprocess_runner=runner,
+    )
+    assert rc == 3
+    assert event_name == f"{EVENT_DOMAIN_PREFIX}.breaker_opened_config_missing"
+
+
+def test_send_alert_handles_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """subprocess.TimeoutExpired → return (-2, '<...>_timeout')."""
+    repo = _make_repo_root(tmp_path)
+    monkeypatch.setenv("DISPATCHER_V3_REPO_ROOT", str(repo))
+
+    def timeout_runner(argv: list[str], **kwargs: Any) -> Any:
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=30)
+
+    rc, event_name = send_alert(
+        message="boom",
+        trigger="breaker_opened",
+        run_id="run-uuid",
+        subprocess_runner=timeout_runner,
+    )
+    assert rc == -2
+    assert event_name == f"{EVENT_DOMAIN_PREFIX}.breaker_opened_timeout"
+
+
+def test_send_alert_logs_stderr_tail_on_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-zero exit attaches stderr_tail to the log extras."""
+    repo = _make_repo_root(tmp_path)
+    monkeypatch.setenv("DISPATCHER_V3_REPO_ROOT", str(repo))
+    runner, _ = _fake_runner(returncode=2, stderr="all sends failed: 502 502 502")
+    with caplog.at_level(logging.WARNING, logger="dispatcher_v3.telegram"):
+        send_alert(
+            message="hi",
+            trigger="needs_review",
+            run_id="run-uuid",
+            subprocess_runner=runner,
+        )
+    # Find the warning-level event; stderr_tail must be present in extras.
+    matching = [rec for rec in caplog.records if "all_send_failed" in rec.message]
+    assert matching, "must log a warning event on non-zero exit"
+    rec = matching[0]
+    assert getattr(rec, "stderr_tail", "").endswith("502")
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def test_render_breaker_opened_includes_v3_specific_strings() -> None:
+    """The breaker message names concurrency_cap_v3 (not v2's cap)."""
+    msg = render_breaker_opened(
+        bad_count=2,
+        window_size=3,
+        window_minutes=60,
+        statuses=["failed", "failed", "succeeded"],
+    )
+    assert "v3" in msg
+    assert "concurrency_cap_v3" in msg
+    assert "2/3" in msg
+    assert "60 min" in msg
+    assert "failed, failed, succeeded" in msg
+
+
+def test_render_needs_review_includes_issue_and_agent() -> None:
+    msg = render_needs_review(
+        issue_number=4242,
+        agent_id="ag-abcd",
+        diagnoser_exit_code=1,
+        diagnoser_exit_reason="OutOfMemoryError",
+    )
+    assert "Issue: #4242" in msg
+    assert "Agent: ag-abcd" in msg
+    assert "Diagnoser exit: 1" in msg
+    assert "OutOfMemoryError" in msg
+
+
+def test_render_needs_review_handles_unknown_exit_code() -> None:
+    """diagnoser_exit_code=None renders as ``?``."""
+    msg = render_needs_review(
+        issue_number=1,
+        agent_id="ag-1",
+        diagnoser_exit_code=None,
+        diagnoser_exit_reason="",
+    )
+    assert "Diagnoser exit: ?" in msg


### PR DESCRIPTION
## Summary

Adds the dispatcher-v3 launcher's overnight-safety circuit breaker and Telegram outbound. Breaker mirrors v2's pattern (#2860 / #3779) but is strictly scoped to v3 terminal outcomes via `terminal_outcomes.parent_run_id` (A1 #3893); on trip flips `concurrency_cap_v3` to 0 (independent of v2's cap), stamps `cap_flipped_by_v3`, and Telegram-alerts. Auto-close after the bad-outcome window has rolled prevents the closed-feedback-loop deadlock from #3779. Telegram outbound wraps `scripts/notify-telegram.sh` (same helper v2 uses, so v3 inherits the `TELEGRAM_BOT_TOKEN` Secrets Manager fetch for free) and is also fired from `_mark_agent_needs_review`, replacing the C5 TODO marker.

Closes #3883

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher_v3/` → All checks passed!)
- [x] Format check passes (`ruff format --check scripts/dispatcher_v3/` → 14 files already formatted)
- [x] Tests pass (101 passed in 1.27s — 59 baseline + 42 new)
- [ ] CI green

### Post-deploy verification

Dispatcher v3's launcher cap is currently 0 (per migration 58 / spec §9 step 2 — "deploy at desired_count=1, cap=0 so the container is RUNNING but not claiming"). Verifying the breaker and Telegram outbound end-to-end requires:

- [ ] Once F4 (#3889) lands the launcher ECS service in dev, run `scripts/dev-db-query.sh` against `dispatcher.terminal_outcomes` to confirm v3 rows appear with non-NULL `parent_run_id` once cap_v3 ≥ 1 has been flipped on for a smoke test.
- [ ] After a v3 agent terminal runs in dev, confirm a `dispatcher_v3.breaker.daemon.terminal_outcome_write_failed_v3` event is NOT present in CloudWatch Logs Insights against `/ecs/judgemind-dispatcher-v3-dev`.
- [ ] Operator manually verifies a Telegram alert delivers when the breaker is forced open in dev (insert ≥5 fake `failed` rows into `dispatcher.terminal_outcomes` with v3-scoped `parent_run_id` and a recent `ended_at`, then trigger any v3 terminal — the next breaker eval should fire). Skip path is acceptable as functional verification — the unit-test seam exercises the wiring; production verification waits on F4 launcher service shipping.
