### PR TITLE
refactor(scraping): drop hardcoded anthropic provider in formatter/gate/summarizer (#4032)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_providers.py
+++ b/packages/scraper-framework/src/ingestion/llm_providers.py
@@ -63,6 +63,44 @@ _PROVIDER_DEFAULT_MODELS: dict[str, str] = {
 }
 
 
+def resolve_provider(provider: str | None = None) -> str:
+    """Resolve the active LLM provider name.
+
+    Resolution order:
+
+    1. Explicit ``provider`` argument.
+    2. ``LLM_PROVIDER`` environment variable.
+    3. Default ``"google"``.
+
+    This is the single source of truth for "which provider will ``call_llm``
+    actually use?" — callers that need to record or log the provider should
+    use this helper rather than reimplementing the precedence locally.
+    """
+    return provider or os.environ.get("LLM_PROVIDER", "google")
+
+
+def resolve_model(provider: str | None = None, model: str | None = None) -> str:
+    """Resolve the active LLM model ID for the given provider.
+
+    Resolution order matches ``call_llm``:
+
+    1. Explicit ``model`` argument.
+    2. ``LLM_MODEL`` environment variable.
+    3. Per-provider default from ``_PROVIDER_DEFAULT_MODELS``.
+    4. ``DEFAULT_HAIKU_MODEL`` (defensive fallback for unknown providers).
+
+    Callers (e.g. the ingestion summarizer) that need to persist or log the
+    model used should call this helper instead of duplicating the precedence
+    logic.  ``call_llm`` itself uses the same resolution.
+    """
+    resolved_provider = resolve_provider(provider)
+    return (
+        model
+        or os.environ.get("LLM_MODEL")
+        or _PROVIDER_DEFAULT_MODELS.get(resolved_provider, DEFAULT_HAIKU_MODEL)
+    )
+
+
 @dataclass
 class LLMResponse:
     """Unified response from any LLM provider."""
@@ -291,12 +329,8 @@ def call_llm(
         An ``LLMResponse`` with the text and token counts, or ``None``
         on any unrecoverable failure.
     """
-    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
-    resolved_model = (
-        model
-        or os.environ.get("LLM_MODEL")
-        or _PROVIDER_DEFAULT_MODELS.get(resolved_provider, DEFAULT_HAIKU_MODEL)
-    )
+    resolved_provider = resolve_provider(provider)
+    resolved_model = resolve_model(resolved_provider, model)
 
     if resolved_provider == "anthropic":
         return _call_anthropic(
@@ -358,12 +392,8 @@ def call_llm_with_images(
     Returns:
         An ``LLMResponse`` or ``None`` on failure.
     """
-    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
-    resolved_model = (
-        model
-        or os.environ.get("LLM_MODEL")
-        or _PROVIDER_DEFAULT_MODELS.get(resolved_provider, DEFAULT_HAIKU_MODEL)
-    )
+    resolved_provider = resolve_provider(provider)
+    resolved_model = resolve_model(resolved_provider, model)
 
     if resolved_provider == "anthropic":
         return _call_anthropic_with_images(
@@ -609,7 +639,7 @@ def create_client(
         A provider-specific client object, or ``None`` if no provider's
         credentials are available.
     """
-    resolved_provider = provider or os.environ.get("LLM_PROVIDER", "google")
+    resolved_provider = resolve_provider(provider)
 
     # Try the primary provider first.
     client = _try_create(resolved_provider)

--- a/packages/scraper-framework/src/ingestion/ruling_formatter.py
+++ b/packages/scraper-framework/src/ingestion/ruling_formatter.py
@@ -1,8 +1,13 @@
 """LLM-powered ruling text formatter for consistent, readable HTML display.
 
-Transforms raw ``ruling_text`` into structured semantic HTML using Claude Haiku.
-The formatted output follows a standard template with consistent CSS classes
-for case headers, captions, hearing info, and ruling body content.
+Transforms raw ``ruling_text`` into structured semantic HTML.  The formatted
+output follows a standard template with consistent CSS classes for case
+headers, captions, hearing info, and ruling body content.
+
+The provider and model are resolved by ``call_llm`` from the ``LLM_PROVIDER``
+and ``LLM_MODEL`` environment variables — this module does not pin a
+provider or model, so flipping ``LLM_PROVIDER`` (e.g. anthropic → google)
+takes effect here without code changes (#4032).
 
 Key guarantees:
 - **Zero information loss**: validates that formatted output preserves all
@@ -15,6 +20,7 @@ Key guarantees:
 Configuration:
 - ``ENABLE_RULING_FORMATTING``: environment variable to enable/disable.
   Defaults to disabled.
+- ``LLM_PROVIDER``, ``LLM_MODEL``: see ``llm_providers.call_llm``.
 """
 
 from __future__ import annotations
@@ -24,7 +30,6 @@ import html
 import re
 
 import structlog
-from judgemind_config import DEFAULT_HAIKU_MODEL
 
 from framework.llm_utils import strip_llm_json_fences
 
@@ -45,10 +50,9 @@ _MIN_TEXT_LENGTH = 100
 # catching content loss or summarization.
 _VALIDATION_THRESHOLD = 0.95
 
-# Default model for formatting — always Haiku for cost efficiency.
-_FORMATTING_MODEL = DEFAULT_HAIKU_MODEL
-
-# Default max output tokens.  Haiku supports up to 8192 output tokens.
+# Default max output tokens.  Both Haiku and Gemini Flash variants
+# comfortably support 8192 output tokens for the long-form HTML this
+# formatter produces.
 _DEFAULT_MAX_TOKENS = 8192
 
 # ---------------------------------------------------------------------------
@@ -291,17 +295,18 @@ def format_ruling_text(
 ) -> str:
     """Format raw ruling text into structured semantic HTML.
 
-    Uses Claude Haiku to transform unstructured court ruling text into
-    clean HTML following a consistent template.  The result is sanitized
-    and validated for zero information loss.
+    Uses the env-configured LLM provider (``LLM_PROVIDER`` — Anthropic or
+    Google) to transform unstructured court ruling text into clean HTML
+    following a consistent template.  The result is sanitized and
+    validated for zero information loss.
 
     On any failure (LLM error, truncation, validation failure), returns
     the original text wrapped in ``<pre>`` tags.
 
     Args:
         ruling_text: Raw ruling text to format.
-        client: Optional pre-created ``anthropic.Anthropic`` client for
-            connection reuse.
+        client: Optional pre-created provider client for connection reuse.
+            The client must match the provider resolved by ``call_llm``.
         timeout: Per-call timeout in seconds.
         max_tokens: Maximum output tokens for the LLM call.
 
@@ -320,12 +325,11 @@ def format_ruling_text(
         )
         return _pre_wrap_fallback(ruling_text)
 
-    # Call LLM for formatting
+    # Call LLM for formatting.  Provider and model resolved from
+    # LLM_PROVIDER / LLM_MODEL env vars (see llm_providers.call_llm).
     llm_response: LLMResponse | None = call_llm(
         system_prompt=_FORMATTING_SYSTEM_PROMPT,
         user_message=ruling_text,
-        provider="anthropic",
-        model=_FORMATTING_MODEL,
         client=client,
         max_tokens=max_tokens,
         timeout=timeout,

--- a/packages/scraper-framework/src/ingestion/ruling_summarizer.py
+++ b/packages/scraper-framework/src/ingestion/ruling_summarizer.py
@@ -1,31 +1,32 @@
-"""Ruling summarization at ingestion time using Claude Haiku.
+"""Ruling summarization at ingestion time using the configured LLM provider.
 
 Generates plain-English summaries of tentative rulings during ingestion.
 Summaries are pre-computed and cached in the ``rulings`` table — user-facing
 pages serve cached summaries without live AI calls.
 
+The provider and model are resolved by ``call_llm`` from the
+``LLM_PROVIDER`` / ``LLM_MODEL`` environment variables — this module does
+not pin a provider, so flipping ``LLM_PROVIDER`` (anthropic → google) takes
+effect here without code changes (#4032).
+
 Gated behind ``ENABLE_RULING_SUMMARIZATION`` environment variable.
 Summary generation failures never block ruling ingestion (graceful degradation).
 
-Uses the same prompt and model as ``scripts/backfill_summaries.py`` and
+Uses the same prompt as ``scripts/backfill_summaries.py`` and
 ``packages/nlp-pipeline/src/summarization/summarizer.py`` for consistency.
 """
 
 from __future__ import annotations
 
 import structlog
-from judgemind_config import DEFAULT_HAIKU_MODEL
 
-from .llm_providers import LLMResponse, call_llm
+from .llm_providers import LLMResponse, call_llm, resolve_model
 
 logger = structlog.get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-# Default model — always Haiku for cost efficiency.
-_SUMMARY_MODEL = DEFAULT_HAIKU_MODEL
 
 # Max output tokens — summaries are 2-4 sentences, 512 is generous.
 _DEFAULT_MAX_TOKENS = 512
@@ -61,24 +62,30 @@ def summarize_ruling(
 ) -> tuple[str | None, str]:
     """Generate a plain-English summary of a tentative ruling.
 
-    Uses Claude Haiku via the provider-agnostic ``call_llm`` adapter.
-    On any failure, returns ``(None, model)`` — the caller should
-    continue without a summary rather than blocking ingestion.
+    Uses the env-configured LLM provider (``LLM_PROVIDER`` — Anthropic or
+    Google) via the provider-agnostic ``call_llm`` adapter.  On any
+    failure, returns ``(None, model)`` — the caller should continue
+    without a summary rather than blocking ingestion.
 
     Args:
         ruling_text: The full text of the tentative ruling.
         case_context: Optional dict with case metadata (e.g. ``case_title``,
             ``motion_type``) to improve summary specificity.
-        client: Optional pre-created Anthropic client for connection reuse.
+        client: Optional pre-created provider client for connection reuse.
+            The client must match the provider resolved by ``call_llm``.
         timeout: Per-call timeout in seconds.
         max_tokens: Maximum output tokens for the LLM call.
 
     Returns:
         Tuple of ``(summary_text_or_none, model_id)``.  The model ID is
         always returned so the caller can persist it even when the summary
-        is ``None`` (for debugging/metrics).
+        is ``None`` (for debugging/metrics).  Resolved using the same
+        precedence as ``call_llm`` (``LLM_MODEL`` env var, then the
+        per-provider default).
     """
-    model = _SUMMARY_MODEL
+    # Resolve the model the same way call_llm does, so the recorded
+    # model in the rulings table matches the one actually called.
+    model = resolve_model()
 
     if not ruling_text or not ruling_text.strip():
         logger.warning("ruling_summarizer.empty_text")
@@ -102,8 +109,6 @@ def summarize_ruling(
         llm_response: LLMResponse | None = call_llm(
             system_prompt=_SYSTEM_PROMPT,
             user_message=user_content,
-            provider="anthropic",
-            model=model,
             client=client,
             max_tokens=max_tokens,
             timeout=timeout,

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -699,8 +699,9 @@ class IngestionWorker:
         self._empty_polls: int = 0
         self._last_event_time: float = time.monotonic()
 
-        # Ruling formatting — uses a dedicated Anthropic client (always Haiku),
-        # separate from the field extraction LLM client which may use Google.
+        # Ruling formatting — uses a dedicated client (provider resolved
+        # from LLM_PROVIDER env var), separate from the field extraction
+        # LLM client so the two paths can be tuned independently.
         self._formatting_enabled = os.environ.get("ENABLE_RULING_FORMATTING", "").lower() in (
             "1",
             "true",
@@ -708,15 +709,16 @@ class IngestionWorker:
         )
         self._formatting_client: object | None = None
         if self._formatting_enabled:
-            self._formatting_client = create_llm_client(provider="anthropic")
+            self._formatting_client = create_llm_client()
             if self._formatting_client is None:
                 logger.warning(
-                    "Ruling formatting enabled but ANTHROPIC_API_KEY not set — "
+                    "Ruling formatting enabled but no LLM provider API key is set — "
                     "formatting will use <pre> fallback"
                 )
 
-        # Ruling summarization — uses a dedicated Anthropic client (always Haiku),
-        # separate from the field extraction LLM client which may use Google.
+        # Ruling summarization — uses a dedicated client (provider resolved
+        # from LLM_PROVIDER env var), separate from the field extraction
+        # LLM client so the two paths can be tuned independently.
         self._summarization_enabled = os.environ.get("ENABLE_RULING_SUMMARIZATION", "").lower() in (
             "1",
             "true",
@@ -724,16 +726,17 @@ class IngestionWorker:
         )
         self._summarization_client: object | None = None
         if self._summarization_enabled:
-            self._summarization_client = create_llm_client(provider="anthropic")
+            self._summarization_client = create_llm_client()
             if self._summarization_client is None:
                 logger.warning(
-                    "Ruling summarization enabled but ANTHROPIC_API_KEY not set — "
+                    "Ruling summarization enabled but no LLM provider API key is set — "
                     "summarization disabled"
                 )
 
         # Ingestion validation gate — LLM-based quality checks between
-        # enrichment and DB write. Uses a dedicated Anthropic client (always
-        # Haiku), separate from extraction and formatting.
+        # enrichment and DB write. Uses a dedicated client (provider
+        # resolved from LLM_PROVIDER env var), separate from extraction
+        # and formatting.
         self._validation_enabled = os.environ.get("ENABLE_INGESTION_VALIDATION", "").lower() in (
             "1",
             "true",
@@ -741,10 +744,10 @@ class IngestionWorker:
         )
         self._validation_client: object | None = None
         if self._validation_enabled:
-            self._validation_client = create_llm_client(provider="anthropic")
+            self._validation_client = create_llm_client()
             if self._validation_client is None:
                 logger.warning(
-                    "Ingestion validation enabled but ANTHROPIC_API_KEY not set — "
+                    "Ingestion validation enabled but no LLM provider API key is set — "
                     "validation disabled"
                 )
                 self._validation_enabled = False
@@ -2301,7 +2304,8 @@ class IngestionWorker:
                 department=department,
                 county=county,
                 client=self._validation_client,
-                provider="anthropic",
+                # Provider intentionally omitted: validate_document falls
+                # through to LLM_PROVIDER env var (#4032).
                 timeout=self._llm_timeout,
             )
 

--- a/packages/scraper-framework/src/validation/gate.py
+++ b/packages/scraper-framework/src/validation/gate.py
@@ -1,9 +1,14 @@
 """Ingestion validation gate — LLM-based quality checks before DB write.
 
 Validates extracted fields against ruling text using a cheap LLM model
-(Haiku-class) to catch data quality issues that regression tests and
-volume-based monitoring miss. Runs inline in the ingestion worker between
-enrichment and DB write.
+to catch data quality issues that regression tests and volume-based
+monitoring miss. Runs inline in the ingestion worker between enrichment
+and DB write.
+
+The provider and model are resolved by ``call_llm`` from the
+``LLM_PROVIDER`` / ``LLM_MODEL`` environment variables — this module
+no longer pins a provider, so flipping ``LLM_PROVIDER`` (anthropic →
+google) takes effect here without code changes (#4032).
 
 Gated behind ``ENABLE_INGESTION_VALIDATION`` environment variable.
 Validation failures never block ingestion — on LLM errors, the document
@@ -20,10 +25,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from judgemind_config import DEFAULT_HAIKU_MODEL
-
 from framework.llm_utils import parse_llm_json
-from ingestion.llm_providers import LLMResponse, call_llm
+from ingestion.llm_providers import LLMResponse, call_llm, resolve_model
 
 if TYPE_CHECKING:
     import psycopg
@@ -33,9 +36,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-# Default model — always Haiku for cost efficiency.
-_VALIDATION_MODEL = DEFAULT_HAIKU_MODEL
 
 # Max output tokens — validation responses are short JSON.
 _DEFAULT_MAX_TOKENS = 512
@@ -141,9 +141,12 @@ def validate_document(
     client : object | None
         Pre-created LLM client for connection reuse.
     provider : str | None
-        LLM provider. Defaults to "anthropic" for validation.
+        LLM provider. Defaults to the value resolved by ``call_llm``
+        (``LLM_PROVIDER`` env var, then ``"google"``).
     model : str | None
-        Model ID. Defaults to Haiku.
+        Model ID. Defaults to the per-provider default resolved by
+        ``call_llm`` (``LLM_MODEL`` env var, then the provider's default
+        model).
     timeout : float | None
         Per-call timeout in seconds.
 
@@ -162,8 +165,9 @@ def validate_document(
             latency_ms=0,
         )
 
-    resolved_model = model or _VALIDATION_MODEL
-    resolved_provider = provider or "anthropic"
+    # Resolve via the same precedence call_llm uses, so the model recorded
+    # in ValidationResult matches the model that was actually called.
+    resolved_model = resolve_model(provider, model)
 
     # Build the user message with extracted fields and ruling text excerpt.
     # Use a 500-char excerpt to keep costs low while providing enough context.
@@ -195,7 +199,7 @@ def validate_document(
         response = call_llm(
             _SYSTEM_PROMPT,
             user_message,
-            provider=resolved_provider,
+            provider=provider,
             model=resolved_model,
             client=client,
             timeout=timeout,

--- a/packages/scraper-framework/tests/test_ruling_formatter.py
+++ b/packages/scraper-framework/tests/test_ruling_formatter.py
@@ -290,3 +290,76 @@ def test_format_ruling_text_strips_code_fences(mock_call_llm: object) -> None:
     result = format_ruling_text(original, client=object())
     assert "```" not in result
     assert '<div class="ruling">' in result
+
+
+# ---------------------------------------------------------------------------
+# Regression test for #4032: provider falls through to LLM_PROVIDER env var.
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.ruling_formatter.call_llm")
+def test_format_ruling_text_falls_through_to_env_provider(
+    mock_call_llm: object,
+) -> None:
+    """call_llm is invoked WITHOUT explicit provider/model so resolution
+    falls through to ``LLM_PROVIDER`` / ``LLM_MODEL`` env vars (#4032).
+
+    Prior to #4032 this module hardcoded ``provider="anthropic"`` plus
+    ``model=DEFAULT_HAIKU_MODEL``, which silently bypassed the env var
+    that the rest of the ingestion pipeline (and #4031's terraform flip)
+    rely on. The regression guarded here is "the formatter pins the
+    provider to Anthropic regardless of LLM_PROVIDER".
+    """
+    mock_call_llm.return_value = LLMResponse(  # type: ignore[union-attr]
+        text='<div class="ruling"><p>'
+        + "The motion for summary judgment is GRANTED. " * 5
+        + "</p></div>",
+        input_tokens=100,
+        output_tokens=200,
+    )
+
+    original = "The motion for summary judgment is GRANTED. " * 5
+    format_ruling_text(original, client=object())
+
+    call_kwargs = mock_call_llm.call_args.kwargs  # type: ignore[union-attr]
+    assert "provider" not in call_kwargs, (
+        f"provider must not be pinned (#4032), got {call_kwargs.get('provider')!r}"
+    )
+    assert "model" not in call_kwargs, (
+        f"model must not be pinned (#4032), got {call_kwargs.get('model')!r}"
+    )
+
+
+def test_format_ruling_text_routes_through_google_when_env_set(
+    monkeypatch: object,
+) -> None:
+    """End-to-end: with ``LLM_PROVIDER=google`` set, the formatter dispatches
+    through ``_call_google`` (not ``_call_anthropic``). This is the
+    integration-style regression for #4032 — covers the full path from
+    ``format_ruling_text`` through ``call_llm`` to the provider adapter.
+    """
+    monkeypatch.setenv("LLM_PROVIDER", "google")  # type: ignore[attr-defined]
+    monkeypatch.delenv("LLM_MODEL", raising=False)  # type: ignore[attr-defined]
+
+    google_response = LLMResponse(
+        text='<div class="ruling"><p>'
+        + "The motion for summary judgment is GRANTED. " * 5
+        + "</p></div>",
+        input_tokens=100,
+        output_tokens=200,
+    )
+
+    with (
+        patch("ingestion.llm_providers._call_google") as mock_google,
+        patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+    ):
+        mock_google.return_value = google_response
+
+        original = "The motion for summary judgment is GRANTED. " * 5
+        format_ruling_text(original, client=object())
+
+    mock_google.assert_called_once()
+    mock_anthropic.assert_not_called()
+    # The model resolves to the per-provider default for google.
+    google_call_args = mock_google.call_args
+    assert google_call_args[0][2] == "gemini-2.5-flash-lite"

--- a/packages/scraper-framework/tests/test_ruling_summarizer.py
+++ b/packages/scraper-framework/tests/test_ruling_summarizer.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from ingestion.llm_providers import LLMResponse, resolve_model
 from ingestion.ruling_summarizer import (
     _MIN_TEXT_LENGTH,
-    _SUMMARY_MODEL,
     _SYSTEM_PROMPT,
     summarize_ruling,
 )
@@ -28,7 +30,7 @@ class TestSummarizeRuling:
         summary, model = summarize_ruling(ruling_text, client=MagicMock())
 
         assert summary == "The court granted the motion for summary judgment."
-        assert model == _SUMMARY_MODEL
+        assert model == resolve_model()
         mock_call_llm.assert_called_once()
 
     @patch("ingestion.ruling_summarizer.call_llm")
@@ -37,7 +39,7 @@ class TestSummarizeRuling:
         summary, model = summarize_ruling("", client=MagicMock())
 
         assert summary is None
-        assert model == _SUMMARY_MODEL
+        assert model == resolve_model()
         mock_call_llm.assert_not_called()
 
     @patch("ingestion.ruling_summarizer.call_llm")
@@ -46,7 +48,7 @@ class TestSummarizeRuling:
         summary, model = summarize_ruling(None, client=MagicMock())
 
         assert summary is None
-        assert model == _SUMMARY_MODEL
+        assert model == resolve_model()
         mock_call_llm.assert_not_called()
 
     @patch("ingestion.ruling_summarizer.call_llm")
@@ -56,7 +58,7 @@ class TestSummarizeRuling:
         summary, model = summarize_ruling(short_text, client=MagicMock())
 
         assert summary is None
-        assert model == _SUMMARY_MODEL
+        assert model == resolve_model()
         mock_call_llm.assert_not_called()
 
     @patch("ingestion.ruling_summarizer.call_llm")
@@ -68,7 +70,7 @@ class TestSummarizeRuling:
         summary, model = summarize_ruling(ruling_text, client=MagicMock())
 
         assert summary is None
-        assert model == _SUMMARY_MODEL
+        assert model == resolve_model()
 
     @patch("ingestion.ruling_summarizer.call_llm")
     def test_returns_none_on_llm_exception(self, mock_call_llm: MagicMock) -> None:
@@ -79,7 +81,7 @@ class TestSummarizeRuling:
         summary, model = summarize_ruling(ruling_text, client=MagicMock())
 
         assert summary is None
-        assert model == _SUMMARY_MODEL
+        assert model == resolve_model()
 
     @patch("ingestion.ruling_summarizer.call_llm")
     def test_passes_case_context_in_user_message(self, mock_call_llm: MagicMock) -> None:
@@ -102,8 +104,9 @@ class TestSummarizeRuling:
         assert "case_title" in user_message
 
     @patch("ingestion.ruling_summarizer.call_llm")
-    def test_uses_anthropic_provider(self, mock_call_llm: MagicMock) -> None:
-        """Always uses the anthropic provider for summarization."""
+    def test_does_not_pin_provider_or_model(self, mock_call_llm: MagicMock) -> None:
+        """call_llm is invoked WITHOUT explicit provider/model so it falls
+        through to ``LLM_PROVIDER`` / ``LLM_MODEL`` env vars (#4032)."""
         mock_response = MagicMock()
         mock_response.text = "Summary."
         mock_response.input_tokens = 50
@@ -114,8 +117,8 @@ class TestSummarizeRuling:
         summarize_ruling(ruling_text, client=MagicMock())
 
         call_kwargs = mock_call_llm.call_args
-        assert call_kwargs.kwargs["provider"] == "anthropic"
-        assert call_kwargs.kwargs["model"] == _SUMMARY_MODEL
+        assert "provider" not in call_kwargs.kwargs
+        assert "model" not in call_kwargs.kwargs
 
     @patch("ingestion.ruling_summarizer.call_llm")
     def test_uses_correct_system_prompt(self, mock_call_llm: MagicMock) -> None:
@@ -163,3 +166,43 @@ class TestSummarizeRuling:
 
         call_kwargs = mock_call_llm.call_args
         assert call_kwargs.kwargs["client"] is client
+
+
+# ---------------------------------------------------------------------------
+# Regression test for #4032: provider falls through to LLM_PROVIDER env var.
+# ---------------------------------------------------------------------------
+
+
+class TestProviderFallthrough:
+    """Regression tests for #4032 — summarizer must not pin provider."""
+
+    def test_routes_through_google_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end: with ``LLM_PROVIDER=google`` set, summarize_ruling
+        dispatches through ``_call_google`` (not ``_call_anthropic``), and
+        the model returned is the Google default — not Anthropic Haiku."""
+        monkeypatch.setenv("LLM_PROVIDER", "google")
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+
+        google_response = LLMResponse(
+            text="The court granted the motion.",
+            input_tokens=100,
+            output_tokens=20,
+        )
+
+        with (
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+        ):
+            mock_google.return_value = google_response
+
+            ruling_text = "The motion for summary judgment is hereby GRANTED. " * 5
+            summary, model = summarize_ruling(ruling_text, client=MagicMock())
+
+        mock_google.assert_called_once()
+        mock_anthropic.assert_not_called()
+        # Model resolves to google's default and is returned for DB persistence.
+        assert model == "gemini-2.5-flash-lite"
+        assert summary == "The court granted the motion."
+        # The model arg into the google adapter matches.
+        google_call_args = mock_google.call_args
+        assert google_call_args[0][2] == "gemini-2.5-flash-lite"

--- a/packages/scraper-framework/tests/test_validation_gate.py
+++ b/packages/scraper-framework/tests/test_validation_gate.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from validation.gate import (
     ValidationResult,
     _parse_validation_response,
@@ -372,3 +374,82 @@ class TestInsertValidationResult:
         assert params[1] == "ruling-789"
         assert params[2] == "flag"
         assert params[3] == "Case title mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Regression test for #4032: provider falls through to LLM_PROVIDER env var.
+# ---------------------------------------------------------------------------
+
+
+class TestProviderFallthrough:
+    """Regression tests for #4032 — validation gate must not pin provider."""
+
+    @patch("validation.gate.call_llm")
+    def test_does_not_pin_provider_when_caller_omits(self, mock_call_llm: MagicMock) -> None:
+        """When the caller omits provider, validate_document does not inject
+        a hardcoded ``"anthropic"``. The ``provider`` kwarg passed to
+        ``call_llm`` is ``None`` so it falls through to ``LLM_PROVIDER``."""
+        from ingestion.llm_providers import LLMResponse
+
+        mock_call_llm.return_value = LLMResponse(
+            text='{"result": "pass", "reason": null}',
+            input_tokens=100,
+            output_tokens=20,
+        )
+
+        validate_document(
+            ruling_text="The motion for summary judgment is GRANTED. " * 5,
+            case_number="23STCV12345",
+            case_title=None,
+            judge_name=None,
+            motion_type=None,
+            outcome=None,
+            hearing_date=None,
+            department=None,
+            county="Los Angeles",
+        )
+
+        call_kwargs = mock_call_llm.call_args.kwargs
+        assert call_kwargs.get("provider") is None, (
+            f"validate_document must not pin provider (#4032), got {call_kwargs.get('provider')!r}"
+        )
+
+    def test_routes_through_google_when_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end: with ``LLM_PROVIDER=google`` set, validate_document
+        dispatches through ``_call_google`` (not ``_call_anthropic``)."""
+        from ingestion.llm_providers import LLMResponse
+
+        monkeypatch.setenv("LLM_PROVIDER", "google")
+        monkeypatch.delenv("LLM_MODEL", raising=False)
+
+        google_response = LLMResponse(
+            text='{"result": "pass", "reason": null}',
+            input_tokens=100,
+            output_tokens=20,
+        )
+
+        with (
+            patch("ingestion.llm_providers._call_google") as mock_google,
+            patch("ingestion.llm_providers._call_anthropic") as mock_anthropic,
+        ):
+            mock_google.return_value = google_response
+
+            result = validate_document(
+                ruling_text="The motion for summary judgment is GRANTED. " * 5,
+                case_number="23STCV12345",
+                case_title=None,
+                judge_name=None,
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+                department=None,
+                county="Los Angeles",
+            )
+
+        mock_google.assert_called_once()
+        mock_anthropic.assert_not_called()
+        # Model resolves to google's default
+        google_call_args = mock_google.call_args
+        assert google_call_args[0][2] == "gemini-2.5-flash-lite"
+        # And the recorded model in ValidationResult matches
+        assert result.model == "gemini-2.5-flash-lite"


### PR DESCRIPTION
## Summary

Drops hardcoded `provider="anthropic"` from the ruling formatter, validation gate, and ruling summarizer (the three call sites named in the issue), plus four additional sites in `ingestion/worker.py` discovered during the scope completeness check (the `_formatting_client` / `_summarization_client` / `_validation_client` constructors and the `validate_document()` invocation). All seven sites now fall through to the `LLM_PROVIDER` env var, so #4031's terraform flip (`anthropic → google`) actually takes effect end-to-end. Adds three regression tests (one per call site) that patch `LLM_PROVIDER=google` and assert the call dispatches via `_call_google` not `_call_anthropic`.

Closes #4032

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass — full scraper-framework suite, 7143 passed / 3 skipped
- [x] Tests pass with `LLM_PROVIDER=google` — 57 passed across the three target test files (AC #3)
- [x] CI green

### Post-deploy verification
- [x] After dev apply, tail `/ecs/judgemind-ingestion-worker-dev` CloudWatch logs during a manual reingest of a non-CA-tentatives source — confirm `llm_providers.provider=google` log lines and absence of `llm_providers.anthropic_*` warnings (AC #5)
- [x] Verification evidence posted on issue (see [#issuecomment-4372863426](https://github.com/judgemind/judgemind/issues/4032#issuecomment-4372863426))
