### PR TITLE
fix(scraping): extend orphan-drop filter to catch bracketed-placeholder titles (#3998)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -2128,7 +2128,8 @@ def _drop_short_unsubstantive_rulings(
 # case_number instead of the real one.
 #
 # Drop condition (all three must hold):
-#   * ``_ROLE_LITERAL_TITLE_RE`` matches ``extracted_case_title``
+#   * ``_ROLE_LITERAL_TITLE_RE`` matches ``extracted_case_title``, OR
+#     ``_BRACKETED_PLACEHOLDER_TITLE_RE`` matches anywhere in the title
 #   * ``extracted_case_number`` is None or empty string
 #   * ``entry_number`` is None
 #
@@ -2162,12 +2163,13 @@ def _drop_role_literal_orphan_rulings(
     Rules:
 
     - A ruling is dropped when ALL THREE conditions hold:
-      1. ``_ROLE_LITERAL_TITLE_RE`` matches ``extracted_case_title``
+      1. ``_ROLE_LITERAL_TITLE_RE`` matches ``extracted_case_title``, OR
+         ``_BRACKETED_PLACEHOLDER_TITLE_RE`` matches anywhere in the title
       2. ``extracted_case_number`` is None or empty
       3. ``entry_number`` is None
     - Rulings with a valid ``extracted_case_number`` are ALWAYS preserved,
-      even when the title happens to be role-literal (genuine pseudonym
-      cases, e.g. Doe v. Smith).
+      even when the title happens to be role-literal or a bracketed
+      placeholder (genuine pseudonym cases, e.g. Doe v. Smith).
     - Rulings with a valid ``entry_number`` are preserved — they are real
       calendar rows, not orphans.
     """
@@ -2176,7 +2178,11 @@ def _drop_role_literal_orphan_rulings(
         title = ruling.extracted_case_title or ""
         has_case_number = bool(ruling.extracted_case_number)
         has_entry_number = ruling.entry_number is not None
-        if _ROLE_LITERAL_TITLE_RE.match(title) and not has_case_number and not has_entry_number:
+        if (
+            (_ROLE_LITERAL_TITLE_RE.match(title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(title))
+            and not has_case_number
+            and not has_entry_number
+        ):
             logger.warning(
                 "llm_extractor.role_literal_orphan_dropped",
                 case_title=ruling.extracted_case_title,

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -4651,6 +4651,34 @@ class TestRoleLiteralOrphanDrop:
         result = _drop_role_literal_orphan_rulings([orphan])
         assert result == []
 
+    def test_drops_orphan_with_bracketed_placeholder_title_no_case_number_no_entry(self) -> None:
+        """Orphan with bracketed-placeholder title, no case_number, no entry_number is dropped."""
+        body_text = (
+            "The Court has reviewed the motion papers.  Plaintiff's motion for "
+            "summary judgment is GRANTED.  Defendant failed to raise a triable "
+            "issue of material fact on any element of the claim.  " * 30
+        )
+        orphan = ExtractedRuling(
+            extracted_case_title="Ezra Arce v. [Defendant not specified]",
+            extracted_case_number=None,
+            entry_number=None,
+            ruling_text=body_text,
+        )
+        result = _drop_role_literal_orphan_rulings([orphan])
+        assert result == []
+
+    def test_preserves_orphan_with_bracketed_placeholder_but_valid_case_number(self) -> None:
+        """Bracketed-placeholder title WITH a valid case_number is NOT dropped."""
+        ruling = ExtractedRuling(
+            extracted_case_title="Ezra Arce v. [Defendant not specified]",
+            extracted_case_number="CIVSB1234567",
+            entry_number=None,
+            ruling_text="The motion is DENIED." * 50,
+        )
+        result = _drop_role_literal_orphan_rulings([ruling])
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "CIVSB1234567"
+
     def test_empty_list(self) -> None:
         """Empty list returns empty list."""
         assert _drop_role_literal_orphan_rulings([]) == []


### PR DESCRIPTION
## Summary

Extended `_drop_role_literal_orphan_rulings` to also drop orphaned rulings with LLM-hallucinated bracketed-placeholder titles (e.g., "Foo v. [Defendant not specified]") in addition to role-literal patterns. This completes the fix from PR #3989, which added `_BRACKETED_PLACEHOLDER_TITLE_RE` but missed this call site in the San Bernardino orphan-drop filter.

Closes #3998

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 7068 tests)
- [x] CI green (pre-push hook green)

### Post-deploy verification

- [ ] Spot-check the next 3 SB ingestion runs show 0 case_titles matching `_BRACKETED_PLACEHOLDER_TITLE_RE` in `derived.cases` (query: `SELECT count(*) FROM derived.cases WHERE jurisdiction LIKE '%San Bernardino%' AND case_title ~ '\[(defendant|plaintiff|respondent|petitioner)'` returns 0)
- [ ] Verification evidence posted on #3998 (see /task-v2-verify output)