### PR TITLE
feat(dispatcher): skip dispatcher/v3-only issues in v2 claim step (#3877)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -821,6 +821,18 @@ ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review")
 #: atomic interlock; the label is human + queue-scan visible.
 STATUS_IN_PROGRESS_LABEL = "status/in-progress"
 
+#: Label that forces v2's claim step to skip an issue, leaving it for
+#: dispatcher-v3 to pick up (issue #3877; see
+#: ``docs/specs/dispatcher-v3-spec.md`` §8.2 item 3). Operators add this
+#: label to a trusted issue during v3's cap=1 smoke / ramp so v2 cannot
+#: race v3 to claim it. Without this filter, v2 would claim the smoke
+#: issue first and v3 would never get a chance to exercise the path the
+#: operator was trying to verify. v3 has no equivalent label today —
+#: v3 claims any ``agent/ready`` issue not already in v2's hands; if
+#: bounding v3 claims becomes useful during ramp, a symmetric
+#: ``dispatcher/v2-only`` filter can be added on the v3 side.
+DISPATCHER_V3_ONLY_LABEL = "dispatcher/v3-only"
+
 #: ``dispatcher.agents.kind`` value used by the ``/task`` skill's claim
 #: rows (issue #2866). Distinct from the daemon's default ``'task'``
 #: value so :meth:`_atomic_claim`'s UniqueViolation handler can emit a
@@ -4145,9 +4157,12 @@ class DispatcherDaemon:
         Returns a list of issue dicts as parsed from ``gh``'s JSON output.
         Each dict has at minimum ``number``, ``title``, ``labels``,
         ``createdAt``. Filters out issues that also carry
-        ``status/blocked`` (defensive — the label-filter flag on ``gh``
-        already excludes them in practice, but a label name change on
-        the server side should not silently inflate the queue count).
+        ``status/blocked``, ``status/in-progress``, ``status/needs-human``,
+        or ``dispatcher/v3-only`` (defensive — the label-filter flag on
+        ``gh`` already excludes ``status/blocked`` in practice, but a
+        label name change on the server side should not silently
+        inflate the queue count, and the other three are not on the
+        ``--label`` flag at all).
 
         Raises :class:`RuntimeError` on subprocess failure so the caller
         (``_scan_queue_and_snapshot``) can log + return -1 for the tick.
@@ -4210,23 +4225,30 @@ class DispatcherDaemon:
             )
 
         # Defensive filter: drop rows that also carry ``status/blocked``,
-        # ``status/in-progress``, or ``status/needs-human``. The
-        # ``gh --label agent/ready`` call returns issues that carry the
-        # label; a blocked, in-progress, or human-flagged issue that
-        # still has ``agent/ready`` attached (e.g. mid-transition or
-        # mid-escalation) should not inflate the queue depth because
-        # the daemon would never spawn on it. ``status/in-progress`` is
-        # the /task-skill↔daemon interlock signal — after #2927 the
-        # /task subagent uses label-only coordination (add
-        # ``status/in-progress`` BEFORE removing ``agent/ready``), so
-        # the label here is the sole race-defense primitive. The
-        # daemon's pre-claim recheck in ``_atomic_claim`` re-reads the
-        # label set at claim time to close the ~100ms propagation race.
+        # ``status/in-progress``, ``status/needs-human``, or
+        # ``dispatcher/v3-only``. The ``gh --label agent/ready`` call
+        # returns issues that carry the label; a blocked, in-progress,
+        # human-flagged, or v3-only issue that still has ``agent/ready``
+        # attached (e.g. mid-transition or operator-routed) should not
+        # inflate the queue depth because the daemon would never spawn
+        # on it. ``status/in-progress`` is the /task-skill↔daemon
+        # interlock signal — after #2927 the /task subagent uses
+        # label-only coordination (add ``status/in-progress`` BEFORE
+        # removing ``agent/ready``), so the label here is the sole
+        # race-defense primitive. The daemon's pre-claim recheck in
+        # ``_atomic_claim`` re-reads the label set at claim time to
+        # close the ~100ms propagation race.
         # ``status/needs-human`` is the diagnoser's escalation signal
         # (see ``_diagnose_and_escalate``); without this consumer-side
         # filter the daemon would re-claim a needs-human issue every
         # tick and waste a full agent run before reaching
         # ``push_and_pr_no_unmerged_files`` (#3825).
+        # ``dispatcher/v3-only`` is the operator's force-route signal
+        # for dispatcher-v3 cap=1 smoke / ramp (issue #3877;
+        # ``docs/specs/dispatcher-v3-spec.md`` §8.2 item 3). Without
+        # this filter v2 would claim the smoke issue and v3 would
+        # never see it; v3 has no equivalent claim filter today and
+        # claims any ``agent/ready`` issue not already in v2's hands.
         filtered: list[dict[str, Any]] = []
         for issue in issues:
             if not isinstance(issue, dict):
@@ -4240,6 +4262,8 @@ class DispatcherDaemon:
             if STATUS_IN_PROGRESS_LABEL in label_names:
                 continue
             if "status/needs-human" in label_names:
+                continue
+            if DISPATCHER_V3_ONLY_LABEL in label_names:
                 continue
             filtered.append(issue)
         return filtered
@@ -5542,6 +5566,11 @@ class DispatcherDaemon:
                 "source/dispatcher-audit",
                 "FBCA04",
                 "Filed by /dispatcher-audit periodic operational-health check",
+            ),
+            (
+                DISPATCHER_V3_ONLY_LABEL,
+                "FBCA04",
+                "Force-route this issue to dispatcher v3 only (v2 skips)",
             ),
         ]
         attempted = 0

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -3848,6 +3848,77 @@ class TestQueueScanExcludesNeedsHumanLabel:
         assert [i["number"] for i in issues] == [1, 3]
 
 
+class TestQueueScanExcludesDispatcherV3OnlyLabel:
+    """``_fetch_agent_ready_issues`` filters out ``dispatcher/v3-only`` (#3877).
+
+    During dispatcher-v3 cap=1 smoke / ramp, operators add
+    ``dispatcher/v3-only`` to specific issues so v3 (and only v3)
+    claims them. Without this consumer-side filter, v2's queue scan
+    would happily return the issue, the dispatcher would atomically
+    claim it before v3's launcher saw it, and the operator's
+    force-route never happens. The fix mirrors the existing
+    ``status/in-progress`` / ``status/needs-human`` filters: one
+    literal-string check inside the same loop.
+
+    See ``docs/specs/dispatcher-v3-spec.md`` §8.2 item 3.
+    """
+
+    def test_v3_only_label_excludes_issue_from_candidate_list(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Issues carrying ``dispatcher/v3-only`` alongside ``agent/ready`` drop.
+
+        The operator-side write is the producer; this filter is the
+        consumer side. Without it, v2 races v3 to claim the smoke
+        issue and the force-route the operator wanted never happens.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok",
+                    },
+                    {
+                        "number": 2,
+                        "labels": [
+                            {"name": "agent/ready"},
+                            {"name": daemon.DISPATCHER_V3_ONLY_LABEL},
+                        ],
+                        "title": "v3-only smoke",
+                    },
+                    {
+                        "number": 3,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok2",
+                    },
+                ]
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        issues = d._fetch_agent_ready_issues()
+        # #2 drops; #1 + #3 remain.
+        assert [i["number"] for i in issues] == [1, 3]
+
+    def test_dispatcher_v3_only_label_constant_value(self) -> None:
+        """The constant matches the literal string the spec + label require.
+
+        This pins the literal so a rename in code without an
+        accompanying GitHub label rename + spec edit can't slip
+        through silently. The label name appears in
+        ``docs/specs/dispatcher-v3-spec.md`` §8.2 and is created by
+        ``ensure_required_labels`` at boot.
+        """
+        assert daemon.DISPATCHER_V3_ONLY_LABEL == "dispatcher/v3-only"
+
+
 class TestGhIssueRemoveLabelsHelper:
     """Thin helper tests for :meth:`_gh_issue_remove_labels` (#2866)."""
 

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -1191,6 +1191,10 @@ class TestEnsureRequiredLabels:
         assert attempted >= 1
         # status/needs-human is in the essential set.
         assert any("status/needs-human" in c for c in calls)
+        # dispatcher/v3-only is in the essential set (#3877). The v2
+        # daemon creates this label on boot so operators can add it to
+        # smoke-route issues without first running ``gh label create``.
+        assert any(daemon.DISPATCHER_V3_ONLY_LABEL in c for c in calls)
         # --force is passed so re-runs are idempotent (gh 'create' is
         # otherwise non-idempotent — it errors on an existing label).
         assert any("--force" in c for c in calls)


### PR DESCRIPTION
## Summary

Add the optional `dispatcher/v3-only` skip filter described in `docs/specs/dispatcher-v3-spec.md` §8.2 item 3. v2's queue-scan claim step (`_fetch_agent_ready_issues` in `scripts/dispatcher/daemon.py`) now drops any `agent/ready` issue that also carries `dispatcher/v3-only`, leaving it for dispatcher-v3 to claim during cap=1 smoke / ramp.

Mirrors the existing `status/in-progress` (#2866) and `status/needs-human` (#3825) filters: one literal-string label check inside the same loop. The label is also added to the daemon's `ensure_required_labels` boot-time set so v2 idempotently re-creates it on every restart; it was also created manually via `gh label create` so the AC verification holds even before the next dispatcher restart.

Closes #3877

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] After v2 dispatcher redeploys, observe a CloudWatch log line confirming `ensure_required_labels` ran and `dispatcher/v3-only` was attempted (idempotent re-creation) — OR — confirm the label remains present in the repo with the expected color/description.
- [ ] Verification evidence posted on issue #3877 (see A.8).
