### PR TITLE
chore(dispatcher-v3): spec + schema cleanup from audit findings (#3977)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -42,7 +42,7 @@ claude -p "/diagnose-failure $AGENT_ID"
 
 1. **The agent's row** — current state of the failed agent.
    ```sql
-   SELECT agent_id, issue_number, task_arn, session_s3_key, status, exit_code,
+   SELECT agent_id, issue_number, task_arn, status, exit_code,
           exit_reason, pr_number, outcome_summary, current_milestone,
           current_milestone_detail, current_milestone_at, started_at, ended_at,
           parent_run_id

--- a/docs/specs/dispatcher-v3-spec.md
+++ b/docs/specs/dispatcher-v3-spec.md
@@ -31,7 +31,7 @@ When we want phase-level granularity for a specific failure mode, we add it as a
 - Phase-level retry budgets. `/task` retries internally; if it exits non-zero, the whole task is the unit of retry.
 - A daemon-resident orchestrator. The "daemon" is a thin scheduler.
 - Mid-pipeline resume after daemon crash. Daemon crashes are rare and don't affect in-flight ECS tasks (they keep running).
-- **Per-phase liveness machinery.** No phase-aware stuck-timeout, no per-phase "agent has been on step X for N minutes" check, no DB column the daemon polls to detect "agent disagrees with what phase I think it's in." v3 keeps two coarse liveness signals only: a wall-clock cap (default 6h, §11 OQ#4) and a session-log silent-hang detector (no log growth in 30min, §4.1) — both read external signals (ECS task state, CloudWatch Logs `lastEventTimestamp`), neither requires the daemon to know `/task`'s internal state. The v2-shape `agent_silent_hang` and `stuck_timeout` machinery still applies in spirit (Anthropic-side hangs and network blips affect `claude -p` regardless of who owns the phase loop), but v3 satisfies it with two simple checks rather than five overlapping ones.
+- **Per-phase liveness machinery.** No phase-aware stuck-timeout, no per-phase "agent has been on step X for N minutes" check, no DB column the daemon polls to detect "agent disagrees with what phase I think it's in." v3 keeps two coarse liveness signals only: a wall-clock cap (default 6h, §11 OQ#3) and a session-log silent-hang detector (no log growth in 30min, §4.1) — both read external signals (ECS task state, CloudWatch Logs `lastEventTimestamp`), neither requires the daemon to know `/task`'s internal state. The v2-shape `agent_silent_hang` and `stuck_timeout` machinery still applies in spirit (Anthropic-side hangs and network blips affect `claude -p` regardless of who owns the phase loop), but v3 satisfies it with two simple checks rather than five overlapping ones.
 - Shadow-mode parallel runs (v2 §6b's "second runner executes the same phase in parallel with output discarded"), multi-tenant. Same as v2 non-goals.
 - Sub-1M-token context runners. The design assumes the runner provides ≥1M tokens of context (Claude Sonnet/Opus 4.5+ era). If a future runner ships with a smaller window we'd need to re-introduce phase-style splits — explicitly out of scope for v3 v1.
 
@@ -52,7 +52,17 @@ The only long-lived process. Loop runs every 30s:
    - `RUNNING` and session log size unchanged for `silent_hang_minutes` (default 30) → `ecs:StopTask`, mark `failed` with `exit_reason='silent_hang'`, launch diagnoser. The session log size is read from CloudWatch Logs (`DescribeLogStreams` returns `lastEventTimestamp`) — no S3 round-trip per tick.
    - `STOPPED, exit 0` → mark `succeeded`.
    - `STOPPED, exit non-zero` → mark `failed`, capture `stoppedReason`, launch the diagnoser ECS task (§4.2).
-4. **Claim if cap allows.** If `count(running) < concurrency_cap`, scan `gh issue list --label agent/ready --state open`, pick one trusted issue (author trust check via `scripts/check-issue-author.sh`), check **per-issue claim budget** (`SELECT count(*) FROM agents WHERE issue_number = $1` < `claim_attempts_max`, default 3), then `ecs:RunTask` against the `task-runner` task definition with `TASK_ISSUE_NUMBER=<n>` and `AGENT_ID=<uuid>` env. Issues that have hit the claim budget get `status/needs-human` + Telegram-alert and are skipped. Atomic claim sequence: add `status/in-progress` label → INSERT agents row (`status='claiming'`) → remove `agent/ready` → `ecs:RunTask` → UPDATE agents row with `task_arn`, `status='running'`. Failure mid-sequence reconciles on the next tick.
+4. **Claim if cap allows.** If `count(running) < concurrency_cap`, scan `gh issue list --label agent/ready --state open`, pick one trusted issue (author trust check via `scripts/check-issue-author.sh`), check **per-issue claim budget** (`SELECT count(*) FROM agents WHERE issue_number = $1` < `claim_attempts_max`, default 3), then `ecs:RunTask` against the `task-runner` task definition with `TASK_ISSUE_NUMBER=<n>` and `AGENT_ID=<uuid>` env. Issues that have hit the claim budget get `status/needs-human` + Telegram-alert and are skipped.
+
+   **Atomic claim sequence (matches v2's order — DB row first, see `daemon.py:5142-5240`):**
+
+   1. INSERT `dispatcher.agents` row with `parent_run_id=<this-run>`, `status='running'`, `current_milestone='claiming'`. The partial UNIQUE INDEX on `(issue_number) WHERE status IN ('running', 'retrying')` (migration 25) is the atomic primitive — a duplicate INSERT raises `UniqueViolation` and the launcher abandons the claim. **Note:** writing `status='claiming'` would skip the index gate (the partial predicate does not include `'claiming'`), which under v2/v3 cohabitation would race two daemons to the same `RunTask`. The launcher therefore writes `status='running'` for the row and carries the claiming-step semantics in `current_milestone='claiming'` for cockpit visibility.
+   2. Add `status/in-progress` label.
+   3. Remove `agent/ready` label.
+   4. `ecs:RunTask` against the `task-runner` task definition with `AGENT_ID`, `TASK_ISSUE_NUMBER`, `RUNNER`, `SESSIONS_BUCKET` env.
+   5. UPDATE `dispatcher.agents` SET `task_arn`, advance `current_milestone='running'`.
+
+   Failure mid-sequence reconciles on the next tick.
 5. **Circuit breaker.** Rolling 2-of-3 in last 1h on terminal outcomes; if tripped, set `concurrency_cap=0` and Telegram-alert.
 
 That's the entire launcher. Target ~700 LOC.
@@ -190,7 +200,6 @@ dispatcher.agents (
   issue_number int,
   task_arn text,                       -- ECS task running /task
   diagnoser_arn text,                  -- ECS task running /diagnose-failure (if any)
-  session_s3_key text,                 -- s3://<bucket>/<agent_id>.jsonl, written by task-runner on exit
   status text NOT NULL,                -- claiming, running, succeeded, failed, needs_review
   started_at, ended_at,
   exit_code int,
@@ -302,7 +311,7 @@ The cross-daemon claim race is already handled: both daemons add `status/in-prog
 
 ### 8.3 Schema strategy
 
-- v3 adds: `runs.dispatcher_version`, `terminal_outcomes.parent_run_id`, plus the v3-only columns on `agents` (`current_milestone`, `current_milestone_at`, `session_s3_key`, `diagnoser_arn`, `outcome_summary`).
+- v3 adds: `runs.dispatcher_version`, `terminal_outcomes.parent_run_id`, plus the v3-only columns on `agents` (`current_milestone`, `current_milestone_at`, `diagnoser_arn`, `outcome_summary`). The session-log S3 path is deterministic — `s3://<SESSIONS_BUCKET>/<AGENT_ID>.jsonl` — and the diagnoser builds it from `AGENT_ID` directly, so no column is needed.
 - v2 keeps writing to: `phase_transitions`, `retry_markers`, `failures`, `diagnoses`, `phase_outputs`, `phase_attempts` (if it existed), and the v2-specific columns on `agents` (`phase`, `retries_used`, `merge_unstick_attempts`, `merge_conflict_attempts`, `execution_mode`, `agent_task_arn`).
 - v3 doesn't read any v2-only column. v2 doesn't read any v3-only column. Cross-daemon writes are scoped by `parent_run_id`.
 
@@ -349,10 +358,11 @@ Production accounts are **not** in scope. The trust policy on the agent task rol
 
 1. **Session-log retention and size.** A long ralph run can produce a stream-json transcript of 50–200 MB. CloudWatch Logs retention default 30 days; S3 archive default 90 days, parameterized per `dispatcher.config.session_retention_days`. The diagnoser may want to summarize-then-discard for very large sessions, but that's an in-skill concern, not infra.
 2. **EventBridge vs a tiny scheduler in the launcher.** EventBridge gives outright separation of concerns and zero state coupling, at the cost of one more thing to operate. For four crons, EventBridge is cheaper to operate than a scheduler-in-Python. Default to EventBridge; revisit if a skill needs operator intervention beyond cron.
-3. **Hooks (`PreToolUse`, `SubagentStop`, etc.) inside `/task`'s ECS task.** v2 has hooks writing to `dispatcher.failures` to catch sub-task signals. v3 doesn't have `dispatcher.failures`; the same signals are present in the session log (every tool call is in stream-json), so the diagnoser sees them naturally. **Exception:** the gh-rate-budget hook stays as a *block* (exits non-zero so the tool call is denied locally) — not as a `dispatcher.*` write. It's a circuit breaker, not observation, and lives entirely inside the task-runner.
-4. **The `/task` ECS task wall-clock cap.** Wall-clock cap is the *coarse* liveness check (silent-hang detection in §4.1 is the fine-grained one). Pick a generous wall-clock — 6h covers virtually every real `/task` run including a long ralph + fix-CI cycle. Configure as ECS task `stopTimeout` plus a launcher-side deadline check. If 6h proves wrong, raise it. Silent-hang threshold (default 30min no log growth) is the more typical kill path.
-5. **Trust check — at queue claim or at `/task` start?** Today the launcher does it before `RunTask`. Keep that; it's cheap and the gate is critical.
-6. **`/task` SKILL.md AGENT_ID env-var read.** One-line edit: read `AGENT_ID` from env if set, else fall back to cwd-derived id. Land this edit in v2's `/task` SKILL.md before v3 cutover so v2 still works (env var unset → cwd derivation, same as today).
+3. **The `/task` ECS task wall-clock cap.** Wall-clock cap is the *coarse* liveness check (silent-hang detection in §4.1 is the fine-grained one). Pick a generous wall-clock — 6h covers virtually every real `/task` run including a long ralph + fix-CI cycle. Configure as ECS task `stopTimeout` plus a launcher-side deadline check. If 6h proves wrong, raise it. Silent-hang threshold (default 30min no log growth) is the more typical kill path.
+4. **Trust check — at queue claim or at `/task` start?** Today the launcher does it before `RunTask`. Keep that; it's cheap and the gate is critical.
+5. **`/task` SKILL.md AGENT_ID env-var read.** One-line edit: read `AGENT_ID` from env if set, else fall back to cwd-derived id. Land this edit in v2's `/task` SKILL.md before v3 cutover so v2 still works (env var unset → cwd derivation, same as today).
+
+**Future direction — gh API rate-budget protection.** v2 ships a `PreToolUse` `gh-rate-budget` hook that exits non-zero when remaining API budget is below threshold. v3 does **not** carry the hook over: in practice v2's hook rarely fires (cap=3-5 sustained for months without rate-limit pain in incident logs), and the natural failure mode of `gh` returning 403 is acceptable — agents back off and the v3 circuit breaker catches runaway terminal outcomes before they cascade. Adding the hook is over-engineering against a hypothetical. If rate-limit pain emerges in production, the cleaner intervention is a launcher-side claim gate (~20 LOC): query `gh api rate_limit` each tick, refuse to claim new agents when remaining < threshold. That's a *global* brake (one decision per tick, not per tool call) and *prevents* the problem rather than papering over it after the agent is already running.
 
 ---
 
@@ -402,7 +412,7 @@ What stays runner-shaped:
 
 - **Skills already work cross-tool.** `/task` lives at `.claude/skills/task/SKILL.md`. Symlink `.agents/skills/task/` → that directory and Gemini + OpenCode pick it up natively (the `agentskills.io` standard). OpenCode also reads `.claude/skills/` directly. Cursor 2.4+ supports SKILL.md.
 
-- **Hooks differ per runner.** v2 §6b enumerated the differences (`PreToolUse` vs `BeforeTool`, tool-name namespaces, etc.). The single hook v3 keeps as a *block* (gh-rate-budget, §11 OQ#3) needs a per-runner adapter. Defer until a second runner actually lands.
+- **Hooks differ per runner.** v2 §6b enumerated the differences (`PreToolUse` vs `BeforeTool`, tool-name namespaces, etc.). v3 deliberately keeps zero hooks (rate-budget protection moved to the launcher-side future direction in §11); when a second runner lands and hook adapters become relevant again, the differences are bounded — defer until a second runner actually lands.
 
 - **Per-task runner selection.** `dispatcher.config.runner` (default `claude`) sets the global default. Per-issue override via a label (e.g. `runner/gemini`) read by the launcher at claim-time and passed as env to the task-runner.
 

--- a/packages/api/migrations/60_dispatcher-v3-breaker-defaults.sql
+++ b/packages/api/migrations/60_dispatcher-v3-breaker-defaults.sql
@@ -1,0 +1,92 @@
+-- Up Migration
+--
+-- Dispatcher v3 — seed the three v3-specific circuit breaker config
+-- rows so the breaker boots with the spec's 2-of-3-in-1h calibration
+-- instead of falling back to v2's 5-of-10-in-30min defaults.
+--
+-- Issue #3977 (spec + schema cleanup from audit findings, Item 2).
+--
+-- Why
+-- ---
+-- ``scripts/dispatcher_v3/breaker.py`` reads three v3-specific config
+-- keys with v2 fallbacks:
+--
+--   * ``circuit_breaker_v3_window_size``        (v2 fallback: 10)
+--   * ``circuit_breaker_v3_bad_outcome_threshold`` (v2 fallback: 5)
+--   * ``circuit_breaker_v3_window_minutes``     (v2 fallback: 30)
+--
+-- v2's defaults are calibrated for v2's throughput profile (cap 3-5
+-- sustaining 10 outcomes per 30-min window). v3's ramp throughput is
+-- much lower — at cap=4, ~4 outcomes per 30min, which never fills v2's
+-- window. The breaker effectively never fires until cap=8 sustained,
+-- which is exactly when the conservative protection is no longer
+-- needed.
+--
+-- Spec ``docs/specs/dispatcher-v3-spec.md`` §4.1 step 5 calls out
+-- "Rolling 2-of-3 in last 1h on terminal outcomes" as the v3 breaker
+-- shape. This migration seeds those three rows so the breaker boots
+-- with the spec's calibration on a fresh deploy.
+--
+-- Design notes
+-- ------------
+-- * ``ON CONFLICT (key) DO NOTHING`` makes the migration idempotent
+--   and non-destructive. If an operator (or a future migration) has
+--   already seeded these keys via a ``dispatcher.commands`` write or
+--   a direct UPDATE, this migration leaves their values alone.
+-- * ``value`` is stored as a JSONB integer (``'3'::jsonb``,
+--   ``'2'::jsonb``, ``'60'::jsonb``) — same shape as v2's breaker rows
+--   from migration 21. ``breaker.py``'s ``_read_int_config`` reads
+--   ``SELECT value FROM dispatcher.config WHERE key = $1`` and casts
+--   via ``int()``; the JSONB integer literal is the contract.
+-- * ``updated_by = 'init'`` matches the seed convention from migration
+--   21 / 58 (live-editable keys whose initial value came from a
+--   migration, not an operator edit). The cockpit and audit query
+--   already filter on this value to distinguish migration seeds from
+--   subsequent operator flips.
+-- * ``dispatcher.config`` has no ``notes`` column — the rationale for
+--   each key lives in this migration's comments only. The issue body
+--   referenced a ``notes`` column; it does not exist on the table.
+--   See the schema definition in migration 21 (``CREATE TABLE
+--   dispatcher.config``) — columns are ``(key, value, updated_at,
+--   updated_by)`` only.
+--
+-- Verify (per the issue's AC)
+-- ---------------------------
+--   ``scripts/dev-db-query.sh "SELECT key, value FROM dispatcher.config
+--   WHERE key LIKE 'circuit_breaker_v3_%' ORDER BY key"`` returns
+--   three rows: ``bad_outcome_threshold='2'``, ``window_minutes='60'``,
+--   ``window_size='3'``.
+--
+-- Per-key rationale (so an operator inspecting the rows in psql can
+-- find the "why" without needing to read this file):
+--
+--   * ``circuit_breaker_v3_window_size = 3`` — spec §4.1 (2-of-3 in
+--     1h). v2's default of 10 is calibrated for v2 throughput; v3's
+--     ramp throughput is too low to fill that window.
+--   * ``circuit_breaker_v3_bad_outcome_threshold = 2`` — spec §4.1
+--     (2-of-3 in 1h).
+--   * ``circuit_breaker_v3_window_minutes = 60`` — spec §4.1 (2-of-3
+--     in 1h). 1h gives headroom for retries to settle at low cap.
+
+INSERT INTO dispatcher.config (key, value, updated_by)
+VALUES
+    ('circuit_breaker_v3_window_size',           '3'::jsonb,  'init'),
+    ('circuit_breaker_v3_bad_outcome_threshold', '2'::jsonb,  'init'),
+    ('circuit_breaker_v3_window_minutes',        '60'::jsonb, 'init')
+ON CONFLICT (key) DO NOTHING;
+
+
+-- Down Migration
+--
+-- Drop the three rows. After rollback, the breaker falls back to
+-- ``circuit_breaker_window_size``, ``circuit_breaker_bad_outcome_threshold``,
+-- and ``circuit_breaker_window_minutes`` (v2's shared keys), which is
+-- the pre-#3977 behavior. Non-destructive in effect — no data is lost
+-- and the breaker keeps functioning, just with v2's calibration.
+
+DELETE FROM dispatcher.config
+ WHERE key IN (
+    'circuit_breaker_v3_window_size',
+    'circuit_breaker_v3_bad_outcome_threshold',
+    'circuit_breaker_v3_window_minutes'
+ );

--- a/packages/api/migrations/61_dispatcher-drop-session-s3-key.sql
+++ b/packages/api/migrations/61_dispatcher-drop-session-s3-key.sql
@@ -1,0 +1,63 @@
+-- Up Migration
+--
+-- Dispatcher v3 — drop the unused ``dispatcher.agents.session_s3_key``
+-- column. Issue #3977 (spec + schema cleanup from audit findings,
+-- Item 3).
+--
+-- Why
+-- ---
+-- Migration 56 added ``session_s3_key`` intending it to be written by
+-- ``scripts/dispatcher_v3/agent_runner.py`` on session-log upload. The
+-- implementation never wires it: the runner uploads the session
+-- transcript to a deterministic S3 path
+-- (``s3://<SESSIONS_BUCKET>/<AGENT_ID>.jsonl``) and the diagnoser builds
+-- the key from ``AGENT_ID`` directly without reading the column. The
+-- column has been NULL on every v3-written row since A1 (PR #3893)
+-- shipped. It's vestigial design hubris from the spec; dropping it
+-- removes a misleading shape from the schema.
+--
+-- If a future renaming-of-paths reason ever emerges (e.g. moving to a
+-- per-environment prefix), the column can be re-added in a forward
+-- migration. Today it's dead surface, and the deterministic path
+-- pattern is simpler to reason about.
+--
+-- Design notes
+-- ------------
+-- * ``DROP COLUMN IF EXISTS`` makes the migration idempotent — re-runs
+--   are a no-op, and the column may already be absent on a freshly
+--   regenerated dev DB.
+-- * No data backfill or migration is needed: the column is NULL on
+--   every row, so no values are lost.
+-- * Migration 56's down section already includes
+--   ``DROP COLUMN IF EXISTS session_s3_key`` (alongside the other v3
+--   cohabitation columns); this migration is the forward-only drop.
+--   Migration 56 stays intact as a historical record — applying it
+--   from a fresh DB still adds the column, which is then dropped here.
+-- * ``.claude/skills/diagnose-failure/SKILL.md`` is updated in the same
+--   PR to remove ``session_s3_key`` from its agents-row SELECT.
+-- * ``docs/specs/dispatcher-v3-spec.md`` §5 state model is updated in
+--   the same PR to remove the column from the agents-table sketch.
+--
+-- Verify (per the issue's AC)
+-- ---------------------------
+--   ``scripts/dev-db-query.sh "SELECT column_name FROM information_schema.columns
+--   WHERE table_schema='dispatcher' AND table_name='agents' AND
+--   column_name='session_s3_key'"`` returns 0 rows.
+
+ALTER TABLE dispatcher.agents DROP COLUMN IF EXISTS session_s3_key;
+
+
+-- Down Migration
+--
+-- Re-add the column, NULL on every row. Anything that wrote to the
+-- column previously (nothing — the writer was never wired) is
+-- recoverable from S3 directly via ``s3://<SESSIONS_BUCKET>/<AGENT_ID>.jsonl``,
+-- so the down migration is non-destructive in effect.
+
+ALTER TABLE dispatcher.agents ADD COLUMN IF NOT EXISTS session_s3_key text;
+
+COMMENT ON COLUMN dispatcher.agents.session_s3_key IS
+    'v3-only — S3 key of the agent''s transcript bundle. NULL on every '
+    'v2-written row. Issue #3872. Dropped in migration 61 (#3977) — this '
+    'down section restores the column for symmetry but the writer was '
+    'never wired so the value is always NULL.';

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 59 migrations.
+-- Generated from 61 migrations.
 
 
 
@@ -375,7 +375,6 @@ CREATE TABLE dispatcher.agents (
     current_milestone text,
     current_milestone_detail text,
     current_milestone_at timestamp with time zone,
-    session_s3_key text,
     diagnoser_arn text,
     outcome_summary text
 );
@@ -436,9 +435,6 @@ COMMENT ON COLUMN dispatcher.agents.current_milestone_detail IS 'v3-only — fre
 
 
 COMMENT ON COLUMN dispatcher.agents.current_milestone_at IS 'v3-only — timestamp the current milestone was entered. NULL on every v2-written row. Issue #3872.';
-
-
-COMMENT ON COLUMN dispatcher.agents.session_s3_key IS 'v3-only — S3 key of the agent''s transcript bundle. NULL on every v2-written row. Issue #3872.';
 
 
 COMMENT ON COLUMN dispatcher.agents.diagnoser_arn IS 'v3-only — ECS task ARN of the running diagnoser when an async-spawned diagnoser is in flight for this agent. NULL when no diagnoser is active and on every v2-written row. Issue #3872.';


### PR DESCRIPTION
## Summary

Bundles four small spec/schema drifts surfaced by the dispatcher-v3 spec-vs-implementation audit:

- Spec §4.1 atomic-claim ordering now matches the implementation (INSERT-first, `status='running' + current_milestone='claiming'`, with the partial-UNIQUE-INDEX rationale spelled out).
- Migration 60 seeds the three v3 breaker config rows (`window_size=3`, `bad_outcome_threshold=2`, `window_minutes=60`) so the breaker boots with the spec's 2-of-3-in-1h calibration instead of falling back to v2's 5-of-10/30min defaults.
- Migration 61 drops the unused `dispatcher.agents.session_s3_key` column (never wired — `agent_runner.py` uses a deterministic S3 path); spec §5/§8.3 and the diagnose-failure SKILL.md SELECT updated to match.
- Spec §11 OQ#3 (gh-rate-budget hook) dropped, OQ#4-6 renumbered, cross-references updated, and a "Future direction" note frames a launcher-side claim gate as the cleaner intervention if rate-limit pain emerges.

Closes #3977

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Pre-push hooks (already green locally)
- [x] Markdown link check (99 files, 0 broken links)
- [x] Schema drift check (`schema.sql` regenerated via `scripts/regenerate_schema.sh`)
- [x] Filename separator collision check

### Migration verification (already green locally)
- [x] Apply migration 60 + 61 to fresh temp DB succeeds
- [x] `SELECT key, value FROM dispatcher.config WHERE key LIKE 'circuit_breaker_v3_%' ORDER BY key` returns three rows: `bad_outcome_threshold=2`, `window_minutes=60`, `window_size=3`
- [x] `SELECT column_name FROM information_schema.columns WHERE table_schema='dispatcher' AND table_name='agents' AND column_name='session_s3_key'` returns 0 rows
- [x] Idempotency: re-applying both migrations is a no-op

### Spec verification (already green locally)
- [x] `grep -A 12 "Atomic claim sequence" docs/specs/dispatcher-v3-spec.md` shows the new five-step sequence with the UNIQUE INDEX rationale
- [x] `grep "session_s3_key" docs/specs/dispatcher-v3-spec.md` returns 0 hits
- [x] `grep -E "gh-rate-budget|rate_limit" docs/specs/dispatcher-v3-spec.md` shows the new "Future direction" framing only

### Post-deploy verification
- [ ] Migrations 60 + 61 applied on dev (will run automatically when the API service deploys)
- [ ] Verify on dev: `scripts/dev-db-query.sh "SELECT key, value FROM dispatcher.config WHERE key LIKE 'circuit_breaker_v3_%' ORDER BY key"` returns the three seeded rows
- [ ] Verify on dev: `scripts/dev-db-query.sh "SELECT column_name FROM information_schema.columns WHERE table_schema='dispatcher' AND table_name='agents' AND column_name='session_s3_key'"` returns 0 rows
- [ ] Verification evidence posted on issue
