### PR TITLE
feat(infra): add DLQ-depth alarm for dispatcher-v3 (#3956)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -1077,3 +1077,8 @@ output "dispatcher_v3_scheduled_skills_alarm_names" {
   description = "Map of skill name -> CloudWatch alarm name on `AWS/Events FailedInvocations` for the per-rule alarm. Closes adversarial-review MAJOR 7 (silent skill failures)."
   value       = module.dispatcher_v3_scheduled_skills.alarm_names
 }
+
+output "dispatcher_v3_scheduled_skills_dlq_depth_alarm_name" {
+  description = "CloudWatch alarm name for the DLQ depth secondary-signal alarm (`AWS/SQS ApproximateNumberOfMessagesVisible`). Null when alerts are disabled. Issue #3956."
+  value       = module.dispatcher_v3_scheduled_skills.dlq_depth_alarm_name
+}

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/main.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/main.tf
@@ -297,6 +297,44 @@ resource "aws_cloudwatch_metric_alarm" "eventbridge_failures" {
   }
 }
 
+# ─── CloudWatch alarm: DLQ depth (secondary signal) ─────────────────────────
+# Secondary to the FailedInvocations alarm above: the FailedInvocations metric
+# fires when EventBridge cannot invoke the ECS target (IAM error, ECS
+# unavailability). The DLQ-depth alarm fires when EventBridge successfully
+# enqueued the dead-letter but the ECS task never drained it -- a different
+# failure mode. Operators can `aws sqs receive-message` the DLQ to inspect the
+# original event payload for root-cause analysis. Also catches any future
+# producer that inadvertently writes to this DLQ. Issues #3956 / #3890.
+#
+# Single resource (not for_each) because the DLQ is shared across all four
+# rules and ApproximateNumberOfMessagesVisible is a per-queue metric, not
+# per-rule.
+
+resource "aws_cloudwatch_metric_alarm" "dlq_depth" {
+  count = var.enable_alerts && var.alert_sns_topic_arn != "" ? 1 : 0
+
+  alarm_name        = "${var.name_prefix}-scheduled-skills-dlq-depth-${var.environment}"
+  alarm_description = "One or more messages are sitting in the dispatcher-v3 scheduled-skills dead-letter queue (`judgemind-${var.name_prefix}-scheduled-skills-dlq-${var.environment}`). Inspect via `aws sqs receive-message --queue-url $(terraform output -raw dispatcher_v3_scheduled_skills_dlq_url)`. Secondary signal to the per-rule FailedInvocations alarms. Issues #3956 / #3890."
+
+  namespace   = "AWS/SQS"
+  metric_name = "ApproximateNumberOfMessagesVisible"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.dlq_depth_threshold
+  period              = var.dlq_depth_period_seconds
+  evaluation_periods  = var.dlq_depth_evaluation_periods
+  datapoints_to_alarm = var.dlq_depth_evaluation_periods
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+
+  dimensions = {
+    QueueName = aws_sqs_queue.scheduled_skills_dlq.name
+  }
+}
+
 # ─── Postcondition assertions on every rule + target ────────────────────────
 # Defense-in-depth against the silent-drop class (#2840 / #3764) for
 # the SKILL_NAME override. If a regression ever drops the override

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/outputs.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/outputs.tf
@@ -29,3 +29,8 @@ output "alarm_names" {
   description = "Map of skill name -> CloudWatch alarm name (one alarm per rule). Empty when `enable_alerts = false` or `alert_sns_topic_arn` is unset."
   value       = { for k, v in aws_cloudwatch_metric_alarm.eventbridge_failures : k => v.alarm_name }
 }
+
+output "dlq_depth_alarm_name" {
+  description = "CloudWatch alarm name for the DLQ depth secondary-signal alarm (`AWS/SQS ApproximateNumberOfMessagesVisible`). Null when `enable_alerts = false` or `alert_sns_topic_arn` is unset."
+  value       = try(aws_cloudwatch_metric_alarm.dlq_depth[0].alarm_name, null)
+}

--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
@@ -21,6 +21,7 @@
 #   * 1× aws_sqs_queue_policy       (EventBridge sendMessage)
 #   * 1× aws_iam_role + 2× policies (EventBridge -> RunTask + PassRole)
 #   * 1× aws_cloudwatch_metric_alarm (FailedInvocations across rules)
+#   * 1× aws_cloudwatch_metric_alarm (DLQ depth)
 #
 # Cohabitation with v2: v2's daemon already runs these scheduled skills
 # via its in-process scheduler. During cohabitation both can fire -- the
@@ -179,6 +180,31 @@ variable "failed_invocations_period_seconds" {
 
 variable "failed_invocations_evaluation_periods" {
   description = "Number of consecutive evaluation periods that must breach before the alarm fires. Default 1 -- any failed invocation should be visible immediately (the spec adversarial-review's MAJOR 7 explicitly calls out silent skill failures)."
+  type        = number
+  default     = 1
+}
+
+# --- DLQ depth alarm --------------------------------------------------
+
+variable "dlq_depth_threshold" {
+  description = "Threshold for the DLQ depth alarm (alarm fires when ApproximateNumberOfMessagesVisible strictly exceeds this value). Default 0 -- any message landing in the DLQ is worth alerting on."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.dlq_depth_threshold >= 0
+    error_message = "dlq_depth_threshold must be >= 0 -- ApproximateNumberOfMessagesVisible is a non-negative count metric."
+  }
+}
+
+variable "dlq_depth_period_seconds" {
+  description = "Evaluation period for the DLQ depth alarm in seconds. Default 300 (5 minutes) -- matches the FailedInvocations alarm cadence."
+  type        = number
+  default     = 300
+}
+
+variable "dlq_depth_evaluation_periods" {
+  description = "Number of consecutive evaluation periods that must breach before the DLQ depth alarm fires. Default 1 -- any DLQ depth > 0 should surface immediately."
   type        = number
   default     = 1
 }


### PR DESCRIPTION
## Summary

Added a secondary CloudWatch alarm on the dispatcher-v3 scheduled-skills dead-letter queue depth (`AWS/SQS ApproximateNumberOfMessagesVisible`). This complements the existing per-rule FailedInvocations alarms and gives operators a different debugging affordance: they can `aws sqs receive-message` to inspect original event payloads. The DLQ serves as a forensic record of events that exhausted EventBridge's 185 retries over 24h, and this alarm surfaces that accumulation immediately.

Closes #3956

## Test plan

### Automated checks

- [x] Terraform format check (`terraform fmt -check`)
- [x] Terraform validation (`terraform init -lockfile=readonly && terraform validate`)
- [x] Lint passes (no Python/TypeScript in this change)
- [x] Tests pass (no new test files; terraform module fixture at `tests/postconditions/` unchanged)
- [x] CI green (dev-apply job will run `terraform apply -auto-approve` on merge)

### Post-deploy verification

- [ ] DLQ depth alarm exists in CloudWatch with correct name and threshold (post-deploy, /task-v2-verify will run)
- [ ] Alarm fires on synthetic test message sent to DLQ (post-deploy, /task-v2-verify will run)
- [ ] Alarm publishes to the same SNS topic as FailedInvocations alarms (post-deploy, /task-v2-verify will run)
- [ ] Verification evidence posted on #3956 (see /task-v2-verify output)