### PR TITLE
fix(api): validate createAlertSubscription filter length and shape (#4005)

### DIFF
--- a/packages/api/src/graphql/alert-resolvers.ts
+++ b/packages/api/src/graphql/alert-resolvers.ts
@@ -1,4 +1,5 @@
 import type { Pool } from 'pg';
+import { z } from 'zod';
 import { GraphQLError } from 'graphql';
 import type { AuthUser } from '../auth';
 
@@ -9,7 +10,16 @@ interface AlertContext {
   user: AuthUser | null;
 }
 
-const VALID_ALERT_TYPES = ['case_docket', 'judge_ruling', 'keyword', 'party_attorney'];
+const MAX_FILTERS_LEN = 4096;
+
+const filterSchemas = {
+  judge_ruling:   z.object({ judge_id: z.string().uuid() }).strict(),
+  case_docket:    z.object({ case_id:  z.string().uuid() }).strict(),
+  keyword:        z.object({ keyword:  z.string().min(1).max(200) }).strict(),
+  party_attorney: z.object({ party_id: z.string().uuid() }).strict(),
+} as const;
+
+const VALID_ALERT_TYPES = Object.keys(filterSchemas);
 
 function requireAuth(user: AuthUser | null): AuthUser {
   if (!user) {
@@ -40,6 +50,13 @@ export const alertResolvers = {
     ) => {
       const authed = requireAuth(user);
 
+      if (filters.length > MAX_FILTERS_LEN) {
+        throw new GraphQLError(
+          `filters must not exceed ${MAX_FILTERS_LEN} characters`,
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+
       if (!VALID_ALERT_TYPES.includes(alertType)) {
         throw new GraphQLError(
           `Invalid alert type: ${alertType}. Must be one of: ${VALID_ALERT_TYPES.join(', ')}`,
@@ -48,11 +65,20 @@ export const alertResolvers = {
       }
 
       // Validate filters is valid JSON
-      let parsedFilters: Record<string, unknown>;
+      let rawParsed: unknown;
       try {
-        parsedFilters = JSON.parse(filters) as Record<string, unknown>;
+        rawParsed = JSON.parse(filters);
       } catch {
         throw new GraphQLError('filters must be a valid JSON string', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      // Validate filters shape against per-alert-type strict Zod schema
+      const schema = filterSchemas[alertType as keyof typeof filterSchemas];
+      const result = schema.safeParse(rawParsed);
+      if (!result.success) {
+        throw new GraphQLError(result.error.issues[0].message, {
           extensions: { code: 'BAD_USER_INPUT' },
         });
       }
@@ -61,7 +87,7 @@ export const alertResolvers = {
         `INSERT INTO alert_subscriptions (user_id, alert_type, filters)
          VALUES ($1, $2, $3)
          RETURNING *`,
-        [authed.id, alertType, JSON.stringify(parsedFilters)],
+        [authed.id, alertType, JSON.stringify(result.data)],
       );
 
       return rows[0];

--- a/packages/api/tests/alerts.integration.test.ts
+++ b/packages/api/tests/alerts.integration.test.ts
@@ -432,6 +432,62 @@ describe('Alert subscriptions — integration', () => {
     });
   });
 
+  describe('filters validation', () => {
+    it('rejects filters payload exceeding 4096 chars', async () => {
+      const bigFilters = JSON.stringify({ judge_id: judgeId, pad: 'x'.repeat(4100) });
+      const body = await gql(
+        `mutation($type: String!, $filters: String!) {
+          createAlertSubscription(alertType: $type, filters: $filters) { id }
+        }`,
+        { type: 'judge_ruling', filters: bigFilters },
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+      expect(body.errors![0].message).toContain('4096');
+    });
+
+    it('rejects unknown filter keys via strict schema', async () => {
+      const filters = JSON.stringify({ judge_id: judgeId, evil: 'x' });
+      const body = await gql(
+        `mutation($type: String!, $filters: String!) {
+          createAlertSubscription(alertType: $type, filters: $filters) { id }
+        }`,
+        { type: 'judge_ruling', filters },
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+    });
+
+    it('rejects filters with wrong key shape for alert_type', async () => {
+      const filters = JSON.stringify({ judge_id: judgeId });
+      const body = await gql(
+        `mutation($type: String!, $filters: String!) {
+          createAlertSubscription(alertType: $type, filters: $filters) { id }
+        }`,
+        { type: 'keyword', filters },
+        authHeaders(),
+      );
+      expect(body.errors).toBeDefined();
+      expect(body.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+    });
+
+    it('accepts existing valid keyword filters', async () => {
+      const filters = JSON.stringify({ keyword: 'msj' });
+      const body = await gql(
+        `mutation($type: String!, $filters: String!) {
+          createAlertSubscription(alertType: $type, filters: $filters) { id alertType }
+        }`,
+        { type: 'keyword', filters },
+        authHeaders(),
+      );
+      expect(body.errors).toBeUndefined();
+      const sub = body.data?.createAlertSubscription as Record<string, unknown>;
+      expect(sub.alertType).toBe('keyword');
+    });
+  });
+
   describe('deleteAlertSubscription', () => {
     it('deletes an owned subscription', async () => {
       const body = await gql(


### PR DESCRIPTION
## Summary

- Add a 4096-character length cap on the raw `filters` string before `JSON.parse` to prevent unbounded JSON blob storage
- Add per-`alert_type` strict Zod schemas (`judge_ruling`, `case_docket`, `keyword`, `party_attorney`) that reject unknown keys and enforce correct field types
- Store only the schema-validated result, not the raw parsed object

## Test plan

- [x] Reject a >4096-char filters string with `BAD_USER_INPUT` referencing the limit
- [x] Reject unknown filter keys via `.strict()` Zod schema
- [x] Reject wrong key shapes for mismatched `alert_type` (e.g. `judge_id` passed to `keyword` type)
- [x] Accept valid existing filter shapes without regression

Closes #4005

🤖 Generated with [Claude Code](https://claude.com/claude-code)