### PR TITLE
feat(dx): add check-no-nonascii-tf-descriptions to pre-push hook (#3923)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -434,6 +434,22 @@ while read -r local_ref local_sha remote_ref remote_sha; do
             echo "  WARNING: terraform not found — skipping fmt check" >&2
         fi
 
+        # Non-ASCII byte check: AWS rejects non-ASCII chars in description
+        # fields at apply time (terraform plan/validate do not catch it).
+        # See issue #3321 for the em-dash incident that broke three apply runs.
+        echo "pre-push: checking for non-ASCII bytes in Terraform description fields..." >&2
+        if [ -x scripts/check-no-nonascii-tf-descriptions.sh ]; then
+            if ! run_check "terraform" "check-no-nonascii-tf-descriptions" scripts/check-no-nonascii-tf-descriptions.sh; then
+                echo "  A Terraform description field contains a non-ASCII byte." >&2
+                echo "  AWS rejects these at apply time. Replace with 7-bit ASCII." >&2
+                echo "  Common offender: em-dash U+2014 -- use '--' or '-' instead." >&2
+                echo "  See issue #3321 for background." >&2
+                failures=$((failures + 1))
+            fi
+        else
+            echo "  WARNING: scripts/check-no-nonascii-tf-descriptions.sh not found or not executable — skipping" >&2
+        fi
+
         # Empty-resource risk check: IAM resources with compact([var.*])
         # Resource lists that lack a count/for_each guard (#2739).
         echo "pre-push: checking for unguarded compact([var.*]) Resource lists..." >&2

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -31,6 +31,7 @@
 #  11. run_check helper surfaces ruff error tail + Full log path (#2973 AC1)
 #  12. Migration-only push skips TS lint  no 'checking TypeScript package' (#2877 AC1)
 #  13. Real TS change still fires lint    'checking TypeScript package' present (#2877 AC2)
+#  18. Non-ASCII tf description rejected  em-dash in description -> hook fails (#3923)
 #
 # Run:
 #   scripts/tests/test_pre_push.sh
@@ -854,6 +855,44 @@ PY
         fi
     else
         report_pass "annotated daemon.py SQL site passes pre-push hook (#3818)"
+    fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 18: Non-ASCII tf description rejected by pre-push hook (#3923)
+# ───────────────────────────────────────────────────────────────────────
+# Seeds infra/terraform/bad.tf with a description containing an em-dash
+# (U+2014), copies the real check script into the scratch repo (mirrors the
+# markdown-links scenario 5 pattern), and asserts the hook exits non-zero
+# with the expected FAILED message.
+echo "[scenario 18] non-ASCII tf description (em-dash) — hook rejects push (#3923)"
+init_workspace
+
+NONASCII_TF_SH="$REPO_ROOT/scripts/check-no-nonascii-tf-descriptions.sh"
+if [ ! -x "$NONASCII_TF_SH" ]; then
+    report_skip "scripts/check-no-nonascii-tf-descriptions.sh unavailable — cannot exercise"
+else
+    git -C "$WORK" checkout --quiet -b feature-nonascii-tf
+    mkdir -p "$WORK/infra/terraform" "$WORK/scripts"
+    cp "$NONASCII_TF_SH" "$WORK/scripts/check-no-nonascii-tf-descriptions.sh"
+    chmod +x "$WORK/scripts/check-no-nonascii-tf-descriptions.sh"
+    # Write a .tf file with an em-dash (U+2014) in the description field.
+    # Use printf to embed the UTF-8 encoding of U+2014 (0xE2 0x80 0x94)
+    # without relying on the editor or locale interpretation.
+    printf 'resource "aws_security_group" "bad" {\n  description = "Allows inbound traffic \xe2\x80\x94 see docs"\n}\n' \
+        > "$WORK/infra/terraform/bad.tf"
+    git -C "$WORK" add infra/terraform/bad.tf scripts/check-no-nonascii-tf-descriptions.sh
+    git -C "$WORK" commit --quiet -m "infra: add tf with em-dash description"
+    feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+    run_hook "refs/heads/feature-nonascii-tf $feat_sha refs/heads/feature-nonascii-tf $ZERO_SHA"
+
+    if [ "$hook_rc" -eq 0 ]; then
+        report_fail "expected hook to reject em-dash tf description (#3923), exit was 0" "$hook_out"
+    elif ! echo "$hook_out" | grep -q "FAILED: check-no-nonascii-tf-descriptions for terraform"; then
+        report_fail "expected 'FAILED: check-no-nonascii-tf-descriptions for terraform' in output (#3923)" "$hook_out"
+    else
+        report_pass "hook rejects push with non-ASCII Terraform description field (#3923)"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Wire the existing AWS-description-encoding check from the CI workflow into the pre-push hook so developers catch non-ASCII bytes (em-dashes, smart quotes, section signs) in Terraform description fields at push time, not after a full CI run. The check runs inside the existing `changed_terraform=true` gate and mirrors the pattern of other terraform checks in the hook.

Closes #3923

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (agent tooling / pre-push hook)