### PR TITLE
fix(scraping): raise min_party_overlap floor to 0.5 to defeat generic-party case collisions (#4024)

### DIFF
--- a/packages/scraper-framework/src/framework/enrichment.py
+++ b/packages/scraper-framework/src/framework/enrichment.py
@@ -279,7 +279,13 @@ class EnrichmentEngine:
         Default is 2.
     min_party_overlap : float
         Minimum party overlap (Jaccard similarity) required for a fuzzy
-        case number match to be accepted. Default is 0.3 (30%).
+        case number match to be accepted. Default is 0.5 (50%).
+
+        The floor is set at majority overlap to defeat the generic-party
+        collision class: when two cases share only a single generic party
+        (e.g. "State of Texas", "United States") the Jaccard score is
+        typically 1/3 ≈ 0.33, well below the 0.5 threshold
+        (Federal/CourtListener regression — see #4024).
 
         When party data is missing on either side (empty ``extracted_parties``
         or empty candidate parties) and the caller has explicitly provided
@@ -301,7 +307,7 @@ class EnrichmentEngine:
         *,
         court_portal: CourtPortalLookup | None = None,
         max_levenshtein: int = 2,
-        min_party_overlap: float = 0.3,
+        min_party_overlap: float = 0.5,
         max_fuzzy_candidates: int = 500,
     ) -> None:
         self._conn = conn
@@ -386,13 +392,13 @@ class EnrichmentEngine:
 
         # Step 2: Fuzzy match
         #
-        # Party-identity validation (#2467): track whether the caller has
-        # party information available for this ruling.  ``extracted_parties
-        # is None`` means "no party data known" (legacy caller contract) —
-        # accept on distance alone.  An empty or non-empty list means the
-        # caller DOES have a notion of the ruling's parties — require
-        # non-empty parties on both sides AND Jaccard overlap >= threshold
-        # to accept the fuzzy match.  Silent acceptance without party
+        # Party-identity validation (#2467, see also #4024): track whether the
+        # caller has party information available for this ruling.
+        # ``extracted_parties is None`` means "no party data known" (legacy
+        # caller contract) — accept on distance alone.  An empty or non-empty
+        # list means the caller DOES have a notion of the ruling's parties —
+        # require non-empty parties on both sides AND Jaccard overlap >=
+        # threshold to accept the fuzzy match.  Silent acceptance without party
         # validation collapses distinct rulings onto the same case_number
         # when near-duplicate numbers exist in the court.
         _parties_known = extracted_parties is not None

--- a/packages/scraper-framework/tests/test_enrichment.py
+++ b/packages/scraper-framework/tests/test_enrichment.py
@@ -495,6 +495,107 @@ class TestMatchCaseNumberProbateRegression:
 
 
 # ---------------------------------------------------------------------------
+# EnrichmentEngine — Federal/CourtListener generic-party regression (#4024)
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCaseNumberFederalGenericPartyRegression:
+    """Regression tests for the Federal/CourtListener generic-party false-positive
+    fuzzy-match bug (#4024).  Spotcheck 2026-05-03.
+
+    The root cause: two unrelated cases from the same court share a single
+    generic party (e.g. "State of Texas", "United States") whose Jaccard
+    similarity is 1/3 ≈ 0.333.  With the old 0.3 threshold those two cases
+    could be silently merged.  Raising the floor to 0.5 (majority overlap)
+    defeats the whole generic-party collision class.
+    """
+
+    def test_two_texas_appellate_cases_sharing_only_state_of_texas_do_not_fuzzy_match(
+        self,
+    ) -> None:
+        """AC #1 (unit-level): two unrelated Texas appellate cases that share
+        only "State of Texas" (Jaccard=1/3≈0.333 < 0.5) and are within
+        Levenshtein distance 2 must NOT fuzzy-match.
+
+        Extracted ruling parties: ["Oliver Perry Harris", "State of Texas"]
+        Candidate DB parties:     ["Joey Sullivan", "State of Texas"]
+        Query case number:        02-25-00173-CR
+        Candidate case number:    02-25-00131-CR
+        Normalized distance:      levenshtein("022500173CR", "022500131CR") = 2
+        Jaccard:                  |{State of Texas}| / |{Oliver Perry Harris,
+                                   State of Texas, Joey Sullivan}| = 1/3 ≈ 0.333
+        """
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            (
+                "case-uuid-sullivan",
+                "02-25-00131-CR",
+                ["joey sullivan", "state of texas"],
+            ),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "02-25-00173-CR",
+            "court-uuid-tx-2nd",
+            extracted_parties=["Oliver Perry Harris", "State of Texas"],
+        )
+
+        # Jaccard = 1/3 ≈ 0.333 < 0.5 threshold → must NOT fuzzy-match
+        assert result.match_type == "new", (
+            "Two Texas appellate cases sharing only 'State of Texas' "
+            "must not fuzzy-match (#4024 regression)"
+        )
+        assert result.case_id == ""
+
+    def test_two_georgia_sct_cases_sharing_only_the_state_do_not_fuzzy_match(
+        self,
+    ) -> None:
+        """Second generic-party pattern: two Georgia Supreme Court cases
+        sharing only "State" (Chapple v. State / Kerns v. State), where
+        near-sequential docket numbers (S25A1158 vs S25A1159) place them
+        within Levenshtein distance 1.
+
+        Jaccard = 1/2 = 0.5 — exactly at the threshold, which must NOT
+        be accepted (overlap must be strictly >= threshold, enforced by the
+        ``< self._min_party_overlap`` guard, so 0.5 == 0.5 IS accepted).
+        Use a three-party set so Jaccard falls to 1/3 ≈ 0.333 < 0.5.
+
+        Extracted parties: ["Chapple", "State"]
+        Candidate parties: ["Kerns", "State"]
+        Query case number: S25A1158
+        Candidate:         S25A1159
+        Distance:          1
+        Jaccard:           1/3 ≈ 0.333 < 0.5 → must NOT fuzzy-match
+        """
+        conn = _make_mock_conn()
+        cursor = conn.cursor().__enter__()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = [
+            (
+                "case-uuid-kerns",
+                "S25A1159",
+                ["kerns", "state"],
+            ),
+        ]
+
+        engine = EnrichmentEngine(conn)
+        result = engine.match_case_number(
+            "S25A1158",
+            "court-uuid-ga-sct",
+            extracted_parties=["Chapple", "State"],
+        )
+
+        # Jaccard = |{state}| / |{chapple, state, kerns}| = 1/3 ≈ 0.333 < 0.5
+        assert result.match_type == "new", (
+            "Two Georgia SCT cases sharing only 'State' must not fuzzy-match (#4024 regression)"
+        )
+        assert result.case_id == ""
+
+
+# ---------------------------------------------------------------------------
 # EnrichmentEngine — Fuzzy candidate query filtering
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Raised the minimum party-overlap threshold for fuzzy case-number matching from 0.3 to 0.5 (Jaccard similarity, majority required). This defeats the generic-party collision regression where two unrelated Federal/CourtListener rulings sharing only a single generic party (e.g., "State of Texas", "United States") could be silently merged due to Jaccard ≈ 0.333 exceeding the old floor. Spotcheck 2026-05-03 found ~20% of Federal rulings affected.

Updated the `EnrichmentEngine` docstring and inline comment (Step 2 of `match_case_number`) to document the rationale and reference #4024. Added regression tests covering the Texas appellate and Georgia SCT false-positive patterns observed in the spotcheck.

Closes #4024

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 96 tests in `scraper-framework` pass
- [x] CI green

### Post-deploy verification

- [ ] Backfill Federal/CourtListener mislinked rulings via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --prefix federal/` (post-deploy)
- [ ] SQL audit confirms 0 mismatches between `derived.cases.case_title` and source `cluster.case_name` for Federal jurisdiction rulings (post-deploy)
- [ ] Spot-check Federal rulings 1–10 match source document content (post-deploy via `scripts/ecs-run-task.sh scripts/spotcheck/run_spotcheck.py -- --n 10`)
- [ ] Verification evidence posted on #4024 (see `/task-v2-verify` output)