### PR TITLE
fix(scraping): catch LLM-hallucinated bracketed placeholder case titles (#3988)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -86,6 +86,9 @@ from framework.la_parser_utils import (
     SKIP_RESPONDING_PHRASES as _SKIP_RESPONDING_PHRASES,
 )
 from framework.llm_extractor import (
+    _BRACKETED_PLACEHOLDER_TITLE_RE as _BRACKETED_PLACEHOLDER_TITLE_RE,
+)
+from framework.llm_extractor import (
     _ROLE_LITERAL_TITLE_RE as _ROLE_LITERAL_TITLE_RE,
 )
 from framework.llm_extractor import (
@@ -619,20 +622,36 @@ def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
                     parties.append({"name": name, "role": str(p["role"])})
 
         case_title = entry.get("extracted_case_title")
-        if case_title and _ROLE_LITERAL_TITLE_RE.match(case_title):
+        if case_title and (
+            _ROLE_LITERAL_TITLE_RE.match(case_title)
+            or _BRACKETED_PLACEHOLDER_TITLE_RE.search(case_title)
+        ):
             rebuilt = _rebuild_title_from_parties(case_title, parties)
             if rebuilt is not None:
-                logger.info(
-                    "la.llm_role_literal_title_rebuilt",
-                    before=case_title,
-                    after=rebuilt,
-                )
+                if _BRACKETED_PLACEHOLDER_TITLE_RE.search(case_title):
+                    logger.info(
+                        "la.llm_bracketed_placeholder_title_rebuilt",
+                        before=case_title,
+                        after=rebuilt,
+                    )
+                else:
+                    logger.info(
+                        "la.llm_role_literal_title_rebuilt",
+                        before=case_title,
+                        after=rebuilt,
+                    )
                 case_title = rebuilt
             else:
-                logger.info(
-                    "la.llm_role_literal_title_dropped",
-                    before=case_title,
-                )
+                if _BRACKETED_PLACEHOLDER_TITLE_RE.search(case_title):
+                    logger.info(
+                        "la.llm_bracketed_placeholder_title_dropped",
+                        before=case_title,
+                    )
+                else:
+                    logger.info(
+                        "la.llm_role_literal_title_dropped",
+                        before=case_title,
+                    )
                 case_title = None
 
         # Reversed-title sanitizer (#3846): detect and correct cases where the

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -136,6 +136,18 @@ _ROLE_LITERAL_TITLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Matches a case_title that contains an LLM-hallucinated bracketed placeholder
+# for a party name, e.g. "Ezra Arce v. [Defendant not specified]" or
+# "[Plaintiff name unknown] v. Smith".  The bracket must contain a role word
+# (plaintiff/defendant/petitioner/respondent/party/name/case) followed by a
+# qualifier (not specified, unknown, missing, not listed, not provided, tbd).
+# No anchor — the bracket can appear anywhere in the title.  See #3988.
+_BRACKETED_PLACEHOLDER_TITLE_RE = re.compile(
+    r"\[(?:plaintiff|defendant|petitioner|respondent|party|name|case)[^\]]*"
+    r"(?:not specified|unknown|missing|not listed|not provided|tbd)[^\]]*\]",
+    re.IGNORECASE,
+)
+
 # ---------------------------------------------------------------------------
 # LLM result cache
 # ---------------------------------------------------------------------------
@@ -1410,7 +1422,9 @@ def _rebuild_title_from_parties(
         Rebuilt title string, or ``None`` if the pattern does not match or
         parties are insufficient to rebuild.
     """
-    if not title or not _ROLE_LITERAL_TITLE_RE.match(title):
+    if not title or not (
+        _ROLE_LITERAL_TITLE_RE.match(title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(title)
+    ):
         return None
 
     # Determine which role pair to look for.  Petitions use petitioner/respondent;

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -4300,3 +4300,48 @@ class TestRebuildReversedTitleFromParties:
     def test_returns_none_on_empty_parties(self) -> None:
         result = _rebuild_reversed_title_from_parties("Foo v. Bar", [])
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestLlmExtractRulingsBracketedPlaceholderTitle — bracketed placeholder guard
+# (#3988)
+# ---------------------------------------------------------------------------
+
+
+class TestLlmExtractRulingsBracketedPlaceholderTitle:
+    """Tests for bracketed-placeholder case_title sanitization in _llm_extract_rulings().
+
+    The LA LLM occasionally emits hallucinated bracketed placeholders like
+    "Ezra Arce v. [Defendant not specified]" instead of the real party name.
+    When no defendant is extractable, the post-processor should drop the title
+    to None.  When both parties are present, it should rebuild a clean title.
+    See #3988.
+    """
+
+    def test_bracketed_placeholder_title_drops_to_none_on_la_path(self) -> None:
+        """LA Arce shape: bracketed placeholder with only plaintiff → case_title is None.
+
+        'Ezra Arce v. [Defendant not specified]' + parties list containing only
+        a plaintiff.  The gate should trigger, _rebuild_title_from_parties cannot
+        build 'P v. D' (no defendant), so case_title is dropped to None.
+        """
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV12345",
+                "extracted_case_title": "Ezra Arce v. [Defendant not specified]",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [
+                    {"name": "Ezra Arce", "role": "plaintiff"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV12345</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title is None

--- a/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
+++ b/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import pytest
 
 from framework.llm_extractor import (
+    _BRACKETED_PLACEHOLDER_TITLE_RE,
     _SB_CASE_NUMBER_RE,
     _disjoint_plaintiff_names,
     _rebuild_title_from_parties,
@@ -222,6 +223,70 @@ def test_rebuild_title_from_parties_accepts_dict_shaped_parties() -> None:
     ]
     result = _rebuild_title_from_parties("Plaintiff v. General Motors, LLC", parties)
     assert result == "Sumayya Aasi v. General Motors, LLC"
+
+
+# ---------------------------------------------------------------------------
+# _BRACKETED_PLACEHOLDER_TITLE_RE — bracketed-placeholder title guard (#3988)
+# ---------------------------------------------------------------------------
+
+
+def test_bracketed_placeholder_re_matches_defendant_not_specified() -> None:
+    """Matches the canonical Arce shape: 'Ezra Arce v. [Defendant not specified]'."""
+    assert _BRACKETED_PLACEHOLDER_TITLE_RE.search("Ezra Arce v. [Defendant not specified]")
+
+
+def test_bracketed_placeholder_re_matches_plaintiff_unknown() -> None:
+    """Matches bracketed placeholder at start of title: '[Plaintiff name unknown] v. Smith'."""
+    assert _BRACKETED_PLACEHOLDER_TITLE_RE.search("[Plaintiff name unknown] v. Smith")
+
+
+def test_bracketed_placeholder_re_matches_respondent_missing() -> None:
+    """Matches mid-title bracketed placeholder: 'In re Doe [Respondent missing]'."""
+    assert _BRACKETED_PLACEHOLDER_TITLE_RE.search("In re Doe [Respondent missing]")
+
+
+def test_bracketed_placeholder_re_does_not_match_clean_title() -> None:
+    """A clean title like 'Smith v. Jones' produces no match."""
+    assert not _BRACKETED_PLACEHOLDER_TITLE_RE.search("Smith v. Jones")
+
+
+def test_bracketed_placeholder_re_does_not_match_non_role_brackets() -> None:
+    """False-positive guardrail: 'Smith v. Acme [DBA Acme Corp.]' should NOT match.
+
+    'DBA' is a real annotation bracket, not a placeholder — the regex must
+    restrict matches to role words followed by qualifier words.
+    """
+    assert not _BRACKETED_PLACEHOLDER_TITLE_RE.search("Smith v. Acme [DBA Acme Corp.]")
+
+
+def test_rebuild_title_from_parties_handles_bracketed_placeholder() -> None:
+    """Bracketed-placeholder title with only one real party returns None (drop path).
+
+    The LA Arce shape: 'Ezra Arce v. [Defendant not specified]' with only a
+    plaintiff in extracted_parties.  _rebuild_title_from_parties cannot build
+    'P v. D', so returns None — caller nulls the title.
+    """
+    result = _rebuild_title_from_parties(
+        "Ezra Arce v. [Defendant not specified]",
+        [{"name": "Ezra Arce", "role": "plaintiff"}],
+    )
+    assert result is None
+
+
+def test_rebuild_title_from_parties_rebuilds_bracketed_placeholder_with_both_parties() -> None:
+    """Bracketed-placeholder title with both parties returns rebuilt 'P v. D'.
+
+    When extracted_parties contains both plaintiff and defendant, the title
+    should be rebuilt as 'PlaintiffName v. DefendantName'.
+    """
+    result = _rebuild_title_from_parties(
+        "Ezra Arce v. [Defendant not specified]",
+        [
+            {"name": "Ezra Arce", "role": "plaintiff"},
+            {"name": "John Doe Corp", "role": "defendant"},
+        ],
+    )
+    assert result == "Ezra Arce v. John Doe Corp"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add framework-level regex `_BRACKETED_PLACEHOLDER_TITLE_RE` to catch LLM-hallucinated bracketed placeholder titles like "Ezra Arce v. [Defendant not specified]" that bypass the existing `_ROLE_LITERAL_TITLE_RE`. Wire the regex into the `_rebuild_title_from_parties` gate and the LA tentatives caller with distinct structured log keys for observability. The framework-level change protects all downstream extractors.

Closes #3988

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Verify derived.cases contains zero rows with bracketed-placeholder case_title (post-deploy)
- [ ] Reingest LA Arce HTML and confirm case_title is either rebuilt from extracted parties or NULL (post-deploy)
- [ ] Verification evidence posted on #3988 (see /task-v2-verify output)

## Implementation notes

**Test file location note:** Ralph added tests in `packages/scraper-framework/tests/test_san_bernardino_multi_case.py` and `packages/scraper-framework/tests/courts/test_la_tentatives.py`. The AC verify instruction points to `test_llm_extractor.py`, which will need operator adjustment to:

```bash
pytest packages/scraper-framework/tests/ -k 'bracketed_placeholder or rebuild_title'
```

All 8 tests are present and comprehensive (covering defendant-not-specified, plaintiff-unknown, respondent-missing, false-positive guardrails, and both drop and rebuild paths).