### PR TITLE
fix(scraping): resolve OC stub cross-references when case numbers collide (#4000)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -2342,6 +2342,34 @@ _XREF_REF_MIN_TEXT_LENGTH = 100
 _XREF_STUB_MAX_TEXT_LENGTH = 2000
 
 
+def _build_case_number_to_index(rulings: list[ExtractedRuling]) -> dict[str, int]:
+    """Build a case-number → ruling-index map that prefers the substantive entry (#4000).
+
+    When multiple OC rulings share a case number (a stub and the substantive
+    ruling it references), a plain dict comprehension with last-write-wins
+    semantics may store the stub index instead of the substantive one.  The
+    stub's xref then resolves to itself (``ref_idx == i``) and stays unresolved.
+
+    This helper breaks the tie by keeping the index of the entry with the
+    *longest* ``ruling_text`` for each case number.  Length is a reliable
+    proxy for substantiveness: OC stubs are by construction short cross-
+    reference phrases, while substantive rulings contain the full court text.
+    """
+    result: dict[str, int] = {}
+    for i, r in enumerate(rulings):
+        if not r.extracted_case_number:
+            continue
+        key = r.extracted_case_number
+        current_text = r.ruling_text or ""
+        if key not in result:
+            result[key] = i
+        else:
+            existing_text = rulings[result[key]].ruling_text or ""
+            if len(current_text) > len(existing_text):
+                result[key] = i
+    return result
+
+
 def _resolve_cross_references(
     rulings: list[ExtractedRuling],
     entry_number_to_index: dict[int, int] | None = None,
@@ -2400,10 +2428,9 @@ def _resolve_cross_references(
         }
 
     # When no case-number map is provided, build it from per-ruling extracted_case_number.
+    # Use the helper so that duplicate case numbers keep the substantive (longest) entry.
     if case_number_to_index is None:
-        case_number_to_index = {
-            r.extracted_case_number: i for i, r in enumerate(rulings) if r.extracted_case_number
-        }
+        case_number_to_index = _build_case_number_to_index(rulings)
 
     # Build reverse map: index -> entry_number (for "order above" lookups).
     index_to_entry: dict[int, int] = {v: k for k, v in entry_number_to_index.items()}
@@ -2524,7 +2551,12 @@ def _resolve_cross_references(
                     rulings[i] = ruling.model_copy(
                         update={
                             "ruling_text": ref_text,
-                            "cross_reference_source": ref_ruling.entry_number,
+                            # Use entry_number when available; fall back to the
+                            # list index so cross_reference_source is always set
+                            # (the only consumer is ``is not None`` guard logic).
+                            "cross_reference_source": ref_ruling.entry_number
+                            if ref_ruling.entry_number is not None
+                            else ref_idx,
                         }
                     )
                     logger.info(
@@ -4360,9 +4392,7 @@ def _join_page_rows(
     # "See Ruling for #N Above".  Orange County PDFs use case-number refs.
     # Copy the ruling text from the referenced entry so enrichment can
     # extract an outcome.
-    case_number_to_index = {
-        r.extracted_case_number: i for i, r in enumerate(rulings) if r.extracted_case_number
-    }
+    case_number_to_index = _build_case_number_to_index(rulings)
     rulings = _resolve_cross_references(
         rulings, entry_number_to_index or None, case_number_to_index
     )

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -25,6 +25,7 @@ from framework.llm_extractor import (
     PDF_PER_PAGE_PROMPT,
     LlmExtractor,
     _append_ruling_from_case,
+    _build_case_number_to_index,
     _create_google_client,
     _deduplicate_ruling_texts,
     _drop_calendar_listing_rulings,
@@ -3755,6 +3756,114 @@ class TestResolveCrossReferences:
         result = _resolve_cross_references(rulings, None)
         assert result[0].ruling_text == "See Line 1 for tentative ruling."
         assert result[0].cross_reference_source is None
+
+    def test_oc_duplicate_case_number_stub_resolves_to_substantive_entry(self) -> None:
+        """OC stub with same case number as substantive entry resolves correctly (#4000).
+
+        Substantive at index 0, stub at index 1.  Both share case number 06CC10916.
+        The helper must pick the entry with the longest ruling_text (index 0) so
+        the stub (index 1) resolves to the substantive ruling, not to itself.
+        """
+        substantive_text = (
+            "The motion for summary judgment is DENIED. "
+            "Plaintiff has demonstrated triable issues of material fact. "
+        ) * 10  # > 100 chars, clearly substantive
+        stub_text = "See the tentative ruling above for Smith, case no. 06CC10916"
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="06CC10916",
+                ruling_text=substantive_text,
+            ),
+            ExtractedRuling(
+                extracted_case_number="06CC10916",
+                ruling_text=stub_text,
+            ),
+        ]
+        # Pass both maps as None so _build_case_number_to_index is exercised.
+        result = _resolve_cross_references(
+            rulings, entry_number_to_index=None, case_number_to_index=None
+        )
+        assert result[1].ruling_text == substantive_text
+        assert result[1].cross_reference_source is not None
+
+    def test_oc_duplicate_case_number_stub_first_substantive_second(self) -> None:
+        """OC stub at index 0, substantive at index 1 — stub still resolves (#4000).
+
+        Verifies the helper's longest-text preference is order-independent.
+        """
+        substantive_text = (
+            "The demurrer is OVERRULED. Defendant shall answer within 10 days. "
+        ) * 10  # > 100 chars
+        stub_text = "See the tentative ruling above for Jones, case no. 06CC10916"
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="06CC10916",
+                ruling_text=stub_text,
+            ),
+            ExtractedRuling(
+                extracted_case_number="06CC10916",
+                ruling_text=substantive_text,
+            ),
+        ]
+        result = _resolve_cross_references(
+            rulings, entry_number_to_index=None, case_number_to_index=None
+        )
+        assert result[0].ruling_text == substantive_text
+        assert result[0].cross_reference_source is not None
+
+    def test_oc_three_rulings_share_case_number_prefers_longest(self) -> None:
+        """Three OC rulings with same case number — both stubs resolve to longest (#4000)."""
+        longest_text = (
+            "The motion to compel further responses is GRANTED IN PART. "
+            "Defendant shall provide further responses within 30 days. "
+        ) * 10  # > 100 chars, clearly the substantive entry
+        stub_a = "See the tentative ruling above for Brown, case no. 30-2022-01234567"
+        stub_b = "See the tentative ruling above for Davis, case no. 30-2022-01234567"
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2022-01234567",
+                ruling_text=stub_a,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2022-01234567",
+                ruling_text=longest_text,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2022-01234567",
+                ruling_text=stub_b,
+            ),
+        ]
+        result = _resolve_cross_references(
+            rulings, entry_number_to_index=None, case_number_to_index=None
+        )
+        # Both stubs should resolve to the longest entry (index 1).
+        assert result[0].ruling_text == longest_text
+        assert result[0].cross_reference_source is not None
+        assert result[2].ruling_text == longest_text
+        assert result[2].cross_reference_source is not None
+        # The substantive entry itself should be unchanged.
+        assert result[1].ruling_text == longest_text
+        assert result[1].cross_reference_source is None
+
+    def test_build_case_number_to_index_prefers_longest(self) -> None:
+        """_build_case_number_to_index picks the index with the longest ruling_text (#4000)."""
+        short_text = "See ruling above for Smith, case no. 06CC10916"
+        long_text = "The motion is GRANTED. " * 20
+        medium_text = "DENIED without prejudice. " * 5
+
+        rulings = [
+            ExtractedRuling(extracted_case_number="06CC10916", ruling_text=short_text),
+            ExtractedRuling(extracted_case_number="06CC10916", ruling_text=long_text),
+            ExtractedRuling(extracted_case_number="06CC10916", ruling_text=medium_text),
+            ExtractedRuling(extracted_case_number="OTHER-001", ruling_text="Different case text."),
+        ]
+        result = _build_case_number_to_index(rulings)
+        # Must pick index 1 (longest text) for 06CC10916.
+        assert result["06CC10916"] == 1
+        # OTHER-001 has only one entry — straightforward.
+        assert result["OTHER-001"] == 3
+        # Entries without a case number are not in the map (none here).
+        assert len(result) == 2
 
 
 class TestCrossReferenceIntegration:


### PR DESCRIPTION
## Summary

Added `_build_case_number_to_index` helper that picks the longest `ruling_text` per case number, replacing last-write-wins dict comprehensions at both build sites in `llm_extractor.py`. This fixes the bug where Orange County stubs with the same case number as substantive rulings would resolve to themselves rather than the substantive entry.

Closes #4000

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 7081 tests pass
- [x] CI green

### Post-deploy verification

- [ ] Query for OC rulings whose `ruling_text` matches the stub-xref pattern but whose final `case_title` is empty/identical to the stub returns a count <10 (down from a higher pre-fix baseline). See /task-v2-verify for live query and evidence.