### PR TITLE
fix(scraping): make OC department leading-zero regex case-insensitive (#3999)

### DIFF
--- a/packages/scraper-framework/src/ingestion/department_normalize.py
+++ b/packages/scraper-framework/src/ingestion/department_normalize.py
@@ -77,7 +77,7 @@ _SB_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
 # Leading zeros after a letter prefix: "W08" -> "W8", "H001" -> "H1".
 # Anchored at start; replaces LETTERS+ZEROS+SIGNIFICANT_DIGIT prefix with
 # LETTERS+SIGNIFICANT_DIGIT, leaving trailing characters intact.
-_OC_LEADING_ZERO_RE = re.compile(r"^([A-Z]+)0+([1-9])")
+_OC_LEADING_ZERO_RE = re.compile(r"^([A-Za-z]+)0+([1-9])")
 
 
 # ---------------------------------------------------------------------------
@@ -196,5 +196,10 @@ def _normalize_orange(dept: str) -> str:
     Strips leading zeros from letter+number codes (``W08`` -> ``W8``,
     ``H001`` -> ``H1``).  Trailing characters after the significant digit
     are preserved (``H012`` -> ``H12``, ``L0612`` -> ``L612``).
+
+    Input is uppercased before applying the regex so that lowercase and
+    mixed-case codes (``w08``, ``Cm01``) are normalised to their canonical
+    uppercase form (``W8``, ``CM1``).
     """
+    dept = dept.upper()
     return _OC_LEADING_ZERO_RE.sub(r"\1\2", dept)

--- a/packages/scraper-framework/tests/test_department_normalize.py
+++ b/packages/scraper-framework/tests/test_department_normalize.py
@@ -233,6 +233,20 @@ class TestOrangeCounty:
     def test_no_leading_zero_unchanged(self, raw: str) -> None:
         assert normalize_department("Orange", raw) == raw
 
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("w08", "W8"),
+            ("Cm01", "CM1"),
+            ("cm01", "CM1"),
+            ("h001", "H1"),
+            ("cx02", "CX2"),
+            ("l0612", "L612"),
+        ],
+    )
+    def test_case_insensitive_leading_zero(self, raw: str, expected: str) -> None:
+        assert normalize_department("Orange", raw) == expected
+
 
 # ---------------------------------------------------------------------------
 # Other counties — passthrough


### PR DESCRIPTION
## Summary

Extended the OC department code regex from `[A-Z]+` to `[A-Za-z]+` to match mixed-case prefixes, and added `.upper()` in `_normalize_orange` to canonicalize inputs before regex matching. This prevents silent no-ops on lowercase/mixed-case codes (w08 → W8, cm01 → CM1), which was breaking the W08↔W8 dedup fix from PR #3969.

Closes #3999

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — all 139 tests pass, including new 6-case parametrized test)
- [ ] CI green

### Post-deploy verification

- [ ] Query `SELECT DISTINCT department FROM derived.rulings WHERE jurisdiction LIKE '%Orange%' AND department ~ '^[a-z]'` returns 0 rows (no lowercase codes leak through)
- [ ] Verification evidence posted on #3999 (see /task-v2-verify output)