### PR TITLE
infra(scraping): flip ingestion-worker LLM provider to google (#4031)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -121,7 +121,7 @@ module "compute" {
   db_connection_secret_arn           = module.database.db_connection_secret_arn
   opensearch_url                     = "https://${module.search.domain_endpoint}"
   opensearch_credentials_secret_arn  = module.search.master_credentials_secret_arn
-  llm_provider                       = "anthropic"
+  llm_provider                       = "google"
   anthropic_api_key_secret_arn       = data.aws_secretsmanager_secret.anthropic_api_key.arn
   google_api_key_secret_arn          = data.aws_secretsmanager_secret.google_api_key.arn
   proxy_secret_arn                   = data.aws_secretsmanager_secret.residential_proxy.arn

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -20,6 +20,13 @@ data "aws_secretsmanager_secret" "capsolver_api_key" {
   name = "judgemind/capsolver/api-key"
 }
 
+# Anthropic API access is disabled (cost control, #4031); we point the
+# production ingestion worker at Gemini. The secret is shared across envs
+# (single AWS account, same AI Studio project), matching the dev wiring.
+data "aws_secretsmanager_secret" "google_api_key" {
+  name = "judgemind/google/api-key"
+}
+
 module "networking" {
   source      = "../../modules/networking"
   environment = "production"
@@ -68,6 +75,8 @@ module "compute" {
   scraper_task_role_arn              = module.iam_scraper.role_arn
   redis_url                          = "redis://${module.cache.redis_endpoint}:${module.cache.redis_port}"
   document_archive_bucket            = module.document_archive.bucket_id
+  llm_provider                       = "google"
+  google_api_key_secret_arn          = data.aws_secretsmanager_secret.google_api_key.arn
   proxy_secret_arn                   = data.aws_secretsmanager_secret.residential_proxy.arn
   courtlistener_api_token_secret_arn = data.aws_secretsmanager_secret.courtlistener_api_token.arn
   capsolver_api_key_secret_arn       = data.aws_secretsmanager_secret.capsolver_api_key.arn

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -113,9 +113,9 @@ variable "opensearch_credentials_secret_arn" {
 }
 
 variable "llm_provider" {
-  description = "LLM provider for the ingestion worker: \"anthropic\" or \"google\". Must match the API key secret that is provisioned."
+  description = "LLM provider for the ingestion worker: \"anthropic\" or \"google\". Must match the API key secret that is provisioned. Default is \"google\" -- Anthropic API access has been disabled as a cost-control measure (see #4031); flip to \"anthropic\" only after re-enabling that account."
   type        = string
-  default     = "anthropic"
+  default     = "google"
 
   validation {
     condition     = contains(["anthropic", "google"], var.llm_provider)


### PR DESCRIPTION
## Summary

Anthropic API access has been disabled as a cost-control measure (scraper LLM extraction was costing more than budgeted). Flip the ingestion-worker LLM provider from `anthropic` to `google` in three Terraform locations -- `modules/compute/variables.tf` default, `environments/dev/main.tf` explicit override, and `environments/production/main.tf` (which previously had no Google secret wiring at all). The compute module already supports both providers, so this is a config flip, not a code port.

Production currently runs no ingestion-worker service (`aws ecs list-services --cluster judgemind-production` returns empty); the prod wiring is added structurally so when production scraping turns on it inherits Gemini by default.

Closes #4031

## Test plan

### Automated checks
- [x] Lint passes (terraform fmt -check, non-ASCII description check)
- [x] Validate dev passes
- [x] Validate production passes
- [x] Terraform plan (dev) is clean
- [x] CI green
- [x] dev-apply succeeds on the merge commit

### Post-deploy verification
- [x] `aws ecs describe-task-definition --task-definition judgemind-ingestion-worker-dev --region us-west-2 --query 'taskDefinition.containerDefinitions[0].environment[?name==\`LLM_PROVIDER\`].value'` returns `["google"]`
- [x] Verification evidence posted on issue (see A.8)
