### PR TITLE
fix(dispatcher-v3): match v2 spotcheck cadence (hourly, not weekly)

### DIFF
--- a/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
+++ b/infra/terraform/modules/dispatcher-v3-scheduled-skills/variables.tf
@@ -136,9 +136,9 @@ variable "dispatcher_daily_report_schedule_expression" {
 }
 
 variable "spotcheck_schedule_expression" {
-  description = "Schedule expression for the `spotcheck` rule. Default `cron(0 18 ? * MON *)` (weekly Monday 18:00 UTC) per issue body."
+  description = "Schedule expression for the `spotcheck` rule. Default `cron(0 * * * ? *)` (hourly at :00) - matches v2's live cadence per migration 52 (#3459 operator directive 2026-04-26). The skill's own state-awareness (gh issue list + comment-on-existing) prevents the higher cadence from filing duplicate findings."
   type        = string
-  default     = "cron(0 18 ? * MON *)"
+  default     = "cron(0 * * * ? *)"
 }
 
 variable "schedule_state_enabled" {


### PR DESCRIPTION
## Summary

F5's PR #3951 set spotcheck to `cron(0 18 ? * MON *)` (weekly Monday 18:00 UTC). v2's live cadence per migration 52 (#3459 operator directive 2026-04-26) is `0 * * * *` — **hourly**. The 168x under-fire was a real cadence regression vs v2.

The skill's own state-awareness (gh issue list + comment-on-existing rather than file-duplicate) keeps the higher cadence from spamming GitHub with duplicate findings — the v2 directive notes this explicitly.

## Test plan

- [x] One-line variable default change.
- [x] EventBridge cron format: `cron(0 * * * ? *)` (Minutes Hours Day-of-month Month Day-of-week Year, with `?` placeholder).
- [x] No `dev/main.tf` override — variable default flows through.
- [ ] Post-merge `dev-apply` updates the EventBridge rule's `ScheduleExpression` from weekly to hourly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
