### PR TITLE
fix(scraping): preserve LA regional courthouse department codes in rebuild path (#4014)

### DIFF
--- a/packages/scraper-framework/src/ingestion/department_normalize.py
+++ b/packages/scraper-framework/src/ingestion/department_normalize.py
@@ -8,7 +8,17 @@ Rules by county:
 
 * **Los Angeles** — strip courtroom/calendar suffixes (`` #N``, ``N`` glued
   to single-letter depts), strip courthouse prefixes (``SSC-``), map
-  ``SEP`` -> ``P``.
+  ``SEP`` -> ``P``.  The single-letter+digits collapse (``X14`` → ``X``) is
+  **skipped** for regional courthouses (Long Beach, Chatsworth, Antelope
+  Valley) where the combined code identifies a distinct courtroom.  The
+  carve-out can be triggered two ways:
+    1. Pass ``courthouse=<name or code>`` — checked against
+       ``_LA_LETTER_DIGITS_KEEP_COURTHOUSES``.
+    2. Pass ``case_number=<number>`` — prefix checked against
+       ``_LA_LETTER_DIGITS_KEEP_CASE_PREFIX_RE`` (covers LBCV/LBCP,
+       CHCV/CHCP, AVCV/AVCP).  ``PC`` is intentionally omitted — it
+       collides with LASC's old BC/PC format used across multiple
+       courthouses.
 * **Riverside** — strip leading zeros from purely numeric departments.
 * **San Bernardino** — strip hyphens from letter+number codes
   (``S-17`` -> ``S17``).
@@ -20,6 +30,7 @@ Called by the ingestion worker before DB writes so both scraper-provided
 and LLM-extracted department values are normalized.
 
 See: https://github.com/judgemind/judgemind/issues/2141
+See: https://github.com/judgemind/judgemind/issues/4014
 """
 
 from __future__ import annotations
@@ -48,13 +59,43 @@ _LA_COURTHOUSE_ALIASES: dict[str, str] = {
     "SEP": "P",
 }
 
-# Long Beach Courthouse identifiers (case-folded).
-# S25–S29 are distinct courtrooms at LB; we skip the letter+digits collapse
-# so these codes survive normalization intact.  The display name comes from
-# ``_OPTION_TEXT_RE`` in ``la_tentatives.py``; ``LBC``/``LBCV`` are the
-# case-number prefixes — included defensively in case they ever appear in the
-# event payload.
-_LA_LB_COURTHOUSE_NAMES: frozenset[str] = frozenset({"long beach courthouse", "lbc", "lbcv"})
+# Courthouse identifiers for regional LA courthouses where the letter+digits
+# collapse must be skipped.  Values are case-folded for comparison.
+#
+# Long Beach: S25–S29 are distinct courtrooms.  Display name from
+# ``_OPTION_TEXT_RE`` in ``la_tentatives.py``; ``LBC``/``LBCV`` are case-
+# number prefixes included defensively.
+#
+# Chatsworth: F43–F51 are distinct courtrooms.  ``CHC`` is the courthouse
+# code variant.
+#
+# Antelope Valley: A14 etc. are distinct courtrooms.  ``AV`` is the code.
+_LA_LETTER_DIGITS_KEEP_COURTHOUSES: frozenset[str] = frozenset(
+    {
+        # Long Beach
+        "long beach courthouse",
+        "lbc",
+        "lbcv",
+        # Chatsworth
+        "chatsworth courthouse north",
+        "chc",
+        # Antelope Valley
+        "antelope valley courthouse",
+        "av",
+    }
+)
+
+# Case-number prefixes that indicate a regional courthouse where the
+# letter+digits collapse must be skipped.
+# - LBCV/LBCP → Long Beach Civil / Long Beach Complex
+# - CHCV/CHCP → Chatsworth Civil / Chatsworth Complex
+# - AVCV/AVCP → Antelope Valley Civil / Antelope Valley Complex
+# ``PC`` is intentionally excluded — it collides with LASC old-format
+# BC/PC numbers used across multiple courthouses (see llm_extractor.py:517).
+_LA_LETTER_DIGITS_KEEP_CASE_PREFIX_RE = re.compile(
+    r"^\d{2}(LBCV|LBCP|CHCV|CHCP|AVCV|AVCP)\d",
+    re.IGNORECASE,
+)
 
 # ---------------------------------------------------------------------------
 # Riverside
@@ -90,6 +131,7 @@ def normalize_department(
     department: str | None,
     *,
     courthouse: str | None = None,
+    case_number: str | None = None,
 ) -> str | None:
     """Normalize a department name using county-specific rules.
 
@@ -101,8 +143,14 @@ def normalize_department(
         The raw department value from the scraper or LLM.
     courthouse : str | None
         Optional courthouse display name or code.  Used by the LA normalizer
-        to skip the letter+digits collapse for courthouses (e.g. Long Beach)
-        where the combined code is a real identifier, not a glued suffix.
+        to skip the letter+digits collapse for regional courthouses (Long
+        Beach, Chatsworth, Antelope Valley) where the combined code
+        identifies a distinct courtroom.
+    case_number : str | None
+        Optional case number.  Used by the LA normalizer as a fallback when
+        ``courthouse`` is absent — a LBCV/CHCV/AVCV prefix triggers the
+        same letter+digits keep rule.  ``PC`` is intentionally omitted from
+        the prefix set (collision with LASC old-format BC/PC numbers).
 
     Returns
     -------
@@ -120,7 +168,7 @@ def normalize_department(
     county_lower = county.lower()
 
     if county_lower == "los angeles":
-        dept = _normalize_la(dept, courthouse=courthouse)
+        dept = _normalize_la(dept, courthouse=courthouse, case_number=case_number)
     elif county_lower == "riverside":
         dept = _normalize_riverside(dept)
     elif county_lower == "san bernardino":
@@ -131,7 +179,12 @@ def normalize_department(
     return dept if dept else None
 
 
-def _normalize_la(dept: str, *, courthouse: str | None = None) -> str:
+def _normalize_la(
+    dept: str,
+    *,
+    courthouse: str | None = None,
+    case_number: str | None = None,
+) -> str:
     """Normalize an LA County department name.
 
     Transformations (applied in order):
@@ -140,9 +193,13 @@ def _normalize_la(dept: str, *, courthouse: str | None = None) -> str:
     2. Map known courthouse aliases (``SEP`` -> ``P``).
     3. Strip `` #N`` courtroom/calendar suffix.
     4. Strip single-letter + digits glue (``X14`` -> ``X``), **unless**
-       the courthouse is a Long Beach courthouse — at LB these combined
-       codes (``S25``–``S29``) identify distinct courtrooms and must be
-       preserved.
+       the department is from a regional courthouse (Long Beach, Chatsworth,
+       Antelope Valley) where the combined code identifies a distinct
+       courtroom.  The carve-out fires when either:
+       * ``courthouse`` (case-folded) is in
+         ``_LA_LETTER_DIGITS_KEEP_COURTHOUSES``, or
+       * ``case_number`` matches ``_LA_LETTER_DIGITS_KEEP_CASE_PREFIX_RE``
+         (LBCV/LBCP/CHCV/CHCP/AVCV/AVCP prefixes).
     """
     # 1. Strip SSC- prefix first to reveal underlying patterns
     m = _LA_SSC_PREFIX_RE.match(dept)
@@ -158,9 +215,14 @@ def _normalize_la(dept: str, *, courthouse: str | None = None) -> str:
     dept = _LA_COURTROOM_SUFFIX_RE.sub("", dept).strip()
 
     # 4. Single letter + digits -> letter only.
-    # Skip for Long Beach Courthouse where the combined code is meaningful.
-    is_lb = (courthouse or "").strip().lower() in _LA_LB_COURTHOUSE_NAMES
-    if not is_lb:
+    # Skip when the courthouse or case_number indicates a regional courthouse
+    # where letter+digit codes are meaningful identifiers.
+    courthouse_keep = (courthouse or "").strip().lower() in _LA_LETTER_DIGITS_KEEP_COURTHOUSES
+    case_number_keep = bool(
+        case_number and _LA_LETTER_DIGITS_KEEP_CASE_PREFIX_RE.match(case_number)
+    )
+    keep_letter_digits = courthouse_keep or case_number_keep
+    if not keep_letter_digits:
         m = _LA_LETTER_PLUS_DIGITS_RE.match(dept)
         if m:
             dept = m.group(1)

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -2029,6 +2029,7 @@ class IngestionWorker:
             county,
             department,
             courthouse=event_data.get("courthouse"),
+            case_number=case_number,
         )
 
         # Apply Contra Costa department reassignment mapping (#2612).

--- a/packages/scraper-framework/tests/test_department_normalize.py
+++ b/packages/scraper-framework/tests/test_department_normalize.py
@@ -403,19 +403,32 @@ class TestAlphanumericDepartmentCodes:
 
 
 # ---------------------------------------------------------------------------
-# LA County — Long Beach courthouse (S25–S29 must survive, #3741)
+# LA County — Long Beach / Chatsworth / AV courthouses (letter+digits must
+# survive for regional courthouses, #3741 and #4014)
 # ---------------------------------------------------------------------------
 
 
-class TestLALongBeach:
-    """S25–S29 dept codes survive when courthouse is Long Beach.
+class TestLALetterDigitsKeep:
+    """S25–S29, F43–F51, A14 etc. dept codes survive for regional courthouses.
 
-    These are distinct courtrooms at the Long Beach Courthouse.  The generic
-    LA letter+digits collapse rule must be skipped for LB courthouses so that
-    analytics can distinguish S25 from S27 etc.
+    Long Beach (S-prefix), Chatsworth (F-prefix), and Antelope Valley
+    (A-prefix) all use letter+digits codes that identify distinct courtrooms.
+    The generic LA letter+digits collapse rule must be skipped for these
+    courthouses.
+
+    Carve-out mechanisms:
+    1. Courthouse name/code in the ``courthouse`` kwarg.
+    2. Case-number prefix (LBCV/LBCP/CHCV/CHCP/AVCV/AVCP) in the
+       ``case_number`` kwarg (covers the rebuild path where courthouse may
+       not be in the event).
 
     See: https://github.com/judgemind/judgemind/issues/3741
+    See: https://github.com/judgemind/judgemind/issues/4014
     """
+
+    # ------------------------------------------------------------------
+    # Long Beach — courthouse name path
+    # ------------------------------------------------------------------
 
     @pytest.mark.parametrize("dept", ["S25", "S26", "S27", "S28", "S29"])
     @pytest.mark.parametrize(
@@ -433,6 +446,100 @@ class TestLALongBeach:
         """S25–S29 must not be collapsed to 'S' for Long Beach Courthouse."""
         assert normalize_department("Los Angeles", dept, courthouse=courthouse) == dept
 
+    # ------------------------------------------------------------------
+    # Long Beach — case_number prefix path (AC1)
+    # ------------------------------------------------------------------
+
+    def test_lb_via_case_number(self) -> None:
+        """S27 + LB case_number (25LBCV03352) must survive as 'S27' (AC1)."""
+        assert normalize_department("Los Angeles", "S27", case_number="25LBCV03352") == "S27"
+
+    @pytest.mark.parametrize(
+        "case_number",
+        ["25LBCV03352", "24LBCP01234", "23LBCV99999"],
+    )
+    def test_lb_case_number_variants(self, case_number: str) -> None:
+        """Any LBCV/LBCP case_number should keep letter+digit dept intact."""
+        assert normalize_department("Los Angeles", "S27", case_number=case_number) == "S27"
+
+    # ------------------------------------------------------------------
+    # Chatsworth — courthouse name path (AC2)
+    # ------------------------------------------------------------------
+
+    def test_chatsworth_via_courthouse_name(self) -> None:
+        """F49 + Chatsworth courthouse must survive as 'F49' (AC2)."""
+        assert (
+            normalize_department("Los Angeles", "F49", courthouse="Chatsworth Courthouse North")
+            == "F49"
+        )
+
+    @pytest.mark.parametrize(
+        "courthouse",
+        ["Chatsworth Courthouse North", "chatsworth courthouse north", "CHC", "chc"],
+    )
+    def test_chatsworth_courthouse_variants(self, courthouse: str) -> None:
+        """All Chatsworth courthouse name/code variants keep F-prefix depts."""
+        assert normalize_department("Los Angeles", "F49", courthouse=courthouse) == "F49"
+
+    # ------------------------------------------------------------------
+    # Chatsworth — case_number prefix path
+    # ------------------------------------------------------------------
+
+    def test_chatsworth_via_case_number(self) -> None:
+        """F49 + CHCV case_number must survive as 'F49'."""
+        assert normalize_department("Los Angeles", "F49", case_number="24CHCV03577") == "F49"
+
+    @pytest.mark.parametrize(
+        "case_number",
+        ["24CHCV03577", "23CHCP00123", "25CHCV99999"],
+    )
+    def test_chatsworth_case_number_variants(self, case_number: str) -> None:
+        """Any CHCV/CHCP case_number should keep letter+digit dept intact."""
+        assert normalize_department("Los Angeles", "F49", case_number=case_number) == "F49"
+
+    # ------------------------------------------------------------------
+    # Antelope Valley — courthouse name path (AC3)
+    # ------------------------------------------------------------------
+
+    def test_av_via_courthouse_name(self) -> None:
+        """A14 + Antelope Valley courthouse must survive as 'A14' (AC3)."""
+        assert (
+            normalize_department("Los Angeles", "A14", courthouse="Antelope Valley Courthouse")
+            == "A14"
+        )
+
+    @pytest.mark.parametrize(
+        "courthouse",
+        ["Antelope Valley Courthouse", "antelope valley courthouse", "AV", "av"],
+    )
+    def test_av_courthouse_variants(self, courthouse: str) -> None:
+        """All AV courthouse name/code variants keep A-prefix depts."""
+        assert normalize_department("Los Angeles", "A14", courthouse=courthouse) == "A14"
+
+    # ------------------------------------------------------------------
+    # Antelope Valley — case_number prefix path
+    # ------------------------------------------------------------------
+
+    def test_av_via_case_number(self) -> None:
+        """A14 + AVCV case_number must survive as 'A14'."""
+        assert normalize_department("Los Angeles", "A14", case_number="23AVCV00370") == "A14"
+
+    @pytest.mark.parametrize(
+        "case_number",
+        ["23AVCV00370", "24AVCP01234", "25AVCV99999"],
+    )
+    def test_av_case_number_variants(self, case_number: str) -> None:
+        """Any AVCV/AVCP case_number should keep letter+digit dept intact."""
+        assert normalize_department("Los Angeles", "A14", case_number=case_number) == "A14"
+
+    # ------------------------------------------------------------------
+    # Guard test — Stanley Mosk must still collapse (no carve-out)
+    # ------------------------------------------------------------------
+
+    def test_stanley_mosk_still_collapses(self) -> None:
+        """X14 + Stanley Mosk case_number (25STCV) must still collapse to 'X'."""
+        assert normalize_department("Los Angeles", "X14", case_number="25STCV12345") == "X"
+
     def test_pomona_l10_still_collapses(self) -> None:
         """Non-LB courthouse: L10 must still collapse to 'L'."""
         assert normalize_department("Los Angeles", "L10", courthouse="Pomona Courthouse") == "L"
@@ -440,3 +547,12 @@ class TestLALongBeach:
     def test_courthouse_omitted_back_compat(self) -> None:
         """Omitting courthouse kwarg preserves existing collapse behaviour."""
         assert normalize_department("Los Angeles", "X14") == "X"
+
+    def test_case_number_none_back_compat(self) -> None:
+        """Passing case_number=None preserves existing collapse behaviour."""
+        assert normalize_department("Los Angeles", "X14", case_number=None) == "X"
+
+    def test_three_arg_call_back_compat(self) -> None:
+        """3-arg call (no case_number kwarg) still collapses as before."""
+        assert normalize_department("Los Angeles", "X14") == "X"
+        assert normalize_department("Los Angeles", "S27") == "S"

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -3243,3 +3243,79 @@ class TestMainPerCourtResetDispatch:
                 pass  # expected — argparse rejects mutually exclusive args
             else:
                 raise AssertionError("expected SystemExit from argparse mutual exclusion")
+
+
+# ---------------------------------------------------------------------------
+# build_event courthouse extraction tests (#4014)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEventCourthouse:
+    """build_event sets event["courthouse"] from HTML body text (#4014).
+
+    The rebuild path does not have a courthouse field in the S3 key metadata.
+    A best-effort regex scan of the HTML body extracts the courthouse name so
+    that normalize_department can skip the letter+digits collapse for LB/CH/AV
+    courthouses.
+    """
+
+    def _la_parsed(self, content_hash: str = "abc123def456") -> dict[str, str]:
+        return {
+            "state": "ca",
+            "county": "los_angeles",
+            "court": "superior_court",
+            "content_hash": content_hash,
+            "ext": "html",
+        }
+
+    def test_chatsworth_courthouse_extracted(self) -> None:
+        """HTML body with 'Chatsworth Courthouse North' → event["courthouse"]."""
+        html = (
+            b"<html><body>Chatsworth Courthouse North Department F49 Tentative Ruling</body></html>"
+        )
+        parsed = self._la_parsed()
+        key = "ca/los_angeles/superior_court/raw/abc123def456.html"
+        event = rebuild_db.build_event(key, html, parsed, "test-bucket")
+        assert event.get("courthouse") == "Chatsworth Courthouse North"
+
+    def test_long_beach_courthouse_extracted(self) -> None:
+        """HTML body with 'Long Beach Courthouse' → event["courthouse"]."""
+        html = b"<html><body>Long Beach Courthouse Department S27 Tentative Ruling</body></html>"
+        parsed = self._la_parsed()
+        key = "ca/los_angeles/superior_court/raw/abc123def456.html"
+        event = rebuild_db.build_event(key, html, parsed, "test-bucket")
+        assert event.get("courthouse") == "Long Beach Courthouse"
+
+    def test_antelope_valley_courthouse_extracted(self) -> None:
+        """HTML body with 'Antelope Valley Courthouse' → event["courthouse"]."""
+        html = (
+            b"<html><body>Antelope Valley Courthouse Department A14 Tentative Ruling</body></html>"
+        )
+        parsed = self._la_parsed()
+        key = "ca/los_angeles/superior_court/raw/abc123def456.html"
+        event = rebuild_db.build_event(key, html, parsed, "test-bucket")
+        assert event.get("courthouse") == "Antelope Valley Courthouse"
+
+    def test_no_courthouse_omits_key(self) -> None:
+        """HTML body without any courthouse string must not set courthouse."""
+        html = b"<html><body>Department X14 Tentative Ruling text here</body></html>"
+        parsed = self._la_parsed()
+        key = "ca/los_angeles/superior_court/raw/abc123def456.html"
+        event = rebuild_db.build_event(key, html, parsed, "test-bucket")
+        assert "courthouse" not in event
+
+    def test_courthouse_extraction_idempotent_non_la(self) -> None:
+        """Non-LA county HTML with a courthouse name: key may or may not appear,
+        but no crash — idempotent."""
+        html = b"<html><body>Long Beach Courthouse some content</body></html>"
+        parsed = {
+            "state": "ca",
+            "county": "orange",
+            "court": "superior_court",
+            "content_hash": "abc123def456",
+            "ext": "html",
+        }
+        key = "ca/orange/superior_court/raw/abc123def456.html"
+        # Should not raise
+        event = rebuild_db.build_event(key, html, parsed, "test-bucket")
+        assert isinstance(event, dict)

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -87,6 +87,31 @@ KEY_PATTERN = re.compile(
 
 EXT_TO_FORMAT = {"html": "html", "pdf": "pdf", "docx": "docx", "txt": "txt"}
 
+# Best-effort courthouse name extraction from HTML body text (#4014).
+# Used in build_event to set event["courthouse"] so that the ingestion worker's
+# normalize_department() can skip the letter+digits collapse for regional LA
+# courthouses (Long Beach, Chatsworth, Antelope Valley) whose combined codes
+# (S25–S29, F43–F51, A14, etc.) identify distinct courtrooms.
+# Kept conservative — only exact proper-noun courthouse names; no fuzzy matching.
+_LA_BODY_COURTHOUSE_RE = re.compile(
+    r"\b(Chatsworth Courthouse North"
+    r"|Long Beach Courthouse"
+    r"|Antelope Valley Courthouse"
+    r"|Pomona Courthouse"
+    r"|Stanley Mosk Courthouse"
+    r"|Norwalk Courthouse"
+    r"|Spring Street Courthouse"
+    r"|Van Nuys Courthouse"
+    r"|Alhambra Courthouse"
+    r"|Compton Courthouse"
+    r"|Glendale Courthouse"
+    r"|Inglewood Courthouse"
+    r"|Pasadena Courthouse"
+    r"|Torrance Courthouse"
+    r"|Burbank Courthouse"
+    r"|Beverly Hills Courthouse)\b"
+)
+
 # Timezone lookup by state (expand as we add states)
 STATE_TIMEZONES = {
     "ca": "America/Los_Angeles",
@@ -274,6 +299,14 @@ def build_event(
                     event["hearing_date"] = str(hearing_dt)
             except ImportError:
                 pass
+
+            # Best-effort courthouse extraction from HTML body (#4014).
+            # Sets event["courthouse"] so normalize_department() can skip the
+            # letter+digits collapse for regional LA courthouses.
+            ch_match = _LA_BODY_COURTHOUSE_RE.search(text)
+            if ch_match:
+                event["courthouse"] = ch_match.group(1)
+
     elif content_format in ("pdf", "docx"):
         event["ruling_text"] = content.decode("latin-1")
 


### PR DESCRIPTION
## Summary

Fixed rebuild_db.build_event omitting the courthouse field, which defeats the department normalization carve-out for Long Beach, Chatsworth, and Antelope Valley courthouses (446 affected rulings). Extended the carve-out logic to include case-number prefix matching (LBCV/CHCV/AVCV) and implemented courthouse extraction from HTML body in the rebuild path.

Closes #4014

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check`)
- [ ] Format check passes (`ruff format --check`)
- [ ] Tests pass (`pytest packages/scraper-framework/`)
- [ ] CI green

### Post-deploy verification

- [ ] Run rebuild: `scripts/ecs-run-task.sh rebuild_db --county 'Los Angeles' --bust-llm-cache`
- [ ] Verify department codes: `scripts/dev-db-query.sh "SELECT department, COUNT(*) FROM derived.rulings r JOIN derived.courts c ON r.court_id = c.id WHERE c.county = 'Los Angeles' AND department IN ('S25','S27','S28','S29','A14','F43','F47','F49','F51') GROUP BY department;"` — returns ≥1 for each code
- [ ] Verify bare-letter drop: `scripts/dev-db-query.sh "SELECT department, COUNT(*) FROM derived.rulings r JOIN derived.courts c ON r.court_id = c.id WHERE c.county = 'Los Angeles' AND department IN ('S','F','A') GROUP BY department;"` — each should be <50
- [ ] Verification evidence posted on #4014 (see /task-v2-verify output)