### PR TITLE
fix(scraping): map generic motion event types to canonical values

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -88,6 +88,13 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     ),
     (
         re.compile(
+            r"\b(?:certify|decertify)(?:\s*/\s*(?:certify|decertify))?\s+class\s+action\b",
+            re.IGNORECASE,
+        ),
+        "motion_for_class_certification",
+    ),
+    (
+        re.compile(
             r"\bclass\s+action\s+settlement\b|\bpreliminary\s+approval\b",
             re.IGNORECASE,
         ),
@@ -554,6 +561,14 @@ _MOTION_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         "other",
+    ),
+    (
+        re.compile(r"\bdiscovery\s+hearing\b", re.IGNORECASE),
+        "discovery",
+    ),
+    (
+        re.compile(r"\bmotion\s+hearing\b", re.IGNORECASE),
+        "motion_hearing_generic",
     ),
 ]
 

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -1129,11 +1129,17 @@ class TestNormalizeMotionType:
     def test_already_normalized_ex_parte(self) -> None:
         assert normalize_motion_type("ex_parte_application") == "ex_parte_application"
 
+    def test_already_normalized_motion_hearing_generic(self) -> None:
+        assert normalize_motion_type("motion_hearing_generic") == "motion_hearing_generic"
+
+    def test_already_normalized_discovery(self) -> None:
+        assert normalize_motion_type("discovery") == "discovery"
+
     # --- SD calendar event types ---
 
     def test_sd_calendar_motion_hearing(self) -> None:
-        """Generic 'Motion Hearing' cannot be mapped — return None."""
-        assert normalize_motion_type("Motion Hearing") is None
+        """Generic 'Motion Hearing' maps to motion_hearing_generic."""
+        assert normalize_motion_type("Motion Hearing") == "motion_hearing_generic"
 
     def test_sd_calendar_demurrer_motion_to_strike(self) -> None:
         """Composite 'Demurrer/Motion to Strike' matches demurrer first."""
@@ -1143,8 +1149,8 @@ class TestNormalizeMotionType:
         assert normalize_motion_type("Summary Judgment/Summary Adjudication") == "msj_partial"
 
     def test_sd_calendar_discovery_hearing(self) -> None:
-        """Generic 'Discovery Hearing' cannot be mapped — return None."""
-        assert normalize_motion_type("Discovery Hearing") is None
+        """Generic 'Discovery Hearing' maps to discovery."""
+        assert normalize_motion_type("Discovery Hearing") == "discovery"
 
     def test_sd_calendar_motion_to_quash(self) -> None:
         assert normalize_motion_type("Motion to Quash") == "motion_to_quash"
@@ -1153,8 +1159,11 @@ class TestNormalizeMotionType:
         assert normalize_motion_type("Motion for Sanctions") == "motion_for_sanctions"
 
     def test_sd_calendar_class_action(self) -> None:
-        """Generic class action certify/decertify cannot be mapped."""
-        assert normalize_motion_type("Motion Hearing to Certify/Decertify Class Action") is None
+        """Class action certify/decertify maps to motion_for_class_certification."""
+        assert (
+            normalize_motion_type("Motion Hearing to Certify/Decertify Class Action")
+            == "motion_for_class_certification"
+        )
 
     # --- SD tentatives title-case values ---
 
@@ -1511,6 +1520,9 @@ _SD_CALENDAR_SAMPLES: list[tuple[str, str]] = [
     ("Demurrer/Motion to Strike", "demurrer"),
     ("Motion to Quash", "motion_to_quash"),
     ("Motion for Sanctions", "motion_for_sanctions"),
+    ("Motion Hearing", "motion_hearing_generic"),
+    ("Discovery Hearing", "discovery"),
+    ("Motion Hearing to Certify/Decertify Class Action", "motion_for_class_certification"),
 ]
 
 # -- SD Tentatives (from parse_motion_type in sc_tentatives.py) ---------------


### PR DESCRIPTION
## Summary

Add fallback normalization in `normalize_motion_type()` for three previously-unmapped generic motion event types from SD calendar. This prevents NULL `motion_type` in `derived.rulings` for calendar-sourced rows where the splitter confirmed the event is motion-related. Maps "Motion Hearing" → `motion_hearing_generic`, "Discovery Hearing" → `discovery`, and "Motion Hearing to Certify/Decertify Class Action" → `motion_for_class_certification`.

Closes #2597

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — all 560 tests pass)
- [x] CI green

### Post-deploy verification

- [ ] Run: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.rulings r JOIN derived.courts ct ON r.court_id = ct.id WHERE ct.county = 'San Diego' AND r.motion_type IS NULL AND r.ruling_text ILIKE '%Event Type: Motion Hearing%'"` returns 0
- [ ] Verification evidence posted on #2597 (see /task-v2-verify output)