### PR TITLE
docs: ban Monitor tool for CI watch (root cause of subagent yields)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -597,6 +597,8 @@ scripts/dispatcher/progress.sh "$AGENT_ID" awaiting_ci "PR #<PR-N>" || true
 
 **Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher. **Use `timeout: 1200000`** as CI runs typically take 10-25 minutes.
 
+**Do NOT use the `Monitor` tool for CI watch.** Monitor's bash-while-loop pattern fires a wake-up event on every state-string change, and `gh pr view --json mergeable` flickers between `UNKNOWN` and `MERGEABLE` while CI is still running. Each flicker is an unproductive turn for you and the calling dispatcher — observed root cause behind C2 (#3909), C3 (#3922), C4 (#3927), F2 (#3926) prematurely yielding before they could merge their own PRs. If `scripts/wait-for-ci.sh` gets auto-backgrounded by the harness, **just retry it directly** — do NOT switch to Monitor. Synchronous polling with the canonical helper is the only sanctioned CI-watch path.
+
 Use `scripts/wait-for-ci.sh` as the canonical PR CI gate:
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, 
 
 ### NEVER — Workflow
 - Never use `run_in_background` in any subagent (`/task`, `/ralph`, or Agent-spawned workers). All commands inside subagents run synchronously.
+- Never use the `Monitor` tool. Use synchronous polling instead — `scripts/wait-for-ci.sh` for PR CI gates, `gh run watch --interval 60` for workflow runs. Monitor's change-detection fires a wake-up event on every state-string change, including innocuous flickers like `mergeable=UNKNOWN ↔ MERGEABLE` while CI is still running, which bombards the agent with no-progress turns until it yields. Verified failure mode in PR #3927 / #3922 / #3909 transcripts.
 - Never commit directly to `main` during autonomous task work.
 - **You MAY merge your own PRs** after `/ralph` and CI are green: `gh pr merge <N> --repo judgemind/judgemind --squash --delete-branch`.
 - Never exit or stop after `/ralph` completes without finishing the full `/task` workflow (steps A.3–A.9 in the task skill). Ralph completing means code is ready — not committed, not pushed, not merged. See #721.


### PR DESCRIPTION
## Summary

Forbids the `Monitor` tool for CI watch in both CLAUDE.md (general NEVER rule) and `/task` SKILL.md A.5 (with rationale + cite of the four PRs whose transcripts confirm the failure mode).

## Root cause

Investigation of why /task subagents (#3909, #3922, #3927, #3926) yielded prematurely during CI watch — never reaching their own merge step — surfaced this:

1. /task SKILL.md A.5 says use `scripts/wait-for-ci.sh` synchronously.
2. The harness occasionally auto-backgrounds `wait-for-ci.sh` (separate retro #3900 tracks the underlying flakiness).
3. When backgrounded, the agent improvised: "Backgrounded. Let me use the Monitor tool instead."
4. The Monitor command ran `gh pr view --json statusCheckRollup,mergeable` in a `while true; sleep 30` loop with `if [ "$cur" != "$prev" ]` change-detection on the full state string `pending=N failed=M mergeable=X`.
5. **`mergeable` flickers between `UNKNOWN` and `MERGEABLE` while CI is still running** — GitHub recomputes mergeability constantly. Each flicker = state change = `echo` = Monitor wake-up event = unproductive turn for the agent.
6. After 30+ flicker wake-ups with `pending` unchanged, the agent yields with messages like "I'll wait for the Monitor notification rather than poll."

Verified directly in the C4 transcript: the Monitor watched `pending=2 failed=0 mergeable=$mergeable` and got bombarded with `pending=2 failed=0 mergeable=UNKNOWN` ↔ `pending=2 failed=0 mergeable=MERGEABLE` flickers for ~30 minutes.

## Fix

Two-line additions:

- **CLAUDE.md NEVER — Workflow:** "Never use the `Monitor` tool. Use synchronous polling instead..."
- **/task SKILL.md A.5:** "Do NOT use the `Monitor` tool for CI watch... If `scripts/wait-for-ci.sh` gets auto-backgrounded by the harness, **just retry it directly**."

## Test plan

- [x] `grep -nE "Monitor" CLAUDE.md` shows the new rule under NEVER — Workflow.
- [x] `grep -nE "Monitor" .claude/skills/task/SKILL.md` shows the prohibition in A.5 with citation of the 4 PRs.
- [ ] Markdown link check (CI).
- [ ] Future /task subagents pushed through long CI watches do not yield prematurely (verifiable post-merge by spawning one and watching the transcript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
