### PR TITLE
docs(dispatcher-v3): update stale OQ# backreferences after PR #3980 spec renumber (#4007)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -38,7 +38,7 @@ After confirming the worktree, set up the agent status file so the dispatcher ca
 
 **Determining the agent-id (`AGENT_ID` env var precedence):**
 
-1. **If the `AGENT_ID` environment variable is set, use that value verbatim** as `{agent-id}`. The dispatcher-v3 task-runner ECS task launches `claude -p --worktree=agent-<uuid> "/task #N"` with `AGENT_ID=<uuid>` exported in the env. Using the launcher-assigned id ensures `/task`'s claim comment and every `progress.sh` milestone call correlate with the dispatcher's DB rows for the same agent. See the dispatcher-v3 spec (§11 OQ#6 and §4.3) for the full launcher contract — and #3873 for the issue that landed this env-var precedence.
+1. **If the `AGENT_ID` environment variable is set, use that value verbatim** as `{agent-id}`. The dispatcher-v3 task-runner ECS task launches `claude -p --worktree=agent-<uuid> "/task #N"` with `AGENT_ID=<uuid>` exported in the env. Using the launcher-assigned id ensures `/task`'s claim comment and every `progress.sh` milestone call correlate with the dispatcher's DB rows for the same agent. See the dispatcher-v3 spec (§11 OQ#5 and §4.3) for the full launcher contract — and #3873 for the issue that landed this env-var precedence.
 2. **Otherwise, fall back to the cwd-derived id** (e.g. `agent-ab4722a2` from `.claude/worktrees/agent-ab4722a2`, or `worker-2` from `worktrees/worker-2`). This is today's behavior — Agent-tool spawn via the dispatcher-v2 daemon does not export `AGENT_ID`, so the cwd-derived path remains the fallback.
 
 Quick check (env var first, cwd fallback): `echo "${AGENT_ID:-$(basename "$PWD")}"`.

--- a/scripts/dispatcher_v3/launcher.py
+++ b/scripts/dispatcher_v3/launcher.py
@@ -133,7 +133,7 @@ EXIT_REASON_SILENT_HANG = "silent_hang"
 
 #: Default wall-clock cap (seconds) for a task-runner ECS task. The
 #: launcher's ``_watch_in_flight`` loop ecs:StopTask's any task-runner
-#: whose ``now - started_at`` exceeds this. Matches v3 spec §11 OQ#4:
+#: whose ``now - started_at`` exceeds this. Matches v3 spec §11 OQ#3:
 #: 6h covers virtually every real ``/task`` run including a long ralph
 #: + fix-CI cycle.
 #:
@@ -656,7 +656,7 @@ class Launcher:
           ``task_runner_wall_clock_seconds`` (default 21600, 6h) →
           ``ecs:StopTask`` + ``failed`` with
           ``exit_reason='wall_clock_exceeded'``. The wall-clock cap is
-          the *coarse* liveness check per spec §11 OQ#4; pre-#3940 it
+          the *coarse* liveness check per spec §11 OQ#3; pre-#3940 it
           was rendered into the task-def's ``stopTimeout`` field, but
           Fargate rejects task-defs with ``stopTimeout > 120s``, so the
           launcher enforces it here instead. Checked BEFORE the silent-

--- a/scripts/dispatcher_v3/tests/test_launcher.py
+++ b/scripts/dispatcher_v3/tests/test_launcher.py
@@ -1491,7 +1491,7 @@ def test_wall_clock_exit_reason_is_distinct_from_silent_hang() -> None:
 
 
 def test_wall_clock_default_constants_match_spec() -> None:
-    """Pin the default cap values per spec §11 OQ#4 + issue body.
+    """Pin the default cap values per spec §11 OQ#3 + issue body.
 
     A future change that bumps these defaults must do so deliberately
     (the test fails loudly) -- the spec values are referenced by


### PR DESCRIPTION
## Summary

Fixed four stale §11 OQ# backreferences in the codebase after PR #3980 renumbered the open questions in docs/specs/dispatcher-v3-spec.md §11. References now point at the correct OQ numbers: OQ#3 (wall-clock cap) and OQ#5 (AGENT_ID env-var).

Closes #4007

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] N/A — docs only (no deployed component)