### PR TITLE
fix(dispatcher): backfill + close two more zombie terminal-write paths (#3574)

### DIFF
--- a/packages/api/migrations/62_dispatcher-backfill-zombie-ended-at.sql
+++ b/packages/api/migrations/62_dispatcher-backfill-zombie-ended-at.sql
@@ -1,0 +1,81 @@
+-- Up Migration
+--
+-- Issue #3574 — backfill ``ended_at`` on zombie agent rows.
+--
+-- Problem
+-- -------
+-- ``dispatcher.agents`` accumulated rows in a "zombie" state:
+-- ``status`` in TERMINAL_AGENT_STATUSES (``failed``, ``crashed``,
+-- ``succeeded``, ``plan_blocked``, ``needs_review``) AND
+-- ``ended_at IS NULL``. The agent's ECS task ended and the daemon
+-- classified it as terminal, but ``ended_at`` was never written.
+--
+-- This is bookkeeping invisibility:
+--
+-- 1. Monitoring queries that ``ORDER BY ended_at DESC`` silently skip
+--    these rows. The cockpit cooldown function reads ``started_at`` and
+--    works correctly, but any "what's the latest terminal for this
+--    issue" query using ``ended_at`` sorts returns the older non-zombie
+--    terminal as if it's current.
+-- 2. The autonomous monitoring loop missed at least 5 issues in active
+--    retry-loops on 2026-04-27 (``#2777, #2813, #2832, #2854, #3297``,
+--    all stuck in ``ralph_baseline_transition_unrecognized`` zombies).
+-- 3. By 2026-04-29 the zombie count had grown to 187 rows (35 in the
+--    last 24h, 152 in the prior 7 days).
+--
+-- The runtime fix landed in three places:
+--
+-- * ``scripts/dispatcher/agent-runner-entrypoint.sh`` — ``advance_phase``
+--   and ``agent_runner_reaped_failure`` now stamp ``ended_at`` when the
+--   new status is terminal (#3822).
+-- * ``scripts/dispatcher/daemon.py`` — the ``_launch_scheduled_skill_agent``
+--   fail-path and ``_restore_succeeded_phase_done`` now stamp ``ended_at``
+--   (#3574 — companion to this migration).
+-- * ``scripts/dispatcher/daemon.py:_backfill_terminal_ended_at`` — a
+--   per-tick safety net that bulk-stamps any row that slipped through
+--   (#3822).
+--
+-- This migration is the one-shot cleanup of the historical accumulated
+-- pile — sets ``ended_at`` on every existing zombie row immediately at
+-- deploy time so monitoring queries return correct results without
+-- waiting for the next housekeeping tick.
+--
+-- Fix
+-- ---
+-- Single UPDATE round-trip: for every row with terminal status and
+-- ``ended_at IS NULL``, stamp ``ended_at`` from the best available
+-- timestamp. The most accurate source is the latest entry in
+-- ``dispatcher.phase_transitions`` for that agent (the moment the
+-- terminal phase was logged); fall back to ``started_at`` for rows
+-- with no transitions logged yet. ``GREATEST(..., started_at)``
+-- guarantees ``ended_at >= started_at`` even if a transition row
+-- somehow predates the agent row.
+--
+-- Idempotent — re-running this migration is a no-op once all rows have
+-- ``ended_at IS NOT NULL``. The runtime backfill in
+-- ``_backfill_terminal_ended_at`` and the per-write fixes ensure no
+-- new zombies accrue.
+
+UPDATE dispatcher.agents AS a
+   SET ended_at = GREATEST(
+                      a.started_at,
+                      COALESCE(
+                          (SELECT MAX(pt.ts)
+                             FROM dispatcher.phase_transitions pt
+                            WHERE pt.agent_id = a.agent_id),
+                          a.started_at
+                      )
+                  )
+ WHERE a.status IN ('failed', 'crashed', 'succeeded', 'plan_blocked', 'needs_review')
+   AND a.ended_at IS NULL;
+
+
+-- Down Migration
+--
+-- This migration contains no DDL — there are no columns or constraints
+-- to drop. The ``ended_at`` stamp written above is NOT reversed on
+-- down-migrate: any row whose terminal status was correct at the time
+-- of the up-migrate now has the right ``ended_at`` value, and clearing
+-- it back to NULL would re-introduce the zombie state the migration
+-- exists to eliminate. There is no scenario where a down-migrate of
+-- this migration would be desirable.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -8770,10 +8770,17 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before update"
         try:
             with self._conn.cursor() as cur:
+                # Issue #3574: defensively stamp ``ended_at`` so the
+                # zombie invariant (status terminal ⇒ ended_at NOT NULL)
+                # holds even if a caller invokes restore on a row that
+                # never had ended_at written. ``COALESCE(ended_at,
+                # now())`` preserves any earlier stamp from the original
+                # success path.
                 cur.execute(
                     "UPDATE dispatcher.agents "
                     "SET status = 'succeeded', "
                     "    phase = 'done', "
+                    "    ended_at = COALESCE(ended_at, now()), "
                     "    failure_summary = NULL "
                     "WHERE agent_id = %s",
                     (agent_id,),
@@ -24272,10 +24279,18 @@ class DispatcherDaemon:
             )
             try:
                 with self._conn.cursor() as cur:
+                    # Issue #3574: stamp ``ended_at`` synchronously with the
+                    # terminal status write. Without this, the launch-failed
+                    # row becomes a zombie (status='failed' AND ended_at IS
+                    # NULL), invisible to monitoring queries that order by
+                    # ``ended_at DESC``. ``COALESCE(ended_at, now())`` is
+                    # idempotent + race-safe with the housekeeping bulk
+                    # backfill in :meth:`_backfill_terminal_ended_at`.
                     cur.execute(
                         "UPDATE dispatcher.agents "
                         "   SET status = 'failed', "
-                        "       phase = 'scheduled_skill_launch_failed' "
+                        "       phase = 'scheduled_skill_launch_failed', "
+                        "       ended_at = COALESCE(ended_at, now()) "
                         " WHERE agent_id = %s",
                         (agent_id,),
                     )

--- a/scripts/dispatcher/tests/test_no_zombie_terminals.py
+++ b/scripts/dispatcher/tests/test_no_zombie_terminals.py
@@ -1,0 +1,277 @@
+"""Issue #3574 — guard the zombie-terminal invariant.
+
+A "zombie" agent row has ``status`` in
+:data:`scripts.dispatcher.daemon.TERMINAL_AGENT_STATUSES`
+(``failed``, ``crashed``, ``succeeded``, ``plan_blocked``, ``needs_review``)
+AND ``ended_at IS NULL``. Such rows are invisible to monitoring queries that
+order by ``ended_at DESC`` (the cockpit's "Recently Completed" panel, the
+daily report's strict green-streak counter, the orphan-PR resurrection
+sweep). On 2026-04-27 a population of zombie rows caused the autonomous
+monitoring loop to silently miss 5 issues stuck in active retry-loops.
+
+Two layers enforce the invariant:
+
+1. **Per-write stamping** — every UPDATE site that writes a terminal
+   status to ``dispatcher.agents`` MUST also stamp ``ended_at``
+   (either ``ended_at = now()`` or
+   ``ended_at = COALESCE(ended_at, now())``). The ``COALESCE`` form is
+   preferred for restore/resurrect paths so any earlier stamp is
+   preserved.
+2. **Bulk backfill safety net** — :meth:`DispatcherDaemon._backfill_terminal_ended_at`
+   runs every housekeeping tick and heals any row that slipped through.
+
+This test covers layer 1: it scans the SQL UPDATE statements in
+``scripts/dispatcher/daemon.py`` and asserts that every UPDATE that sets
+a terminal ``status`` value also includes ``ended_at`` in its SET clause.
+The agent-runner side (``agent-runner-entrypoint.sh``) is covered by
+:mod:`test_agent_runner_terminal_ended_at`.
+
+This is a static AST-style scan of the daemon source — it parses the
+file text rather than executing the daemon. The intent is to catch the
+regression class where a new failure path lands but the author forgets
+the ``ended_at`` clause in its UPDATE.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+_DAEMON_PATH = Path(daemon.__file__)
+_DAEMON_TEXT = _DAEMON_PATH.read_text(encoding="utf-8")
+
+
+def _terminal_statuses() -> frozenset[str]:
+    """Return the canonical TERMINAL_AGENT_STATUSES frozenset.
+
+    Sourced from the daemon module so the test stays in lockstep with
+    the runtime definition. Adding a new terminal status to
+    ``TERMINAL_AGENT_STATUSES`` automatically extends this test's
+    coverage without any test edit.
+    """
+    return daemon.TERMINAL_AGENT_STATUSES
+
+
+def _terminal_status_pattern() -> re.Pattern[str]:
+    """Regex matching ``status = 'X'`` for any X in TERMINAL_AGENT_STATUSES.
+
+    Matches both single- and double-quoted forms. The status value can
+    be inside a Python string literal (``"... SET status = 'failed' ..."``).
+    """
+    statuses = "|".join(re.escape(s) for s in sorted(_terminal_statuses()))
+    return re.compile(rf"status\s*=\s*['\"]({statuses})['\"]")
+
+
+# UPDATE statements in daemon.py are split across multiple Python string
+# literals concatenated by Python's adjacent-string-concatenation
+# semantics. The cursor.execute() call accepts the concatenated value
+# at runtime. To analyze a logical SQL statement we extract the
+# enclosing call: ``cur.execute("UPDATE dispatcher.agents " ... ")``.
+#
+# Why we use ``ast`` instead of a single regex: the daemon's SQL
+# contains literal single-quoted values (e.g. ``status = 'failed'``)
+# inside Python double-quoted strings. A naive
+# ``[\"'][^\"']*[\"']`` pattern stops at the first inner ``'``,
+# dropping the rest of the SQL. The Python ``ast`` module gives us
+# proper string-literal handling; we use it to walk every
+# ``cur.execute(...)`` call and concatenate adjacent string literals
+# into the full SQL via the ``ast.Constant.value`` it produces.
+
+
+def _extract_update_statements() -> list[tuple[int, str]]:
+    """Return ``(line_no, concatenated_sql)`` tuples for every
+    ``cur.execute("UPDATE dispatcher.agents ...")`` call in daemon.py.
+
+    Uses Python's ``ast`` module to walk the source and find calls to
+    ``cur.execute`` whose first argument is a string literal (or an
+    implicit-concatenation of string literals, which the ast module
+    folds into a single ``Constant`` node automatically). Filters out
+    UPDATEs that don't target ``dispatcher.agents`` (e.g.
+    ``dispatcher.diagnoses``, ``dispatcher.config``).
+    """
+    tree = ast.parse(_DAEMON_TEXT)
+    out: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match calls of the form ``X.execute(...)`` — the X part is
+        # almost always ``cur`` but we don't constrain it (other names
+        # like ``cursor`` are fine too).
+        if not isinstance(node.func, ast.Attribute):
+            continue
+        if node.func.attr != "execute":
+            continue
+        if not node.args:
+            continue
+        first_arg = node.args[0]
+        # ast folds adjacent string literals into a single Constant.
+        # If the first argument is anything else (e.g. an f-string,
+        # a variable, a function call), skip it — those are not the
+        # static SQL strings we're auditing.
+        if not isinstance(first_arg, ast.Constant) or not isinstance(
+            first_arg.value, str
+        ):
+            continue
+        sql = first_arg.value
+        if "UPDATE dispatcher.agents" not in sql:
+            continue
+        out.append((node.lineno, sql))
+    return out
+
+
+def _has_ended_at_stamp(sql: str) -> bool:
+    """True if the SQL contains an ``ended_at = ...`` clause that writes
+    a non-NULL value.
+
+    Accepts the canonical forms used in daemon.py:
+
+    * ``ended_at = now()``
+    * ``ended_at = COALESCE(ended_at, now())``
+
+    Rejects ``ended_at = NULL`` (used by retry-reset paths to clear
+    the stamp before a re-run — those are NOT terminal writes).
+    """
+    # Strip whitespace inside the SET clause so multi-line SQL parses cleanly.
+    normalized = re.sub(r"\s+", " ", sql)
+    # Look for ``ended_at =`` followed by something that's not NULL.
+    # The regex is intentionally permissive — any non-NULL right-hand
+    # side counts as a stamp.
+    m = re.search(r"ended_at\s*=\s*([^,]+?)(?:,|\s+WHERE|\s*$)", normalized)
+    if m is None:
+        return False
+    rhs = m.group(1).strip().upper()
+    if rhs == "NULL":
+        return False
+    return True
+
+
+def _has_terminal_status_set(sql: str) -> bool:
+    """True if the SQL's SET clause writes a literal terminal status.
+
+    Returns True for ``SET status = 'failed'`` etc. Returns False for
+    ``SET status = %s`` (parameterized) — those are handled by
+    :func:`_writes_terminal_status_via_parameter` based on the
+    surrounding control flow (the parameterized site in
+    ``_mark_agent_terminal`` has its own branch-level guarantee that
+    ``ended_at`` is set when ``status`` is terminal).
+    """
+    return bool(_terminal_status_pattern().search(sql))
+
+
+class TestTerminalStatuses:
+    """The test's source-of-truth status set matches the daemon's."""
+
+    def test_terminal_statuses_match_daemon_constant(self) -> None:
+        statuses = _terminal_statuses()
+        assert "failed" in statuses
+        assert "crashed" in statuses
+        assert "succeeded" in statuses
+        assert "plan_blocked" in statuses
+        assert "needs_review" in statuses
+        # Defensive — if the daemon adds a new terminal status, this
+        # test inherits the coverage. Locking the cardinality here
+        # would force an unrelated edit on every addition; instead,
+        # simply assert the set is non-empty.
+        assert len(statuses) >= 5
+
+
+class TestEveryTerminalUpdateStampsEndedAt:
+    """Every ``UPDATE dispatcher.agents`` that writes a literal terminal
+    ``status`` value MUST also stamp ``ended_at``. This is the
+    invariant that makes ``status terminal ⇒ ended_at NOT NULL`` hold
+    at write time (the housekeeping backfill is the safety net, not the
+    primary contract).
+    """
+
+    def test_no_zombie_creating_update_in_daemon(self) -> None:
+        """Walk every cur.execute("UPDATE dispatcher.agents ...") in
+        daemon.py and assert: if the SET clause writes a terminal
+        ``status`` literal, it must also include ``ended_at``.
+        """
+        offenders: list[tuple[int, str]] = []
+        for line_no, sql in _extract_update_statements():
+            if not _has_terminal_status_set(sql):
+                continue
+            if _has_ended_at_stamp(sql):
+                continue
+            # Truncate the SQL for a readable failure message.
+            normalized = re.sub(r"\s+", " ", sql).strip()
+            preview = normalized[:140] + ("..." if len(normalized) > 140 else "")
+            offenders.append((line_no, preview))
+
+        assert not offenders, (
+            "daemon.py has UPDATE sites that write a terminal status to "
+            "dispatcher.agents WITHOUT also stamping ended_at. Each one "
+            "creates a zombie row (#3574). Add `ended_at = COALESCE(ended_at, "
+            "now())` (idempotent + race-safe with _backfill_terminal_ended_at) "
+            "to the SET clause:\n\n"
+            + "\n".join(f"  daemon.py:{n}  {sql}" for n, sql in offenders)
+        )
+
+
+class TestBackfillUpdateUsesEndedAtIsNullGuard:
+    """The bulk backfill in ``_backfill_terminal_ended_at`` must filter
+    on ``ended_at IS NULL`` so it doesn't clobber correct stamps. This
+    guard also makes the UPDATE idempotent — a no-op once every
+    terminal row has ``ended_at NOT NULL``.
+    """
+
+    def test_backfill_filters_on_ended_at_is_null(self) -> None:
+        # The method body is short — read it as a string and assert
+        # the WHERE clause contains both the terminal-status filter and
+        # the ``ended_at IS NULL`` guard.
+        # _backfill_terminal_ended_at is the canonical bulk healer,
+        # introduced in #3822 and called every housekeeping tick.
+        method_text = _extract_method_body("_backfill_terminal_ended_at")
+        assert "ended_at IS NULL" in method_text, (
+            "_backfill_terminal_ended_at must filter on ended_at IS NULL "
+            "to be idempotent and avoid clobbering correct stamps."
+        )
+        assert "status = ANY(" in method_text, (
+            "_backfill_terminal_ended_at must filter on the terminal status set."
+        )
+        assert "SET ended_at = now()" in method_text, (
+            "_backfill_terminal_ended_at must stamp ended_at = now()."
+        )
+
+
+def _extract_method_body(method_name: str) -> str:
+    """Return the source text of a method on ``DispatcherDaemon``.
+
+    Walks indentation: starts at the method's ``def`` line, includes
+    every line indented deeper than the ``def`` until the next
+    method/class definition at the same or lesser indent. Used to
+    scope SQL-shape assertions to one method instead of the whole
+    27-thousand-line daemon.
+    """
+    text = _DAEMON_TEXT
+    pattern = rf"^(\s+)def {re.escape(method_name)}\("
+    m = re.search(pattern, text, re.MULTILINE)
+    assert m is not None, f"method {method_name}() not found in daemon.py"
+    method_indent = len(m.group(1))
+    start = m.start()
+    lines: list[str] = []
+    seen_body = False
+    for line in text[start:].splitlines(keepends=False):
+        stripped = line.lstrip()
+        if not stripped:
+            # Blank line — keep, doesn't terminate.
+            lines.append(line)
+            continue
+        line_indent = len(line) - len(stripped)
+        if seen_body and line_indent <= method_indent:
+            # Hit the next def/class at the same or lesser indent — stop.
+            break
+        lines.append(line)
+        if line_indent > method_indent:
+            seen_body = True
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Closes the remaining two zombie-row UPDATE paths in `daemon.py` that #3822 didn't cover, adds a regression test (static AST scan of `daemon.py`) that catches the regression class at PR time, and ships a one-shot backfill migration to clean up historical zombie rows on deploy.

The zombie invariant (`status terminal ⇒ ended_at NOT NULL`) is now defended at three layers: per-write stamping (this PR + #3822), per-tick housekeeping bulk backfill (#3822), and an immediate one-shot migration cleanup (this PR's migration 62).

Closes #3574

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Migration 62 applied successfully on dev (terraform-apply runs migrate on push:main).
- [x] `dispatcher.agents` zombie count on dev = 0 — verified via `scripts/dev-db-query.sh` (was 187 pre-fix, now 0).
- [x] `test_no_zombie_terminals.py` passes in CI green run.
- [x] Verification evidence posted on issue (see comment).
