### PR TITLE
fix(scraping): split CourtListener plain_text vs html for ruling_text

### DIFF
--- a/packages/scraper-framework/src/courts/federal/courtlistener.py
+++ b/packages/scraper-framework/src/courts/federal/courtlistener.py
@@ -373,19 +373,26 @@ class CourtListenerScraper(BaseScraper):
         Returns:
             A CapturedDocument, or None if the opinion has no usable content.
         """
-        # The opinion text can come from several fields; prefer html, fall back
-        # to plain_text.  If neither exists the opinion has no content we can use.
-        opinion_text = (
+        # CourtListener opinions ship two parallel representations:
+        #   - plain_text:           clean text, no markup (what we want for ruling_text)
+        #   - html_with_citations:  same text wrapped in <pre class="inline"> with
+        #                           inline <span class="citation"> links
+        # Storing html_with_citations into ruling_text leaves <pre>/<span> markup
+        # in the canonical text column (derived.rulings.ruling_text); the schema
+        # already has a separate ruling_text_html column for the rich version.
+        plain_text_value = opinion.get("plain_text") or ""
+        html_text_value = (
             opinion.get("html_with_citations")
             or opinion.get("html")
             or opinion.get("html_columbia")
             or opinion.get("html_lawbox")
-            or opinion.get("plain_text")
             or ""
         )
 
-        if not opinion_text:
+        if not plain_text_value and not html_text_value:
             return None
+
+        canonical_text = plain_text_value or html_text_value
 
         raw_content = json.dumps(
             {"cluster": cluster, "opinion": opinion},
@@ -442,7 +449,8 @@ class CourtListenerScraper(BaseScraper):
         doc.case_number = _extract_docket_number(cluster)
         doc.judge_name = _extract_judge_names(cluster)
         doc.hearing_date = _parse_date(cluster.get("date_filed"))
-        doc.ruling_text = opinion_text[:10000] if opinion_text else None
+        doc.ruling_text = canonical_text[:10000] if canonical_text else None
+        doc.ruling_text_html = html_text_value[:10000] if html_text_value else None
         doc.outcome = None  # CourtListener opinions don't have a simple outcome field
         doc.motion_type = _map_opinion_type(opinion.get("type"))
 

--- a/packages/scraper-framework/tests/courts/test_courtlistener.py
+++ b/packages/scraper-framework/tests/courts/test_courtlistener.py
@@ -401,14 +401,19 @@ class TestCourtListenerScraper:
         assert doc.court == "CourtListener"
 
     @respx.mock
-    def test_fetch_documents_prefers_html(self) -> None:
-        """Scraper prefers html_with_citations over plain_text."""
+    def test_fetch_documents_uses_plain_text_for_ruling_text(self) -> None:
+        """ruling_text uses plain_text; ruling_text_html captures the HTML variant.
+
+        derived.rulings has separate columns for the canonical text and a rich
+        HTML representation. Storing html_with_citations in ruling_text leaves
+        <pre>/<span> markup in the canonical text column and breaks downstream
+        consumers that expect ruling_text to be plain.
+        """
         cluster = _make_cluster()
         opinion = _make_opinion(
             plain_text="Plain version",
             html="<p>HTML version</p>",
         )
-        # html_with_citations takes priority, set it directly
         opinion["html_with_citations"] = "<p>HTML with <a>citations</a></p>"
 
         respx.get(f"{API_BASE_URL}/clusters/").mock(
@@ -424,7 +429,31 @@ class TestCourtListenerScraper:
         docs = scraper.fetch_documents()
 
         assert len(docs) == 1
-        assert docs[0].ruling_text == "<p>HTML with <a>citations</a></p>"
+        assert docs[0].ruling_text == "Plain version"
+        assert docs[0].ruling_text_html == "<p>HTML with <a>citations</a></p>"
+
+    @respx.mock
+    def test_fetch_documents_falls_back_to_html_when_plain_text_empty(self) -> None:
+        """When plain_text is empty, ruling_text falls back to the HTML variant."""
+        cluster = _make_cluster()
+        opinion = _make_opinion(plain_text="", html="")
+        opinion["html_with_citations"] = "<p>Only HTML available</p>"
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+
+        config = _make_scraper_config()
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        assert docs[0].ruling_text == "<p>Only HTML available</p>"
+        assert docs[0].ruling_text_html == "<p>Only HTML available</p>"
 
     @respx.mock
     def test_fetch_documents_skips_empty_opinions(self) -> None:


### PR DESCRIPTION
## Root cause

`packages/scraper-framework/src/courts/federal/courtlistener.py:378-385` (pre-change) set `doc.ruling_text` from `opinion["html_with_citations"]` whenever it was present, falling back to `opinion["plain_text"]` only as a last resort. The CourtListener API populates both fields for most opinions, so for the typical case `ruling_text` ended up containing raw HTML markup like `<pre class="inline">USCA11 Case: 25-13869…</pre>` and `<span class="citation no-link">…</span>`.

The schema separates plain text (`derived.rulings.ruling_text`) from rich HTML (`derived.rulings.ruling_text_html`) — the GraphQL resolver and the web app's ruling-detail page both expect `ruling_text` to be plain. The mapper had been writing HTML into the plain column AND never populating the HTML column at all, so `ruling_text_html` is currently NULL for every CourtListener-sourced ruling.

## Fix

Prefer `plain_text` for the canonical text; fall back to the HTML variants (`html_with_citations` → `html` → `html_columbia` → `html_lawbox`) only when `plain_text` is empty. Populate `doc.ruling_text_html` from the HTML variant separately so the rich-text column starts getting filled.

## Test updates

- `test_fetch_documents_prefers_html` was asserting the buggy behavior (that HTML wins over plain text). Renamed to `test_fetch_documents_uses_plain_text_for_ruling_text` and inverted the assertions to lock in the correct behavior.
- New `test_fetch_documents_falls_back_to_html_when_plain_text_empty` covers the empty-plain-text path.

## Sequencing

#3978 is queued to reingest 1,701 Federal docs under `ExtractionMethod.NONE`. Without this fix, that reingest would replace the small intermittent HTML-residue surface with a systematic one. This PR should land first.

## Test plan

- [x] `pytest packages/scraper-framework/tests/courts/test_courtlistener.py -k fetch_documents`
- [x] `ruff check packages/scraper-framework/`
- [x] `ruff format --check packages/scraper-framework/`

Found by: /spotcheck (2026-05-02)
