### PR TITLE
feat(scraping): parallelize run_scrapers with env-driven knob (#3642)

### DIFF
--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 import json
 import os
 import sys
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -413,6 +415,122 @@ def get_scraper_ids() -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Runner helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_one_scraper(
+    entry: tuple[str, type, Any],
+    *,
+    bucket: str,
+    archiver: Any,
+    event_bus: Any,
+    court_id_cache: dict[tuple[str, str], str | None],
+    court_id_cache_lock: threading.Lock,
+    dept_judge_maps: dict[str, dict[str, str]],
+    db_conn_factory: Any,
+    owns_conn: bool,
+) -> tuple[str, bool]:
+    """Run a single scraper entry and return ``(scraper_id, had_failure)``.
+
+    *db_conn_factory* is a callable that returns a DB connection (or None).
+    In sequential mode it returns the shared top-level connection and
+    *owns_conn* is False (the caller manages the connection lifecycle).
+    In parallel mode it calls ``_connect_db`` and *owns_conn* is True,
+    so this function closes the connection in a ``finally`` block.
+    """
+    scraper_id, scraper_cls, config_factory = entry
+    log = logger.bind(scraper_id=scraper_id)
+    log.info("Running scraper")
+
+    config: ScraperConfig = config_factory(s3_bucket=bucket)
+
+    extra_kwargs: dict[str, object] = {}
+    if scraper_id in dept_judge_maps and dept_judge_maps[scraper_id]:
+        extra_kwargs["dept_judge_map"] = dept_judge_maps[scraper_id]
+
+    db_conn = db_conn_factory()
+
+    run_started_at = datetime.now(UTC)
+    run_start = time.monotonic()
+    try:
+        try:
+            scraper = scraper_cls(
+                config=config,
+                archiver=archiver,
+                event_bus=event_bus,
+                db_conn=db_conn,
+                **extra_kwargs,
+            )
+        except Exception as exc:
+            log.error("Scraper construction failed", error=str(exc))
+            if db_conn:
+                with court_id_cache_lock:
+                    cache_snapshot = dict(court_id_cache)
+                record_scraper_exception(
+                    db_conn,
+                    scraper_id,
+                    config,
+                    run_started_at,
+                    str(exc),
+                    time.monotonic() - run_start,
+                    cache_snapshot,
+                )
+                with court_id_cache_lock:
+                    court_id_cache.update(cache_snapshot)
+            return scraper_id, True
+
+        try:
+            health = scraper.run()
+        except Exception as exc:
+            log.error("Unhandled exception in scraper", error=str(exc))
+            elapsed = time.monotonic() - run_start
+            if db_conn:
+                with court_id_cache_lock:
+                    cache_snapshot = dict(court_id_cache)
+                record_scraper_exception(
+                    db_conn,
+                    scraper_id,
+                    config,
+                    run_started_at,
+                    str(exc),
+                    elapsed,
+                    cache_snapshot,
+                )
+                with court_id_cache_lock:
+                    court_id_cache.update(cache_snapshot)
+            return scraper_id, True
+
+        if db_conn:
+            with court_id_cache_lock:
+                cache_snapshot = dict(court_id_cache)
+            record_scraper_run(db_conn, health, config, cache_snapshot)
+            with court_id_cache_lock:
+                court_id_cache.update(cache_snapshot)
+
+        if health.success:
+            log.info(
+                "Scraper completed",
+                records=health.records_captured,
+                time_seconds=round(health.response_time_seconds, 2),
+            )
+            return scraper_id, False
+        else:
+            log.error(
+                "Scraper reported failure",
+                error=health.error_message,
+                records=health.records_captured,
+            )
+            return scraper_id, True
+    finally:
+        if owns_conn and db_conn:
+            try:
+                db_conn.close()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -567,83 +685,69 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
                     error=str(exc),
                 )
 
-        for scraper_id, scraper_cls, config_factory in entries:
-            log = logger.bind(scraper_id=scraper_id)
-            log.info("Running scraper")
+        # Build a per-scraper-id dept-judge map dict for _run_one_scraper.
+        dept_judge_maps: dict[str, dict[str, str]] = {}
+        for sid in la_scraper_ids:
+            dept_judge_maps[sid] = la_dept_judge_map
+        for sid in riv_scraper_ids:
+            dept_judge_maps[sid] = riv_dept_judge_map
+        for sid in ventura_scraper_ids:
+            dept_judge_maps[sid] = ventura_dept_judge_map
+        for sid in sf_civil_scraper_ids:
+            dept_judge_maps[sid] = sf_dept_judge_map
 
-            config: ScraperConfig = config_factory(s3_bucket=bucket)
+        court_id_cache_lock = threading.Lock()
 
-            # Pass dept-judge mapping to LA, Riverside, Ventura, and SF scrapers
-            extra_kwargs: dict[str, object] = {}
-            if scraper_id in la_scraper_ids and la_dept_judge_map:
-                extra_kwargs["dept_judge_map"] = la_dept_judge_map
-            if scraper_id in riv_scraper_ids and riv_dept_judge_map:
-                extra_kwargs["dept_judge_map"] = riv_dept_judge_map
-            if scraper_id in ventura_scraper_ids and ventura_dept_judge_map:
-                extra_kwargs["dept_judge_map"] = ventura_dept_judge_map
-            if scraper_id in sf_civil_scraper_ids and sf_dept_judge_map:
-                extra_kwargs["dept_judge_map"] = sf_dept_judge_map
+        # Determine parallelism level from env var (default 1 = sequential).
+        max_workers = int(os.environ.get("SCRAPER_RUNNER_PARALLEL", "1"))
 
-            run_started_at = datetime.now(UTC)
-            run_start = time.monotonic()
-
-            try:
-                scraper = scraper_cls(
-                    config=config,
+        if max_workers <= 1:
+            # Sequential path — preserves existing behaviour exactly.
+            for entry in entries:
+                _, entry_had_failure = _run_one_scraper(
+                    entry,
+                    bucket=bucket,
                     archiver=archiver,
                     event_bus=event_bus,
-                    db_conn=db_conn,
-                    **extra_kwargs,
+                    court_id_cache=court_id_cache,
+                    court_id_cache_lock=court_id_cache_lock,
+                    dept_judge_maps=dept_judge_maps,
+                    db_conn_factory=lambda: db_conn,
+                    owns_conn=False,
                 )
-            except Exception as exc:
-                log.error("Scraper construction failed", error=str(exc))
-                if db_conn:
-                    record_scraper_exception(
-                        db_conn,
-                        scraper_id,
-                        config,
-                        run_started_at,
-                        str(exc),
-                        time.monotonic() - run_start,
-                        court_id_cache,
-                    )
-                had_failure = True
-                continue
-
-            try:
-                health = scraper.run()
-            except Exception as exc:
-                log.error("Unhandled exception in scraper", error=str(exc))
-                elapsed = time.monotonic() - run_start
-                if db_conn:
-                    record_scraper_exception(
-                        db_conn,
-                        scraper_id,
-                        config,
-                        run_started_at,
-                        str(exc),
-                        elapsed,
-                        court_id_cache,
-                    )
-                had_failure = True
-                continue
-
-            if db_conn:
-                record_scraper_run(db_conn, health, config, court_id_cache)
-
-            if health.success:
-                log.info(
-                    "Scraper completed",
-                    records=health.records_captured,
-                    time_seconds=round(health.response_time_seconds, 2),
-                )
-            else:
-                log.error(
-                    "Scraper reported failure",
-                    error=health.error_message,
-                    records=health.records_captured,
-                )
-                had_failure = True
+                if entry_had_failure:
+                    had_failure = True
+        else:
+            # Parallel path — each thread opens and closes its own DB connection.
+            effective_workers = min(max_workers, len(entries)) if entries else 1
+            with ThreadPoolExecutor(max_workers=effective_workers) as pool:
+                futures = {
+                    pool.submit(
+                        _run_one_scraper,
+                        entry,
+                        bucket=bucket,
+                        archiver=archiver,
+                        event_bus=event_bus,
+                        court_id_cache=court_id_cache,
+                        court_id_cache_lock=court_id_cache_lock,
+                        dept_judge_maps=dept_judge_maps,
+                        db_conn_factory=_connect_db,
+                        owns_conn=True,
+                    ): entry[0]
+                    for entry in entries
+                }
+                for future in as_completed(futures):
+                    try:
+                        _, entry_had_failure = future.result()
+                    except Exception as exc:
+                        logger.error(
+                            "Unexpected error in parallel scraper task",
+                            scraper_id=futures[future],
+                            error=str(exc),
+                        )
+                        entry_had_failure = True
+                    if entry_had_failure:
+                        had_failure = True
     finally:
         if db_conn:
             try:

--- a/packages/scraper-framework/tests/test_runner.py
+++ b/packages/scraper-framework/tests/test_runner.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
+import time
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1199,3 +1202,236 @@ class TestRunScrapersDbRecording:
 
         assert exit_code == 1
         mock_conn.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Parallel runner tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunScrapersParallel:
+    """Tests for SCRAPER_RUNNER_PARALLEL env var — parallel execution path."""
+
+    def test_default_is_sequential(self) -> None:
+        """With no SCRAPER_RUNNER_PARALLEL set, ThreadPoolExecutor must not be used."""
+        entries = [("test-stub", StubScraper, _stub_config)]
+
+        env = os.environ.copy()
+        env.pop("SCRAPER_RUNNER_PARALLEL", None)
+
+        with (
+            _patch_registry(entries),
+            patch.dict(os.environ, env, clear=True),
+            patch("framework.runner.ThreadPoolExecutor") as mock_tpe,
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 0
+        mock_tpe.assert_not_called()
+
+    def test_parallel_max_workers_one_takes_sequential_path(self) -> None:
+        """SCRAPER_RUNNER_PARALLEL=1 must behave identically to the default (no TPE)."""
+        entries = [("test-stub", StubScraper, _stub_config)]
+
+        with (
+            _patch_registry(entries),
+            patch.dict(os.environ, {"SCRAPER_RUNNER_PARALLEL": "1"}),
+            patch("framework.runner.ThreadPoolExecutor") as mock_tpe,
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 0
+        mock_tpe.assert_not_called()
+
+    def test_parallel_runs_concurrently(self) -> None:
+        """SCRAPER_RUNNER_PARALLEL=4 with 4 scrapers should run them concurrently.
+
+        Each scraper blocks on a barrier until all 4 have entered fetch_documents,
+        proving that all 4 are executing in parallel and not sequentially.
+        The wall time must be significantly less than 4× a single scraper's sleep.
+        """
+        barrier = threading.Barrier(4, timeout=10)
+        thread_ids: list[int] = []
+        lock = threading.Lock()
+
+        class BarrierScraper(BaseScraper):
+            def fetch_documents(self) -> list[CapturedDocument]:
+                with lock:
+                    thread_ids.append(threading.get_ident())
+                # Wait until all 4 scrapers have entered — proves concurrency
+                barrier.wait()
+                time.sleep(0.05)
+                return []
+
+            def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+                return doc
+
+        def make_config(scraper_id: str) -> Any:
+            def config_factory(s3_bucket: str = "") -> ScraperConfig:
+                return ScraperConfig(
+                    scraper_id=scraper_id,
+                    state="CA",
+                    county="Test",
+                    court="Superior Court",
+                    target_urls=["https://example.com"],
+                )
+
+            return config_factory
+
+        entries = [
+            (f"parallel-stub-{i}", BarrierScraper, make_config(f"parallel-stub-{i}"))
+            for i in range(4)
+        ]
+
+        start = time.monotonic()
+        with (
+            _patch_registry(entries),
+            patch.dict(os.environ, {"SCRAPER_RUNNER_PARALLEL": "4"}),
+        ):
+            exit_code = run_scrapers()
+        elapsed = time.monotonic() - start
+
+        assert exit_code == 0
+        assert len(thread_ids) == 4
+        # All 4 ran in parallel — wall time < 4 × 0.05s sleep (i.e., < 0.18s)
+        assert elapsed < 0.18, f"Expected parallel execution but elapsed={elapsed:.3f}s"
+        # All 4 scrapers ran in distinct threads
+        assert len(set(thread_ids)) == 4, "Expected 4 distinct thread IDs"
+
+    def test_parallel_db_writes_all_land(self) -> None:
+        """SCRAPER_RUNNER_PARALLEL=4 with 8 scrapers: each gets its own per-call
+        MagicMock connection; exactly 8 INSERT INTO scraper_runs calls must be
+        recorded (one per scraper, none lost).
+
+        Note: _connect_db is called once at the top of run_scrapers for the shared
+        roster connection, then once per scraper in parallel mode — so 9 total calls
+        for 8 scrapers.  Each per-scraper connection (the last 8) must be closed by
+        the helper exactly once.
+        """
+        per_conn_mocks: list[MagicMock] = []
+        conns_lock = threading.Lock()
+
+        def make_conn() -> MagicMock:
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+            mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+            with conns_lock:
+                per_conn_mocks.append(mock_conn)
+            return mock_conn
+
+        def make_config(scraper_id: str) -> Any:
+            def config_factory(s3_bucket: str = "") -> ScraperConfig:
+                return ScraperConfig(
+                    scraper_id=scraper_id,
+                    state="CA",
+                    county="Test",
+                    court="Superior Court",
+                    target_urls=["https://example.com"],
+                )
+
+            return config_factory
+
+        entries = [(f"db-stub-{i}", StubScraper, make_config(f"db-stub-{i}")) for i in range(8)]
+
+        with (
+            _patch_registry(entries),
+            patch.dict(os.environ, {"SCRAPER_RUNNER_PARALLEL": "4"}),
+            patch("framework.runner._connect_db", side_effect=make_conn),
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 0
+        # 1 top-level call + 8 per-scraper calls = 9 total
+        assert len(per_conn_mocks) == 9
+
+        # Tally INSERT INTO scraper_runs calls across all connections
+        total_inserts = 0
+        for mock_conn in per_conn_mocks:
+            mock_cursor = mock_conn.cursor.return_value.__enter__.return_value
+            for call in mock_cursor.execute.call_args_list:
+                if call[0] and "INSERT INTO scraper_runs" in str(call[0][0]):
+                    total_inserts += 1
+
+        assert total_inserts == 8, f"Expected 8 inserts, got {total_inserts}"
+
+        # Each per-scraper connection (index 1..8) must be closed by the helper.
+        # The top-level conn (index 0) is closed by run_scrapers' finally block.
+        for mock_conn in per_conn_mocks:
+            mock_conn.close.assert_called_once()
+
+    def test_parallel_failure_isolated(self) -> None:
+        """3 scrapers with SCRAPER_RUNNER_PARALLEL=3: the middle one raises an
+        exception. exit_code must be 1 AND the other two scrapers must still have
+        recorded their successful rows.
+        """
+        ran: list[str] = []
+        ran_lock = threading.Lock()
+        per_conn_mocks: list[MagicMock] = []
+        conns_lock = threading.Lock()
+
+        def make_conn() -> MagicMock:
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+            mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+            with conns_lock:
+                per_conn_mocks.append(mock_conn)
+            return mock_conn
+
+        class TrackingStub(StubScraper):
+            def fetch_documents(self) -> list[CapturedDocument]:
+                with ran_lock:
+                    ran.append(self.config.scraper_id)
+                return []
+
+        class FailingScraper2(BaseScraper):
+            def fetch_documents(self) -> list[CapturedDocument]:
+                raise RuntimeError("middle scraper explodes")
+
+            def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+                return doc
+
+        def make_config(scraper_id: str) -> Any:
+            def config_factory(s3_bucket: str = "") -> ScraperConfig:
+                return ScraperConfig(
+                    scraper_id=scraper_id,
+                    state="CA",
+                    county="Test",
+                    court="Superior Court",
+                    target_urls=["https://example.com"],
+                )
+
+            return config_factory
+
+        entries = [
+            ("iso-good-1", TrackingStub, make_config("iso-good-1")),
+            ("iso-fail", FailingScraper2, make_config("iso-fail")),
+            ("iso-good-2", TrackingStub, make_config("iso-good-2")),
+        ]
+
+        with (
+            _patch_registry(entries),
+            patch.dict(os.environ, {"SCRAPER_RUNNER_PARALLEL": "3"}),
+            patch("framework.runner._connect_db", side_effect=make_conn),
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 1, "Expected exit_code=1 due to failing scraper"
+        assert "iso-good-1" in ran, "iso-good-1 must still run"
+        assert "iso-good-2" in ran, "iso-good-2 must still run"
+
+        # Verify that good scrapers recorded successful rows
+        total_success_inserts = 0
+        for mock_conn in per_conn_mocks:
+            mock_cursor = mock_conn.cursor.return_value.__enter__.return_value
+            for call in mock_cursor.execute.call_args_list:
+                if call[0] and "INSERT INTO scraper_runs" in str(call[0][0]):
+                    params = call[0][1]
+                    if params[4] == "success":
+                        total_success_inserts += 1
+
+        assert total_success_inserts == 2, (
+            f"Expected 2 successful inserts (iso-good-1 and iso-good-2), "
+            f"got {total_success_inserts}"
+        )


### PR DESCRIPTION
## Summary

Extracted `_run_one_scraper()` helper and added `SCRAPER_RUNNER_PARALLEL` env var to enable concurrent scraper execution via `ThreadPoolExecutor`. Default remains 1 (sequential) for backward compatibility. Each thread gets its own DB connection; `court_id_cache` access is protected by `threading.Lock`.

Closes #3642

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 70 scraper-framework tests green, 5 new parallel tests added
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (code-only change; ECS env-var wiring is a separate rollout PR)