### PR TITLE
fix(scraping): reject bare 'v[s].' case_titles in ingestion chain (#3990)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1402,6 +1402,11 @@ _TRAILING_CONNECTOR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Bare vs-separator at the end of a title — no defendant name follows (#3990).
+# Matches strings that end in a dangling "v", "vs", "vs." with no following text.
+# Examples: "Steinman v", "Doe vs", "Aoyagi vs.", "Serrato Vs"
+_BARE_VS_SUFFIX_RE = re.compile(r"(?:^|\s)[Vv][Ss]?\.?\s*$")
+
 
 def strip_trailing_connectors(title: str) -> str:
     """Strip trailing English connector words from a case title.
@@ -1426,6 +1431,25 @@ def strip_trailing_connectors(title: str) -> str:
     if stripped == title:
         return title
     return stripped.rstrip(".,;: ") or title
+
+
+def has_bare_vs_suffix(title: str) -> bool:
+    """Return True if *title* ends with a bare vs-separator and no defendant name.
+
+    Detects titles like ``"Steinman v"``, ``"Doe vs"``, ``"Aoyagi vs."``,
+    ``"Serrato Vs"`` where the LLM extracted the plaintiff but the defendant
+    name is missing, leaving only the dangling separator (#3990).
+
+    Args:
+        title: The case title string to check.
+
+    Returns:
+        True if the title ends with a bare "v", "vs", or "vs." with no
+        following party name.
+    """
+    if not title:
+        return False
+    return bool(_BARE_VS_SUFFIX_RE.search(title))
 
 
 def is_plausible_case_title(title: str) -> bool:
@@ -1477,6 +1501,11 @@ def is_plausible_case_title(title: str) -> bool:
     # contamination like "TAYLOR VS. AMAZON MSC21-02349 Romeo Cerina"
     # (#2242).
     if _PLAUSIBILITY_CASE_NUMBER_RE.search(stripped):
+        return False
+
+    # Reject titles that end with a bare vs-separator with no defendant name
+    # following — e.g. "Steinman v", "Doe vs", "Aoyagi vs." (#3990).
+    if _BARE_VS_SUFFIX_RE.search(stripped):
         return False
 
     return True

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -77,6 +77,7 @@ from .extract import (
     extract_case_type_from_title,
     extract_hearing_date,
     extract_judge_name,
+    has_bare_vs_suffix,
     is_plausible_case_title,
     is_plausible_hearing_date,
     is_probate_decedent_name,
@@ -1888,6 +1889,22 @@ class IngestionWorker:
                     },
                 )
                 case_title = sanitized
+
+        # Null bare-vs titles before the plausibility check: titles like
+        # "Steinman v" or "Doe vs." are partial — the defendant name was
+        # truncated/missing.  Accept NULL over a malformed partial title
+        # (option (b) from issue #3990).
+        if case_title and has_bare_vs_suffix(case_title):
+            logger.info(
+                "Nulled bare-vs case title (no defendant name follows)",
+                extra={
+                    "document_id": document_id,
+                    "old_title": case_title[:120],
+                    "telemetry_event": "bare_vs_title_nulled",
+                },
+            )
+            case_title = None
+            extraction_methods.pop("case_title", None)
 
         # For LLM-extracted events, the LLM-provided case_title can be
         # messy (motion descriptions, case citations, multiple parties).

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -2552,6 +2552,76 @@ class TestStripTrailingCaseNumber:
         raw = "X 2024cubco20894"
         assert strip_trailing_case_number(raw) == "X"
 
+
+# ---------------------------------------------------------------------------
+# Bare "v" / "vs" suffix rejection (#3990)
+# ---------------------------------------------------------------------------
+
+
+class TestBareVsSuffix:
+    """Unit tests for bare-vs-suffix detection and rejection (#3990).
+
+    Covers:
+      - has_bare_vs_suffix() helper
+      - is_plausible_case_title() rejecting bare-vs inputs
+      - clean_case_title() returning None for bare-vs inputs
+      - test_bare_vs_separator_rejected (AC #3 named test)
+    """
+
+    def test_strips_bare_vs_suffix_helper(self) -> None:
+        """has_bare_vs_suffix() correctly identifies bare-vs trailing suffixes."""
+        from ingestion.extract import has_bare_vs_suffix
+
+        assert has_bare_vs_suffix("Steinman v") is True
+        assert has_bare_vs_suffix("Doe vs") is True
+        assert has_bare_vs_suffix("Aoyagi vs.") is True
+        assert has_bare_vs_suffix("Serrato Vs") is True
+        assert has_bare_vs_suffix("Bridges vs.") is True
+        # Titles with text after vs. are NOT bare-vs suffixes
+        assert has_bare_vs_suffix("Smith v. Jones") is False
+        assert has_bare_vs_suffix("Smith vs. State of California") is False
+        assert has_bare_vs_suffix("In re Marriage of Garcia") is False
+
+    def test_is_plausible_case_title_rejects_bare_vs(self) -> None:
+        """is_plausible_case_title() returns False for bare-vs trailing suffix."""
+        assert is_plausible_case_title("Steinman v") is False
+        assert is_plausible_case_title("Doe vs") is False
+        assert is_plausible_case_title("Aoyagi vs.") is False
+        assert is_plausible_case_title("Serrato Vs") is False
+        assert is_plausible_case_title("Bridges vs.") is False
+
+    def test_clean_case_title_returns_none_for_bare_vs(self) -> None:
+        """clean_case_title() returns None for bare-vs inputs (existing behavior)."""
+        assert clean_case_title("Steinman v") is None
+        assert clean_case_title("Doe vs") is None
+        assert clean_case_title("Aoyagi vs.") is None
+
+    def test_bare_vs_separator_rejected(self) -> None:
+        """AC #3: LA/OC/RV-shaped fixture inputs that previously produced bare 'v.'
+        must produce None (never the partial form).
+
+        These simulate LLM outputs where the defendant name was truncated/missing,
+        leaving a trailing bare vs-separator.
+        """
+        # LA-shaped: plaintiff name with trailing vs
+        la_fixture_1 = "Steinman v"
+        la_fixture_2 = "Doe vs."
+        # OC-shaped: longer name with trailing vs.
+        oc_fixture = "Aoyagi vs."
+        # RV-shaped: mixed case vs
+        rv_fixture = "Serrato Vs"
+
+        for fixture in [la_fixture_1, la_fixture_2, oc_fixture, rv_fixture]:
+            # is_plausible_case_title must reject it
+            assert is_plausible_case_title(fixture) is False, (
+                f"Expected is_plausible_case_title({fixture!r}) to be False"
+            )
+            # clean_case_title must return None (never the partial form)
+            result = clean_case_title(fixture)
+            assert result is None, (
+                f"Expected clean_case_title({fixture!r}) to be None, got {result!r}"
+            )
+
     def test_strips_4_digit_trailing(self) -> None:
         """Strip Ventura new-format case number with 4-digit sequence (#3511)."""
         from ingestion.extract import strip_trailing_case_number

--- a/packages/scraper-framework/tests/test_worker.py
+++ b/packages/scraper-framework/tests/test_worker.py
@@ -1,0 +1,145 @@
+"""Integration tests for bare-vs case title sanitization in the worker cleanup chain (#3990).
+
+Verifies that when the LLM returns a bare-vs title (e.g. "Steinman v"),
+the worker.py cleanup chain logs the nulling and never persists the partial form.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingestion.worker import IngestionWorker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_worker() -> IngestionWorker:
+    """Return an IngestionWorker with all external dependencies mocked out."""
+    redis_mock = MagicMock()
+    os_mock = MagicMock()
+    s3_mock = MagicMock()
+    os_mock.indices.exists.return_value = False
+
+    worker = IngestionWorker(
+        redis_client=redis_mock,
+        pg_dsn="postgresql://localhost/test",
+        opensearch_client=os_mock,
+        s3_client=s3_mock,
+        archive_bucket="test-bucket",
+    )
+    # Disable enrichment so _llm_enrich_fields is never reached.
+    worker._enrichment_client = None
+    # Disable framework extractor (LLM split path).
+    worker._get_framework_extractor = lambda: None  # type: ignore[method-assign]
+    return worker
+
+
+def _make_la_event(**overrides: object) -> dict:
+    """Return an LA-shaped event payload."""
+    base: dict = {
+        "document_id": "cccccccc-0000-0000-0000-000000000001",
+        "scraper_id": "ca-la-tentatives-civil",
+        "state": "CA",
+        "county": "Los Angeles",
+        "court": "Superior Court",
+        "source_url": "https://www.lacourt.org/tentativerulings/1",
+        "content_format": "html",
+        "content_hash": "barevstest001",
+        "s3_key": "ca/los_angeles/superior_court/raw/barevstest001.html",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "case_number": "24STCV00001",
+        "case_title": "Steinman v",
+        "judge_name": "Hon. Jane Smith",
+        "ruling_text": "Tentative ruling: GRANTED.",
+        "hearing_date": "2026-04-15",
+        "capture_timestamp": "2026-04-14T23:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerBareVsChain:
+    """AC #1: The worker.py cleanup chain must null bare-vs case titles.
+
+    When the LLM returns a bare-vs title (e.g. "Steinman v", "Doe vs.",
+    "Aoyagi vs."), the sanitizer chain in process_event must log the nulling
+    before persisting, never storing the partial form.
+    """
+
+    @pytest.mark.parametrize(
+        "bare_vs_title",
+        [
+            "Steinman v",
+            "Doe vs",
+            "Aoyagi vs.",
+            "Serrato Vs",
+            "Bridges vs.",
+        ],
+    )
+    def test_worker_bare_vs_chain_returns_null(
+        self,
+        bare_vs_title: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The worker sanitizer chain logs bare-vs title nulling before DB upsert.
+
+        Drives the cleanup chain with a bare-vs LLM input and asserts
+        the bare_vs_title_nulled telemetry event was logged, confirming
+        case_title was nulled before any DB write.
+        """
+        worker = _make_worker()
+
+        mock_conn = MagicMock()
+        mock_conn.closed = False
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        # fetchone returns court-uuid, case-uuid, True (doc exists check)
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        with (
+            caplog.at_level(logging.INFO, logger="ingestion.worker"),
+            patch.object(worker, "_get_connection", return_value=mock_conn),
+            patch("ingestion.worker.psycopg") as mock_psycopg,
+        ):
+            mock_psycopg.connect.return_value = mock_conn
+            event = _make_la_event(case_title=bare_vs_title)
+
+            # Drive the worker through its cleanup chain.
+            # We don't assert on the return value — we assert on the log output,
+            # which records the nulling of the bare-vs title.
+            try:
+                worker.process_event(event)
+            except Exception:  # noqa: BLE001
+                # DB mocking may not be exhaustive; downstream errors are OK.
+                # We only care that the bare-vs nulling guard fired.
+                pass
+
+        # Assert the worker logged the bare-vs title nulling event.
+        info_msgs = [r for r in caplog.records if r.levelname in ("INFO", "WARNING")]
+        bare_vs_nulled_msgs = [
+            r
+            for r in info_msgs
+            if getattr(r, "telemetry_event", None) == "bare_vs_title_nulled"
+            or "bare-vs" in r.getMessage().lower()
+            or "bare_vs" in r.getMessage().lower()
+        ]
+        assert bare_vs_nulled_msgs, (
+            f"Expected the worker to log nulling of bare-vs title {bare_vs_title!r} "
+            f"with telemetry_event='bare_vs_title_nulled'. "
+            f"Log records: {[r.getMessage() for r in info_msgs]}"
+        )

--- a/scripts/backfill_bare_vs_case_titles.py
+++ b/scripts/backfill_bare_vs_case_titles.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Backfill bare-vs case titles in derived.cases (#3990).
+
+Finds rows in derived.cases where the case_title ends with a bare vs-separator
+(e.g. "Steinman v", "Doe vs", "Aoyagi vs.") — indicating the defendant name
+was truncated or missing when the LLM extracted the title — and NULLs the
+case_title column so the display layer shows no title rather than a partial form.
+
+The 22 historical rows that landed before the worker.py guard was deployed are
+addressed by this script.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- scripts/run-py.sh scripts/backfill_bare_vs_case_titles.py
+
+Options:
+    --dry-run         Print what would be updated without writing to the database.
+    --limit N         Maximum total cases to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+# Select cases whose case_title is a bare-vs form:
+# starts with at least one uppercase letter, then any non-period characters,
+# then ends with whitespace + v/vs/vs. (case-insensitive).
+# Uses keyset pagination on (id) for efficient batching.
+FETCH_QUERY = """
+    SELECT id, case_title, county
+    FROM derived.cases
+    WHERE case_title ~* '^[A-Z][^.]*\\s+v[s]?\\.?\\s*$'
+      AND id > %s
+    ORDER BY id
+    LIMIT %s
+"""
+
+NULL_QUERY = """
+    UPDATE derived.cases
+    SET case_title = NULL,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+"""
+
+# Zero UUID for the first batch cursor
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+# Default batch size
+_DEFAULT_BATCH_SIZE = 100
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    cursor: str = _CURSOR_MIN_UUID,
+    dry_run: bool = False,
+) -> tuple[int, int, str, dict[str, int]]:
+    """Process one batch of affected case titles.
+
+    Returns (processed, updated, next_cursor, county_counts).
+    """
+    processed = 0
+    updated = 0
+    next_cursor = cursor
+    county_counts: dict[str, int] = {}
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, cursor, county_counts
+
+    for case_id, old_title, county in rows:
+        processed += 1
+        next_cursor = str(case_id)
+
+        if not old_title:
+            continue
+
+        county_key = county or "unknown"
+        county_counts[county_key] = county_counts.get(county_key, 0) + 1
+
+        logger.info(
+            "Case %s [%s]: nulling bare-vs title %r",
+            case_id,
+            county_key,
+            old_title[:80],
+        )
+
+        if not dry_run:
+            with conn.cursor() as cur:
+                cur.execute(NULL_QUERY, (str(case_id),))
+        updated += 1
+
+    return processed, updated, next_cursor, county_counts
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = _DEFAULT_BATCH_SIZE,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, object]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    all_county_counts: dict[str, int] = {}
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated, cursor, county_counts = backfill_batch(
+                conn,
+                effective_batch,
+                cursor,
+                dry_run=dry_run,
+            )
+            total_processed += processed
+            total_updated += updated
+            for county, count in county_counts.items():
+                all_county_counts[county] = all_county_counts.get(county, 0) + count
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    if all_county_counts:
+        logger.info("Per-county counts: %s", all_county_counts)
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+        "county_counts": all_county_counts,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill bare-vs case titles — null them in derived.cases.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=_DEFAULT_BATCH_SIZE,
+        help=f"Number of cases per batch (default: {_DEFAULT_BATCH_SIZE}).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d cases processed, %d nulled%s",
+        stats["total_processed"],
+        stats["total_updated"],
+        " [dry-run]" if args.dry_run else "",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes a regression where bare 'v[s].' case titles (e.g., "Steinman v", "Doe vs", "Aoyagi vs.") with no defendant name were being persisted. These malformed titles indicate the LLM extraction was incomplete or the source was truncated. Now properly rejected in the ingestion sanitizer chain and nulled, with comprehensive test coverage for LA/OC/RV fixture cases.

Closes #3990

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 569 tests, all pass)
- [x] CI green (pre-push hook passed)

### Post-deploy verification

- [ ] New rows test: `scripts/dev-db-query.sh "SELECT co.county, COUNT(*) FROM derived.cases ca JOIN derived.courts co ON co.id = ca.court_id WHERE ca.case_title ~* '^[A-Z][^.]*\s+v[s]?\.?\s*$' AND ca.created_at > '<deploy_date>' GROUP BY 1"` returns 0 (no new bare-vs titles after fix)
- [ ] Backfill test: Run `scripts/with-secret.sh -e DATABASE_URL=judgemind/dev/db/connection:.url -- scripts/run-py.sh scripts/backfill_bare_vs_case_titles.py` to null the 22 historical rows
- [ ] Verification evidence posted on #3990 (see /task-v2-verify output)