### PR TITLE
feat(dispatcher): add progress.sh helper for v3 milestone updates (#3884)

### DIFF
--- a/scripts/dispatcher/progress.sh
+++ b/scripts/dispatcher/progress.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# progress.sh — Best-effort milestone update for the dispatcher v3 cockpit.
+#
+# `/task` invokes this helper at each natural milestone (planning, ralph,
+# summary, push_and_pr, awaiting_ci, fix_ci, merge, awaiting_deploy, verify,
+# retro, …) so the cockpit can show "where is this agent right now" without
+# reintroducing a phase state machine. The helper does ONE UPDATE on the
+# `dispatcher.agents` row and returns 0 unconditionally — see the design
+# requirements in `docs/specs/dispatcher-v3-spec.md` §4.3.
+#
+# Usage:
+#   scripts/dispatcher/progress.sh <agent_id> <milestone> [detail]
+#
+# Best-effort contract — exits 0 on every path:
+#   * Missing args                 → exit 0 (usage to stderr)
+#   * Missing DATABASE_URL          → exit 0 (note to stderr)
+#   * psql binary not on PATH       → exit 0 (note to stderr)
+#   * DB connect / query failure    → exit 0 (psql stderr swallowed)
+#   * Successful UPDATE              → exit 0
+#
+# This contract is non-negotiable. The helper lives on the hot path of every
+# `/task` agent; a non-zero exit would propagate up and trip pre-push hooks,
+# CI pre-flight checks, or the agent-runner entrypoint. v3 milestones are
+# observation, not control.
+#
+# SQL injection safety:
+#
+#   The user-controlled inputs (agent_id, milestone, detail) are passed to
+#   psql via the `-v` flag, then referenced inside the SQL with the
+#   `:'name'` substitution syntax. psql expands `:'name'` as a properly
+#   single-quoted SQL string literal with internal quotes doubled, so values
+#   like `'; DROP TABLE agents; --` end up as a literal string, not as
+#   executable SQL. See psql(1) "SQL Interpolation" in the PostgreSQL docs.
+#
+# Cohabitation note:
+#
+#   v2 daemon-managed agents do not call this helper, so their
+#   `current_milestone*` columns stay NULL — exactly the expected v2 behavior
+#   per migration 56's column comments. v3 agents call it, the cockpit reads
+#   it, nothing else does.
+
+set -uo pipefail
+# NOTE: deliberately NOT `set -e`. We want every error path to fall through
+# to the final `exit 0` so a DB blip never blocks `/task`.
+
+PROG="$(basename "$0")"
+
+# ── Arg validation ─────────────────────────────────────────────────────────
+#
+# Two required positional args (agent_id, milestone) and an optional third
+# (detail). Per the best-effort contract, missing args go to stderr but
+# still exit 0.
+
+if [ $# -lt 2 ] || [ -z "${1:-}" ] || [ -z "${2:-}" ]; then
+    echo "usage: $PROG <agent_id> <milestone> [detail]" >&2
+    exit 0
+fi
+
+AGENT_ID="$1"
+MILESTONE="$2"
+DETAIL="${3:-}"
+
+# ── Environment validation ─────────────────────────────────────────────────
+
+if [ -z "${DATABASE_URL:-}" ]; then
+    echo "$PROG: DATABASE_URL not set, skipping milestone update" >&2
+    exit 0
+fi
+
+if ! command -v psql >/dev/null 2>&1; then
+    echo "$PROG: psql not on PATH, skipping milestone update" >&2
+    exit 0
+fi
+
+# ── UPDATE via parameterized psql ───────────────────────────────────────────
+#
+# Why `psql -v` + `:'name'` instead of inline shell interpolation:
+#
+#   The naïve form `psql -c "UPDATE … SET col = '$MILESTONE' …"` lets a
+#   crafted milestone string (e.g. `'; DROP TABLE agents; --`) escape its
+#   quotes and execute arbitrary SQL. `:'name'` substitution by psql is
+#   immune: the shell only ever passes the value as a CLI flag value, and
+#   psql does its own quoting of the value when expanding `:'name'`.
+#
+# Why `-f -` (stdin) instead of `-c`:
+#
+#   psql's variable interpolation runs during *file/stdin parsing*. With
+#   `-c`, the SQL string is sent straight to the server without `:'name'`
+#   expansion (ERROR: syntax error at or near ":"). Reading the SQL from
+#   stdin via `-f -` lets psql perform the substitution before sending.
+#
+# Flags:
+#   -X                    Skip ~/.psqlrc (avoid surprise side effects).
+#   -q                    Quiet — no banner / row count chatter on stdout.
+#   -v ON_ERROR_STOP=0    Tolerant — a bad row or bad column does not abort.
+#   -v agent_id=…         Bind input to psql variables for `:'name'` use.
+#   -f -                  Read SQL from stdin so `:'name'` interpolation runs.
+#
+# The query runs under `statement_timeout = 5000` so a wedged DB lock can't
+# stall the helper forever. 5s is generous for a single-row UPDATE on a
+# table that's already keyed on `agent_id`. PGCONNECT_TIMEOUT=5 prevents
+# a black-holed network from blocking past the cockpit's freshness window.
+
+psql_output_log="$(mktemp -t progress.XXXXXX 2>/dev/null || echo /tmp/progress.$$.log)"
+
+# The SQL body. `:'name'` placeholders are expanded by psql as
+# properly-escaped string literals — see comment block above.
+read -r -d '' SQL_BODY <<'SQL' || true
+SET statement_timeout = 5000;
+UPDATE dispatcher.agents
+SET current_milestone = :'milestone',
+    current_milestone_detail = :'detail',
+    current_milestone_at = now()
+WHERE agent_id = :'agent_id';
+SQL
+
+if ! printf '%s\n' "$SQL_BODY" | PGCONNECT_TIMEOUT="${PGCONNECT_TIMEOUT:-5}" \
+        psql "$DATABASE_URL" \
+            -X -q -v ON_ERROR_STOP=0 \
+            -v "agent_id=$AGENT_ID" \
+            -v "milestone=$MILESTONE" \
+            -v "detail=$DETAIL" \
+            -f - \
+            >/dev/null 2>"$psql_output_log"; then
+    # Connect failure / network blip / permissions issue / etc. Echo the
+    # first line of psql's stderr so an operator tail-ing the agent log
+    # sees what happened, but DO NOT propagate a non-zero exit.
+    if [ -s "$psql_output_log" ]; then
+        first_err_line="$(head -n 1 "$psql_output_log")"
+        echo "$PROG: psql failed (swallowed): $first_err_line" >&2
+    else
+        echo "$PROG: psql failed (swallowed)" >&2
+    fi
+fi
+
+rm -f "$psql_output_log" 2>/dev/null || true
+
+exit 0

--- a/scripts/dispatcher/tests/test_progress_sh.sh
+++ b/scripts/dispatcher/tests/test_progress_sh.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# test_progress_sh.sh — Regression test for issue #3884.
+#
+# Exercises scripts/dispatcher/progress.sh — the best-effort milestone
+# helper invoked by /task at each natural step (planning, ralph, summary,
+# push_and_pr, …) per dispatcher-v3 spec §4.3.
+#
+# What this verifies (acceptance criteria from #3884):
+#
+#   AC1 — Helper exists and is executable.
+#   AC2 — Helper exits 0 on missing args, missing DATABASE_URL, missing
+#         psql, and DB error. (Best-effort contract: never block /task.)
+#   AC3 — Helper invokes psql with the expected `-v` flags so the SQL
+#         body's `:'name'` placeholders interpolate to properly-quoted
+#         literals. We stub `psql` and assert on the captured argv.
+#   AC4 — SQL-injection safety: when invoked with a milestone string
+#         containing `'; DROP TABLE …; --`, the value is passed via the
+#         `-v` flag verbatim. The shell does NOT splice it into the SQL
+#         body. (psql then quotes-and-escapes during `:'name'` expansion
+#         — verified independently against a real Postgres before this
+#         script was committed; see issue #3884 for the manual probe.)
+#
+# Stubbing strategy:
+#
+#   The test prepends a $TMP/bin directory to $PATH containing a fake
+#   `psql` shell script. The fake records its argv to $PSQL_LOG, reads
+#   stdin to $PSQL_STDIN, and exits with $PSQL_EXIT_CODE (default 0).
+#   This lets us assert on the exact CLI invocation without a real DB.
+#
+# Usage:
+#   scripts/dispatcher/tests/test_progress_sh.sh
+#
+# Exit codes:
+#   0 — all assertions passed.
+#   1 — one or more assertions failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$SCRIPT_DIR/dispatcher/progress.sh"
+
+FAILURES=0
+TESTS=0
+
+TEMP_DIRS=()
+TEMP_FILES=()
+# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`.
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    for f in ${TEMP_FILES[@]+"${TEMP_FILES[@]}"}; do
+        if [[ -n "$f" && -e "$f" ]]; then
+            rm -f "$f"
+        fi
+    done
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Build a fresh tmp dir + stub `psql` for one test case. The stub:
+#   * Captures argv to $TMP/psql.argv (one line per arg).
+#   * Captures stdin to $TMP/psql.stdin.
+#   * Exits with the value in $TMP/psql.exit_code (defaults to 0).
+make_psql_stub() {
+    local tmp
+    tmp=$(mktemp -d -t progress_test.XXXXXX)
+    TEMP_DIRS+=("$tmp")
+    mkdir -p "$tmp/bin"
+    cat > "$tmp/bin/psql" <<STUB
+#!/usr/bin/env bash
+exit_code=\$(cat "$tmp/psql.exit_code" 2>/dev/null || echo 0)
+# Record argv one-per-line for easy grep assertions.
+: > "$tmp/psql.argv"
+for a in "\$@"; do
+    printf '%s\n' "\$a" >> "$tmp/psql.argv"
+done
+# Drain stdin so the SQL body is captured.
+cat > "$tmp/psql.stdin"
+if [[ "\$exit_code" -ne 0 ]]; then
+    echo "psql: simulated failure" >&2
+fi
+exit "\$exit_code"
+STUB
+    chmod +x "$tmp/bin/psql"
+    echo "$tmp"
+}
+
+# ── Precondition: the helper exists and is executable ────────────────────────
+
+if [[ ! -f "$HELPER" ]]; then
+    fail "helper script exists" "expected $HELPER to be present"
+    echo
+    echo "Tests: $TESTS, Failures: $FAILURES"
+    exit 1
+fi
+pass "helper script $HELPER exists"
+
+if [[ ! -x "$HELPER" ]]; then
+    fail "helper is executable" "expected -rwxr-xr-x at $HELPER"
+else
+    pass "helper is executable"
+fi
+
+# ── AC2: missing args → exit 0 ───────────────────────────────────────────────
+
+run_no_args() {
+    local err rc
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    "$HELPER" 2>"$err"
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+        pass "no args → exit 0"
+    else
+        fail "no args → exit 0" "got exit code $rc"
+    fi
+    if grep -q "usage:" "$err"; then
+        pass "no args prints usage to stderr"
+    else
+        fail "no args prints usage to stderr" "stderr was: $(cat "$err")"
+    fi
+    rm -f "$err"
+}
+run_no_args
+
+run_one_arg() {
+    local err rc
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    "$HELPER" only-one-arg 2>"$err"
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+        pass "one arg → exit 0"
+    else
+        fail "one arg → exit 0" "got exit code $rc"
+    fi
+    if grep -q "usage:" "$err"; then
+        pass "one arg prints usage to stderr"
+    else
+        fail "one arg prints usage to stderr" "stderr was: $(cat "$err")"
+    fi
+    rm -f "$err"
+}
+run_one_arg
+
+# Empty-string second arg should also be rejected (treated as missing).
+run_empty_milestone() {
+    local err rc
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    "$HELPER" agent-1 "" 2>"$err"
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+        pass "empty milestone → exit 0"
+    else
+        fail "empty milestone → exit 0" "got exit code $rc"
+    fi
+    if grep -q "usage:" "$err"; then
+        pass "empty milestone prints usage"
+    else
+        fail "empty milestone prints usage" "stderr was: $(cat "$err")"
+    fi
+    rm -f "$err"
+}
+run_empty_milestone
+
+# ── AC2: missing DATABASE_URL → exit 0 ───────────────────────────────────────
+
+run_no_db_url() {
+    local err rc
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    # `env -u` removes DATABASE_URL even if the surrounding test env set one.
+    env -u DATABASE_URL "$HELPER" agent-1 ralph "iter 3" 2>"$err"
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+        pass "missing DATABASE_URL → exit 0"
+    else
+        fail "missing DATABASE_URL → exit 0" "got exit code $rc"
+    fi
+    if grep -q "DATABASE_URL not set" "$err"; then
+        pass "missing DATABASE_URL prints note to stderr"
+    else
+        fail "missing DATABASE_URL prints note" "stderr was: $(cat "$err")"
+    fi
+    rm -f "$err"
+}
+run_no_db_url
+
+# ── AC2: psql binary not on PATH → exit 0 ────────────────────────────────────
+
+run_no_psql() {
+    local err rc bin_only
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    bin_only=$(mktemp -d -t progress_nopath.XXXXXX)
+    TEMP_DIRS+=("$bin_only")
+    # Symlink only the binaries the script (and its shebang) need:
+    # `env` and `bash`. This guarantees `psql` is unfindable while the
+    # script's `#!/usr/bin/env bash` shebang still resolves. Falls back
+    # to /bin if /usr/bin is absent on some image.
+    for b in env bash sh head mktemp rm basename grep; do
+        if [[ -x "/usr/bin/$b" ]]; then
+            ln -sf "/usr/bin/$b" "$bin_only/$b"
+        elif [[ -x "/bin/$b" ]]; then
+            ln -sf "/bin/$b" "$bin_only/$b"
+        fi
+    done
+    PATH="$bin_only" DATABASE_URL="postgresql://x@y:5/z" \
+        "$HELPER" agent-1 ralph 2>"$err"
+    rc=$?
+    if [[ $rc -eq 0 ]]; then
+        pass "psql not on PATH → exit 0"
+    else
+        fail "psql not on PATH → exit 0" "got exit code $rc; stderr: $(cat "$err")"
+    fi
+    if grep -q "psql not on PATH" "$err"; then
+        pass "psql-missing prints note to stderr"
+    else
+        fail "psql-missing prints note" "stderr was: $(cat "$err")"
+    fi
+}
+run_no_psql
+
+# ── AC2 & AC3: stubbed psql success → exit 0 + correct argv ──────────────────
+
+run_stubbed_success() {
+    local stub_dir rc err
+    stub_dir=$(make_psql_stub)
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    echo 0 > "$stub_dir/psql.exit_code"
+
+    PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \
+        "$HELPER" "agent-uuid-1" "ralph" "iter 3" 2>"$err"
+    rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "stubbed success → exit 0"
+    else
+        fail "stubbed success → exit 0" "got exit code $rc; stderr: $(cat "$err")"
+    fi
+
+    if [[ ! -f "$stub_dir/psql.argv" ]]; then
+        fail "psql was invoked" "no argv log at $stub_dir/psql.argv"
+    else
+        pass "psql was invoked"
+    fi
+
+    # Each `-v name=value` becomes two argv entries: "-v" then "name=value".
+    if grep -qFx "agent_id=agent-uuid-1" "$stub_dir/psql.argv"; then
+        pass "psql received -v agent_id=agent-uuid-1"
+    else
+        fail "psql received -v agent_id=…" "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+    if grep -qFx "milestone=ralph" "$stub_dir/psql.argv"; then
+        pass "psql received -v milestone=ralph"
+    else
+        fail "psql received -v milestone=…" "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+    if grep -qFx "detail=iter 3" "$stub_dir/psql.argv"; then
+        pass "psql received -v detail=iter 3"
+    else
+        fail "psql received -v detail=…" "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+    # Read SQL from stdin: argv must contain `-f` immediately followed
+    # by `-`. Use awk to scan for that adjacency.
+    if awk 'BEGIN{f=0} /^-f$/{f=1; next} f==1 && /^-$/{print "ok"; exit 0} {f=0}' \
+            "$stub_dir/psql.argv" | grep -q ok; then
+        pass "psql received -f - (stdin SQL)"
+    else
+        fail "psql received -f -" "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+
+    # The DATABASE_URL must be passed positionally (one of the argv entries).
+    if grep -qFx "postgresql://stub@localhost:0/x" "$stub_dir/psql.argv"; then
+        pass "psql received DATABASE_URL positionally"
+    else
+        fail "psql received DATABASE_URL" "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+    rm -f "$err"
+}
+run_stubbed_success
+
+# ── AC2: stubbed psql DB error → exit 0 (best-effort) ────────────────────────
+
+run_stubbed_db_error() {
+    local stub_dir rc err
+    stub_dir=$(make_psql_stub)
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    echo 2 > "$stub_dir/psql.exit_code"
+
+    PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \
+        "$HELPER" "agent-uuid-1" "ralph" "iter 3" 2>"$err"
+    rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "DB error (psql exit 2) → script exit 0"
+    else
+        fail "DB error → script exit 0" "got exit code $rc; stderr: $(cat "$err")"
+    fi
+
+    if grep -q "psql failed (swallowed)" "$err"; then
+        pass "DB error logs swallowed-failure note to stderr"
+    else
+        fail "DB error logs swallowed-failure note" "stderr was: $(cat "$err")"
+    fi
+    rm -f "$err"
+}
+run_stubbed_db_error
+
+# ── AC3 & AC4: SQL injection input is passed via -v, not spliced into SQL ─────
+#
+# The malicious milestone string `'; DROP TABLE dispatcher.agents; --` must
+# appear verbatim in the argv as `milestone=…` AND must NOT appear inside
+# the SQL body sent on stdin. (The SQL body uses `:'milestone'` — a psql
+# substitution token — not the literal value.)
+
+run_injection_safe() {
+    local stub_dir rc err evil
+    stub_dir=$(make_psql_stub)
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    echo 0 > "$stub_dir/psql.exit_code"
+
+    evil="'; DROP TABLE dispatcher.agents; --"
+
+    PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \
+        "$HELPER" "agent-uuid-1" "$evil" "still here" 2>"$err"
+    rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "injection input → exit 0"
+    else
+        fail "injection input → exit 0" "got exit code $rc; stderr: $(cat "$err")"
+    fi
+
+    # The full payload (after `milestone=`) must appear in argv unaltered.
+    if grep -qFx "milestone=$evil" "$stub_dir/psql.argv"; then
+        pass "injection payload passed verbatim via -v milestone="
+    else
+        fail "injection payload passed verbatim via -v milestone=" \
+             "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+
+    # The SQL body sent on stdin must NOT contain a literal `DROP TABLE`
+    # — the helper must use the `:'milestone'` placeholder token instead.
+    if grep -q "DROP TABLE" "$stub_dir/psql.stdin"; then
+        fail "SQL body free of injected DROP TABLE" \
+             "stdin SQL was: $(cat "$stub_dir/psql.stdin")"
+    else
+        pass "SQL body free of injected DROP TABLE"
+    fi
+
+    # The SQL body MUST use the :'milestone' placeholder.
+    if grep -q ":'milestone'" "$stub_dir/psql.stdin"; then
+        pass "SQL body uses :'milestone' placeholder"
+    else
+        fail "SQL body uses :'milestone' placeholder" \
+             "stdin SQL was: $(cat "$stub_dir/psql.stdin")"
+    fi
+    if grep -q ":'agent_id'" "$stub_dir/psql.stdin"; then
+        pass "SQL body uses :'agent_id' placeholder"
+    else
+        fail "SQL body uses :'agent_id' placeholder" \
+             "stdin SQL was: $(cat "$stub_dir/psql.stdin")"
+    fi
+    if grep -q ":'detail'" "$stub_dir/psql.stdin"; then
+        pass "SQL body uses :'detail' placeholder"
+    else
+        fail "SQL body uses :'detail' placeholder" \
+             "stdin SQL was: $(cat "$stub_dir/psql.stdin")"
+    fi
+
+    rm -f "$err"
+}
+run_injection_safe
+
+# ── AC2: detail is optional ──────────────────────────────────────────────────
+
+run_optional_detail() {
+    local stub_dir rc err
+    stub_dir=$(make_psql_stub)
+    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    echo 0 > "$stub_dir/psql.exit_code"
+
+    PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \
+        "$HELPER" "agent-uuid-1" "ralph" 2>"$err"
+    rc=$?
+
+    if [[ $rc -eq 0 ]]; then
+        pass "detail omitted → exit 0"
+    else
+        fail "detail omitted → exit 0" "got exit code $rc; stderr: $(cat "$err")"
+    fi
+
+    # detail should be an empty string in argv.
+    if grep -qFx "detail=" "$stub_dir/psql.argv"; then
+        pass "detail omitted → -v detail= (empty value)"
+    else
+        fail "detail omitted → -v detail=" \
+             "argv was: $(cat "$stub_dir/psql.argv")"
+    fi
+    rm -f "$err"
+}
+run_optional_detail
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo
+echo "Tests: $TESTS, Failures: $FAILURES"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/dispatcher/progress.sh` — the best-effort milestone helper that `/task` will call at each natural step (planning, ralph, summary, push_and_pr, awaiting_ci, fix_ci, merge, awaiting_deploy, verify, retro, …) so the dispatcher-v3 cockpit can show "where is this agent right now" without a phase state machine. Per `docs/specs/dispatcher-v3-spec.md` §4.3.

The helper does ONE `UPDATE dispatcher.agents` against the milestone columns landed by A1 (#3893) and returns 0 unconditionally — every error path falls through to `exit 0`, so a transient DB blip never blocks `/task`. SQL-injection-safe via `psql -v name=value` + `:'name'` substitution, with `psql -f -` (stdin) so the substitution actually runs (it's a no-op on `-c` strings).

Wiring `/task` SKILL.md to actually call this helper is intentionally out of scope here per the issue body — that lands later via the /task SKILL evolution in dispatcher-v3 B1.

Closes #3884

## Test plan

### Automated checks
- [ ] Lint passes (shellcheck clean)
- [ ] Format check passes
- [ ] Tests pass (`scripts/dispatcher/tests/test_progress_sh.sh` — 29 assertions, stub-based, auto-discovered by the existing `TESTS_DIR=scripts/dispatcher/tests scripts/run-scripts-tests.sh` CI job)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (helper script lives in `scripts/`, baked into the agent-runner / v3 images on the next deploy of those images; the helper is not invoked by anything in this PR — `/task` SKILL wiring is a separate downstream change). Verified end-to-end against a local Postgres before push: a real UPDATE landed, and the SQL-injection probe (`milestone="'; DROP TABLE dispatcher.agents; --"`) left the table intact and stored the payload as literal text. See the issue's process-summary comment for evidence.
