### PR TITLE
fix(api): add GraphQL DoS hardening (depth/complexity/body limits) (#4003)

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -19,6 +19,8 @@
         "fastify": "^5.8",
         "google-auth-library": "^9.15.1",
         "graphql": "^16.8",
+        "graphql-depth-limit": "^1.1.0",
+        "graphql-validation-complexity": "^0.4.2",
         "jsonwebtoken": "^9.0",
         "node-pg-migrate": "^8.0.4",
         "pg": "^8.11",
@@ -28,6 +30,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^5",
+        "@types/graphql-depth-limit": "^1.1.6",
         "@types/jsonwebtoken": "^9",
         "@types/node": "^20",
         "@types/pg": "^8",
@@ -3372,6 +3375,30 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/graphql-depth-limit": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql-depth-limit/-/graphql-depth-limit-1.1.6.tgz",
+      "integrity": "sha512-WU4bjoKOzJ8CQE32Pbyq+YshTMcLJf2aJuvVtSLv1BQPwDUGa38m2Vr8GGxf0GZ0luCQcfxlhZeHKu6nmTBvrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graphql": "^14.5.3"
+      }
+    },
+    "node_modules/@types/graphql-depth-limit/node_modules/graphql": {
+      "version": "14.7.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+      "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+      "deprecated": "No longer supported; please update to a newer version. Details: https://github.com/graphql/graphql-js#version-support",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterall": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 6.x"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -3945,6 +3972,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/assertion-error": {
@@ -5604,6 +5640,33 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "license": "MIT",
+      "dependencies": {
+        "arrify": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "*"
+      }
+    },
+    "node_modules/graphql-validation-complexity": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/graphql-validation-complexity/-/graphql-validation-complexity-0.4.2.tgz",
+      "integrity": "sha512-4tzmN/70a06c2JH5fvISkoLX6oBDpqK22cvr2comge3HZHtBLD3n5Sl6MnQYMVhQqKGlpZWcCgD00MnyKNzYYg==",
+      "license": "MIT",
+      "dependencies": {
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.9.5"
+      }
+    },
     "node_modules/gtoken": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
@@ -5947,6 +6010,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -6240,6 +6310,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loose-envify/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -8659,6 +8747,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/webidl-conversions": {
@@ -11124,6 +11221,26 @@
         "@types/send": "*"
       }
     },
+    "@types/graphql-depth-limit": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@types/graphql-depth-limit/-/graphql-depth-limit-1.1.6.tgz",
+      "integrity": "sha512-WU4bjoKOzJ8CQE32Pbyq+YshTMcLJf2aJuvVtSLv1BQPwDUGa38m2Vr8GGxf0GZ0luCQcfxlhZeHKu6nmTBvrw==",
+      "dev": true,
+      "requires": {
+        "graphql": "^14.5.3"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "14.7.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.7.0.tgz",
+          "integrity": "sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==",
+          "dev": true,
+          "requires": {
+            "iterall": "^1.2.2"
+          }
+        }
+      }
+    },
     "@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -11531,6 +11648,11 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -12717,6 +12839,22 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
       "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA=="
     },
+    "graphql-depth-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-depth-limit/-/graphql-depth-limit-1.1.0.tgz",
+      "integrity": "sha512-+3B2BaG8qQ8E18kzk9yiSdAa75i/hnnOwgSeAxVJctGQPvmeiLtqKOYF6HETCyRjiF7Xfsyal0HbLlxCQkgkrw==",
+      "requires": {
+        "arrify": "^1.0.1"
+      }
+    },
+    "graphql-validation-complexity": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/graphql-validation-complexity/-/graphql-validation-complexity-0.4.2.tgz",
+      "integrity": "sha512-4tzmN/70a06c2JH5fvISkoLX6oBDpqK22cvr2comge3HZHtBLD3n5Sl6MnQYMVhQqKGlpZWcCgD00MnyKNzYYg==",
+      "requires": {
+        "warning": "^4.0.3"
+      }
+    },
     "gtoken": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
@@ -12948,6 +13086,12 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==",
+      "dev": true
+    },
     "jackspeak": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
@@ -13161,6 +13305,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        }
+      }
     },
     "loupe": {
       "version": "2.3.7",
@@ -14672,6 +14831,14 @@
         "vite": "^5.0.0",
         "vite-node": "1.6.1",
         "why-is-node-running": "^2.2.2"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "webidl-conversions": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,6 +29,8 @@
     "fastify": "^5.8",
     "google-auth-library": "^9.15.1",
     "graphql": "^16.8",
+    "graphql-depth-limit": "^1.1.0",
+    "graphql-validation-complexity": "^0.4.2",
     "jsonwebtoken": "^9.0",
     "node-pg-migrate": "^8.0.4",
     "pg": "^8.11",
@@ -38,6 +40,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^5",
+    "@types/graphql-depth-limit": "^1.1.6",
     "@types/jsonwebtoken": "^9",
     "@types/node": "^20",
     "@types/pg": "^8",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -2,6 +2,8 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { ApolloServer, HeaderMap } from '@apollo/server';
 import type { Pool } from 'pg';
 import type { Client } from '@opensearch-project/opensearch';
+import depthLimit from 'graphql-depth-limit';
+import { createComplexityLimitRule } from 'graphql-validation-complexity';
 import { typeDefs } from './graphql/schema';
 import { resolvers } from './graphql/resolvers';
 import { createLoaders } from './graphql/dataloader';
@@ -18,6 +20,7 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
   const app = Fastify({
     logger: process.env.NODE_ENV !== 'test',
     trustProxy: true,
+    bodyLimit: 100_000,
   });
 
   // ── CORS ────────────────────────────────────────────────────────────────
@@ -46,6 +49,12 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
     resolvers,
     // Introspection disabled in production to reduce attack surface.
     introspection: process.env.NODE_ENV !== 'production',
+    validationRules: [
+      depthLimit(10),
+      createComplexityLimitRule(1000, {
+        onCost: (cost: number) => app.log.info({ cost }, 'graphql.cost'),
+      }),
+    ],
   });
   await apollo.start();
 

--- a/packages/api/src/types/graphql-validation-complexity.d.ts
+++ b/packages/api/src/types/graphql-validation-complexity.d.ts
@@ -1,0 +1,20 @@
+declare module 'graphql-validation-complexity' {
+  import type { ValidationRule } from 'graphql';
+
+  export interface ComplexityLimitRuleOptions {
+    onCost?: (cost: number) => void;
+    createError?: (cost: number, node: unknown) => Error;
+    formatErrorMessage?: (cost: number) => string;
+    scalarCost?: number;
+    objectCost?: number;
+    listFactor?: number;
+    introspectionListFactor?: number;
+  }
+
+  export function createComplexityLimitRule(
+    maxCost: number,
+    options?: ComplexityLimitRuleOptions,
+  ): ValidationRule;
+
+  export function complexityLimitExceededErrorMessage(): string;
+}

--- a/packages/api/tests/graphql-dos-limits.unit.test.ts
+++ b/packages/api/tests/graphql-dos-limits.unit.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildApp();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+// Generates a deeply nested GraphQL query using the Case ↔ Ruling circular
+// relationship (Case.latestRuling → Ruling, Ruling.case → Case).
+// graphql-depth-limit counts each object field as +1 from its parent.
+// Nesting pattern: case(1) → latestRuling(2) → case(3) → latestRuling(4) → …
+// Each pair of latestRuling+case adds 2 levels. For depth ≥ 11, use pairs=5:
+//   case(1) → latestRuling(2) → case(3) → … → latestRuling(10) → case(11) → id(leaf)
+// To trigger the maxDepth=10 limit, the reported depth must be > 10 (i.e. ≥ 11).
+function buildDepthQuery(targetDepth: number): string {
+  if (targetDepth <= 1)
+    return '{ case(id: "00000000-0000-0000-0000-000000000000") { id } }';
+
+  // Build innermost part: leaf scalar inside the deepest case
+  let inner = 'id';
+  // Each iteration wraps with latestRuling { case { … } } adding 2 depth levels.
+  // Starting from depth=1 (outer case), each pair adds 2. We need targetDepth-1
+  // more levels. Use Math.ceil((targetDepth - 1) / 2) pairs.
+  const pairs = Math.ceil((targetDepth - 1) / 2);
+  for (let i = 0; i < pairs; i++) {
+    // Ruling.case is a plain field (no argument); only root Query.case takes id.
+    inner = `latestRuling { case { ${inner} } }`;
+  }
+  return `{ case(id: "00000000-0000-0000-0000-000000000000") { ${inner} } }`;
+}
+
+describe('GraphQL DoS limits', () => {
+  it('depth-11 query returns 400 with depth-limit error', async () => {
+    const query = buildDepthQuery(11);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ query }),
+    });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+    expect(Array.isArray(body.errors)).toBe(true);
+    expect(body.errors.length).toBeGreaterThan(0);
+    // At least one error should mention depth
+    const hasDepthError = body.errors.some(
+      (e: { message: string }) =>
+        typeof e.message === 'string' && e.message.toLowerCase().includes('depth'),
+    );
+    expect(hasDepthError).toBe(true);
+  });
+
+  it('oversized body (200KB) returns 413 Payload Too Large', async () => {
+    // Pad the query to exceed 100KB
+    const padding = 'x'.repeat(200_000);
+    const oversizedPayload = JSON.stringify({
+      query: `{ __typename }`,
+      extensions: { padding },
+    });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: { 'content-type': 'application/json' },
+      payload: oversizedPayload,
+    });
+    expect(res.statusCode).toBe(413);
+  });
+
+  it('depth-5 legitimate query passes validation (no validation errors)', async () => {
+    // Depth 5: query(1) → case(2) → judges(3) → court(4) → courtName(5)
+    // Case.judges returns [Judge!]!, and Judge.court returns Court.
+    const query = `{
+      case(id: "00000000-0000-0000-0000-000000000000") {
+        caseNumber
+        court {
+          courtName
+        }
+        judges {
+          canonicalName
+          court {
+            state
+          }
+        }
+        parties {
+          id
+        }
+      }
+    }`;
+    const res = await app.inject({
+      method: 'POST',
+      url: '/graphql',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ query }),
+    });
+    // Should not be 400 (validation error) — may be 200 with data null and resolver errors (no DB)
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    // Must not have validation errors (validation errors use 400); any errors here
+    // are resolver errors (DB not available), which still return 200.
+    // Specifically, there should be no depth-limit or complexity errors.
+    if (body.errors) {
+      const hasValidationError = body.errors.some(
+        (e: { message: string; extensions?: { code?: string } }) =>
+          e.message.toLowerCase().includes('depth') ||
+          e.message.toLowerCase().includes('complexity') ||
+          e.extensions?.code === 'GRAPHQL_VALIDATION_FAILED',
+      );
+      expect(hasValidationError).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds DoS hardening to the public `/graphql` endpoint: Fastify bodyLimit (100KB), GraphQL depth limit (10), and complexity limit (1000). Prevents classic DoS patterns like deeply nested queries and oversized payloads without affecting legitimate user queries.

Closes #4003

## Test plan

### Automated checks

- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`prettier`)
- [x] Tests pass (`npm test` — 366 passed)
- [x] TypeScript strict mode (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)
- [x] CI green

### Post-deploy verification

- [ ] Verify: `curl` a depth-11 query against `/graphql` on dev returns 400 with depth-limit error message
- [ ] Verify: `curl` a 200KB GraphQL body returns 413 Payload Too Large
- [ ] Verify: existing legitimate frontend queries still execute (manual sanity check on dev)
- [ ] Verification evidence posted on #4003 (see /task-v2-verify output)