### PR TITLE
fix(scraping): strip leading zeros from Orange County department codes (#3968)

### DIFF
--- a/packages/scraper-framework/src/ingestion/department_normalize.py
+++ b/packages/scraper-framework/src/ingestion/department_normalize.py
@@ -12,6 +12,8 @@ Rules by county:
 * **Riverside** — strip leading zeros from purely numeric departments.
 * **San Bernardino** — strip hyphens from letter+number codes
   (``S-17`` -> ``S17``).
+* **Orange** — strip leading zeros from letter+number codes
+  (``W08`` -> ``W8``, ``H01`` -> ``H1``).
 * All other counties — pass through unchanged (after whitespace strip).
 
 Called by the ingestion worker before DB writes so both scraper-provided
@@ -68,6 +70,15 @@ _LA_LB_COURTHOUSE_NAMES: frozenset[str] = frozenset({"long beach courthouse", "l
 # Hyphen between letter and number: "S-17" -> "S17", "R-14" -> "R14".
 _SB_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
 
+# ---------------------------------------------------------------------------
+# Orange
+# ---------------------------------------------------------------------------
+
+# Leading zeros after a letter prefix: "W08" -> "W8", "H001" -> "H1".
+# Anchored at start; replaces LETTERS+ZEROS+SIGNIFICANT_DIGIT prefix with
+# LETTERS+SIGNIFICANT_DIGIT, leaving trailing characters intact.
+_OC_LEADING_ZERO_RE = re.compile(r"^([A-Z]+)0+([1-9])")
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -114,6 +125,8 @@ def normalize_department(
         dept = _normalize_riverside(dept)
     elif county_lower == "san bernardino":
         dept = _normalize_san_bernardino(dept)
+    elif county_lower == "orange":
+        dept = _normalize_orange(dept)
 
     return dept if dept else None
 
@@ -175,3 +188,13 @@ def _normalize_san_bernardino(dept: str) -> str:
     if m:
         return f"{m.group(1)}{m.group(2)}"
     return dept
+
+
+def _normalize_orange(dept: str) -> str:
+    """Normalize an Orange County department name.
+
+    Strips leading zeros from letter+number codes (``W08`` -> ``W8``,
+    ``H001`` -> ``H1``).  Trailing characters after the significant digit
+    are preserved (``H012`` -> ``H12``, ``L0612`` -> ``L612``).
+    """
+    return _OC_LEADING_ZERO_RE.sub(r"\1\2", dept)

--- a/packages/scraper-framework/tests/test_department_normalize.py
+++ b/packages/scraper-framework/tests/test_department_normalize.py
@@ -189,6 +189,52 @@ class TestSanBernardino:
 
 
 # ---------------------------------------------------------------------------
+# Orange County — leading-zero strip
+# ---------------------------------------------------------------------------
+
+
+class TestOrangeCounty:
+    """Strip leading zeros from letter+number Orange County department codes.
+
+    Canonical form is unpadded (W08 -> W8, H01 -> H1).  Consistent with the
+    Riverside leading-zero-strip pattern for numeric-only departments.
+
+    See: https://github.com/judgemind/judgemind/issues/3968
+    """
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("W08", "W8"),
+            ("W8", "W8"),  # idempotent
+            ("H01", "H1"),
+            ("H001", "H1"),
+            ("C03", "C3"),
+            ("H012", "H12"),  # multi-digit suffix preserved
+            ("L0612", "L612"),
+            ("CX02", "CX2"),
+            ("CM01", "CM1"),
+        ],
+    )
+    def test_leading_zero_stripped(self, raw: str, expected: str) -> None:
+        assert normalize_department("Orange", raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "L10",  # no leading zero — unchanged
+            "L11",
+            "W5",
+            "L611",
+            "H0",  # letter+zero only, no significant digit — unchanged
+            "C44",
+        ],
+    )
+    def test_no_leading_zero_unchanged(self, raw: str) -> None:
+        assert normalize_department("Orange", raw) == raw
+
+
+# ---------------------------------------------------------------------------
 # Other counties — passthrough
 # ---------------------------------------------------------------------------
 
@@ -199,7 +245,8 @@ class TestOtherCounties:
     @pytest.mark.parametrize(
         "county",
         [
-            "Orange",
+            # Orange is no longer pure passthrough — it has a leading-zero
+            # strip rule; see TestOrangeCounty below.
             "San Diego",
             "Fresno",
             "Ventura",
@@ -214,6 +261,7 @@ class TestOtherCounties:
         assert normalize_department(county, "14") == "14"
 
     def test_whitespace_stripped(self) -> None:
+        # C25 has no leading zeros so it survives Orange's leading-zero strip.
         assert normalize_department("Orange", "  C25  ") == "C25"
 
 
@@ -327,16 +375,16 @@ class TestAlphanumericDepartmentCodes:
             "N1",
             "N15",
             "C44",
-            "CM01",
+            # CM01 and CX02 are now actively normalized to CM1/CX2 by the
+            # Orange leading-zero strip rule — removed from passthrough list.
             "CM7",
-            "CX02",
             "W5",
             "L10",
         ],
     )
     def test_orange_alphanumeric_passthrough(self, raw: str) -> None:
-        """Orange uses alphanumeric codes (CX*, CM*, N*, W*, L*, C*) — all
-        must pass through."""
+        """Orange uses alphanumeric codes (CX*, CM*, N*, W*, L*, C*) — codes
+        without leading zeros must pass through unchanged."""
         assert normalize_department("Orange", raw) == raw
 
 


### PR DESCRIPTION
## Summary

Added Orange County leading-zero strip to `department_normalize.py` to fix the splitting of department codes (W8 vs W08) that affects 424 rulings and Sheila Recio's per-judge analytics. The fix normalizes codes to a single canonical form via regex pattern matching and includes comprehensive test coverage.

Closes #3968

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 133 tests pass, 100% coverage on module
- [x] CI green — pre-push hook verified

### Post-deploy verification

- [ ] Backfill UPDATE executes on derived.rulings: rewrite 75 affected Orange County rulings from W08→W8 (or chosen canonical form)
- [ ] SQL verification: confirm Orange County has exactly one form per canonical department (zero rows in conflict query)
- [ ] SQL verification: confirm Sheila Recio's per-department aggregate shows single bucket of 424 rulings
- [ ] Verification evidence posted on #3968 (see /task-v2-verify output)