### PR TITLE
chore(ingestion): backfill OC W08→W8 department codes (#3981)

### DIFF
--- a/scripts/one_off/backfill_oc_dept_w08_to_w8.py
+++ b/scripts/one_off/backfill_oc_dept_w08_to_w8.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Backfill Orange County department codes: normalize W08 → W8 in derived.rulings.
+
+The forward-fix normalizer (_normalize_orange in
+packages/scraper-framework/src/ingestion/department_normalize.py) was shipped in
+#3969 (commit 2fc8911) and already canonicalizes W08→W8 for new captures. This
+script patches the 75 existing rows that were ingested before the fix.
+
+The UPDATE is idempotent: once all W08 rows have been renamed to W8, a re-run
+returns 0 rows and prints "Updated 0 rulings".
+
+Usage via ECS (dev DB is in a private VPC):
+    scripts/ecs-run-task.sh scripts/one_off/backfill_oc_dept_w08_to_w8.py
+
+See: https://github.com/judgemind/judgemind/issues/3981
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+UPDATE_SQL = """
+    UPDATE derived.rulings
+    SET department = 'W8'
+    WHERE department = 'W08'
+      AND court_id IN (SELECT id FROM derived.courts WHERE county = 'Orange')
+    RETURNING id
+"""
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Run the backfill and log row counts."""
+    logger.info("Connecting to database")
+    with psycopg.connect(DATABASE_URL) as conn:
+        with conn.cursor() as cur:
+            logger.info("Updating derived.rulings: W08 → W8 for Orange County courts")
+            cur.execute(UPDATE_SQL)
+            updated_ids = [row[0] for row in cur.fetchall()]
+            updated_count = len(updated_ids)
+            logger.info("Updated ruling IDs: %s", updated_ids)
+
+        conn.commit()
+        logger.info("Backfill complete — rulings_updated=%d", updated_count)
+
+    print(f"Updated {updated_count} rulings")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        logger.exception("Backfill failed")
+        sys.exit(1)


### PR DESCRIPTION
## Summary

Adds a one-off backfill script to normalize 75 existing Orange County rulings with department='W08' to the canonical 'W8' form. The forward-fix normalizer shipped in #3969 already canonicalizes new captures; this script patches the pre-fix historical rows that were causing user-facing analytics splits.

Closes #3981
Closes #3968 (verification gap)

## Test plan

### Automated checks

- [x] Script headers verified: `# venv: scraper-framework` and `# one-off: true` present
- [x] SQL UPDATE statement correct: filters by Orange County courts and department='W08', RETURNING id
- [x] Rowcount logging implemented: prints "Updated <N> rulings" message
- [x] Idempotent design: re-runs return 0 rows and print "Updated 0 rulings"
- [x] Error handling with try/except and sys.exit(1)
- [x] Linting/formatting: passed pre-PR checks

### Post-deploy verification

All acceptance criteria require live database verification after deployment:
- [ ] Script execution via `scripts/ecs-run-task.sh scripts/one_off/backfill_oc_dept_w08_to_w8.py` shows "Updated 75 rulings"
- [ ] SQL verification: GROUP BY canonical form query returns 0 rows (no split forms)
- [ ] User-facing impact: Sheila Recio's per-department aggregate consolidates to single W8 bucket with 424 rulings
- [ ] Verification-evidence comment posted on #3981 and #3968

Post-deploy verification will be conducted by /task-v2-verify.