### PR TITLE
cleanup(telemetry): delete test-fixture pollution from scraper_runs (#3806)

### DIFF
--- a/packages/scraper-framework/tests/test_cleanup_test_telemetry_pollution.py
+++ b/packages/scraper-framework/tests/test_cleanup_test_telemetry_pollution.py
@@ -1,0 +1,164 @@
+"""Tests for the cleanup_test_telemetry_pollution script (#3806).
+
+All database access is mocked — these tests verify cleanup logic, logging,
+and rollback/commit behaviour without requiring a live database.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS_ONEOFF_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+    "oneoff",
+)
+sys.path.insert(0, _SCRIPTS_ONEOFF_DIR)
+cleanup = importlib.import_module("cleanup_test_telemetry_pollution")
+
+
+# ---------------------------------------------------------------------------
+# Constant assertions
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticIdSet:
+    """Verify the module-level constant matches the issue spec."""
+
+    def test_synthetic_id_set_matches_issue(self) -> None:
+        expected = {
+            "test-stub",
+            "good",
+            "failing",
+            "run-raiser",
+            "scraper-b",
+            "good-after",
+            "good-after-ctor",
+            "failing-ctor",
+            "ctor-fail-db",
+        }
+        assert set(cleanup.SYNTHETIC_SCRAPER_IDS) == expected
+        assert len(cleanup.SYNTHETIC_SCRAPER_IDS) == 9
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_conn(pre_rows: list[tuple], post_rows: list[tuple]) -> MagicMock:
+    """Build a mock psycopg connection whose cursor returns pre/post rows."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+
+    # fetchall: first call returns pre_rows, second returns post_rows
+    mock_cur.fetchall.side_effect = [pre_rows, post_rows]
+
+    mock_cur.__enter__ = MagicMock(return_value=mock_cur)
+    mock_cur.__exit__ = MagicMock(return_value=False)
+
+    mock_conn.cursor.return_value = mock_cur
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    return mock_conn
+
+
+# ---------------------------------------------------------------------------
+# Pre-count logging
+# ---------------------------------------------------------------------------
+
+
+class TestPreCountLogging:
+    """Verify pre-count rows are each logged individually."""
+
+    @patch("cleanup_test_telemetry_pollution.psycopg")
+    def test_pre_count_logs_per_id_breakdown(self, mock_psycopg: MagicMock) -> None:
+        pre_rows = [("test-stub", 100), ("good", 50)]
+        mock_conn = _make_mock_conn(pre_rows=pre_rows, post_rows=[])
+        mock_psycopg.connect.return_value = mock_conn
+
+        with patch("cleanup_test_telemetry_pollution.logger") as mock_logger:
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                cleanup.run_cleanup("postgresql://test")
+
+        # Each (id, count) pair must appear in a logger.info call
+        info_calls = [str(c) for c in mock_logger.info.call_args_list]
+        assert any("test-stub" in c and "100" in c for c in info_calls)
+        assert any("good" in c and "50" in c for c in info_calls)
+
+
+# ---------------------------------------------------------------------------
+# Happy path — post-count zero → commit
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteThenPostCountAssertion:
+    """Verify happy path: post-count zero causes commit."""
+
+    @patch("cleanup_test_telemetry_pollution.psycopg")
+    def test_delete_then_post_count_assertion(self, mock_psycopg: MagicMock) -> None:
+        pre_rows = [("test-stub", 10), ("failing", 5)]
+        mock_conn = _make_mock_conn(pre_rows=pre_rows, post_rows=[])
+        mock_psycopg.connect.return_value = mock_conn
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+            stats = cleanup.run_cleanup("postgresql://test")
+
+        assert stats["pre_total"] == 15
+        assert stats["post_total"] == 0
+        mock_conn.commit.assert_called_once()
+        mock_conn.rollback.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Defensive — post-count non-zero → raise + rollback
+# ---------------------------------------------------------------------------
+
+
+class TestPostCountNonzeroRaisesAndRollsBack:
+    """Verify that leftover rows after DELETE raise and trigger rollback."""
+
+    @patch("cleanup_test_telemetry_pollution.psycopg")
+    def test_post_count_nonzero_raises_and_rolls_back(self, mock_psycopg: MagicMock) -> None:
+        pre_rows = [("test-stub", 10)]
+        # Simulate rows still present after DELETE
+        post_rows = [("test-stub", 3)]
+        mock_conn = _make_mock_conn(pre_rows=pre_rows, post_rows=post_rows)
+        mock_psycopg.connect.return_value = mock_conn
+
+        import pytest
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+            with pytest.raises(RuntimeError, match="Post-delete count is 3"):
+                cleanup.run_cleanup("postgresql://test")
+
+        mock_conn.rollback.assert_called()
+        mock_conn.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Dry run — rollback instead of commit
+# ---------------------------------------------------------------------------
+
+
+class TestDryRun:
+    """Verify dry-run mode calls rollback and not commit."""
+
+    @patch("cleanup_test_telemetry_pollution.psycopg")
+    def test_dry_run_calls_rollback_not_commit(self, mock_psycopg: MagicMock) -> None:
+        pre_rows = [("good", 200)]
+        mock_conn = _make_mock_conn(pre_rows=pre_rows, post_rows=[])
+        mock_psycopg.connect.return_value = mock_conn
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+            stats = cleanup.run_cleanup("postgresql://test", dry_run=True)
+
+        assert stats["pre_total"] == 200
+        mock_conn.rollback.assert_called_once()
+        mock_conn.commit.assert_not_called()

--- a/scripts/oneoff/cleanup_test_telemetry_pollution.py
+++ b/scripts/oneoff/cleanup_test_telemetry_pollution.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Delete test-fixture pollution from telemetry.scraper_runs (#3806).
+
+Removes rows where scraper_id belongs to the closed set of synthetic IDs
+introduced by unit-test fixtures that leaked into the dev database before
+the _block_telemetry_db_writes guard (PR #3526) was in place.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- scripts/run-py.sh scripts/oneoff/cleanup_test_telemetry_pollution.py
+
+Options:
+    --dry-run    Log what would be deleted without writing to the database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+SYNTHETIC_SCRAPER_IDS = (
+    "test-stub",
+    "good",
+    "failing",
+    "run-raiser",
+    "scraper-b",
+    "good-after",
+    "good-after-ctor",
+    "failing-ctor",
+    "ctor-fail-db",
+)
+
+_PRE_COUNT_QUERY = """
+    SELECT scraper_id, COUNT(*) AS cnt
+    FROM telemetry.scraper_runs
+    WHERE scraper_id IN %s
+    GROUP BY scraper_id
+    ORDER BY scraper_id
+"""
+
+_DELETE_QUERY = """
+    DELETE FROM telemetry.scraper_runs
+    WHERE scraper_id IN %s
+"""
+
+_POST_COUNT_QUERY = """
+    SELECT scraper_id, COUNT(*) AS cnt
+    FROM telemetry.scraper_runs
+    WHERE scraper_id IN %s
+    GROUP BY scraper_id
+"""
+
+
+def run_cleanup(dsn: str, *, dry_run: bool = False) -> dict[str, int]:
+    """Delete synthetic-scraper rows from telemetry.scraper_runs.
+
+    Returns a dict with 'pre_total' and 'post_total'.
+    """
+    id_tuple = tuple(SYNTHETIC_SCRAPER_IDS)
+
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            # Pre-count
+            cur.execute(_PRE_COUNT_QUERY, (id_tuple,))
+            pre_rows = cur.fetchall()
+            pre_total = 0
+            for scraper_id, cnt in pre_rows:
+                logger.info("pre-count  scraper_id=%s  count=%d", scraper_id, cnt)
+                pre_total += cnt
+            logger.info("pre-count total: %d row(s) to delete", pre_total)
+
+            # Delete
+            cur.execute(_DELETE_QUERY, (id_tuple,))
+
+            # Post-count — assert zero
+            cur.execute(_POST_COUNT_QUERY, (id_tuple,))
+            post_rows = cur.fetchall()
+            post_total = 0
+            for scraper_id, cnt in post_rows:
+                post_total += cnt
+            if post_total != 0:
+                conn.rollback()
+                raise RuntimeError(
+                    f"Post-delete count is {post_total}, expected 0 — rolled back"
+                )
+
+        if dry_run:
+            conn.rollback()
+            logger.info(
+                "DRY RUN: would delete %d row(s) [rolled back]",
+                pre_total,
+            )
+        else:
+            conn.commit()
+            logger.info(
+                "Committed: deleted %d row(s), post-count confirmed zero",
+                pre_total,
+            )
+
+    return {"pre_total": pre_total, "post_total": post_total}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Delete test-fixture pollution from telemetry.scraper_runs (#3806).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log what would be deleted without writing to the database.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_cleanup(dsn, dry_run=args.dry_run)
+
+    logger.info(
+        "Cleanup complete: pre_total=%d, post_total=%d",
+        stats["pre_total"],
+        stats["post_total"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Created a one-shot cleanup script to delete 3,235 stale test-fixture rows from `telemetry.scraper_runs` that leaked during test runs before the `_block_telemetry_db_writes` fixture (PR #3526) was deployed. The script executes a parameterized DELETE against a closed 9-ID set, with pre-count logging, post-count zero assertion, and defensive rollback on failure. Includes --dry-run mode and comprehensive unit tests.

Closes #3806

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 5 test cases: constant validation, pre-count logging, happy-path commit, defensive rollback, dry-run)
- [x] CI green

### Post-deploy verification

- [ ] Execute cleanup script against dev via `scripts/ecs-run-task.sh` with DATABASE_URL=judgemind/dev/db/connection:.url; verify exit code 0 and log output shows post-count = 0
- [ ] Query dev: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM telemetry.scraper_runs WHERE scraper_id IN ('test-stub','good','failing','run-raiser','scraper-b','good-after','good-after-ctor','failing-ctor','ctor-fail-db')"` returns 0
- [ ] Smoke check real-scraper telemetry: `scripts/dev-db-query.sh "SELECT scraper_id, COUNT(*) FROM telemetry.scraper_runs WHERE started_at > NOW() - INTERVAL '7 days' GROUP BY scraper_id ORDER BY scraper_id"` returns only real scraper IDs (e.g., ca-la-tentatives, ca-oc-tentatives, …)
- [ ] Verification evidence posted on #3806 (see /task-v2-verify output)