### PR TITLE
fix(scraping): add regex fallback for null LLM outcome/motion_type in CC LLM-split path (#4029)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives.py
@@ -665,6 +665,11 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
                                 doc.ruling_text = ruling.ruling_text
                                 doc.motion_type = ruling.motion_type
                                 doc.outcome = ruling.outcome
+                                # Regex fallback for null LLM fields (#4029)
+                                if doc.outcome is None and doc.ruling_text:
+                                    doc.outcome = _cc_extract_outcome(doc.ruling_text)
+                                if doc.motion_type is None and doc.ruling_text:
+                                    doc.motion_type = _cc_extract_motion_type(doc.ruling_text)
                                 doc.parties = ruling.parties
                                 doc.extra["_llm_extracted"] = True
                                 doc.extra["pre_split"] = True

--- a/packages/scraper-framework/tests/courts/test_cc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_cc_tentatives.py
@@ -1639,6 +1639,190 @@ def test_cc_fetch_llm_disabled_uses_regex(mock_llm_enabled: MagicMock) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Regex fallback for null LLM outcome/motion_type fields (#4029)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
+def test_cc_llm_split_null_outcome_fallback(
+    mock_llm_enabled: MagicMock,
+    mock_extract: MagicMock,
+) -> None:
+    """When LLM returns outcome=None, the regex fallback populates outcome from ruling_text."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 16 - Judge Reyes\\16_031126.pdf">Mar 11</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    mock_extract.return_value = [
+        CCSplitRuling(
+            ruling_index=1,
+            case_number="C24-01512",  # valid case number in cc_dept16_031126.pdf
+            ruling_text="Motion for Summary Judgment is granted.",
+            case_title="Smith v. Jones",
+            case_type="civil",
+            motion_type="motion_for_summary_judgment",
+            outcome=None,  # LLM left this None
+            parties=[],
+        ),
+    ]
+
+    docs = scraper.fetch_documents()
+
+    assert len(docs) == 1
+    # Regex fallback should have extracted "granted" from ruling_text
+    assert docs[0].outcome == "granted"
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
+def test_cc_llm_split_null_motion_type_fallback(
+    mock_llm_enabled: MagicMock,
+    mock_extract: MagicMock,
+) -> None:
+    """When LLM returns motion_type=None, the regex fallback populates it from ruling_text."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 16 - Judge Reyes\\16_031126.pdf">Mar 11</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    mock_extract.return_value = [
+        CCSplitRuling(
+            ruling_index=1,
+            case_number="C24-01512",  # valid case number in cc_dept16_031126.pdf
+            ruling_text="*HEARING ON MOTION TO COMPEL\nThe motion is granted.",
+            case_title="Smith v. Jones",
+            case_type="civil",
+            motion_type=None,  # LLM left this None
+            outcome="granted",
+            parties=[],
+        ),
+    ]
+
+    docs = scraper.fetch_documents()
+
+    assert len(docs) == 1
+    # Regex fallback should have extracted a motion type from the HEARING ON MOTION line
+    assert docs[0].motion_type is not None
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
+def test_cc_llm_split_preserves_positive_llm_classification(
+    mock_llm_enabled: MagicMock,
+    mock_extract: MagicMock,
+) -> None:
+    """When LLM returns non-None outcome/motion_type, regex fallback must NOT overwrite."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 16 - Judge Reyes\\16_031126.pdf">Mar 11</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    mock_extract.return_value = [
+        CCSplitRuling(
+            ruling_index=1,
+            case_number="C24-01512",  # valid case number in cc_dept16_031126.pdf
+            # ruling_text says "is granted" but LLM says "denied" — LLM wins
+            ruling_text="*HEARING ON MOTION TO COMPEL\nThe motion is granted.",
+            case_title="Smith v. Jones",
+            case_type="civil",
+            motion_type="motion_to_compel",
+            outcome="denied",  # LLM classification
+            parties=[],
+        ),
+    ]
+
+    docs = scraper.fetch_documents()
+
+    assert len(docs) == 1
+    # LLM values must be preserved; regex fallback must NOT run
+    assert docs[0].outcome == "denied"
+    assert docs[0].motion_type == "motion_to_compel"
+
+
+@respx.mock
+@patch("courts.ca.cc_tentatives._llm_extract_rulings")
+@patch("courts.ca.cc_tentatives._cc_llm_enabled", return_value=True)
+def test_cc_llm_split_null_fields_with_no_ruling_text(
+    mock_llm_enabled: MagicMock,
+    mock_extract: MagicMock,
+) -> None:
+    """When LLM returns both fields None and ruling_text is empty, both remain None (no crash)."""
+    config = cc_default_config()
+    scraper = CCTentativeRulingsScraper(config)
+
+    index_html = (
+        "<html><body>"
+        '<a class="tentative-ruling" '
+        'href="TR\\Department 16 - Judge Reyes\\16_031126.pdf">Mar 11</a>'
+        "</body></html>"
+    )
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=index_html))
+
+    pdf_bytes = _load_bytes("cc_dept16_031126.pdf")
+    respx.route(method="GET", url__regex=r".*\.pdf$").mock(
+        return_value=httpx.Response(200, content=pdf_bytes)
+    )
+
+    mock_extract.return_value = [
+        CCSplitRuling(
+            ruling_index=1,
+            case_number="C24-01512",  # valid case number in cc_dept16_031126.pdf
+            ruling_text="",  # Empty ruling text
+            case_title="Smith v. Jones",
+            case_type="civil",
+            motion_type=None,
+            outcome=None,
+            parties=[],
+        ),
+    ]
+
+    docs = scraper.fetch_documents()
+
+    assert len(docs) == 1
+    # Both fields remain None — no crash, no spurious match
+    assert docs[0].outcome is None
+    assert docs[0].motion_type is None
+
+
+# ---------------------------------------------------------------------------
 # Regression: probate PDFs use content-hash filenames — hearing_date from PDF header
 # (#3739)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the Contra Costa LLM-split path's 51% NULL outcome rate by adding a deterministic regex fallback that populates outcome and motion_type when the LLM left them null. The fallback only runs per-ruling (using ruling_text already scoped by the LLM) and never overwrites positive LLM classifications. After reingest, NULL-outcome rate should drop materially to <15%.

Closes #4029

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework/tests/courts/test_cc_tentatives.py` — all 93 tests pass)
- [x] CI green

### Post-deploy verification

- [ ] Run CC reingest: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "Contra Costa" --bust-llm-cache=false`
- [ ] Verify NULL-outcome rate drops to <15%: `SELECT COUNT(*) FILTER (WHERE outcome IS NULL) / NULLIF(COUNT(*), 0) FROM derived.rulings WHERE county='Contra Costa' AND case_number NOT LIKE 'UNKNOWN-%'`
- [ ] Verify sample rulings (cdd013e0, 841d1a62, 4831eb48, 9154888b, 39d9b786) have non-NULL outcome/motion_type post-reingest
- [ ] Verification evidence posted on #4029 (see /task-v2-verify output)