### PR TITLE
feat(skills): /task must block dependents + file tracking issues, not just leave status/in-progress (#4035)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -430,6 +430,27 @@ For non-testable tasks that skip /ralph, the `planning` milestone is the only on
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
 - **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see `docs/agent/code-standards.md` §Pre-PR Checks) and review your own diff before continuing.
 - **For ingestion/extraction pipeline tasks** (scraper changes, LLM prompt changes, enrichment logic): use the local dev stack to iterate. The local DB + S3 cache enables fast iteration without deploying to dev. Run `scripts/rebuild_db.sh --skip-reset` to re-process documents through the pipeline and verify data correctness against source documents. See `docs/agent/local-dev.md`. **Prioritize correctness over completeness** — verify that extracted fields match the source document, not just that fields are populated.
+**When the agent determines the work cannot proceed for non-ralph reasons.** Sometimes the agent (not /ralph) discovers — during scope-completeness checks, dependency setup, or initial probing on dev — that the requested work cannot proceed because of an upstream condition. Common cases:
+
+- The prescribed command (e.g. `rebuild_db.py --county <name>`) cannot drain the bug class the issue is asking about (LLM-cache-resident extraction bugs, OpenSearch admin password rotation, billing/credit balance depleted).
+- An external secret has rotated, or an external account/budget has hit a hard limit.
+- An infra-level service is down and the failure is operator-only to resolve.
+
+In these cases, posting a thorough BLOCKED verification-evidence comment is necessary but **not sufficient**. Two follow-ups are MANDATORY before stopping, otherwise the issue stays `agent/ready` and the next agent re-investigates the same upstream condition (see #4035 root cause):
+
+1. **Block the dependent issue against every identified upstream blocker.** For each upstream cause:
+   - If a GitHub issue already tracks it, run `scripts/block-issue.sh <this-issue> <existing-tracker>` — this adds `Blocked by #<existing>` to the body, sets `status/blocked`, and removes `agent/ready`.
+   - If no GitHub issue tracks it yet, use `scripts/block-on-new-issue.sh <this-issue> --title "..." --body-file <path> --priority p1 [--label area/...]` — this files the tracker AND wires `Blocked by #<new>` atomically. Do NOT add `agent/ready` to the new tracker if its resolution is operator-only (billing, secrets, account-level) — leaving an operator-only issue `agent/ready` just sends another agent down the same dead end.
+2. **Verify the dependent issue is now BLOCKED, not READY.** After step 1, the dependent issue must carry `status/blocked` (and not `agent/ready`). `block-issue.sh` already removes `agent/ready` as part of its label edit; the post-condition you're confirming is that the daemon's queue scan will skip this issue on its next tick.
+
+The `Blocked by #N` line + `status/blocked` label is the only signal that auto-restores `agent/ready` when the upstream blocker closes (via the `unblock-issues` workflow / `scripts/unblock-dependents.sh`). A bare BLOCKED comment with `agent/ready` left in place produces the failure mode in #4035 — another agent picks the issue up hours/days later and runs the same investigation again. See `docs/agent/task-dependencies.md` for the full mechanics.
+
+After both follow-ups land, **release the label interlock** as usual:
+```
+gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
+```
+Then stop — the worktree will be cleaned up automatically.
+
 - If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Before stopping, **release the label interlock** so the issue isn't permanently hidden from future agents:
   ```
   gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ See **`docs/agent/code-standards.md`** for the full reference. Highlights:
 
 See **`docs/agent/task-dependencies.md`** and **`docs/agent/issue-authoring.md`** for the full mechanics. Core rules:
 
-- **Blocking:** use `scripts/block-issue.sh <issue> <blocker>`. Both the `status/blocked` label AND a `Blocked by #N` line in the issue body are required. Label-only blocks never auto-unblock. `Parent: #N` is hierarchy, not a dependency.
+- **Blocking:** use `scripts/block-issue.sh <issue> <blocker>`. Both the `status/blocked` label AND a `Blocked by #N` line in the issue body are required. Label-only blocks never auto-unblock. `Parent: #N` is hierarchy, not a dependency. When the upstream blocker has no GitHub issue yet, use `scripts/block-on-new-issue.sh <issue> --title "..." --body-file <path> --priority p1 [--label ...]` — it files the tracker AND wires `Blocked by #<new>` atomically.
 - **Unblocking:** PR merges auto-unblock via `Closes #N`. For non-PR completions, run `scripts/unblock-dependents.sh <your-issue>`. For manual unblock of a single issue (rather than auto-unblock of all dependents of a closed issue), use `scripts/unblock-issue.sh <N>` — never bare `gh issue edit --remove-label status/blocked`.
 - **Sub-tasks:** reference the parent as `Parent: #N`; each sub-task should be independently pickup-able.
 - **Acceptance criteria:** concrete and machine-checkable. Each criterion has at least one `Verify:` line. **Data cleanup on `derived.*` defaults to `rebuild_db.py --county <name>`** — surgical scripts are a last resort.

--- a/docs/agent/task-dependencies.md
+++ b/docs/agent/task-dependencies.md
@@ -33,6 +33,28 @@ This atomically:
 
 **Note:** `Parent: #N` expresses hierarchy (this is a sub-task of #N), not dependency. A sub-task can be worked on independently even while the parent is open. Only use `Blocked by #N` when the issue genuinely cannot proceed until #N is resolved.
 
+### When the upstream blocker has no GitHub issue yet
+
+A common /task failure mode: the agent discovers an upstream condition (billing depleted, secret rotated, infra-only failure) that does not yet have a GitHub issue tracking it. Posting a BLOCKED comment is necessary but not sufficient — without a tracker + `Blocked by #N` line, the issue stays `agent/ready` and the next agent re-investigates the same upstream condition (see #4035).
+
+Use the helper:
+
+```
+scripts/block-on-new-issue.sh <dependent-issue> \
+    --title "<conventional-commits style title>" \
+    --body-file <path> \
+    [--label <label> ...] \
+    [--priority p0|p1|p2|p3]
+```
+
+This atomically:
+
+1. Files a new tracker issue with the supplied title / body / labels.
+2. Calls `block-issue.sh` to wire `Blocked by #<new>` + `status/blocked` on the dependent issue.
+3. Prints both numbers (and URLs) to stdout.
+
+**Do NOT pass `--label agent/ready`** for operator-only blockers (billing, secrets, account-level limits). Leaving an operator-only tracker `agent/ready` just sends another agent down the same dead end. Pick a `priority/p1` (workflow accelerator) or `priority/p0` (pipeline halted) label instead, and let the operator pick it up.
+
 ## When you finish a task
 
 **Implementation tasks (PRs):** dependent issues are unblocked automatically by the `unblock-issues` CI workflow when the PR merges. The PR body must include `Closes #N`.

--- a/scripts/block-on-new-issue.sh
+++ b/scripts/block-on-new-issue.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# block-on-new-issue.sh — Atomically file a new tracking issue AND mark another
+# issue as blocked by it.
+#
+# This is the canonical wrapper for the "BLOCK on a new issue" pattern that
+# /task agents need when they discover an upstream blocker that does not yet
+# have a GitHub issue (e.g. a billing problem, an operator-only handoff, an
+# infra failure with no existing tracker). Without this helper, agents tend
+# to do part of the workflow (post a BLOCKED comment) but skip the durable
+# parts (file the tracker, set `Blocked by #N`, add `status/blocked`). The
+# next agent then re-investigates the same upstream cause.
+#
+# What this script does, atomically from the operator's perspective:
+#   1. Creates a new GitHub issue (`gh issue create`) with the supplied
+#      title / body-file / labels. Captures its number.
+#   2. Calls `scripts/block-issue.sh <dependent> <new-issue>` which:
+#       - Adds `Blocked by #<new>` to the dependent's body (under a
+#         `## Dependencies` section, creating it if absent).
+#       - Adds the `status/blocked` label and removes `agent/ready`.
+#   3. Prints both numbers (and URLs) to stdout so the caller can reference
+#      them in a follow-up comment / PR / log line.
+#
+# Usage:
+#   scripts/block-on-new-issue.sh <dependent-issue> \
+#       --title "<conventional-commits style title>" \
+#       --body-file <path> \
+#       [--label <label> ...] \
+#       [--priority p0|p1|p2|p3] \
+#       [--repo <owner/name>]    # default: judgemind/judgemind
+#
+# Notes:
+# - --label may be specified multiple times. Common labels for tracker issues
+#   include the relevant `area/*` and `type/*` labels. Do NOT pass
+#   `agent/ready` if the new issue requires operator action — agent-ready on
+#   an operator-only blocker just sends another agent down the same dead end.
+# - --priority is sugar for `--label priority/<level>`; supplying both is fine
+#   (label dedup is handled by GitHub).
+# - The new issue's body MUST come from a file (`--body-file`) rather than
+#   inline — this matches the rest of the codebase's convention (see
+#   CLAUDE.md §Issue Creation in MEMORY.md) and avoids quoting headaches.
+# - On any failure after the new issue is created, the script does NOT delete
+#   the new issue. The operator can either edit it or close it manually. The
+#   common failure mode (block-issue.sh fails) leaves a tracker that the
+#   operator can wire up by hand with `scripts/block-issue.sh`.
+
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage:
+  scripts/block-on-new-issue.sh <dependent-issue> \
+      --title "<title>" \
+      --body-file <path> \
+      [--label <label> ...] \
+      [--priority p0|p1|p2|p3] \
+      [--repo <owner/name>]
+
+Files a new tracker issue and marks <dependent-issue> as Blocked by it.
+USAGE
+}
+
+if [ $# -lt 1 ]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+esac
+
+DEPENDENT="${1#\#}"
+shift
+
+if ! [[ "$DEPENDENT" =~ ^[0-9]+$ ]]; then
+    echo "Error: <dependent-issue> must be an issue number (digits only). Got: $DEPENDENT" >&2
+    usage
+    exit 1
+fi
+
+TITLE=""
+BODY_FILE=""
+LABELS=()
+PRIORITY=""
+REPO="judgemind/judgemind"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --title)
+            TITLE="${2:-}"
+            shift 2
+            ;;
+        --body-file)
+            BODY_FILE="${2:-}"
+            shift 2
+            ;;
+        --label)
+            LABELS+=("${2:-}")
+            shift 2
+            ;;
+        --priority)
+            PRIORITY="${2:-}"
+            shift 2
+            ;;
+        --repo)
+            REPO="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$TITLE" ]; then
+    echo "Error: --title is required." >&2
+    usage
+    exit 1
+fi
+
+if [ -z "$BODY_FILE" ]; then
+    echo "Error: --body-file is required." >&2
+    usage
+    exit 1
+fi
+
+if [ ! -f "$BODY_FILE" ]; then
+    echo "Error: --body-file '$BODY_FILE' does not exist or is not a regular file." >&2
+    exit 1
+fi
+
+if [ -n "$PRIORITY" ]; then
+    case "$PRIORITY" in
+        p0|p1|p2|p3)
+            LABELS+=("priority/$PRIORITY")
+            ;;
+        *)
+            echo "Error: --priority must be one of p0, p1, p2, p3. Got: $PRIORITY" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# Resolve the script's own directory so we can call sibling helpers reliably
+# regardless of caller cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ ! -x "$SCRIPT_DIR/block-issue.sh" ]; then
+    echo "Error: companion '$SCRIPT_DIR/block-issue.sh' is not executable." >&2
+    exit 1
+fi
+
+# Build the gh issue create invocation.
+CREATE_ARGS=(issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE")
+for label in "${LABELS[@]}"; do
+    if [ -n "$label" ]; then
+        CREATE_ARGS+=(--label "$label")
+    fi
+done
+
+echo "Creating new tracker issue in $REPO..." >&2
+NEW_URL="$(gh "${CREATE_ARGS[@]}")"
+
+if [ -z "$NEW_URL" ]; then
+    echo "Error: 'gh issue create' returned an empty URL." >&2
+    exit 1
+fi
+
+# Extract the issue number from the URL (last path segment).
+NEW_NUM="${NEW_URL##*/}"
+if ! [[ "$NEW_NUM" =~ ^[0-9]+$ ]]; then
+    echo "Error: could not parse issue number from URL: $NEW_URL" >&2
+    exit 1
+fi
+
+echo "Created issue #$NEW_NUM ($NEW_URL)" >&2
+
+# Wire the dependency. block-issue.sh handles label + body atomically.
+"$SCRIPT_DIR/block-issue.sh" "$DEPENDENT" "$NEW_NUM"
+
+echo
+echo "Done."
+echo "  new tracker: #$NEW_NUM ($NEW_URL)"
+echo "  dependent:   #$DEPENDENT (now Blocked by #$NEW_NUM)"


### PR DESCRIPTION
## Summary

Adds a new "When the agent determines the work cannot proceed for non-ralph reasons" sub-section to `.claude/skills/task/SKILL.md` §A.2 that makes blocking + tracker-filing MANDATORY when a /task agent discovers an upstream blocker. Also adds `scripts/block-on-new-issue.sh` — a thin wrapper that files a tracker issue and wires `Blocked by #<new>` + `status/blocked` atomically — and documents it in CLAUDE.md and `docs/agent/task-dependencies.md`.

Root cause for the change: #4035 documents a 4-day-recurring failure where agents posted thorough BLOCKED comments but left issues `agent/ready`, and a follow-up agent re-investigated the same upstream blocker hours later (observed twice on #3855).

Closes #4035

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (SKILL.md, CLAUDE.md, docs, and a new shell helper only — none of these ship to a running service). The behavioural re-test (AC#3) happens on the next /task that organically encounters an upstream blocker; recorded in the process-summary comment as a future spot-check.
