### PR TITLE
fix(infra): restore OpenSearch Principal=* so basic-auth works (#3771)

### DIFF
--- a/infra/terraform/modules/search/main.tf
+++ b/infra/terraform/modules/search/main.tf
@@ -107,15 +107,32 @@ resource "aws_opensearch_domain" "main" {
     }
   }
 
-  # Defence-in-depth (#3704): the security group is the network gate (HTTPS
-  # from VPC CIDR only); this IAM policy is the second layer, restricting
-  # es:* to enumerated role ARNs instead of the prior AWS="*" wildcard.
+  # Access policy is intentionally wide-open at the IAM layer
+  # (Principal = "*").  This is NOT a permissive misconfiguration —
+  # see #3771 for the chain of reasoning.  Short version: with
+  # fine-grained access control + internal user database (basic auth via
+  # Secrets Manager), HTTP requests using basic auth have no IAM
+  # principal at the AWS layer.  AWS evaluates the access policy
+  # against "anonymous" principal in that case.  If the policy is
+  # narrower than `*` (e.g. specific role ARNs), every basic-auth
+  # request is denied as "User: anonymous is not authorized" before
+  # FGAC's internal user DB ever validates the username/password.
+  # PR #3720 attempted to tighten this to enumerated role ARNs (#3704)
+  # and immediately broke ingestion-worker startup with the exact
+  # 403-anonymous symptom in #3771.  Reverted here; defence-in-depth
+  # remains via the SG (VPC-only HTTPS), encrypt-at-rest,
+  # node-to-node encryption, and FGAC's internal user database.
+  # The principal_arns variable is preserved (and dev/prod still pass
+  # specific ARNs to it) so that a future SigV4 migration of all
+  # OpenSearch clients can re-tighten the policy without a TF
+  # interface change.  Tracking issue for that migration: see the
+  # follow-up filed against #3704 in this PR's body.
   access_policies = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
         Effect    = "Allow"
-        Principal = { AWS = var.principal_arns }
+        Principal = { AWS = "*" }
         Action    = "es:*"
         Resource  = "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/judgemind-${var.environment}/*"
       }

--- a/infra/terraform/modules/search/variables.tf
+++ b/infra/terraform/modules/search/variables.tf
@@ -49,11 +49,7 @@ variable "master_user_name" {
 }
 
 variable "principal_arns" {
-  description = "IAM role/user ARNs allowed to call es:* on this OpenSearch domain (#3704). An empty list would deny all IAM access, so at least one ARN is required."
+  description = "IAM role/user ARNs that should be allowed to call es:* on this OpenSearch domain. CURRENTLY UNUSED in the access policy (see #3771): the policy is `Principal = AWS = '*'` because basic-auth requests via FGAC's internal user database carry no IAM principal at the AWS layer, so any narrower policy denies them as 'User: anonymous'. The variable is kept on the module interface so callers (dev/prod env blocks) don't need to change when a future SigV4 migration re-tightens the policy."
   type        = list(string)
-
-  validation {
-    condition     = length(var.principal_arns) > 0
-    error_message = "principal_arns must contain at least one ARN; an empty list would deny all IAM access to OpenSearch."
-  }
+  default     = []
 }

--- a/packages/api/src/search/client.ts
+++ b/packages/api/src/search/client.ts
@@ -9,6 +9,14 @@ const clientOptions: ConstructorParameters<typeof Client>[0] = {
   ssl: { rejectUnauthorized: false },
 };
 
+// HTTP Basic auth via OpenSearch FGAC's internal user database. The
+// domain's resource-based access policy MUST permit Principal = "*" for
+// basic-auth requests to be evaluated by FGAC at all — see #3771 for the
+// full root-cause analysis of what happens when the policy is narrowed.
+// A future migration to SigV4-signed requests would let the access policy
+// re-tighten to enumerated role ARNs (#3704); track that follow-up issue
+// (filed alongside #3771) before changing the policy in
+// `infra/terraform/modules/search/main.tf`.
 if (OPENSEARCH_USERNAME && OPENSEARCH_PASSWORD) {
   clientOptions.auth = {
     username: OPENSEARCH_USERNAME,

--- a/packages/scraper-framework/src/framework/search/indexer.py
+++ b/packages/scraper-framework/src/framework/search/indexer.py
@@ -34,8 +34,8 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from opensearchpy import helpers
+from opensearchpy.exceptions import AuthorizationException, ConnectionTimeout, TransportError
 from opensearchpy.exceptions import ConnectionError as OSConnectionError
-from opensearchpy.exceptions import ConnectionTimeout, TransportError
 
 from .mapping import TENTATIVE_RULINGS_ALIAS, create_index
 
@@ -49,6 +49,38 @@ logger = logging.getLogger(__name__)
 CONSUMER_GROUP = "indexer"
 CONSUMER_NAME = "indexer-1"
 STREAM_DOCUMENT_VALIDATED = "document.validated"
+
+
+def _is_anonymous_user_403(exc: BaseException) -> bool:
+    """Return True if the exception is OpenSearch's "User: anonymous" 403.
+
+    The 403-anonymous case is OpenSearch-FGAC's behavior when the AWS-level
+    domain access policy is narrower than ``Principal: AWS=*`` AND the
+    request uses HTTP Basic auth (which has no IAM principal at the AWS
+    layer).  Detecting this case lets the worker emit an actionable
+    diagnostic instead of a generic 403 swallow.  See issue #3771.
+
+    Robust to either 2-arg ``AuthorizationException(403, body)`` or 3-arg
+    ``AuthorizationException(403, msg, info)`` construction — opensearchpy
+    uses both shapes depending on the call path.
+    """
+    if not isinstance(exc, AuthorizationException):
+        return False
+    # opensearchpy's AuthorizationException stores the response under .error
+    # for 2-arg construction and .info for 3-arg construction.  Stringify both
+    # because the body may be a JSON string, a dict, or already-decoded text.
+    haystack_parts: list[str] = []
+    for attr in ("error", "info"):
+        try:
+            value = getattr(exc, attr, None)
+        except IndexError:
+            # .info raises IndexError when args has fewer than 3 elements.
+            value = None
+        if value is not None:
+            haystack_parts.append(str(value))
+    haystack_parts.append(str(exc))
+    haystack = " ".join(haystack_parts).lower()
+    return "anonymous" in haystack
 
 
 class IndexingConsumer:
@@ -86,6 +118,40 @@ class IndexingConsumer:
                     "without index pre-check; indexing may degrade until resolved. %s",
                     exc,
                 )
+
+                # Self-diagnosing escalation for the 403-anonymous-user case:
+                # when OpenSearch returns 403 with "User: anonymous" in the
+                # body, log an ERROR-level diagnostic naming the two known
+                # root causes so the next occurrence is self-diagnosing
+                # instead of mysterious silence.  Acceptance criterion #4
+                # of issue #3771.
+                if _is_anonymous_user_403(exc):
+                    logger.error(
+                        "OpenSearch denied request as 'User: anonymous' "
+                        "(403). The OpenSearch client is sending requests "
+                        "that the cluster treats as having NO authenticated "
+                        "AWS principal. Most likely root causes (in priority "
+                        "order):\n"
+                        "  1. The OPENSEARCH_USERNAME / OPENSEARCH_PASSWORD "
+                        "env vars are missing or empty in this task — the "
+                        "client falls back to anonymous when basic-auth is "
+                        "not configured.\n"
+                        "  2. The OpenSearch domain access policy does not "
+                        "grant 'Principal: AWS=*' for es:* actions. With "
+                        "fine-grained access control + internal user DB, "
+                        "basic-auth requests are evaluated as anonymous at "
+                        "the AWS layer; if the access policy is narrowed to "
+                        "specific role ARNs, basic auth is rejected before "
+                        "FGAC can validate the username/password. Either "
+                        "widen the policy back to '*' or migrate the "
+                        "client to SigV4-signed requests.\n"
+                        "  3. The OpenSearch master_user password in "
+                        "Secrets Manager has drifted from the actual "
+                        "domain master user (rotated out of band). "
+                        "See issue #3771 for the full root-cause analysis. "
+                        "Underlying exception: %s",
+                        exc,
+                    )
 
     # ------------------------------------------------------------------
     # Direct indexing interface

--- a/packages/scraper-framework/tests/test_search_indexer.py
+++ b/packages/scraper-framework/tests/test_search_indexer.py
@@ -697,6 +697,143 @@ class TestEnsureIndexStartup:
         mock_os.indices.create.assert_called_once()
 
 
+class TestAnonymousUserDiagnostic:
+    """Regression tests for #3771 — when OpenSearch returns 403 with the
+    "User: anonymous" message, the worker must log a structured, actionable
+    diagnostic naming the most likely root causes (basic-auth credentials
+    not propagated, or the OpenSearch domain access policy was tightened to
+    drop ``Principal: AWS=*`` while basic auth is still in use).
+
+    The 403-anonymous case is OpenSearch-FGAC's behavior when the AWS-level
+    access policy is narrower than ``Principal: AWS=*`` AND the request
+    uses basic auth (which has no IAM principal at the AWS layer).  Once
+    the access policy denies the request as "anonymous", FGAC's internal
+    user database never gets to validate the basic-auth header.  See the
+    issue #3771 root-cause analysis for the full chain of evidence.
+    """
+
+    @staticmethod
+    def _anonymous_403() -> AuthorizationException:
+        """Build the exact AuthorizationException shape OpenSearch returns
+        for the access-policy-denies-anonymous case.
+
+        Real-world example from /ecs/judgemind-ingestion-worker-dev:
+            AuthorizationException(403, '{"Message":"User: anonymous is not
+            authorized to perform: es:ESHttpPut because no resource-based
+            policy allows the es:ESHttpPut action"}')
+        """
+        body = (
+            '{"Message":"User: anonymous is not authorized to perform: '
+            "es:ESHttpPut because no resource-based policy allows the "
+            'es:ESHttpPut action"}'
+        )
+        return AuthorizationException(403, body)
+
+    def test_anonymous_user_403_emits_actionable_diagnostic(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The startup 403 swallow must log a clear, actionable warning when
+        the 403 body contains "User: anonymous", because that case is
+        unambiguously caused by either credential-injection failure or a
+        narrowed OpenSearch access policy — not a transient outage.
+        """
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        mock_os.indices.exists.side_effect = self._anonymous_403()
+
+        with caplog.at_level("ERROR", logger="framework.search.indexer"):
+            consumer = IndexingConsumer(
+                opensearch_client=mock_os,
+                s3_client=mock_s3,
+                bucket="test-bucket",
+                ensure_index=True,
+            )
+
+        assert consumer is not None  # worker must NOT crash (#3917)
+
+        # The diagnostic must mention "anonymous" so log scrapers can match it.
+        anonymous_records = [r for r in caplog.records if "anonymous" in r.getMessage().lower()]
+        assert anonymous_records, (
+            "Expected at least one log record mentioning 'anonymous' for the "
+            f"403-anonymous case; got: {[r.getMessage() for r in caplog.records]}"
+        )
+
+        # The diagnostic must be at ERROR level (not just WARNING) because
+        # this is an actionable misconfiguration, not a transient blip.
+        error_records = [r for r in anonymous_records if r.levelname == "ERROR"]
+        assert error_records, (
+            "Expected an ERROR-level diagnostic for 403-anonymous; got levels: "
+            f"{[r.levelname for r in anonymous_records]}"
+        )
+
+        # The diagnostic must name the two most likely root causes so on-call
+        # operators don't have to guess. Match on substrings that an operator
+        # would search for.
+        diag = error_records[0].getMessage().lower()
+        assert "opensearch_username" in diag or "opensearch_password" in diag, (
+            f"Expected diagnostic to name the credential env vars; got: {diag}"
+        )
+        assert "access policy" in diag or "principal" in diag, (
+            f"Expected diagnostic to name the access-policy root cause; got: {diag}"
+        )
+        assert "#3771" in diag, (
+            f"Expected diagnostic to cite issue #3771 for forward link; got: {diag}"
+        )
+
+    def test_anonymous_user_403_does_not_crash_worker(self) -> None:
+        """The new diagnostic must preserve the #3917 contract: a 403 at
+        startup does NOT raise, and the worker still constructs successfully.
+        """
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        mock_os.indices.exists.side_effect = self._anonymous_403()
+
+        # Must NOT raise.
+        consumer = IndexingConsumer(
+            opensearch_client=mock_os,
+            s3_client=mock_s3,
+            bucket="test-bucket",
+            ensure_index=True,
+        )
+        assert consumer is not None
+
+    def test_non_anonymous_403_still_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A 403 whose body does NOT mention "anonymous" must still be
+        swallowed (#3917) but logged at WARNING level — not the louder
+        ERROR-level diagnostic, because it could be a transient policy
+        propagation race or an unrelated authorization issue.
+        """
+        mock_os = MagicMock()
+        mock_s3 = MagicMock()
+        mock_os.indices.exists.side_effect = AuthorizationException(
+            403,
+            '{"Message":"some other authorization failure"}',
+        )
+
+        with caplog.at_level("WARNING", logger="framework.search.indexer"):
+            consumer = IndexingConsumer(
+                opensearch_client=mock_os,
+                s3_client=mock_s3,
+                bucket="test-bucket",
+                ensure_index=True,
+            )
+
+        assert consumer is not None
+        # No ERROR-level "anonymous" diagnostic for this case.
+        error_anonymous = [
+            r
+            for r in caplog.records
+            if r.levelname == "ERROR" and "anonymous" in r.getMessage().lower()
+        ]
+        assert not error_anonymous, (
+            "Non-anonymous 403 must NOT emit the ERROR-level 'anonymous' "
+            f"diagnostic; got: {[r.getMessage() for r in error_anonymous]}"
+        )
+        # And the existing WARNING-level swallow still fires.
+        warning_records = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warning_records, "Expected the existing WARNING swallow log"
+
+
 class TestFetchTextError:
     """Tests for S3 fetch error handling in _fetch_text."""
 


### PR DESCRIPTION
## Summary

Restores `Principal: AWS = "*"` on the OpenSearch domain access policy so HTTP Basic-auth requests (used by the ingestion worker, the API, and the rebuild scripts) reach FGAC's internal-user database for authentication. PR #3720 narrowed the policy to enumerated role ARNs as a defence-in-depth hardening (#3704); within an hour every freshly-launched ingestion-worker task started failing with `AuthorizationException(403, "User: anonymous is not authorized to perform: es:ESHttpPut")` because basic-auth requests carry no IAM principal at the AWS layer — they're treated as anonymous and denied before FGAC ever validates the username/password. Net effect: ingestion has been silently dead-lettering every event to OpenSearch since 2026-04-28T13:31Z. The four other defence-in-depth layers (VPC-only HTTPS via SG, FGAC internal user DB, encrypt-at-rest, node-to-node encryption) remain in place; the IAM-layer hardening from #3704 is correctly tracked in follow-up #4040 as a SigV4 migration that re-narrows the policy after all four OpenSearch clients switch from basic-auth.

Adds a self-diagnosing escalation in `IndexingConsumer.__init__`: when a startup 403's body contains `User: anonymous`, log an ERROR-level message naming the three known root causes (env-var injection failure, access-policy too narrow, secret drift) so the next occurrence is self-diagnosing instead of mysterious silence — acceptance criterion #4 of the issue.

Closes #3771

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (3 new regression tests in `TestAnonymousUserDiagnostic` + 53 existing search-suite tests)
- [ ] CI green
- [ ] Terraform validate passes on dev + production envs

### Post-deploy verification
- [ ] `terraform.yml dev-apply` job applies the access-policy revert on dev OpenSearch domain. Capture `aws opensearch describe-domain` output showing the new policy.
- [ ] After dev-apply lands, force a fresh ingestion-worker deploy (or wait for next scheduled task replacement). Confirm `aws ecs describe-services --cluster judgemind-dev --services judgemind-ingestion-worker-dev` shows `rolloutState: COMPLETED` and `runningCount: 1` for at least 5 minutes.
- [ ] Confirm zero `AuthorizationException` 403s in `/ecs/judgemind-ingestion-worker-dev` for 30 min after the new task lands. Capture the CloudWatch Insights query result.
- [ ] Confirm the worker is processing documents end-to-end: a new doc lands in `derived.documents` AND in the OpenSearch `tentative_rulings` alias. Capture the SQL row count delta + an `_search` hit count.
- [ ] Verification evidence posted on issue #3771 (see A.8).
