### PR TITLE
fix(infra): close terraform-apply / deploy-scraper race on ingestion-worker (#4044)

### DIFF
--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -241,6 +241,7 @@ jobs:
 
     env:
       INGESTION_SERVICE: judgemind-ingestion-worker-dev
+      INGESTION_CONTAINER: ingestion-worker
 
     steps:
       - name: Configure AWS credentials
@@ -269,6 +270,28 @@ jobs:
           INGESTION_SERVICE: ${{ env.INGESTION_SERVICE }}
           LOG_GROUP: /ecs/judgemind-ingestion-worker-dev
         run: bash scripts/ecs-post-deploy-healthcheck.sh
+
+      # Drift gate (#4044): assert the running task-def's container_definitions
+      # match the terraform-rendered SSM parameter. Closes the silent-drift
+      # class where deploy-scraper races terraform.yml dev-apply, reads a
+      # stale SSM parameter, and pins the service to a pre-apply revision
+      # while terraform's intent lives in a strictly-newer revision the
+      # service cannot pick up because of `lifecycle.ignore_changes =
+      # [task_definition]` on the ECS service. Failing this step surfaces
+      # the drift before stale env vars affect production-like dev traffic.
+      - name: Verify ingestion-worker task-def matches terraform SSM (#4044)
+        id: fingerprint
+        env:
+          ECS_CLUSTER: ${{ env.ECS_CLUSTER }}
+          INGESTION_SERVICE: ${{ env.INGESTION_SERVICE }}
+          INGESTION_CONTAINER: ${{ env.INGESTION_CONTAINER }}
+          INGESTION_WORKER_CONTAINER_DEFS_SSM_PARAMETER: ${{ env.INGESTION_WORKER_CONTAINER_DEFS_SSM_PARAMETER }}
+        run: |
+          bash scripts/check-ingestion-worker-task-def-fingerprint.sh \
+            --cluster "$ECS_CLUSTER" \
+            --service "$INGESTION_SERVICE" \
+            --container-name "$INGESTION_CONTAINER" \
+            --ssm-parameter "$INGESTION_WORKER_CONTAINER_DEFS_SSM_PARAMETER"
 
       - name: Set health check status
         if: always()

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,11 +6,19 @@ on:
     paths:
       - "infra/terraform/**"
       - ".github/workflows/terraform.yml"
+      # scripts/wait-for-rollout.sh is invoked by the dev-apply job's
+      # post-apply force-deploy step (#4044). The shared script's paths-
+      # filter contract (#2592) requires every consumer to list it so a
+      # PR that touches only the script triggers each consumer's deploy
+      # path on its own merge — otherwise regressions surface on the
+      # next unrelated apply.
+      - "scripts/wait-for-rollout.sh"
   pull_request:
     branches: [main]
     paths:
       - "infra/terraform/**"
       - ".github/workflows/terraform.yml"
+      - "scripts/wait-for-rollout.sh"
 
 jobs:
   terraform:
@@ -258,4 +266,85 @@ jobs:
             echo '```'
             tail -n 200 "$apply_log" || true
             echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Force-deploy the ingestion-worker service when this apply touched
+      # its task-def or its rendered container_definitions SSM parameter
+      # (#4044, Option B). `aws_ecs_service.ingestion_worker.lifecycle.
+      # ignore_changes = [task_definition]` means terraform never rolls
+      # the service forward on its own — without this step, an infra-only
+      # change leaves the running container on the *old* revision until
+      # the next deploy-scraper.yml run wins the race against another
+      # apply. Self-contained: makes terraform-apply the single place
+      # that's responsible for getting an infra-induced task-def change
+      # onto the running service.
+      #
+      # The detection grep looks for `Creating|Modifying|Destroying...`
+      # lines (the apply-time mutation verbs) targeting either the
+      # task-def or the SSM parameter resource address. Plain
+      # "Refreshing state..." lines run on every apply for every
+      # resource and are explicitly excluded so we only force-deploy
+      # when something actually changed.
+      #
+      # No-op fast path: if neither resource changed, the step exits 0
+      # without making any AWS API calls.
+      - name: Detect ingestion-worker task-def change
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && steps.apply.outputs.apply_log != '' }}
+        id: detect-ingestion-worker-change
+        run: |
+          apply_log="${{ steps.apply.outputs.apply_log }}"
+          if grep -E '^module\.compute\.(aws_ecs_task_definition\.ingestion_worker|aws_ssm_parameter\.ingestion_worker_container_definitions)\[0\]: (Creating|Modifying|Destroying)\.\.\.' "$apply_log" >/dev/null; then
+            echo "ingestion_worker_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Ingestion-worker task-def or container_definitions SSM parameter changed by this apply." | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            echo "ingestion_worker_changed=false" >> "$GITHUB_OUTPUT"
+            echo "Ingestion-worker resources unchanged by this apply — skipping force-deploy." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Force-deploy ingestion-worker (close lifecycle.ignore_changes gap)
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' && steps.detect-ingestion-worker-change.outputs.ingestion_worker_changed == 'true' }}
+        env:
+          ECS_CLUSTER: judgemind-dev
+          ECS_SERVICE: judgemind-ingestion-worker-dev
+          INGESTION_TASK_FAMILY: judgemind-ingestion-worker-dev
+        run: |
+          set -euo pipefail
+
+          # Resolve the latest ACTIVE revision of the family — that is
+          # whatever terraform-apply just registered. Pinning the service
+          # to the family ARN (without :revision) would let ECS pick up
+          # any later revision deploy-scraper.yml registers, which is
+          # exactly the race we're trying to close.
+          NEW_TASK_DEF_ARN=$(aws ecs describe-task-definition \
+            --task-definition "$INGESTION_TASK_FAMILY" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+          export NEW_TASK_DEF_ARN
+
+          echo "Forcing ingestion-worker rollout to $NEW_TASK_DEF_ARN"
+
+          aws ecs update-service \
+            --cluster "$ECS_CLUSTER" \
+            --service "$ECS_SERVICE" \
+            --task-definition "$NEW_TASK_DEF_ARN" \
+            --force-new-deployment \
+            --query 'service.serviceName' \
+            --output text
+
+          # Wait for the rollout to finish so a CI failure on this step
+          # surfaces as a deploy failure (not as silent drift). Reuses
+          # scripts/wait-for-rollout.sh (env-driven: ECS_CLUSTER,
+          # ECS_SERVICE, NEW_TASK_DEF_ARN — same contract as the
+          # ecs-deploy composite action).
+          bash "${GITHUB_WORKSPACE}/scripts/wait-for-rollout.sh"
+
+          {
+            echo "## Forced ingestion-worker rollout (#4044)"
+            echo
+            echo "Task-def: \`$NEW_TASK_DEF_ARN\`"
+            echo
+            echo "This step closed the lifecycle.ignore_changes race by"
+            echo "rolling the service forward after terraform-apply"
+            echo "registered the new revision. See"
+            echo ".github/workflows/terraform.yml + #4044."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -683,6 +683,31 @@ resource "aws_ecs_service" "ingestion_worker" {
 
   # Ignore changes to task_definition so that image tag updates via CI/CD
   # don't trigger a Terraform diff on every plan.
+  #
+  # Silent-drift failure mode (#4044): because terraform never rolls this
+  # service forward, an infra-only change that updates the task-def or the
+  # rendered container_definitions SSM parameter (e.g. a secret-ARN flip,
+  # an env-var rename) does NOT reach the running container on its own.
+  # Historically the next deploy-scraper.yml run rolled it forward, but
+  # when a scraper-touching push and an infra-touching push land on the
+  # same merge commit, the race deploy-scraper-vs-terraform-apply (see
+  # #4044) lets deploy-scraper win, read the *stale* SSM parameter, and
+  # pin the service to a pre-apply task-def revision. terraform-apply
+  # finishes after, registers the correct revision, but cannot roll the
+  # service because of this ignore_changes — i.e. terraform-apply won't
+  # roll the service forward on its own. Result: silent stale env vars
+  # on the running container, with silent-drift between the desired SSM
+  # state and the running task-def, until the next deploy happens to
+  # win the race.
+  #
+  # Mitigations in tree:
+  #   - .github/workflows/terraform.yml dev-apply force-deploys this
+  #     service whenever the apply diff modified its task-def or its
+  #     container_definitions SSM parameter (#4044, Option B).
+  #   - .github/workflows/deploy-scraper.yml post-deploy-health-check
+  #     runs scripts/check-ingestion-worker-task-def-fingerprint.sh,
+  #     which compares the running task-def's container_definitions to
+  #     the terraform-rendered SSM parameter and fails on drift (#4044).
   lifecycle {
     ignore_changes = [task_definition]
   }

--- a/scripts/check-ingestion-worker-task-def-fingerprint.sh
+++ b/scripts/check-ingestion-worker-task-def-fingerprint.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# check-ingestion-worker-task-def-fingerprint.sh — assert the running
+# ingestion-worker service's task-def container_definitions match the
+# terraform-rendered SSM parameter (modulo the per-deploy image tag).
+#
+# Background — #4044:
+#
+#   `aws_ecs_service.ingestion_worker` carries `lifecycle.ignore_changes =
+#   [task_definition]`, so terraform-apply cannot roll the service forward
+#   after registering a new task-def revision. When `terraform.yml dev-apply`
+#   races against `deploy-scraper.yml`'s `deploy-ingestion-worker` job (both
+#   triggered by the same merge commit, both touching ingestion-worker
+#   inputs), deploy-scraper can win — read the *stale* SSM parameter, pin
+#   the service to a pre-apply revision — leaving the running container
+#   with the wrong env vars while terraform's intent lives in a strictly-
+#   newer revision the service never picks up.
+#
+#   This script is the post-deploy gate that closes the silent-drift class:
+#   compute a fingerprint of (a) the desired-state container_definitions
+#   in the terraform-managed SSM parameter and (b) the *running* service's
+#   primary deployment task-def, after stripping the per-deploy `image`
+#   field. If they diverge, fail loudly with a recovery hint.
+#
+#   The script is idempotent and safe to run any time — the periodic
+#   monitoring path uses the same exit codes as the post-deploy gate path.
+#
+# Usage:
+#
+#   check-ingestion-worker-task-def-fingerprint.sh \
+#     [--cluster judgemind-dev] \
+#     [--service judgemind-ingestion-worker-dev] \
+#     [--ssm-parameter /judgemind/ingestion-worker/dev/container-definitions] \
+#     [--container-name ingestion-worker]
+#
+#   All four args have sensible dev defaults.
+#
+# Exit codes:
+#
+#   0 — fingerprints match (no drift).
+#   1 — fingerprints differ; a unified diff of the canonicalized
+#       container_definitions is printed to stderr.
+#   2 — usage error or AWS API failure.
+
+set -euo pipefail
+
+CLUSTER="judgemind-dev"
+SERVICE="judgemind-ingestion-worker-dev"
+SSM_PARAMETER="/judgemind/ingestion-worker/dev/container-definitions"
+CONTAINER_NAME="ingestion-worker"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cluster)
+            CLUSTER="$2"
+            shift 2
+            ;;
+        --service)
+            SERVICE="$2"
+            shift 2
+            ;;
+        --ssm-parameter)
+            SSM_PARAMETER="$2"
+            shift 2
+            ;;
+        --container-name)
+            CONTAINER_NAME="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '1,/^set -euo pipefail$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# ── Step 1: fetch the desired-state container_definitions from SSM ────────
+#
+# This is what terraform last rendered. If it's missing or invalid JSON,
+# the apply path is broken upstream — fail with exit 2 so the caller can
+# distinguish "drift" (exit 1) from "tooling broken" (exit 2).
+SSM_RAW=$(aws ssm get-parameter \
+    --name "$SSM_PARAMETER" \
+    --query 'Parameter.Value' \
+    --output text 2>/dev/null) || {
+    echo "ERROR: failed to read SSM parameter '$SSM_PARAMETER'" >&2
+    exit 2
+}
+
+if ! echo "$SSM_RAW" | jq empty >/dev/null 2>&1; then
+    echo "ERROR: SSM parameter '$SSM_PARAMETER' did not contain valid JSON" >&2
+    exit 2
+fi
+
+# ── Step 2: fetch the running service's primary deployment task-def ───────
+#
+# describe-services returns a list of deployments; the PRIMARY deployment
+# is the one currently rolling (or the steady one). We compare against
+# that — not against the family's latest revision — because the goal is
+# to detect drift on the *running* container, not on whatever terraform
+# most recently registered.
+RUNNING_TD_ARN=$(aws ecs describe-services \
+    --cluster "$CLUSTER" \
+    --services "$SERVICE" \
+    --query "services[0].deployments[?status=='PRIMARY']|[0].taskDefinition" \
+    --output text 2>/dev/null) || {
+    echo "ERROR: failed to describe service '$SERVICE' on cluster '$CLUSTER'" >&2
+    exit 2
+}
+
+if [[ -z "$RUNNING_TD_ARN" || "$RUNNING_TD_ARN" == "None" ]]; then
+    echo "ERROR: could not resolve PRIMARY deployment task-def for service '$SERVICE'" >&2
+    exit 2
+fi
+
+RUNNING_DEFS=$(aws ecs describe-task-definition \
+    --task-definition "$RUNNING_TD_ARN" \
+    --query 'taskDefinition.containerDefinitions' \
+    --output json 2>/dev/null) || {
+    echo "ERROR: failed to describe-task-definition '$RUNNING_TD_ARN'" >&2
+    exit 2
+}
+
+# ── Step 3: canonicalize and fingerprint ──────────────────────────────────
+#
+# Both sides go through the same normalization:
+#   - drop `.image` from each container (varies on every CI build)
+#   - filter to ONLY the named container (the SSM JSON may contain
+#     sidecars; the running task-def may pick them up too, but for the
+#     drift signal we care about the primary container's env vars and
+#     secrets)
+#   - sort keys recursively for deterministic JSON
+#
+# We use jq's `--sort-keys` (top-level) and a recursive walk for nested
+# objects. The `walk` builtin is the canonical way to do this in jq.
+canonicalize() {
+    jq --arg name "$CONTAINER_NAME" '
+        # walk recursively sorts keys at every depth; combined with
+        # del(.image) on the named container we get a stable hashable
+        # representation that ignores per-deploy image-tag changes.
+        def normalize:
+            if type == "object" then
+                with_entries(.value |= normalize)
+                | to_entries
+                | sort_by(.key)
+                | from_entries
+            elif type == "array" then
+                map(normalize)
+            else
+                .
+            end;
+        map(select(.name == $name))
+        | map(del(.image))
+        | normalize
+    '
+}
+
+DESIRED_CANON=$(echo "$SSM_RAW" | canonicalize)
+RUNNING_CANON=$(echo "$RUNNING_DEFS" | canonicalize)
+
+DESIRED_FP=$(echo "$DESIRED_CANON" | shasum -a 256 | awk '{print $1}')
+RUNNING_FP=$(echo "$RUNNING_CANON" | shasum -a 256 | awk '{print $1}')
+
+if [[ "$DESIRED_FP" == "$RUNNING_FP" ]]; then
+    echo "OK: ingestion-worker task-def matches terraform SSM parameter (fingerprint $DESIRED_FP)"
+    exit 0
+fi
+
+# ── Step 4: drift — print a recovery hint and a unified diff ──────────────
+
+echo "DRIFT: running task-def ($RUNNING_TD_ARN) does not match terraform SSM parameter '$SSM_PARAMETER'" >&2
+echo "  desired fingerprint: $DESIRED_FP" >&2
+echo "  running fingerprint: $RUNNING_FP" >&2
+echo "" >&2
+echo "Likely cause: race between terraform.yml dev-apply and deploy-scraper.yml's deploy-ingestion-worker job (#4044)." >&2
+echo "" >&2
+echo "Recovery: re-register from the latest task-def revision and force a deploy:" >&2
+echo "  LATEST=\$(aws ecs describe-task-definition --task-definition judgemind-ingestion-worker-dev --query 'taskDefinition.taskDefinitionArn' --output text)" >&2
+echo "  aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition \"\$LATEST\" --force-new-deployment" >&2
+echo "" >&2
+echo "Diff (canonicalized, image stripped):" >&2
+diff -u <(echo "$DESIRED_CANON") <(echo "$RUNNING_CANON") >&2 || true
+
+exit 1

--- a/scripts/tests/test_check_ingestion_worker_task_def_fingerprint.sh
+++ b/scripts/tests/test_check_ingestion_worker_task_def_fingerprint.sh
@@ -1,0 +1,398 @@
+#!/usr/bin/env bash
+# test_check_ingestion_worker_task_def_fingerprint.sh — Unit tests for
+# scripts/check-ingestion-worker-task-def-fingerprint.sh
+#
+# The fingerprint guard exists to close the silent-drift class introduced
+# by `aws_ecs_service.ingestion_worker.lifecycle.ignore_changes =
+# [task_definition]` (#4044): when terraform-apply registers a new
+# task-def revision but the service stays pinned to a stale one, the
+# running container's env vars no longer match terraform's intent. The
+# guard hashes the running task-def's container_definitions and the
+# terraform-rendered SSM parameter (after stripping the per-deploy image
+# tag and sorting keys) and exits non-zero on mismatch.
+#
+# Tests cover:
+#
+#   1. Match — image-tag-only diff between the two sources is treated as
+#      a match (canonicalization works). Exit 0.
+#
+#   2. Match — keys in different order on each side are treated as a
+#      match (recursive sort works). Exit 0.
+#
+#   3. Drift — env var differs between SSM and running task-def. Exit 1
+#      with a unified diff on stderr and a recovery hint.
+#
+#   4. Drift — secrets list differs (one source has an extra secret).
+#      Exit 1.
+#
+#   5. Tooling-broken — SSM parameter contains invalid JSON. Exit 2
+#      (distinguishes "guard tool broken" from "drift detected", so the
+#      caller can route to the right alert channel).
+#
+#   6. Tooling-broken — describe-services returns no PRIMARY deployment.
+#      Exit 2.
+#
+# Usage:
+#   scripts/tests/test_check_ingestion_worker_task_def_fingerprint.sh
+#
+# Exit codes:
+#   0 — all tests passed.
+#   1 — one or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/check-ingestion-worker-task-def-fingerprint.sh"
+
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+# shellcheck disable=SC2329
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Set up a mock `aws` CLI that emits canned responses for ssm get-parameter,
+# ecs describe-services, and ecs describe-task-definition. The mock reads
+# fixture files from $MOCK_TMPDIR and writes every invocation to call.log.
+#
+# Files in $tmpdir/:
+#   ssm-param-value.txt       — emitted on `aws ssm get-parameter ... --query Parameter.Value --output text`
+#   describe-services.json    — emitted on `aws ecs describe-services`
+#   describe-task-def.json    — emitted on `aws ecs describe-task-definition`
+#   call.log                  — full arg log (one line per call)
+setup_mock_aws() {
+    local tmpdir="$1"
+    local mock="$tmpdir/aws"
+
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR="${MOCK_TMPDIR:?MOCK_TMPDIR required}"
+echo "$*" >> "$TMPDIR/call.log"
+
+case "$1 $2" in
+    "ssm get-parameter")
+        cat "$TMPDIR/ssm-param-value.txt"
+        ;;
+    "ecs describe-services")
+        # The script runs --query "services[0].deployments[?status=='PRIMARY']|[0].taskDefinition" --output text
+        # so emit just the task-def ARN string.
+        cat "$TMPDIR/describe-services.json"
+        ;;
+    "ecs describe-task-definition")
+        # --query 'taskDefinition.containerDefinitions' --output json
+        # so the fixture should already be the containerDefinitions array.
+        cat "$TMPDIR/describe-task-def.json"
+        ;;
+    *)
+        echo "MOCK ERROR: unhandled aws call: $*" >&2
+        exit 99
+        ;;
+esac
+MOCK
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+# Common SSM payload — terraform's intent. JSON array of containers.
+write_ssm_match_baseline() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+[
+  {
+    "name": "ingestion-worker",
+    "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:TFAPPLY",
+    "essential": true,
+    "command": ["ingestion"],
+    "environment": [
+      {"name": "ENVIRONMENT", "value": "dev"},
+      {"name": "LLM_PROVIDER", "value": "google"}
+    ],
+    "secrets": [
+      {"name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"}
+    ]
+  }
+]
+JSON
+}
+
+# Running task-def's containerDefinitions — same content as SSM but with a
+# different image tag (the per-deploy noise the guard must ignore).
+write_running_match_baseline() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+[
+  {
+    "name": "ingestion-worker",
+    "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:DEPLOYSCRAPER",
+    "essential": true,
+    "command": ["ingestion"],
+    "environment": [
+      {"name": "ENVIRONMENT", "value": "dev"},
+      {"name": "LLM_PROVIDER", "value": "google"}
+    ],
+    "secrets": [
+      {"name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"}
+    ]
+  }
+]
+JSON
+}
+
+# Run the script under test against a populated $tmpdir of fixtures.
+run_script() {
+    local tmpdir="$1"
+    shift
+    local mock_path
+    mock_path=$(setup_mock_aws "$tmpdir")
+    local mock_dir
+    mock_dir="$(dirname "$mock_path")"
+
+    PATH="$mock_dir:$PATH" \
+        MOCK_TMPDIR="$tmpdir" \
+        "$SCRIPT_UNDER_TEST" "$@"
+}
+
+# ── Test 1: image-tag-only diff is a match ─────────────────────────────────
+
+test_match_image_tag_only_diff() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_ssm_match_baseline "$tmpdir/ssm-param-value.txt"
+    write_running_match_baseline "$tmpdir/describe-task-def.json"
+    echo "arn:aws:ecs:us-west-2:111:task-definition/judgemind-ingestion-worker-dev:42" > "$tmpdir/describe-services.json"
+
+    if run_script "$tmpdir" >"$tmpdir/stdout" 2>"$tmpdir/stderr"; then
+        if grep -q "OK:" "$tmpdir/stdout"; then
+            pass "match: image-tag-only diff is treated as match"
+        else
+            fail "match: exit 0 but no OK: line on stdout" "$(cat "$tmpdir/stdout")"
+        fi
+    else
+        fail "match: image-tag-only diff exited non-zero" "$(cat "$tmpdir/stderr")"
+    fi
+}
+
+# ── Test 2: key-order diff is a match ──────────────────────────────────────
+
+test_match_key_order_diff() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # SSM in canonical order
+    write_ssm_match_baseline "$tmpdir/ssm-param-value.txt"
+
+    # Running task-def with the SAME logical content but keys in a different order
+    cat > "$tmpdir/describe-task-def.json" << 'JSON'
+[
+  {
+    "secrets": [
+      {"valueFrom": "arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::", "name": "DATABASE_URL"}
+    ],
+    "environment": [
+      {"value": "dev", "name": "ENVIRONMENT"},
+      {"value": "google", "name": "LLM_PROVIDER"}
+    ],
+    "command": ["ingestion"],
+    "essential": true,
+    "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:OTHERSHA",
+    "name": "ingestion-worker"
+  }
+]
+JSON
+    echo "arn:aws:ecs:us-west-2:111:task-definition/judgemind-ingestion-worker-dev:42" > "$tmpdir/describe-services.json"
+
+    if run_script "$tmpdir" >"$tmpdir/stdout" 2>"$tmpdir/stderr"; then
+        pass "match: key-order diff is treated as match"
+    else
+        fail "match: key-order diff exited non-zero" "$(cat "$tmpdir/stderr")"
+    fi
+}
+
+# ── Test 3: env var drift is caught ────────────────────────────────────────
+
+test_drift_env_var() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # SSM — terraform's intent has LLM_PROVIDER=google
+    write_ssm_match_baseline "$tmpdir/ssm-param-value.txt"
+
+    # Running task-def — has LLM_PROVIDER=anthropic (the pre-flip stale value)
+    cat > "$tmpdir/describe-task-def.json" << 'JSON'
+[
+  {
+    "name": "ingestion-worker",
+    "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:STALE",
+    "essential": true,
+    "command": ["ingestion"],
+    "environment": [
+      {"name": "ENVIRONMENT", "value": "dev"},
+      {"name": "LLM_PROVIDER", "value": "anthropic"}
+    ],
+    "secrets": [
+      {"name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"}
+    ]
+  }
+]
+JSON
+    echo "arn:aws:ecs:us-west-2:111:task-definition/judgemind-ingestion-worker-dev:601" > "$tmpdir/describe-services.json"
+
+    set +e
+    run_script "$tmpdir" >"$tmpdir/stdout" 2>"$tmpdir/stderr"
+    local rc=$?
+    set -e
+    if [[ "$rc" -ne 1 ]]; then
+        fail "drift: env var diff should exit 1, got $rc" "$(cat "$tmpdir/stderr")"
+        return
+    fi
+    if ! grep -q "DRIFT:" "$tmpdir/stderr"; then
+        fail "drift: missing DRIFT: marker on stderr" "$(cat "$tmpdir/stderr")"
+        return
+    fi
+    if ! grep -q "anthropic\|google" "$tmpdir/stderr"; then
+        fail "drift: diff body should mention the changed env value" "$(cat "$tmpdir/stderr")"
+        return
+    fi
+    if ! grep -q "force-new-deployment" "$tmpdir/stderr"; then
+        fail "drift: stderr should include a recovery hint with --force-new-deployment" "$(cat "$tmpdir/stderr")"
+        return
+    fi
+    pass "drift: env var diff is caught with diff and recovery hint"
+}
+
+# ── Test 4: secrets-list drift is caught ───────────────────────────────────
+
+test_drift_secrets_list() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # SSM — terraform's intent has only DATABASE_URL
+    write_ssm_match_baseline "$tmpdir/ssm-param-value.txt"
+
+    # Running task-def — has an extra LEGACY_SECRET that terraform has removed
+    cat > "$tmpdir/describe-task-def.json" << 'JSON'
+[
+  {
+    "name": "ingestion-worker",
+    "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:STALE",
+    "essential": true,
+    "command": ["ingestion"],
+    "environment": [
+      {"name": "ENVIRONMENT", "value": "dev"},
+      {"name": "LLM_PROVIDER", "value": "google"}
+    ],
+    "secrets": [
+      {"name": "DATABASE_URL", "valueFrom": "arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},
+      {"name": "LEGACY_SECRET", "valueFrom": "arn:aws:secretsmanager:us-west-2:111:secret:legacy-XXX"}
+    ]
+  }
+]
+JSON
+    echo "arn:aws:ecs:us-west-2:111:task-definition/judgemind-ingestion-worker-dev:601" > "$tmpdir/describe-services.json"
+
+    set +e
+    run_script "$tmpdir" >"$tmpdir/stdout" 2>"$tmpdir/stderr"
+    local rc=$?
+    set -e
+    if [[ "$rc" -eq 1 ]] && grep -q "LEGACY_SECRET" "$tmpdir/stderr"; then
+        pass "drift: secrets-list diff is caught"
+    else
+        fail "drift: secrets-list diff should exit 1 with LEGACY_SECRET in diff" "rc=$rc; $(cat "$tmpdir/stderr")"
+    fi
+}
+
+# ── Test 5: invalid SSM JSON is exit 2 (tooling broken) ────────────────────
+
+test_tooling_broken_invalid_ssm() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    echo "this-is-not-json" > "$tmpdir/ssm-param-value.txt"
+    write_running_match_baseline "$tmpdir/describe-task-def.json"
+    echo "arn:aws:ecs:us-west-2:111:task-definition/judgemind-ingestion-worker-dev:42" > "$tmpdir/describe-services.json"
+
+    set +e
+    run_script "$tmpdir" >"$tmpdir/stdout" 2>"$tmpdir/stderr"
+    local rc=$?
+    set -e
+    if [[ "$rc" -eq 2 ]] && grep -q "did not contain valid JSON" "$tmpdir/stderr"; then
+        pass "tooling broken: invalid SSM JSON exits 2 (distinct from drift exit 1)"
+    else
+        fail "tooling broken: invalid SSM should exit 2, got $rc" "$(cat "$tmpdir/stderr")"
+    fi
+}
+
+# ── Test 6: missing PRIMARY deployment is exit 2 ───────────────────────────
+
+test_tooling_broken_no_primary() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_ssm_match_baseline "$tmpdir/ssm-param-value.txt"
+    write_running_match_baseline "$tmpdir/describe-task-def.json"
+    # describe-services returns the literal "None" that the AWS CLI emits when
+    # --query has no match and --output text is set.
+    echo "None" > "$tmpdir/describe-services.json"
+
+    set +e
+    run_script "$tmpdir" >"$tmpdir/stdout" 2>"$tmpdir/stderr"
+    local rc=$?
+    set -e
+    if [[ "$rc" -eq 2 ]] && grep -q "PRIMARY" "$tmpdir/stderr"; then
+        pass "tooling broken: missing PRIMARY deployment exits 2"
+    else
+        fail "tooling broken: missing PRIMARY should exit 2, got $rc" "$(cat "$tmpdir/stderr")"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_match_image_tag_only_diff
+test_match_key_order_diff
+test_drift_env_var
+test_drift_secrets_list
+test_tooling_broken_invalid_ssm
+test_tooling_broken_no_primary
+
+echo ""
+echo "Tests: $TESTS, Failures: $FAILURES"
+[[ "$FAILURES" -eq 0 ]] || exit 1

--- a/scripts/wait-for-rollout.sh
+++ b/scripts/wait-for-rollout.sh
@@ -20,6 +20,7 @@
 #   regressions surface on the next unrelated deploy. Current callers:
 #     - .github/workflows/deploy-scraper.yml
 #     - .github/workflows/deploy-api.yml
+#     - .github/workflows/terraform.yml (dev-apply force-deploy, #4044)
 #
 # Identifying the deployment:
 #   - CI path knows the new task-def ARN up front.


### PR DESCRIPTION
## Summary

Closes the silent-drift class introduced by `aws_ecs_service.ingestion_worker.lifecycle.ignore_changes = [task_definition]`. When `terraform.yml dev-apply` and `deploy-scraper.yml deploy-ingestion-worker` race on the same merge commit, deploy-scraper can win, read the *stale* SSM `container_definitions`, pin the service to a pre-apply task-def revision, and leave the running container with the wrong env vars indefinitely (verified live during #4031). Three mitigations land together: Option B post-apply force-deploy in `terraform.yml`, a fingerprint drift gate in `deploy-scraper.yml`'s post-deploy-health-check job, and an explanatory comment on the `lifecycle` block.

Closes #4044

## What changed

- `.github/workflows/terraform.yml` — `dev-apply` job now detects whether the apply touched `module.compute.aws_ecs_task_definition.ingestion_worker[0]` or `module.compute.aws_ssm_parameter.ingestion_worker_container_definitions[0]` (greps the apply log for `Creating|Modifying|Destroying...` against those addresses), and if so runs `aws ecs update-service --force-new-deployment` + waits for rollout via `scripts/wait-for-rollout.sh`. Idempotent no-op when neither resource changed.
- `scripts/check-ingestion-worker-task-def-fingerprint.sh` (new) — reads SSM and the running PRIMARY deployment's task-def, canonicalizes both (drops `image`, sort-keys recursively), SHA-256s, exits 1 with diff + recovery hint on drift, exit 2 on tooling failure.
- `.github/workflows/deploy-scraper.yml` — post-deploy-health-check job invokes the new guard so every CI deploy verifies parity.
- `scripts/tests/test_check_ingestion_worker_task_def_fingerprint.sh` (new) — 6 unit tests with mock `aws` CLI: 2 match cases (image-tag-only, key-order), 2 drift cases (env var, secrets), 2 tooling-broken cases (invalid SSM JSON, missing PRIMARY).
- `infra/terraform/modules/compute/main.tf` — `aws_ecs_service.ingestion_worker.lifecycle` block now explains the silent-drift failure mode and links both mitigations.
- `scripts/wait-for-rollout.sh` paths-filter contract: `terraform.yml` added to the consumer list (#2592 contract).

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] After merge, terraform.yml dev-apply runs and exercises the new force-deploy step end-to-end (this PR touches both `infra/terraform/modules/compute/main.tf` and `.github/workflows/terraform.yml`, so `dev-apply` will trigger naturally).
- [ ] deploy-scraper.yml's `post-deploy-health-check` runs the new fingerprint guard against dev (this PR also touches `scripts/wait-for-rollout.sh` which is on deploy-scraper.yml's paths filter, so it triggers).
- [ ] Verify running ingestion-worker task-def matches terraform SSM (fingerprint guard exits 0).
- [ ] Verification evidence posted on issue.
