### PR TITLE
feat(dispatcher-v3): add diagnoser_runner.py + taskdef-module-references CI guard (#3972)

### DIFF
--- a/scripts/dispatcher_v3/diagnoser_runner.py
+++ b/scripts/dispatcher_v3/diagnoser_runner.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Diagnoser entrypoint for the dispatcher-v3 ECS task.
+
+Invoked as ``python -m dispatcher_v3.diagnoser_runner`` by F2's
+``diagnoser`` ECS task definition
+(``infra/terraform/modules/dispatcher-v3-task-defs/main.tf``).
+
+The launcher spawns this task whenever a task-runner ECS task exits
+non-zero (or is killed by silent-hang detection); the failed agent's
+``AGENT_ID`` is passed as a single env-var override on the diagnoser
+container per spec §4.2. This wrapper:
+
+1. Resolves ``AGENT_ID`` from the env (fail-loudly if missing — the
+   launcher contract guarantees it is set).
+2. Spawns ``claude -p "/diagnose-failure $AGENT_ID"`` with stream-json
+   output and partial messages so the diagnoser SKILL's tool calls
+   stream into CloudWatch Logs in real time (same shape as the
+   task-runner — see ``dispatcher_v3.agent_runner``).
+3. Tees the subprocess's stdout to a local jsonl session file so the
+   archive is byte-for-byte identical to what CloudWatch saw.
+4. On EXIT (success or failure) uploads two artifacts to S3:
+   - ``s3://<sessions-bucket>/diagnoser-<agent_id>.jsonl`` — raw
+     stream-json transcript.
+   - ``s3://<sessions-bucket>/diagnoser-<agent_id>.txt`` — rendered
+     compact transcript via ``/opt/judgemind-transcripts/render-transcript.py``
+     (vendored into the image by ``Dockerfile.dispatcher-v3``).
+5. Both uploads are best-effort (try/except, never raise) so the
+   subprocess exit code propagates verbatim — the launcher's diagnoser-
+   watch path keys off that exit code, not the upload result.
+
+The ``diagnoser-`` prefix on both S3 keys is what distinguishes the
+diagnoser session archive from the task-runner archive (which uses just
+``<agent_id>.{jsonl,txt}``). Different prefix → no key collision when
+the same agent's task-runner and diagnoser both upload session archives
+for the same ``agent_id``.
+
+Why a Python wrapper rather than running ``claude -p`` directly via the
+ECS task-def ``command``? Two reasons:
+
+- **Session capture.** The task-runner's archive contract (raw jsonl +
+  rendered compact transcript on S3) is what makes the *task-runner*
+  session diagnose-able. The same shape applied to the diagnoser makes
+  *the diagnoser* itself diagnose-able if it crashes. Without this
+  wrapper, a failed diagnoser leaves no archive — the next-agent retry
+  loop has nothing to read except CloudWatch Logs (which can be missing
+  on SIGKILL/OOM per spec §4.2).
+- **Argv shape.** ``--output-format stream-json`` plus
+  ``--include-partial-messages`` is a multi-arg invocation that is
+  awkward to express in a Terraform JSON literal but trivial in Python.
+  Centralizing it here keeps the task-def's ``command`` short and
+  readable.
+
+This module mirrors ``agent_runner.py`` deliberately — both runners
+share the same EXIT/finally archive contract, so any future
+generalisation (e.g. a shared ``_session_runner`` helper) has a clean
+factoring target. We keep them as two thin top-level modules today
+because the task-def ``command`` references each by name and a refactor
+that breaks those references is a hard runtime failure (the regression
+class this issue's CI guard catches).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+
+# ── Compact-transcript renderer location ─────────────────────────────────
+# Path inside the dispatcher-v3 Docker image (set by F1's
+# ``Dockerfile.dispatcher-v3`` COPY of ``vendor/judgemind-transcripts/``).
+# Module constant so tests can patch it and so the location is documented
+# in code rather than buried inside ``upload_archive``.
+RENDER_TRANSCRIPT_SCRIPT = "/opt/judgemind-transcripts/render-transcript.py"
+
+
+def _session_file(agent_id: str) -> Path:
+    """Path to the raw stream-json diagnoser session log on the local fs.
+
+    The ``diagnoser-`` prefix is what distinguishes this archive from
+    the task-runner archive (which uses ``session-<agent_id>.jsonl``).
+    Different prefix → no key collision when the same agent's
+    task-runner and diagnoser both archive sessions for the same
+    ``agent_id``.
+    """
+    return Path(f"/tmp/diagnoser-{agent_id}.jsonl")
+
+
+def _compact_file(agent_id: str) -> Path:
+    """Path to the rendered compact diagnoser transcript on the local fs."""
+    return Path(f"/tmp/diagnoser-{agent_id}.txt")
+
+
+def build_argv(agent_id: str) -> list[str]:
+    """Return the argv list for ``claude -p /diagnose-failure <agent_id>``.
+
+    Kept module-level so tests can pin the exact shape without going
+    through ``main()``. The ``--output-format stream-json`` +
+    ``--include-partial-messages`` pair matches ``agent_runner``'s claude
+    invocation (see ``dispatcher_v3.runners.RUNNERS["claude"]``) — the
+    diagnoser SKILL's tool calls stream into CloudWatch Logs in real
+    time, which is also the liveness signal the launcher's diagnoser-
+    watch path uses.
+    """
+    return [
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        f"/diagnose-failure {agent_id}",
+    ]
+
+
+def upload_archive() -> None:
+    """Upload the raw session jsonl + rendered compact transcript to S3.
+
+    Best-effort: each upload (and the rendering step) is wrapped in its
+    own try/except so a single failure does not skip the next step. Any
+    exception is printed to stderr; nothing is re-raised. The function
+    returns normally even if every step fails — by design, the caller
+    (the launcher's diagnoser-watch path) tolerates missing archives
+    (CloudWatch Logs is the SIGKILL-survivor fallback per spec §4.2).
+    """
+    agent_id = os.environ["AGENT_ID"]
+    sessions_bucket = os.environ["SESSIONS_BUCKET"]
+    session_file = _session_file(agent_id)
+
+    if not session_file.exists():
+        return
+
+    # Step 1: raw jsonl upload.
+    try:
+        boto3.client("s3").upload_file(
+            str(session_file), sessions_bucket, f"diagnoser-{agent_id}.jsonl"
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort archive
+        print(f"diagnoser-archive-upload-failed: {exc}", file=sys.stderr)
+
+    # Step 2: render the compact transcript and upload it. Both render
+    # and upload are inside the same try/except — if the renderer is
+    # missing from the image (image-rebuild lag, dev environment), the
+    # caller falls back to the raw jsonl uploaded above.
+    compact = _compact_file(agent_id)
+    try:
+        # timeout=120: render-transcript.py is CPU-bound on the local
+        # jsonl file; 2min covers a worst-case ~200MB session per the
+        # judgemind-transcripts repo's measured ratios. The
+        # check-subprocess-timeouts.sh hygiene rule requires a bounded
+        # timeout on every subprocess.run call site under
+        # scripts/**/*.py (#3213).
+        subprocess.run(
+            [
+                "python",
+                RENDER_TRANSCRIPT_SCRIPT,
+                str(session_file),
+                "--output",
+                str(compact),
+            ],
+            check=True,
+            timeout=120,
+        )
+        boto3.client("s3").upload_file(
+            str(compact), sessions_bucket, f"diagnoser-{agent_id}.txt"
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort archive
+        print(f"diagnoser-compact-transcript-upload-failed: {exc}", file=sys.stderr)
+
+
+def main() -> int:
+    """Spawn the diagnoser, tee stdout to the session log, return rc.
+
+    stdout and stderr are merged (``stderr=subprocess.STDOUT``) into a
+    single stream that is teed to both the parent process's stdout (the
+    ECS log driver picks it up and ships to CloudWatch) and the local
+    jsonl file (uploaded to S3 at exit). The duplicate is intentional —
+    CloudWatch is the liveness signal, S3 is the archive (spec §4.2).
+    """
+    agent_id = os.environ["AGENT_ID"]
+    argv = build_argv(agent_id)
+
+    session_file = _session_file(agent_id)
+    with session_file.open("wb") as log:
+        proc = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        assert proc.stdout is not None
+        for chunk in iter(proc.stdout.readline, b""):
+            sys.stdout.buffer.write(chunk)
+            sys.stdout.buffer.flush()
+            log.write(chunk)
+            log.flush()
+        return proc.wait()
+
+
+if __name__ == "__main__":
+    rc = 1
+    try:
+        rc = main()
+    finally:
+        upload_archive()
+    sys.exit(rc)

--- a/scripts/dispatcher_v3/tests/test_diagnoser_runner.py
+++ b/scripts/dispatcher_v3/tests/test_diagnoser_runner.py
@@ -1,0 +1,467 @@
+"""Unit tests for ``dispatcher_v3.diagnoser_runner``.
+
+The tests pin the diagnoser ECS-task contract: argv is
+``claude -p --output-format stream-json --include-partial-messages
+/diagnose-failure $AGENT_ID``, stdout chunks are teed to a local jsonl
+file under ``/tmp/diagnoser-<id>.jsonl``, and on EXIT the raw jsonl +
+the rendered compact transcript are uploaded to S3 under keys
+``diagnoser-<id>.{jsonl,txt}``. ``boto3.client`` and ``subprocess`` are
+mocked so the suite runs without AWS or a real ``render-transcript.py``
+on disk.
+
+The fixtures set the two required env vars (``AGENT_ID``,
+``SESSIONS_BUCKET``) and redirect ``/tmp/diagnoser-<id>.{jsonl,txt}``
+into ``tmp_path`` via ``monkeypatch.setattr`` on the module-level path
+helpers — the production code uses absolute ``/tmp/`` paths so we
+cannot rely on cwd.
+
+Mirrors ``test_agent_runner.py`` deliberately — both runners share the
+same EXIT/finally archive contract, so the test shape is identical
+modulo the diagnoser-specific argv and S3 keys.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from dispatcher_v3 import diagnoser_runner
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Set the two required env vars; return the dict for assertions.
+
+    Unlike ``agent_runner`` the diagnoser does not read
+    ``TASK_ISSUE_NUMBER`` (the failed agent's issue is recoverable from
+    the agent row via the diagnoser SKILL) or ``RUNNER`` (always
+    claude). Only ``AGENT_ID`` and ``SESSIONS_BUCKET`` are required.
+    """
+    env = {
+        "AGENT_ID": "test-agent-id",
+        "SESSIONS_BUCKET": "judgemind-sessions-dev",
+    }
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    return env
+
+
+@pytest.fixture
+def session_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Redirect _session_file / _compact_file into tmp_path.
+
+    The production code writes to ``/tmp/diagnoser-<id>.jsonl`` — that
+    is the contract the ECS image relies on. For tests we monkeypatch
+    the helpers so the writes land under ``tmp_path`` and don't bleed
+    across runs.
+    """
+    session = tmp_path / "diagnoser-test-agent-id.jsonl"
+    compact = tmp_path / "diagnoser-test-agent-id.txt"
+    monkeypatch.setattr(diagnoser_runner, "_session_file", lambda _agent_id: session)
+    monkeypatch.setattr(diagnoser_runner, "_compact_file", lambda _agent_id: compact)
+    return session, compact
+
+
+def _fake_proc(stdout_chunks: list[bytes], returncode: int = 0) -> MagicMock:
+    """Build a Popen-like mock whose ``stdout`` iterates ``stdout_chunks``.
+
+    ``proc.stdout.readline`` returns each chunk in order then ``b""`` (the
+    EOF sentinel that ``iter(readline, b"")`` stops on). ``proc.wait()``
+    returns ``returncode``.
+    """
+    proc = MagicMock(spec=subprocess.Popen)
+    buf = io.BytesIO(b"".join(stdout_chunks))
+    proc.stdout = buf
+    proc.wait.return_value = returncode
+    return proc
+
+
+# ── importability ─────────────────────────────────────────────────────────
+
+
+def test_module_importable() -> None:
+    """The module is importable; the public surface includes ``main``,
+    ``upload_archive``, ``build_argv``, and ``RENDER_TRANSCRIPT_SCRIPT``.
+
+    Pinned because the F2 task-def's ``command = ["python", "-m",
+    "dispatcher_v3.diagnoser_runner"]`` is the runtime contract — if the
+    module name or its public callables drift, the diagnoser ECS task
+    fails at container start with ``ModuleNotFoundError`` (the issue
+    that motivated this whole PR). The taskdef-module-references CI
+    guard (test_taskdef_module_references.py) is the structural defense;
+    this test is the unit-level readback.
+    """
+    assert callable(diagnoser_runner.main)
+    assert callable(diagnoser_runner.upload_archive)
+    assert callable(diagnoser_runner.build_argv)
+    assert isinstance(diagnoser_runner.RENDER_TRANSCRIPT_SCRIPT, str)
+
+
+# ── build_argv: argv shape ────────────────────────────────────────────────
+
+
+def test_build_argv_contains_diagnose_failure_and_agent_id() -> None:
+    """argv carries ``/diagnose-failure <agent_id>`` as a single token.
+
+    Spec §4.2: "the diagnoser task runs ``claude -p
+    '/diagnose-failure $AGENT_ID'`` against the same image." The
+    SLASH-COMMAND + AGENT_ID pair must travel as ONE positional argv
+    token (a single quoted string at the shell level) — splitting them
+    into two tokens would make claude treat ``$AGENT_ID`` as a
+    workspace name rather than a slash-command argument.
+    """
+    argv = diagnoser_runner.build_argv("ag-test-uuid")
+    assert "/diagnose-failure ag-test-uuid" in argv
+    # ``claude`` is the binary, ``-p`` is the prompt-mode flag.
+    assert argv[0] == "claude"
+    assert "-p" in argv
+
+
+def test_build_argv_uses_stream_json_with_partial_messages() -> None:
+    """argv requests ``--output-format stream-json --include-partial-messages``.
+
+    Same shape as the task-runner's claude invocation (see
+    ``dispatcher_v3.runners.RUNNERS["claude"]``) — the diagnoser SKILL's
+    tool calls stream into CloudWatch Logs in real time, which is the
+    liveness signal the launcher's diagnoser-watch path keys off.
+    """
+    argv = diagnoser_runner.build_argv("ag-test-uuid")
+    assert "--output-format" in argv
+    assert "stream-json" in argv
+    # Adjacent placement: stream-json must immediately follow --output-format.
+    fmt_index = argv.index("--output-format")
+    assert argv[fmt_index + 1] == "stream-json"
+    assert "--include-partial-messages" in argv
+
+
+# ── main(): subprocess invocation + tee ───────────────────────────────────
+
+
+def test_main_invokes_popen_with_diagnose_failure_argv(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() calls Popen with ``build_argv(AGENT_ID)`` and stream-json.
+
+    Pins the contract that the entrypoint passes the agent_id through
+    to the slash-command argument verbatim — the diagnoser SKILL reads
+    it positionally.
+    """
+    fake_popen = MagicMock(return_value=_fake_proc([b'{"ok":1}\n']))
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    rc = diagnoser_runner.main()
+
+    assert rc == 0
+    actual_argv = fake_popen.call_args[0][0]
+    assert actual_argv == [
+        "claude",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--include-partial-messages",
+        "/diagnose-failure test-agent-id",
+    ]
+    # stderr merged into stdout per spec §4.1/§4.2 archive contract.
+    assert fake_popen.call_args.kwargs["stderr"] == subprocess.STDOUT
+    assert fake_popen.call_args.kwargs["stdout"] == subprocess.PIPE
+
+
+def test_main_writes_subprocess_stdout_to_session_file(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every chunk read from proc.stdout is written to the diagnoser jsonl."""
+    session_file, _compact = session_paths
+    chunks = [b'{"event":"start"}\n', b'{"event":"tool_use"}\n', b'{"event":"end"}\n']
+    monkeypatch.setattr(subprocess, "Popen", MagicMock(return_value=_fake_proc(chunks)))
+
+    diagnoser_runner.main()
+
+    assert session_file.exists()
+    assert session_file.read_bytes() == b"".join(chunks)
+
+
+def test_main_propagates_subprocess_exit_code(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-zero subprocess returncode is the value main() returns.
+
+    The launcher's diagnoser-watch path keys off this exit code: STOPPED-
+    non-zero flips the agent to ``status='needs_review'`` and Telegram-
+    alerts (spec §4.2). Without faithful exit-code propagation the
+    diagnoser-failure handling is silently broken.
+    """
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        MagicMock(return_value=_fake_proc([b"{}\n"], returncode=42)),
+    )
+
+    rc = diagnoser_runner.main()
+
+    assert rc == 42
+
+
+# ── upload_archive(): both files uploaded with diagnoser- prefix ─────────
+
+
+def test_upload_archive_uploads_jsonl_and_compact_to_s3(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both uploads fire under ``diagnoser-<AGENT_ID>.{jsonl,txt}`` keys.
+
+    The ``diagnoser-`` prefix is what distinguishes this archive from
+    the task-runner archive (``<agent_id>.{jsonl,txt}``). Different
+    prefix → no key collision when the same agent's task-runner and
+    diagnoser both archive sessions for the same agent_id.
+    """
+    session_file, compact = session_paths
+    session_file.write_bytes(b'{"event":"start"}\n')
+
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+
+    # render-transcript.py is mocked — assume it produces the compact file.
+    def _render(cmd: list[str], **_kw: object) -> subprocess.CompletedProcess:
+        compact.write_text("rendered transcript")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", _render)
+
+    diagnoser_runner.upload_archive()
+
+    # Two upload_file calls — one for jsonl, one for txt; both prefixed.
+    assert fake_s3.upload_file.call_count == 2
+    fake_s3.upload_file.assert_has_calls(
+        [
+            call(
+                str(session_file),
+                "judgemind-sessions-dev",
+                "diagnoser-test-agent-id.jsonl",
+            ),
+            call(
+                str(compact),
+                "judgemind-sessions-dev",
+                "diagnoser-test-agent-id.txt",
+            ),
+        ]
+    )
+
+
+def test_upload_archive_invokes_render_transcript_script(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The renderer is invoked with the jsonl input + --output compact path.
+
+    Pins the contract that the entrypoint does not call any other
+    transcript tool, and uses the module-level ``RENDER_TRANSCRIPT_SCRIPT``
+    constant so the Dockerfile path is the single source of truth.
+    """
+    session_file, compact = session_paths
+    session_file.write_bytes(b"{}\n")
+
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=MagicMock()))
+    fake_run = MagicMock(return_value=subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    diagnoser_runner.upload_archive()
+
+    fake_run.assert_called_once()
+    actual_argv = fake_run.call_args[0][0]
+    assert actual_argv == [
+        "python",
+        diagnoser_runner.RENDER_TRANSCRIPT_SCRIPT,
+        str(session_file),
+        "--output",
+        str(compact),
+    ]
+    assert fake_run.call_args.kwargs.get("check") is True
+    # check-subprocess-timeouts.sh hygiene gate (#3213).
+    assert fake_run.call_args.kwargs.get("timeout") == 120
+
+
+def test_upload_archive_returns_silently_when_session_file_missing(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the jsonl never got written (Popen failed before tee), no upload.
+
+    The ECS task may exit before main() opens the session file (e.g.
+    the image lacks the runner binary). upload_archive() must be safe
+    to call in that case — the EXIT cleanup runs unconditionally in a
+    finally block.
+    """
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+    fake_run = MagicMock()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    diagnoser_runner.upload_archive()
+
+    fake_s3.upload_file.assert_not_called()
+    fake_run.assert_not_called()
+
+
+def test_upload_archive_swallows_jsonl_upload_failure(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A boto3 upload error on the jsonl prints to stderr and does not raise.
+
+    The compact-transcript step still runs after the jsonl failure.
+    """
+    session_file, compact = session_paths
+    session_file.write_bytes(b"{}\n")
+
+    fake_s3 = MagicMock()
+    fake_s3.upload_file.side_effect = [
+        RuntimeError("simulated S3 failure"),  # jsonl
+        None,  # compact
+    ]
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+
+    def _render(cmd: list[str], **_kw: object) -> subprocess.CompletedProcess:
+        compact.write_text("rendered")
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", _render)
+
+    # No exception escapes.
+    diagnoser_runner.upload_archive()
+
+    captured = capsys.readouterr()
+    assert "diagnoser-archive-upload-failed" in captured.err
+    # Compact upload still attempted.
+    assert fake_s3.upload_file.call_count == 2
+
+
+def test_upload_archive_swallows_render_transcript_failure(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A render-transcript failure prints to stderr and does not raise.
+
+    The jsonl upload still happens — the launcher's diagnoser-watch
+    path can fall back to the raw jsonl when the compact form is
+    missing.
+    """
+    session_file, _compact = session_paths
+    session_file.write_bytes(b"{}\n")
+
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        MagicMock(side_effect=subprocess.CalledProcessError(1, "render")),
+    )
+
+    diagnoser_runner.upload_archive()
+
+    captured = capsys.readouterr()
+    assert "diagnoser-compact-transcript-upload-failed" in captured.err
+    # Only the jsonl upload succeeded.
+    assert fake_s3.upload_file.call_count == 1
+
+
+# ── EXIT cleanup runs even when main() raises ────────────────────────────
+
+
+def test_module_main_block_runs_upload_archive_on_main_exception(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``if __name__ == '__main__':`` block calls upload_archive() in a
+    finally even when main() raises — exercise the same try/finally
+    shape against a fake main that raises, and assert the EXIT cleanup
+    ran. The exit code propagated is the subprocess's, not the
+    upload's — pinned because the launcher's diagnoser-watch path keys
+    off the subprocess exit code.
+    """
+    cleanup_calls = MagicMock()
+    monkeypatch.setattr(diagnoser_runner, "upload_archive", cleanup_calls)
+
+    def _boom() -> int:
+        raise RuntimeError("simulated mid-run crash")
+
+    monkeypatch.setattr(diagnoser_runner, "main", _boom)
+
+    rc = 1
+    raised: BaseException | None = None
+    try:
+        try:
+            rc = diagnoser_runner.main()
+        finally:
+            diagnoser_runner.upload_archive()
+    except RuntimeError as exc:
+        raised = exc
+
+    cleanup_calls.assert_called_once()
+    assert isinstance(raised, RuntimeError)
+    assert rc == 1  # initial value preserved when main() raised before returning
+
+
+def test_upload_failure_does_not_override_subprocess_exit_code(
+    fake_env: dict[str, str],
+    session_paths: tuple[Path, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The subprocess's exit code propagates even if every upload fails.
+
+    Per AC: "Upload failures don't crash. main() exits with the
+    subprocess's exit code, not the upload's." Models the full
+    main() + upload_archive() invocation pattern from
+    ``if __name__ == "__main__"`` — main returns 7, every upload
+    raises, the final returned/propagated rc is still 7.
+    """
+    session_file, compact = session_paths
+    # Pre-populate the session file so upload_archive() attempts the
+    # boto3 path (the early-return for missing file would mask this).
+    session_file.write_bytes(b"{}\n")
+
+    # Subprocess exited with code 7.
+    monkeypatch.setattr(
+        subprocess,
+        "Popen",
+        MagicMock(return_value=_fake_proc([b"{}\n"], returncode=7)),
+    )
+    # boto3.upload_file always fails.
+    fake_s3 = MagicMock()
+    fake_s3.upload_file.side_effect = RuntimeError("simulated S3 outage")
+    monkeypatch.setattr("boto3.client", MagicMock(return_value=fake_s3))
+    # Renderer also fails so the compact-upload branch raises too.
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        MagicMock(side_effect=subprocess.CalledProcessError(1, "render")),
+    )
+
+    rc = 1
+    try:
+        rc = diagnoser_runner.main()
+    finally:
+        diagnoser_runner.upload_archive()
+
+    assert rc == 7

--- a/scripts/dispatcher_v3/tests/test_taskdef_module_references.py
+++ b/scripts/dispatcher_v3/tests/test_taskdef_module_references.py
@@ -1,0 +1,88 @@
+"""Assert every task-def ``command = ["python", "-m", "<mod>"]`` resolves.
+
+The dispatcher-v3 ECS task definitions in
+``infra/terraform/modules/dispatcher-v3-task-defs/main.tf`` launch a
+shared Docker image with different argv per role:
+
+  - launcher        → ``python -m dispatcher_v3.launcher``
+  - task-runner     → ``python -m dispatcher_v3.agent_runner``
+  - diagnoser       → ``python -m dispatcher_v3.diagnoser_runner``
+  - scheduled-skill → ``python -m dispatcher_v3.scheduled_skill_runner``
+
+If a Terraform argv references a Python module that does not exist on
+the deployed image, the ECS task fails at container start with
+``ModuleNotFoundError: No module named '<mod>'`` — the same failure
+mode that motivated this test (issue #3972: F2's diagnoser task-def
+``command`` named ``dispatcher_v3.diagnoser_runner`` weeks before the
+module landed on main).
+
+This is the boundary where ``docker build`` doesn't help (the build
+succeeds — the missing module isn't reached until container start) and
+``terraform plan`` doesn't help either (the plan shows a syntactically
+valid ``command`` list). A small static check on the Terraform source
+catches the entire class of "argv references unimportable Python
+module" drift in CI, before deploy.
+
+The check is intentionally narrow: it scans for the exact
+``["python", "-m", "<mod>"]`` shape used in v3 task-defs. If we ever
+add task-defs with a different argv shape (e.g. wrapping a shell
+script), this regex won't match them and they pass through this test
+silently. That's by design — only the ``-m <mod>`` shape has the
+"deployed but crashloops at import" failure mode.
+
+Why a regex on the rendered Terraform source rather than parsing the
+HCL? The Terraform AST is not stable across versions and pulling in a
+parser dependency for a five-line check has worse upkeep than a tight
+regex. The pattern is anchored on the literal HCL string ``command =
+[ ... "python" , "-m" , "<mod>" ...`` which is unambiguous in the
+single file we scan.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from pathlib import Path
+
+# Path resolved from this test file's location so the test runs from
+# any cwd: pytest's collection cwd, IDE runners, and CI all work.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+TASKDEFS = _REPO_ROOT / "infra/terraform/modules/dispatcher-v3-task-defs/main.tf"
+
+# Regex matches the literal HCL form
+#   command = ["python", "-m", "<module>"]
+# allowing arbitrary whitespace between tokens so a future formatter
+# tweak doesn't break us silently. The ``re.MULTILINE`` flag is mostly
+# defensive — the pattern doesn't span lines today, but a future
+# multi-line ``command =`` block with the same argv shape should still
+# match.
+PATTERN = re.compile(
+    r'command\s*=\s*\[\s*"python"\s*,\s*"-m"\s*,\s*"([^"]+)"',
+    re.MULTILINE,
+)
+
+
+def test_taskdef_commands_resolve() -> None:
+    """Every ``python -m <mod>`` argv in main.tf is an importable module.
+
+    Catches the class of bug where a Terraform argv references a
+    Python module that does not exist on main — the deployed ECS task
+    crashloops at container start with ``ModuleNotFoundError``. See
+    issue #3972 for the F2 diagnoser drift that motivated this guard.
+    """
+    text = TASKDEFS.read_text()
+    modules = sorted(set(PATTERN.findall(text)))
+    assert modules, (
+        f"regex matched zero ``python -m <mod>`` invocations in {TASKDEFS} — "
+        "either the pattern is broken or the task-def file no longer uses "
+        "the python -m argv shape. Update PATTERN to match the new shape."
+    )
+    missing = []
+    for m in modules:
+        try:
+            importlib.import_module(m)
+        except ImportError as exc:
+            missing.append(f"{m}: {exc}")
+    assert not missing, (
+        "Task-def references unimportable modules:\n  - " + "\n  - ".join(missing)
+    )


### PR DESCRIPTION
## Summary

F2's diagnoser task-def at `infra/terraform/modules/dispatcher-v3-task-defs/main.tf:486` references `python -m dispatcher_v3.diagnoser_runner` but the module did not exist on main — every diagnoser ECS RunTask would crashloop at container start with `ModuleNotFoundError`. This is the shipping blocker for v3 cap > 0.

Adds the missing runner module (mirrors `agent_runner.py`'s shape — spawn `claude -p`, tee stdout, best-effort S3 archive on EXIT) plus a CI regression test that catches the entire class of "Terraform argv references unimportable Python module" drift by scanning the task-def main.tf with a regex and `importlib.import_module()`-ing every match. This is the boundary where `docker build` doesn't help (the build succeeds) and `terraform plan` doesn't help (the plan shows a syntactically valid command list).

The CI guard is the more important deliverable — it prevents this same shape of drift on any future task-def.

Closes #3972

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (`scripts/dispatcher_v3/tests/` 144 passed locally — 130 prior + 14 new)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component yet (the runner module ships as part of the next dispatcher-v3 image build; verifying the runner end-to-end requires v3 cap > 0 which this PR is the prerequisite for). The CI regression test itself runs in CI on this PR — that IS the verification that the missing-module class is now caught.
