### PR TITLE
fix(scraping): use case_name_full first in Federal CourtListener mapper (#3967)

### DIFF
--- a/packages/scraper-framework/src/courts/federal/courtlistener.py
+++ b/packages/scraper-framework/src/courts/federal/courtlistener.py
@@ -433,7 +433,12 @@ class CourtListenerScraper(BaseScraper):
         doc.county = resolved_county
 
         # Map structured fields
-        doc.case_title = cluster.get("case_name") or cluster.get("case_name_short") or None
+        doc.case_title = (
+            cluster.get("case_name_full")
+            or cluster.get("case_name")
+            or cluster.get("case_name_short")
+            or None
+        )
         doc.case_number = _extract_docket_number(cluster)
         doc.judge_name = _extract_judge_names(cluster)
         doc.hearing_date = _parse_date(cluster.get("date_filed"))

--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -147,6 +147,18 @@ _COUNTY_CONFIGS: dict[tuple[str, str], CountyExtractionConfig] = {
         model="gemini-2.5-flash-lite",
         max_output_tokens=32768,
     ),
+    # Federal CourtListener clusters ship structured case_name_full, docket_number,
+    # judges, and date_filed — the per-document plain text is a federal opinion, not
+    # a CA tentative-ruling calendar.  Running the default CA-tuned LLM prompt over
+    # federal opinion text produces truncation and field-contamination failures
+    # (issue #3967).  ExtractionMethod.NONE short-circuits LLM extraction in
+    # worker.py:1579-1588 so the scraper-populated fields are used as-is.
+    # Precedent: the SD calendar _SCRAPER_CONFIGS entry (#2331) uses the same shape.
+    # Key uses ("FEDERAL", "FEDERAL") because get_county_extraction_config uppercases
+    # both halves at extraction_config.py:225.
+    ("FEDERAL", "FEDERAL"): CountyExtractionConfig(
+        method=ExtractionMethod.NONE,
+    ),
 }
 
 

--- a/packages/scraper-framework/tests/courts/test_courtlistener.py
+++ b/packages/scraper-framework/tests/courts/test_courtlistener.py
@@ -1049,3 +1049,81 @@ class TestExtraSurvivesEventEmission:
         payload = _json.loads(mock_redis.xadd.call_args[0][1]["data"])
         assert payload["state"] == "Texas"
         assert payload["county"] == "Statewide"
+
+
+# ---------------------------------------------------------------------------
+# case_title field preference (AC1: case_name_full > case_name > case_name_short)
+# ---------------------------------------------------------------------------
+
+
+class TestCaseTitlePreference:
+    """Verify _map_to_document uses case_name_full > case_name > case_name_short."""
+
+    @respx.mock
+    def test_case_title_prefers_case_name_full(self) -> None:
+        """When case_name_full is set it wins over case_name and case_name_short."""
+        cluster = _make_cluster(case_name="Smith v. Jones")
+        cluster["case_name_full"] = "Joseph Lester Smith v. Williams Jones et al."
+        cluster["case_name_short"] = "Smith"
+        opinion = _make_opinion(plain_text="Opinion text")
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+
+        config = _make_scraper_config()
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        assert docs[0].case_title == "Joseph Lester Smith v. Williams Jones et al."
+
+    @respx.mock
+    def test_case_title_falls_back_to_case_name(self) -> None:
+        """When case_name_full is absent/empty, case_name is used."""
+        cluster = _make_cluster(case_name="Smith v. Jones")
+        cluster["case_name_full"] = ""
+        cluster["case_name_short"] = "Smith"
+        opinion = _make_opinion(plain_text="Opinion text")
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+
+        config = _make_scraper_config()
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        assert docs[0].case_title == "Smith v. Jones"
+
+    @respx.mock
+    def test_case_title_falls_back_to_case_name_short(self) -> None:
+        """When both case_name_full and case_name are absent/empty, case_name_short is used."""
+        cluster = _make_cluster(case_name="")
+        cluster["case_name_full"] = ""
+        cluster["case_name_short"] = "Smith"
+        opinion = _make_opinion(plain_text="Opinion text")
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+
+        config = _make_scraper_config()
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        assert docs[0].case_title == "Smith"

--- a/packages/scraper-framework/tests/test_extraction_config.py
+++ b/packages/scraper-framework/tests/test_extraction_config.py
@@ -1129,3 +1129,35 @@ class TestScraperLevelOverrides:
         """The _SCRAPER_CONFIGS registry contains the SD calendar entry."""
         assert "ca-sd-calendar" in _SCRAPER_CONFIGS
         assert _SCRAPER_CONFIGS["ca-sd-calendar"].method == ExtractionMethod.NONE
+
+
+# ---------------------------------------------------------------------------
+# Federal CourtListener extraction config (#3967)
+# ---------------------------------------------------------------------------
+
+
+class TestFederalExtractionConfig:
+    """Verify Federal CourtListener uses ExtractionMethod.NONE (#3967)."""
+
+    def test_federal_returns_none_method(self) -> None:
+        """Federal state + Federal county returns ExtractionMethod.NONE."""
+        config = get_county_extraction_config("Federal", "Federal")
+        assert config is not None
+        assert config.method == ExtractionMethod.NONE
+
+    def test_federal_uppercase_lookup(self) -> None:
+        """Uppercase 'FEDERAL'/'FEDERAL' lookup also returns NONE."""
+        config = get_county_extraction_config("FEDERAL", "FEDERAL")
+        assert config is not None
+        assert config.method == ExtractionMethod.NONE
+
+    def test_federal_mixed_case_lookup(self) -> None:
+        """Mixed-case lookup is normalized and returns NONE."""
+        config = get_county_extraction_config("federal", "federal")
+        assert config is not None
+        assert config.method == ExtractionMethod.NONE
+
+    def test_federal_county_config_in_registry(self) -> None:
+        """The Federal entry is directly accessible in _COUNTY_CONFIGS."""
+        assert ("FEDERAL", "FEDERAL") in _COUNTY_CONFIGS
+        assert _COUNTY_CONFIGS[("FEDERAL", "FEDERAL")].method == ExtractionMethod.NONE


### PR DESCRIPTION
## Summary

Fixed Federal CourtListener documents falling back to single-word case_name_short values (e.g. "Kohls") instead of the full case caption. The mapper now prefers case_name_full → case_name → case_name_short. Also added a Federal extraction config with ExtractionMethod.NONE to skip the CA-tuned LLM prompt on federal opinion text, which was causing judge-name truncation and case-title contamination.

Closes #3967

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
  - TestCaseTitlePreference: 3 cases covering all fallback paths
  - TestFederalExtractionConfig: 4 cases including mixed-case normalization
  - Full scraper-framework test suite: 7038 passed, 2 skipped
- [x] CI green
- [x] Diff coverage: 100%

### Post-deploy verification

- [ ] AC#2 (zero short-title cases): `scripts/dev-db-query.sh "SELECT count(*) FROM cases cs JOIN rulings r ON r.case_id = cs.id JOIN courts c ON r.court_id = c.id WHERE c.county = 'Federal' AND cs.case_title NOT LIKE '% v. %' AND cs.case_title NOT LIKE 'In re %' AND cs.case_title NOT LIKE 'Ex parte %' AND cs.case_title NOT LIKE 'United States %' AND length(cs.case_title) < 40"` returns 0 (after re-ingest task)
- [ ] AC#4 (no spurious 3-letter surnames): `scripts/dev-db-query.sh "SELECT j.canonical_name, count(*) FROM judges j JOIN rulings r ON r.judge_id = j.id JOIN courts c ON r.court_id = c.id WHERE c.county = 'Federal' AND j.canonical_name ~ '^[A-Z][a-z]+ ([A-Z]\\. )?[A-Z][a-z]{2}$' GROUP BY j.canonical_name"` shows only real judges in roster (after re-ingest task)
- [ ] Verification evidence posted on #3967