### PR TITLE
test(scraping): add parametrized coverage for _BRACKETED_PLACEHOLDER_TITLE_RE (#4002)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -142,6 +142,14 @@ _ROLE_LITERAL_TITLE_RE = re.compile(
 # (plaintiff/defendant/petitioner/respondent/party/name/case) followed by a
 # qualifier (not specified, unknown, missing, not listed, not provided, tbd).
 # No anchor — the bracket can appear anywhere in the title.  See #3988.
+#
+# Explicit non-match envelope (do NOT widen without product confirmation — #4002):
+#   - Role-only:        [DEFENDANT], [Defendant 1]  — no qualifier word present
+#   - Qualifier-only:   [TBD], [Insert defendant here]  — no leading role word
+#   - Possessives:      [defendant's name]  — possessive breaks the role-word token
+#   - Ordinals:         [Defendant 1]  — digit suffix is not a qualifier keyword
+#   - Free-form:        [Name to be determined]  — "Name" alone is not a role word
+#                       used in this position; qualifier phrase not in the allowlist
 _BRACKETED_PLACEHOLDER_TITLE_RE = re.compile(
     r"\[(?:plaintiff|defendant|petitioner|respondent|party|name|case)[^\]]*"
     r"(?:not specified|unknown|missing|not listed|not provided|tbd)[^\]]*\]",

--- a/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
+++ b/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
@@ -230,33 +230,28 @@ def test_rebuild_title_from_parties_accepts_dict_shaped_parties() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_bracketed_placeholder_re_matches_defendant_not_specified() -> None:
-    """Matches the canonical Arce shape: 'Ezra Arce v. [Defendant not specified]'."""
-    assert _BRACKETED_PLACEHOLDER_TITLE_RE.search("Ezra Arce v. [Defendant not specified]")
-
-
-def test_bracketed_placeholder_re_matches_plaintiff_unknown() -> None:
-    """Matches bracketed placeholder at start of title: '[Plaintiff name unknown] v. Smith'."""
-    assert _BRACKETED_PLACEHOLDER_TITLE_RE.search("[Plaintiff name unknown] v. Smith")
-
-
-def test_bracketed_placeholder_re_matches_respondent_missing() -> None:
-    """Matches mid-title bracketed placeholder: 'In re Doe [Respondent missing]'."""
-    assert _BRACKETED_PLACEHOLDER_TITLE_RE.search("In re Doe [Respondent missing]")
-
-
-def test_bracketed_placeholder_re_does_not_match_clean_title() -> None:
-    """A clean title like 'Smith v. Jones' produces no match."""
-    assert not _BRACKETED_PLACEHOLDER_TITLE_RE.search("Smith v. Jones")
-
-
-def test_bracketed_placeholder_re_does_not_match_non_role_brackets() -> None:
-    """False-positive guardrail: 'Smith v. Acme [DBA Acme Corp.]' should NOT match.
-
-    'DBA' is a real annotation bracket, not a placeholder — the regex must
-    restrict matches to role words followed by qualifier words.
-    """
-    assert not _BRACKETED_PLACEHOLDER_TITLE_RE.search("Smith v. Acme [DBA Acme Corp.]")
+@pytest.mark.parametrize(
+    "title,should_match",
+    [
+        # Currently-supported shapes (regression guard) — verbatim from removed tests
+        ("Ezra Arce v. [Defendant not specified]", True),
+        ("[Plaintiff name unknown] v. Smith", True),
+        ("In re Doe [Respondent missing]", True),
+        # Clean / non-placeholder brackets — must NOT match
+        ("Smith v. Jones", False),
+        ("Smith v. Acme [DBA Acme Corp.]", False),
+        # Currently-unsupported but real LLM outputs — documented non-matches.
+        # If product later confirms these need catching, widen regex AND flip to True.
+        ("Smith v. [Defendant 1]", False),
+        ("Smith v. [defendant's name]", False),
+        ("Smith v. [DEFENDANT]", False),
+        ("Smith v. [TBD]", False),
+        ("Smith v. [Name to be determined]", False),
+        ("Smith v. [Insert defendant here]", False),
+    ],
+)
+def test_bracketed_placeholder_regex_coverage(title: str, should_match: bool) -> None:
+    assert bool(_BRACKETED_PLACEHOLDER_TITLE_RE.search(title)) is should_match
 
 
 def test_rebuild_title_from_parties_handles_bracketed_placeholder() -> None:


### PR DESCRIPTION
## Summary

Replaced five individual `_BRACKETED_PLACEHOLDER_TITLE_RE` test functions with a single 11-row parametrized test covering both canonical shapes and documented non-matches. Updated the regex's comment block to explicitly document unsupported shapes (role-only, qualifier-only, possessives, ordinals, free-form), preventing accidental regex widening without product confirmation.

Closes #4002

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 45 tests green, including 11 parametrized cases
- [x] CI green

### Post-deploy verification

- [x] N/A — test-only change (no deployed component)