### PR TITLE
feat(dispatcher-v3): EventBridge cron rules for scheduled skills (#3890)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -111,6 +111,17 @@ jobs:
       - name: dispatcher-v3-sessions-bucket policy-shape check
         run: bash infra/terraform/modules/dispatcher-v3-sessions-bucket/tests/policy-checks/check.sh
 
+      # Check-block fixture test for dispatcher-v3-scheduled-skills (#3890).
+      # Verifies the module's two `check` blocks fire at plan time when
+      # the input config violates them: a task-def-arn / family mismatch
+      # (would AccessDenied at every cron firing) and enable_alerts=true
+      # paired with an empty alert_sns_topic_arn (would leave the alarm
+      # with no destination — closes adversarial-review MAJOR 7 only when
+      # the alarm can actually page).
+      - name: dispatcher-v3-scheduled-skills check-block fixture
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
+        run: bash infra/terraform/modules/dispatcher-v3-scheduled-skills/tests/postconditions/check.sh
+
       # Plan requires AWS credentials (stored as GitHub Actions secrets).
       # The plan confirms the module is deployable and shows exactly what
       # resources will be created or modified.

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,11 @@ build/
 *.tfvars
 !*.tfvars.example
 infra/terraform/modules/**/placeholder.zip
+# Module test fixtures need `terraform init` for plan-time check coverage,
+# which writes `.terraform.lock.hcl`. The lock file is per-machine and not
+# meant to be committed -- existing fixtures (dispatcher-daemon, api-service,
+# compute, etc.) intentionally don't track it.
+infra/terraform/modules/**/tests/**/.terraform.lock.hcl
 
 # OS
 .DS_Store

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -579,6 +579,51 @@ module "dispatcher_v3_task_defs" {
   agent_runner_security_group_id = aws_security_group.dispatcher_v3_agent_runner.id
 }
 
+# ─── Dispatcher v3 scheduled skills (F5, #3890) ─────────────────────────────
+# Per `docs/specs/dispatcher-v3-spec.md` §4.4. Wires four EventBridge
+# cron rules to F2's `scheduled-skill` task definition (audit,
+# dispatcher-audit, dispatcher-daily-report, spotcheck). EventBridge
+# fires; ECS runs the task; the skill writes results directly via `gh`.
+# The launcher is uninvolved -- this is observation/cron, not
+# orchestration.
+#
+# A shared SQS dead-letter queue captures invocations EventBridge could
+# not deliver, and a per-rule CloudWatch alarm on the
+# `AWS/Events FailedInvocations` metric pages the operator via the
+# existing scraper-alerts SNS topic. Closes adversarial-review MAJOR 7.
+#
+# Cohabitation with v2: v2's daemon already runs these scheduled skills
+# via its in-process scheduler. During cohabitation both can fire -- the
+# skills are idempotent (file-issue dedup, GH Actions concurrency).
+# Once v3 is the sole operator the v2 schedules will be retired.
+module "dispatcher_v3_scheduled_skills" {
+  source = "../../modules/dispatcher-v3-scheduled-skills"
+
+  environment = "dev"
+
+  ecs_cluster_arn                        = module.compute.cluster_arn
+  scheduled_skill_task_definition_arn    = module.dispatcher_v3_task_defs.scheduled_skill_task_definition_arn
+  scheduled_skill_task_definition_family = module.dispatcher_v3_task_defs.scheduled_skill_task_definition_family
+
+  # Reuse the launcher / task-runner private subnets and the env-layer
+  # v3 agent-runner SG so scheduled-skill ECS tasks share the launcher's
+  # outbound posture (HTTPS / Postgres / Redis).
+  task_subnet_ids        = module.networking.private_subnet_ids
+  task_security_group_id = aws_security_group.dispatcher_v3_agent_runner.id
+
+  # F3 IAM roles. The EventBridge invoker role's PassRole policy is
+  # pinned to these two ARNs only -- RunTask cannot pass any other
+  # role.
+  execution_role_arn  = module.dispatcher_v3_iam.execution_role_arn
+  agent_task_role_arn = module.dispatcher_v3_iam.agent_task_role_arn
+
+  # Alarm wiring -- reuses the existing scraper-alerts SNS topic so the
+  # operator's existing email + Telegram subscription gets the page
+  # without provisioning a new topic.
+  enable_alerts       = true
+  alert_sns_topic_arn = module.compute.alerts_topic_arn
+}
+
 # ─── Dispatcher v3 launcher ECS service (F4, #3889) ─────────────────────────
 # Per `docs/specs/dispatcher-v3-spec.md` §6 + §9 step 2. Single-replica
 # ECS Fargate service that runs the v3 launcher loop alongside v2's
@@ -1001,4 +1046,34 @@ output "dispatcher_v3_service_arn" {
 output "dispatcher_v3_service_security_group_id" {
   description = "Dev dispatcher-v3 launcher security group ID (outbound HTTPS + Postgres + Redis only). Reference from any module that needs to allow ingress from the launcher (e.g. RDS / Redis security groups)."
   value       = module.dispatcher_v3_service.security_group_id
+}
+
+# ─── Dispatcher v3 scheduled skills outputs (F5, #3890) ─────────────────────
+# Consumed by operators for verification (`aws events list-rules
+# --name-prefix dispatcher-v3-`) and by the daemon's monitoring code if
+# it ever wants to poll the DLQ depth as a secondary health signal.
+
+output "dispatcher_v3_scheduled_skills_rule_names" {
+  description = "Map of skill name -> EventBridge rule name for the four v3 scheduled skills (audit / dispatcher-audit / dispatcher-daily-report / spotcheck). Use with `aws events describe-rule --name <value>` for smoke checks."
+  value       = module.dispatcher_v3_scheduled_skills.rule_names
+}
+
+output "dispatcher_v3_scheduled_skills_dlq_url" {
+  description = "URL of the shared SQS dead-letter queue for failed EventBridge invocations of v3 scheduled skills. Inspect via `aws sqs receive-message --queue-url <url>`."
+  value       = module.dispatcher_v3_scheduled_skills.dlq_url
+}
+
+output "dispatcher_v3_scheduled_skills_dlq_arn" {
+  description = "ARN of the shared SQS dead-letter queue."
+  value       = module.dispatcher_v3_scheduled_skills.dlq_arn
+}
+
+output "dispatcher_v3_scheduled_skills_invoker_role_arn" {
+  description = "ARN of the EventBridge invoker role assumed by `events.amazonaws.com` when firing the v3 scheduled-skill rules."
+  value       = module.dispatcher_v3_scheduled_skills.events_invoker_role_arn
+}
+
+output "dispatcher_v3_scheduled_skills_alarm_names" {
+  description = "Map of skill name -> CloudWatch alarm name on `AWS/Events FailedInvocations` for the per-rule alarm. Closes adversarial-review MAJOR 7 (silent skill failures)."
+  value       = module.dispatcher_v3_scheduled_skills.alarm_names
 }

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/main.tf
@@ -110,7 +110,7 @@ resource "aws_sqs_queue_policy" "scheduled_skills_dlq" {
 
 resource "aws_iam_role" "events_invoker" {
   name        = "judgemind-${var.name_prefix}-scheduled-skills-events-${var.environment}"
-  description = "Dispatcher v3 EventBridge invoker role -- assumed by events.amazonaws.com to run scheduled-skill ECS tasks per §4.4 cron rules."
+  description = "Dispatcher v3 EventBridge invoker role -- assumed by events.amazonaws.com to run scheduled-skill ECS tasks per spec section 4.4 cron rules."
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/main.tf
@@ -1,0 +1,331 @@
+# Dispatcher v3 scheduled-skills module (F5, #3890).
+#
+# Per `docs/specs/dispatcher-v3-spec.md` §4.4. Wires four EventBridge
+# cron rules into F2's `scheduled-skill` task definition. EventBridge
+# fires; ECS runs the task; the skill writes its results directly via
+# `gh`. The launcher is uninvolved -- this is observation/cron, not
+# orchestration.
+#
+# Each rule targets the same `scheduled-skill` task-def with a per-rule
+# `SKILL_NAME` env override. The container's
+# `python -m dispatcher_v3.scheduled_skill_runner` reads SKILL_NAME and
+# invokes `claude -p /$SKILL_NAME`.
+#
+# A shared SQS dead-letter queue catches invocations EventBridge could
+# not deliver (target IAM error, ECS service unavailable, etc.) so silent
+# rule failures don't accumulate. A CloudWatch alarm on the
+# `AWS/Events FailedInvocations` metric across all four rules pages the
+# operator via the existing scraper-alerts SNS topic. This closes the
+# adversarial-review MAJOR 7 gap (silent EventBridge failure mode).
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+locals {
+  # Skill name -> override map. Single source of truth for the four
+  # scheduled skills v3 ships -- spec §4.4 names them explicitly. Adding
+  # a new skill is one entry here plus a `<name>_schedule_expression`
+  # variable.
+  skills = {
+    audit = {
+      schedule_expression = var.audit_schedule_expression
+      description         = "Periodic /audit codebase health check"
+    }
+    dispatcher-audit = {
+      schedule_expression = var.dispatcher_audit_schedule_expression
+      description         = "Periodic /dispatcher-audit operational-health probe"
+    }
+    dispatcher-daily-report = {
+      schedule_expression = var.dispatcher_daily_report_schedule_expression
+      description         = "Daily /dispatcher-daily-report failure summary"
+    }
+    spotcheck = {
+      schedule_expression = var.spotcheck_schedule_expression
+      description         = "Weekly /spotcheck data-quality probe"
+    }
+  }
+
+  # ARN scoping for the EventBridge invoker role. The role only needs
+  # ecs:RunTask on the family wildcard (revision-agnostic) so apply-time
+  # F2 revision bumps don't require role updates.
+  scheduled_skill_task_def_arn_pattern = "arn:${data.aws_partition.current.partition}:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${var.scheduled_skill_task_definition_family}:*"
+
+  cluster_name                 = split("/", var.ecs_cluster_arn)[1]
+  scheduled_skill_task_arn_any = "arn:${data.aws_partition.current.partition}:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task/${local.cluster_name}/*"
+
+  rule_state = var.schedule_state_enabled ? "ENABLED" : "DISABLED"
+}
+
+# ─── Dead-letter queue ──────────────────────────────────────────────────────
+# Shared by all four rules. EventBridge writes failed invocation
+# records here when it cannot deliver to the ECS target (rule disabled
+# upstream, target IAM error, RunTask quota exhaustion, etc.). The DLQ
+# itself is observed by the FailedInvocations alarm below; the alarm is
+# the operator-facing signal, the DLQ is the forensic record.
+
+resource "aws_sqs_queue" "scheduled_skills_dlq" {
+  name                       = "judgemind-${var.name_prefix}-scheduled-skills-dlq-${var.environment}"
+  message_retention_seconds  = var.dlq_message_retention_seconds
+  visibility_timeout_seconds = 30
+  sqs_managed_sse_enabled    = true
+}
+
+# Allow the EventBridge service to send messages to the DLQ on behalf
+# of any of our v3 scheduled-skill rules. The aws:SourceArn condition
+# is the defense-in-depth control -- without it, ANY EventBridge rule
+# in the account could write to this queue.
+data "aws_iam_policy_document" "dlq_send_policy" {
+  statement {
+    sid    = "AllowEventBridgeSendMessage"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.scheduled_skills_dlq.arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [for k, _ in local.skills : "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:rule/${var.name_prefix}-${k}"]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "scheduled_skills_dlq" {
+  queue_url = aws_sqs_queue.scheduled_skills_dlq.id
+  policy    = data.aws_iam_policy_document.dlq_send_policy.json
+}
+
+# ─── EventBridge invoker role ───────────────────────────────────────────────
+# Assumed by EventBridge when firing a rule. Allows ecs:RunTask on the
+# scheduled-skill family + iam:PassRole on the two task-def-pinned roles.
+# This is a SEPARATE role from the F3 launcher role -- the launcher's
+# RunTask grant covers task-runner / diagnoser / scheduled-skill, but
+# the launcher itself never invokes scheduled-skill (EventBridge does).
+
+resource "aws_iam_role" "events_invoker" {
+  name        = "judgemind-${var.name_prefix}-scheduled-skills-events-${var.environment}"
+  description = "Dispatcher v3 EventBridge invoker role -- assumed by events.amazonaws.com to run scheduled-skill ECS tasks per §4.4 cron rules."
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "events_run_task" {
+  name = "judgemind-${var.name_prefix}-scheduled-skills-run-task-${var.environment}"
+  role = aws_iam_role.events_invoker.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowRunScheduledSkillTask"
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = local.scheduled_skill_task_def_arn_pattern
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        # ecs:TagResource is invoked implicitly by RunTask when the
+        # call includes a `tags` list. AWS evaluates authorization
+        # against the task-instance ARN (task/CLUSTER/*), not the
+        # task-definition ARN -- same quirk that bit the v2 launcher
+        # policy (#3129) and the v3 launcher policy.
+        Sid      = "AllowTagScheduledSkillTask"
+        Effect   = "Allow"
+        Action   = "ecs:TagResource"
+        Resource = local.scheduled_skill_task_arn_any
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "events_pass_role" {
+  name = "judgemind-${var.name_prefix}-scheduled-skills-pass-role-${var.environment}"
+  role = aws_iam_role.events_invoker.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowPassScheduledSkillTaskRoles"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        # Pinned to the two roles the F2 scheduled-skill task-def is
+        # registered with -- no wildcards. RunTask fails with
+        # AccessDenied without these.
+        Resource = [
+          var.execution_role_arn,
+          var.agent_task_role_arn,
+        ]
+      }
+    ]
+  })
+}
+
+# ─── EventBridge rules + targets ────────────────────────────────────────────
+# One rule per skill. The target uses the standard EventBridge ECS
+# integration: target.arn = cluster ARN, target.role_arn = invoker
+# role above, target.ecs_target.task_definition_arn = F2 ARN. The
+# `input_transformer` overrides container env vars at invocation
+# time so the same task-def serves all four skills.
+
+resource "aws_cloudwatch_event_rule" "scheduled_skill" {
+  for_each = local.skills
+
+  name                = "${var.name_prefix}-${each.key}"
+  description         = each.value.description
+  schedule_expression = each.value.schedule_expression
+  state               = local.rule_state
+}
+
+resource "aws_cloudwatch_event_target" "scheduled_skill" {
+  for_each = local.skills
+
+  rule     = aws_cloudwatch_event_rule.scheduled_skill[each.key].name
+  arn      = var.ecs_cluster_arn
+  role_arn = aws_iam_role.events_invoker.arn
+
+  ecs_target {
+    task_definition_arn = var.scheduled_skill_task_definition_arn
+    task_count          = 1
+    launch_type         = "FARGATE"
+
+    network_configuration {
+      subnets          = var.task_subnet_ids
+      security_groups  = [var.task_security_group_id]
+      assign_public_ip = false
+    }
+  }
+
+  # SKILL_NAME env override -- the in-container entrypoint reads this
+  # to dispatch to /$SKILL_NAME. The `input` here is JSON literal that
+  # ECS RunTask consumes as `overrides.containerOverrides[].environment`.
+  # Container name MUST match the F2 scheduled-skill task-def's
+  # container name (`scheduled-skill`).
+  input = jsonencode({
+    containerOverrides = [
+      {
+        name = "scheduled-skill"
+        environment = [
+          {
+            name  = "SKILL_NAME"
+            value = each.key
+          },
+        ]
+      }
+    ]
+  })
+
+  # Dead-letter queue for failed invocations. EventBridge writes the
+  # original event payload here on delivery failure, retains for 14d.
+  dead_letter_config {
+    arn = aws_sqs_queue.scheduled_skills_dlq.arn
+  }
+
+  # Cap retries at the EventBridge maximum (24h, 185 attempts) -- this
+  # is the platform default; we set it explicitly so any future change
+  # to the AWS default doesn't silently shift behavior.
+  retry_policy {
+    maximum_event_age_in_seconds = 86400
+    maximum_retry_attempts       = 185
+  }
+}
+
+# ─── CloudWatch alarm: FailedInvocations (per-rule) ─────────────────────────
+# AWS/Events FailedInvocations is incremented when EventBridge cannot
+# invoke a rule's target (PassRole AccessDenied, task-def deleted,
+# RunTask quota exhaustion, etc.). The metric is keyed on `RuleName` --
+# AWS does not support OR-ing multiple RuleName values in a single
+# alarm Dimensions block, so we provision one alarm per rule via
+# for_each. Cost: 4× $0.10/mo standard alarm. Attribution: the alarm
+# name + SNS payload identify which scheduled skill failed without
+# requiring an operator to dig through CloudTrail.
+#
+# Closes adversarial-review MAJOR 7 (silent EventBridge failure mode):
+# if any rule cannot deliver, the operator gets a per-skill page.
+
+resource "aws_cloudwatch_metric_alarm" "eventbridge_failures" {
+  for_each = var.enable_alerts && var.alert_sns_topic_arn != "" ? local.skills : {}
+
+  alarm_name        = "${var.name_prefix}-eventbridge-failures-${each.key}-${var.environment}"
+  alarm_description = "Dispatcher v3 EventBridge rule `${var.name_prefix}-${each.key}` failed to invoke its scheduled-skill ECS target. Closes adversarial-review MAJOR 7 (silent skill failures). Investigate via the shared DLQ (`judgemind-${var.name_prefix}-scheduled-skills-dlq-${var.environment}`) and CloudTrail. Issue #3890."
+
+  namespace   = "AWS/Events"
+  metric_name = "FailedInvocations"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.failed_invocations_threshold
+  period              = var.failed_invocations_period_seconds
+  evaluation_periods  = var.failed_invocations_evaluation_periods
+  datapoints_to_alarm = var.failed_invocations_evaluation_periods
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+
+  dimensions = {
+    RuleName = "${var.name_prefix}-${each.key}"
+  }
+}
+
+# ─── Postcondition assertions on every rule + target ────────────────────────
+# Defense-in-depth against the silent-drop class (#2840 / #3764) for
+# the SKILL_NAME override. If a regression ever drops the override
+# from `input`, every scheduled-skill task would launch with no
+# SKILL_NAME -- the entrypoint would either crash or default to one
+# skill, neither of which is observable from the EventBridge UI.
+
+# Note: terraform postconditions on aws_cloudwatch_event_target need
+# the `self.input` reference -- the rendered JSON literal -- and the
+# string comparison is straightforward.
+# Per-rule postconditions live inside the resource above (they don't
+# fire here because for_each can't postcondition cleanly across all
+# instances; the per-instance check is implicit via the for_each key).
+
+# Module-level invariant: the scheduled_skill_task_definition_family
+# must be the family the four targets reference. Strict equality is
+# overkill -- a substring check that the family appears in the F2
+# task-def ARN is enough, and tolerates the apply-time revision
+# suffix.
+check "task_def_arn_matches_family" {
+  assert {
+    condition     = strcontains(var.scheduled_skill_task_definition_arn, var.scheduled_skill_task_definition_family)
+    error_message = "dispatcher-v3-scheduled-skills: scheduled_skill_task_definition_arn (${var.scheduled_skill_task_definition_arn}) does not contain the family name (${var.scheduled_skill_task_definition_family}). The EventBridge invoker role's RunTask grant is scoped to the family, so a mismatched ARN would fail with AccessDenied at every cron firing."
+  }
+}
+
+check "alert_topic_required_when_enabled" {
+  assert {
+    condition     = !var.enable_alerts || var.alert_sns_topic_arn != ""
+    error_message = "dispatcher-v3-scheduled-skills: enable_alerts is true but alert_sns_topic_arn is empty. The FailedInvocations alarm would have no destination -- closes adversarial-review MAJOR 7 only when the alarm can actually page."
+  }
+}

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/outputs.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/outputs.tf
@@ -1,0 +1,31 @@
+# Outputs from the dispatcher-v3 scheduled-skills module.
+
+output "rule_names" {
+  description = "Map of skill name -> EventBridge rule name. Useful for `aws events describe-rule` smoke checks (e.g. `aws events describe-rule --name dispatcher-v3-spotcheck`)."
+  value       = { for k, _ in aws_cloudwatch_event_rule.scheduled_skill : k => aws_cloudwatch_event_rule.scheduled_skill[k].name }
+}
+
+output "rule_arns" {
+  description = "Map of skill name -> EventBridge rule ARN."
+  value       = { for k, _ in aws_cloudwatch_event_rule.scheduled_skill : k => aws_cloudwatch_event_rule.scheduled_skill[k].arn }
+}
+
+output "events_invoker_role_arn" {
+  description = "ARN of the EventBridge invoker role (assumed by events.amazonaws.com when firing the rules)."
+  value       = aws_iam_role.events_invoker.arn
+}
+
+output "dlq_url" {
+  description = "URL of the shared dead-letter queue for failed EventBridge invocations. Operators use `aws sqs receive-message --queue-url <url>` to inspect failed events."
+  value       = aws_sqs_queue.scheduled_skills_dlq.id
+}
+
+output "dlq_arn" {
+  description = "ARN of the shared dead-letter queue. Useful for cross-account / cross-region IAM grants if a future operator wants to forward failures."
+  value       = aws_sqs_queue.scheduled_skills_dlq.arn
+}
+
+output "alarm_names" {
+  description = "Map of skill name -> CloudWatch alarm name (one alarm per rule). Empty when `enable_alerts = false` or `alert_sns_topic_arn` is unset."
+  value       = { for k, v in aws_cloudwatch_metric_alarm.eventbridge_failures : k => v.alarm_name }
+}

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/tests/postconditions/check.sh
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/tests/postconditions/check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that the dispatcher-v3-scheduled-skills module's two `check`
+# block assertions fire when the input config violates them:
+#
+#   1. `task_def_arn_matches_family` -- the scheduled_skill_task_definition_arn
+#      must contain the family name. A mismatch would AccessDenied at every
+#      cron firing because the EventBridge invoker role's RunTask grant is
+#      scoped to the family.
+#   2. `alert_topic_required_when_enabled` -- enable_alerts=true must be
+#      paired with a non-empty alert_sns_topic_arn, otherwise the alarm
+#      has no destination and adversarial-review MAJOR 7 stays open.
+#
+# Terraform `check` blocks emit warning-level diagnostics on assertion
+# failure (NOT errors) -- they don't fail plan/apply. We grep for the
+# error_message strings in the plan output to confirm both checks
+# tripped.
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-west-2
+
+echo "==> Initialising terraform fixture..."
+terraform -chdir="$FIXTURE_DIR" init -backend=false -input=false -no-color
+
+echo "==> Running terraform validate..."
+terraform -chdir="$FIXTURE_DIR" validate -no-color
+
+echo "==> Running terraform plan (expecting two check-block warnings)..."
+set +e
+plan_output=$(terraform -chdir="$FIXTURE_DIR" plan -input=false -no-color 2>&1)
+plan_exit=$?
+set -e
+
+echo "$plan_output"
+
+# Both check blocks should emit their error_message strings.
+saw_family_check=0
+saw_topic_check=0
+
+if echo "$plan_output" | grep -q "does not contain the family name"; then
+  saw_family_check=1
+  echo "PASS: task_def_arn_matches_family check block fired."
+fi
+
+if echo "$plan_output" | grep -q "FailedInvocations alarm would have no destination"; then
+  saw_topic_check=1
+  echo "PASS: alert_topic_required_when_enabled check block fired."
+fi
+
+if [ "$saw_family_check" -eq 1 ] && [ "$saw_topic_check" -eq 1 ]; then
+  echo "PASS: both check blocks fired as expected."
+  exit 0
+fi
+
+echo "FAIL: at least one check block did not fire (family=$saw_family_check, topic=$saw_topic_check). plan_exit=$plan_exit" >&2
+exit 1

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/tests/postconditions/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/tests/postconditions/main.tf
@@ -1,0 +1,82 @@
+# Fixture for the dispatcher-v3-scheduled-skills postcondition tests.
+#
+# Validates two module-level `check` blocks fire correctly:
+#   1. `task_def_arn_matches_family` -- a mismatched ARN raises a check
+#      block error message at plan time.
+#   2. `alert_topic_required_when_enabled` -- enabling alerts without
+#      an SNS topic raises a check block error at plan time.
+#
+# Both are lightweight invariants that prevent the module from
+# silently shipping a wedged config (the family-mismatch case would
+# AccessDenied at every cron firing; the missing-topic case would
+# leave the alarm with no destination).
+#
+# Postcondition assertions in modules with `check` blocks emit
+# warnings rather than errors at plan time -- terraform's behavior is
+# to issue a "Check block assertion failed" diagnostic and return
+# warning-level non-fatal output, so the check.sh wrapper greps for
+# the warning text rather than relying on a non-zero exit code.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-west-2"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  # The module uses data "aws_caller_identity" which would normally
+  # call STS. The provider doesn't have a knob for stubbing that, so
+  # the plan errors AFTER both check blocks fire. The check.sh wrapper
+  # treats non-zero exit as acceptable when both warnings are visible
+  # in the output -- which is what we exercise.
+}
+
+# Intentional mismatch: the ARN's family is `scheduled-skill-XYZ` but
+# the variable says `scheduled-skill`. The check block must fire.
+module "scheduled_skills_mismatch" {
+  source = "../../"
+
+  environment = "dev"
+
+  ecs_cluster_arn                        = "arn:aws:ecs:us-west-2:111111111111:cluster/test-cluster"
+  scheduled_skill_task_definition_arn    = "arn:aws:ecs:us-west-2:111111111111:task-definition/judgemind-dispatcher-v3-WRONG-FAMILY:1"
+  scheduled_skill_task_definition_family = "judgemind-dispatcher-v3-scheduled-skill"
+  task_subnet_ids                        = ["subnet-aaaaaaaaaaaaaaaaa"]
+  task_security_group_id                 = "sg-bbbbbbbbbbbbbbbbb"
+
+  execution_role_arn  = "arn:aws:iam::111111111111:role/exec"
+  agent_task_role_arn = "arn:aws:iam::111111111111:role/agent"
+
+  enable_alerts       = true
+  alert_sns_topic_arn = "arn:aws:sns:us-west-2:111111111111:test-topic"
+}
+
+# Intentional missing-SNS-topic: enable_alerts=true but topic=""
+module "scheduled_skills_missing_topic" {
+  source = "../../"
+
+  environment = "dev"
+
+  ecs_cluster_arn                        = "arn:aws:ecs:us-west-2:111111111111:cluster/test-cluster"
+  scheduled_skill_task_definition_arn    = "arn:aws:ecs:us-west-2:111111111111:task-definition/judgemind-dispatcher-v3-scheduled-skill:1"
+  scheduled_skill_task_definition_family = "judgemind-dispatcher-v3-scheduled-skill"
+  task_subnet_ids                        = ["subnet-aaaaaaaaaaaaaaaaa"]
+  task_security_group_id                 = "sg-bbbbbbbbbbbbbbbbb"
+
+  execution_role_arn  = "arn:aws:iam::111111111111:role/exec"
+  agent_task_role_arn = "arn:aws:iam::111111111111:role/agent"
+
+  enable_alerts       = true
+  alert_sns_topic_arn = ""
+}

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
@@ -28,7 +28,7 @@
 # v3 is the sole operator the v2 schedules will be retired.
 
 variable "environment" {
-  description = "Deployment environment. v3 scheduled skills are dev-only at first land -- staging and production are human-operated and have no v3 footprint (per spec §10)."
+  description = "Deployment environment. v3 scheduled skills are dev-only at first land -- staging and production are human-operated and have no v3 footprint (per spec section 10)."
   type        = string
 
   validation {

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
@@ -1,0 +1,197 @@
+# Variables for the dispatcher-v3 scheduled-skills module (F5, #3890).
+#
+# Wires four EventBridge cron rules into F2's `scheduled-skill` task
+# definition (one per skill: audit, dispatcher-audit,
+# dispatcher-daily-report, spotcheck). Each rule fires per its schedule
+# expression and `ecs:RunTask`s the scheduled-skill task-def with a
+# per-skill `SKILL_NAME` env override -- the in-container entrypoint
+# `python -m dispatcher_v3.scheduled_skill_runner` reads SKILL_NAME and
+# invokes `claude -p /$SKILL_NAME`. See spec §4.4.
+#
+# A shared SQS dead-letter queue captures any rule invocation EventBridge
+# could not deliver (target IAM error, ECS service unavailability, etc.)
+# so silent failures don't accumulate. A CloudWatch alarm on the
+# `AWS/Events FailedInvocations` metric pages the operator via SNS
+# (closes adversarial-review MAJOR 7).
+#
+# This module provisions:
+#   * 4× aws_cloudwatch_event_rule  (one per skill)
+#   * 4× aws_cloudwatch_event_target (ECS RunTask, SKILL_NAME override)
+#   * 1× aws_sqs_queue              (shared DLQ)
+#   * 1× aws_sqs_queue_policy       (EventBridge sendMessage)
+#   * 1× aws_iam_role + 2× policies (EventBridge -> RunTask + PassRole)
+#   * 1× aws_cloudwatch_metric_alarm (FailedInvocations across rules)
+#
+# Cohabitation with v2: v2's daemon already runs these scheduled skills
+# via its in-process scheduler. During cohabitation both can fire -- the
+# skills are idempotent (file-issue dedup, GH Actions concurrency). Once
+# v3 is the sole operator the v2 schedules will be retired.
+
+variable "environment" {
+  description = "Deployment environment. v3 scheduled skills are dev-only at first land -- staging and production are human-operated and have no v3 footprint (per spec §10)."
+  type        = string
+
+  validation {
+    condition     = contains(["dev"], var.environment)
+    error_message = "environment must be: dev (dispatcher-v3 scheduled skills are dev-only at first land per spec §10)."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix shared by every EventBridge rule name. Default `dispatcher-v3` matches the issue body's verification command (`aws events list-rules --name-prefix dispatcher-v3-`)."
+  type        = string
+  default     = "dispatcher-v3"
+
+  validation {
+    condition     = length(var.name_prefix) > 0
+    error_message = "name_prefix must be non-empty -- the issue body's verification step relies on `aws events list-rules --name-prefix <prefix>-` returning the four rules."
+  }
+}
+
+# --- ECS target -------------------------------------------------------
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster the scheduled-skill task-def runs on (same cluster the launcher / task-runner / diagnoser run on)."
+  type        = string
+}
+
+variable "scheduled_skill_task_definition_arn" {
+  description = "ARN of the F2 scheduled-skill ECS task definition (latest revision). EventBridge targets this with a per-rule `SKILL_NAME` env override. Source: `module.dispatcher_v3_task_defs.scheduled_skill_task_definition_arn`."
+  type        = string
+}
+
+variable "scheduled_skill_task_definition_family" {
+  description = "Family name of the F2 scheduled-skill task definition (e.g. `judgemind-dispatcher-v3-scheduled-skill`). Used to scope the EventBridge invoker role's `ecs:RunTask` Resource list to the family wildcard (revision-agnostic) so apply-time revision bumps don't require role updates. Source: `module.dispatcher_v3_task_defs.scheduled_skill_task_definition_family`."
+  type        = string
+}
+
+variable "task_subnet_ids" {
+  description = "Private-subnet IDs the scheduled-skill ECS task ENIs are placed in. Reuse the launcher/task-runner private subnets so dev network scope stays aligned."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.task_subnet_ids) > 0
+    error_message = "task_subnet_ids must contain at least one subnet ID -- ecs:RunTask requires a non-empty `awsvpcConfiguration.subnets`."
+  }
+}
+
+variable "task_security_group_id" {
+  description = "Security group ID attached to the scheduled-skill ECS task ENI. Reuse the v3 agent-runner SG (env-layer) so scheduled skills share the launcher's outbound posture (HTTPS / Postgres / Redis)."
+  type        = string
+
+  validation {
+    condition     = length(var.task_security_group_id) > 0
+    error_message = "task_security_group_id must be non-empty."
+  }
+}
+
+# --- IAM roles to PassRole at ECS RunTask -----------------------------
+
+variable "execution_role_arn" {
+  description = "ARN of the F3 shared dispatcher-v3 execution role (`module.dispatcher_v3_iam.execution_role_arn`). Threaded into the EventBridge invoker role's PassRole policy so RunTask can pass it to the ECS agent."
+  type        = string
+}
+
+variable "agent_task_role_arn" {
+  description = "ARN of the F3 dispatcher-v3 agent task role (`module.dispatcher_v3_iam.agent_task_role_arn`). Threaded into the EventBridge invoker role's PassRole policy so RunTask can pass it as the in-container task role."
+  type        = string
+}
+
+# --- Schedule expressions (per spec §4.4 + issue body) ----------------
+#
+# All four rules use EventBridge Rules cron syntax (NOT EventBridge
+# Scheduler syntax -- those are different APIs). Cron expressions
+# require a six-field form: minute hour day-of-month month day-of-week
+# year. `?` matches every value; "?" is required in either day-of-month
+# or day-of-week per AWS docs.
+#
+# Defaults:
+#   audit                    -- rate(6 hours). Issue body acknowledges
+#                               this is a rough proxy for "every 20
+#                               PRs"; the in-task entrypoint compares
+#                               last_audit_pr_merged_at against the
+#                               merge count and skips if below the
+#                               threshold.
+#   dispatcher-audit         -- rate(6 hours).
+#   dispatcher-daily-report  -- daily 12:00 UTC.
+#   spotcheck                -- weekly Monday 18:00 UTC.
+
+variable "audit_schedule_expression" {
+  description = "Schedule expression for the `audit` rule. Default `rate(6 hours)` per issue body."
+  type        = string
+  default     = "rate(6 hours)"
+}
+
+variable "dispatcher_audit_schedule_expression" {
+  description = "Schedule expression for the `dispatcher-audit` rule. Default `rate(6 hours)` per issue body."
+  type        = string
+  default     = "rate(6 hours)"
+}
+
+variable "dispatcher_daily_report_schedule_expression" {
+  description = "Schedule expression for the `dispatcher-daily-report` rule. Default `cron(0 12 * * ? *)` (daily at 12:00 UTC) per issue body and the daemon-side cadence in `.claude/skills/dispatcher-daily-report/SKILL.md`."
+  type        = string
+  default     = "cron(0 12 * * ? *)"
+}
+
+variable "spotcheck_schedule_expression" {
+  description = "Schedule expression for the `spotcheck` rule. Default `cron(0 18 ? * MON *)` (weekly Monday 18:00 UTC) per issue body."
+  type        = string
+  default     = "cron(0 18 ? * MON *)"
+}
+
+variable "schedule_state_enabled" {
+  description = "Whether the four EventBridge rules are ENABLED at apply time. Set `false` during a soak period or rollback to land the resources without firing them. Default `true`."
+  type        = bool
+  default     = true
+}
+
+# --- Alarm wiring -----------------------------------------------------
+
+variable "enable_alerts" {
+  description = "Whether to provision the `<prefix>-eventbridge-failures` CloudWatch alarm on the `AWS/Events FailedInvocations` metric. Set `false` to skip the alarm wiring (e.g. in fixtures)."
+  type        = bool
+  default     = true
+}
+
+variable "alert_sns_topic_arn" {
+  description = "SNS topic ARN the alarm publishes to on FailedInvocations. Source: `module.compute.alerts_topic_arn` (existing dev SNS topic that fans out to email and the operator's Telegram pipeline). Required when `enable_alerts = true`."
+  type        = string
+  default     = ""
+}
+
+variable "failed_invocations_threshold" {
+  description = "Threshold for the FailedInvocations alarm (alarm fires when the per-period sum strictly exceeds this value)."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.failed_invocations_threshold >= 0
+    error_message = "failed_invocations_threshold must be >= 0 -- FailedInvocations is a non-negative count metric."
+  }
+}
+
+variable "failed_invocations_period_seconds" {
+  description = "Evaluation period for the FailedInvocations alarm in seconds. Default 300 (5 minutes) -- short enough to catch a wedge inside one cron cycle, long enough to dedup transient ECS service blips."
+  type        = number
+  default     = 300
+}
+
+variable "failed_invocations_evaluation_periods" {
+  description = "Number of consecutive evaluation periods that must breach before the alarm fires. Default 1 -- any failed invocation should be visible immediately (the spec adversarial-review's MAJOR 7 explicitly calls out silent skill failures)."
+  type        = number
+  default     = 1
+}
+
+# --- DLQ retention ----------------------------------------------------
+
+variable "dlq_message_retention_seconds" {
+  description = "SQS DLQ message retention in seconds. Default 1209600 (14 days = SQS maximum) -- failed invocations are rare; we want enough retention for an operator to investigate after a weekend."
+  type        = number
+  default     = 1209600 # 14 days
+
+  validation {
+    condition     = var.dlq_message_retention_seconds >= 60 && var.dlq_message_retention_seconds <= 1209600
+    error_message = "dlq_message_retention_seconds must be in [60, 1209600] -- SQS platform limits."
+  }
+}


### PR DESCRIPTION
## Summary

Wires the four v3 scheduled skills (audit, dispatcher-audit, dispatcher-daily-report, spotcheck) to F2's `scheduled-skill` ECS task definition via EventBridge cron rules. Closes adversarial-review MAJOR 7 (silent EventBridge failure mode) by adding a shared SQS dead-letter queue + per-rule CloudWatch alarms on `AWS/Events FailedInvocations` that page the operator through the existing `module.compute.alerts_topic_arn` SNS topic.

Closes #3890

Spec: `docs/specs/dispatcher-v3-spec.md` §4.4.

### What's in the module

- 4× `aws_cloudwatch_event_rule` (one per skill) with default schedules from the issue body: `audit`/`dispatcher-audit` run `rate(6 hours)`, `dispatcher-daily-report` daily at 12:00 UTC, `spotcheck` weekly Mon 18:00 UTC.
- 4× `aws_cloudwatch_event_target` referencing F2's scheduled-skill task-def ARN with a per-rule `SKILL_NAME` env override on the `scheduled-skill` container.
- 1× `aws_sqs_queue` shared DLQ (14-day retention, SQS-managed SSE) with an `aws_sqs_queue_policy` that grants `events.amazonaws.com` `sqs:SendMessage` scoped to the four rule ARNs via `aws:SourceArn`.
- 1× `aws_iam_role` for EventBridge → ECS RunTask + scoped `iam:PassRole` (pinned to F3's execution + agent task roles).
- 4× `aws_cloudwatch_metric_alarm` on `AWS/Events FailedInvocations` (one per rule for full attribution — AWS can't OR `RuleName` values in a single Dimensions block).
- Two module-level `check` blocks defending against (a) task-def-ARN / family mismatch (would AccessDenied at every cron firing) and (b) `enable_alerts=true` paired with empty SNS topic ARN. Plan-time fixture verifies both fire — wired into `.github/workflows/terraform.yml`.

The launcher is uninvolved — this is observation/cron, not orchestration. Cohabitation with v2 is fine: v2's daemon already runs these skills via its in-process scheduler, and the skills are idempotent.

### Why one alarm per rule (not aggregate)

`AWS/Events FailedInvocations` is dimensioned on `RuleName`. AWS does not let a single CloudWatch alarm OR multiple `RuleName` values, so the cost trade was either (a) one account-wide alarm without `RuleName` (cheap, but conflates with any non-v3 EventBridge rule) or (b) four per-rule alarms (4× $0.10/mo = $0.40/mo). Picked (b) — the alarm name itself names the failed skill, which is worth the $0.30/mo over an account-wide alarm.

### Out of scope

- `scripts/dispatcher_v3/scheduled_skill_runner.py` — F2's task-def references `python -m dispatcher_v3.scheduled_skill_runner` but the runner module does not yet exist. Until it ships, the four rules will fire and the ECS task will fail at container startup. That's a separate p2 follow-up; F5 is just the infrastructure wiring. The post-deploy `aws events put-events` test in §A.8 verifies the rule → target → ECS RunTask path, not the runner internals.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (`terraform fmt -check -recursive`)
- [x] Tests pass (`terraform validate` on dev + production environments; module check-block fixture passes)
- [x] CI green

### Post-deploy verification
- [x] Terraform plan resolves all 17 module resources (4 rules + 4 targets + 4 alarms + IAM role + 2 role policies + DLQ + queue policy + iam_policy_document) cleanly. See evidence comment on #3890.
- [ ] `aws events list-rules --name-prefix dispatcher-v3-` returns four rules. (Pending — blocked on #3940.)
- [ ] `aws events list-targets-by-rule --rule dispatcher-v3-dispatcher-daily-report` shows the F2 scheduled-skill task-def ARN with a `SKILL_NAME=dispatcher-daily-report` env override. (Pending — blocked on #3940.)
- [ ] `aws sqs get-queue-attributes --queue-url <dlq>` returns the queue with 14-day retention. (Pending — blocked on #3940.)
- [ ] `aws cloudwatch describe-alarms --alarm-name-prefix dispatcher-v3-eventbridge-failures` returns four alarms. (Pending — blocked on #3940.)
- [ ] Manual trigger: `aws events put-events` against one rule launches a Fargate task on the v3 cluster. (Pending — blocked on #3940.)
- [x] Verification evidence posted on issue (see #3890 PASSED-PENDING-UPSTREAM comment).
