### PR TITLE
fix(ingestion): add LLM enrichment strict-retry second pass for null outcome/motion_type (#3991)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_enrichment.py
+++ b/packages/scraper-framework/src/framework/llm_enrichment.py
@@ -147,6 +147,15 @@ ENRICHMENT_SYSTEM_PROMPT = (
     "You are a legal document parser for California court tentative rulings.\n\n"
     "Given the text of a single court ruling, extract the following structured "
     "fields into JSON:\n\n"
+    "## Null policy (#3991)\n\n"
+    "Return null for a field ONLY when the ruling text is empty, fragmentary, "
+    "or does not describe a ruling at all. If the text describes a ruling — "
+    "even briefly — pick the best-fitting taxonomy value rather than returning "
+    "null. When the outcome is unclear, prefer `submitted` (taken under "
+    "submission) for hearings with deferred decisions, `continued` for "
+    "postponements, and `other` only as a last resort. The same rule applies "
+    "to motion_type — pick the closest motion in the taxonomy rather than "
+    "leaving the field null when the text describes a motion at all.\n\n"
     '1. **case_title** - The case caption (e.g., "Smith v. Jones"). '
     'Extract the full "Plaintiff v. Defendant" format as it appears. '
     "If no clear case title is present, return null.\n\n"
@@ -170,7 +179,9 @@ ENRICHMENT_SYSTEM_PROMPT = (
     "   - petition\n"
     "   - other (only if none of the above fit)\n"
     "   If the ruling mentions multiple motions, use the PRIMARY motion "
-    "being ruled on. If no motion type can be determined, return null.\n\n"
+    "being ruled on. Per the null policy above, prefer the closest "
+    "taxonomy value over null whenever the text describes a motion at all "
+    "(use `other` only when the closest match is genuinely unclear).\n\n"
     "3. **outcome** - The ruling's outcome, using EXACTLY one of:\n"
     '   - granted (fully granted, including "granted with conditions")\n'
     '   - denied (fully denied, including "denied without prejudice")\n'
@@ -499,6 +510,203 @@ def enrich_ruling_with_retry(
         f"LLM enrichment failed after {max_attempts} attempts"
         + (f": {last_exc}" if last_exc is not None else " (API returned None)")
     )
+
+
+# ---------------------------------------------------------------------------
+# Strict-retry second pass (#3991)
+# ---------------------------------------------------------------------------
+
+# Outcome taxonomy summary used inside the strict-retry prompt.  Mirrors the
+# detail in ENRICHMENT_SYSTEM_PROMPT so the LLM has the same vocabulary on
+# both passes — kept inline here so the strict-retry prompt is self-contained.
+_STRICT_OUTCOME_TAXONOMY = (
+    '   - granted (fully granted, including "granted with conditions")\n'
+    '   - denied (fully denied, including "denied without prejudice")\n'
+    "   - granted_in_part (partially granted and partially denied)\n"
+    "   - denied_in_part (partially denied)\n"
+    "   - moot (no longer relevant)\n"
+    "   - continued (hearing postponed)\n"
+    "   - off_calendar (taken off calendar, vacated, OCAL)\n"
+    "   - submitted (taken under submission for later decision)\n"
+    "   - other (only if none of the above fit)\n"
+    '   Note: "sustained" on a demurrer = granted. "overruled" on a '
+    "demurrer = denied.\n"
+)
+
+_STRICT_MOTION_TYPE_TAXONOMY = (
+    "   - msj (motion for summary judgment)\n"
+    "   - mtd (motion to dismiss)\n"
+    "   - demurrer\n"
+    "   - mil (motion in limine)\n"
+    "   - motion_to_compel\n"
+    "   - motion_to_strike\n"
+    "   - motion_for_attorney_fees\n"
+    "   - motion_to_quash\n"
+    "   - motion_for_summary_adjudication\n"
+    "   - motion_to_compel_arbitration\n"
+    "   - motion_for_new_trial\n"
+    "   - motion_to_tax_costs\n"
+    "   - motion_for_reconsideration\n"
+    "   - motion_to_be_relieved_as_counsel\n"
+    "   - motion_pro_hac_vice\n"
+    "   - petition\n"
+    "   - other (only if none of the above fit)\n"
+)
+
+
+def _build_strict_retry_prompt(
+    *, missing_outcome: bool, missing_motion_type: bool
+) -> tuple[str, str]:
+    """Build the system prompt and JSON skeleton for the strict-retry pass.
+
+    Returns a (system_prompt, json_skeleton) tuple where the skeleton names
+    only the requested fields so the LLM's response is small and focused.
+    """
+    missing_list: list[str] = []
+    if missing_outcome:
+        missing_list.append("outcome")
+    if missing_motion_type:
+        missing_list.append("motion_type")
+    missing_str = ", ".join(missing_list) if missing_list else "(none)"
+
+    sections: list[str] = [
+        "You are a legal document parser for California court tentative "
+        "rulings, performing a SECOND PASS on a ruling whose first-pass "
+        "enrichment left specific fields null.\n\n",
+        "## Why you're being asked again (#3991)\n\n"
+        "On your previous attempt, you left these fields null: "
+        f"{missing_str}.\n\n"
+        "Re-read the ruling text and provide your best classification using "
+        "the taxonomies below.  Returning null is only acceptable if the "
+        "text is empty or does not describe any ruling.  If the text "
+        "describes a ruling — even briefly — pick the closest taxonomy "
+        "value.  Use `other` only when no closer match exists.\n\n",
+        "## Fields to return\n\n",
+    ]
+
+    if missing_outcome:
+        sections.append("- **outcome** - The ruling's outcome, using EXACTLY one of:\n")
+        sections.append(_STRICT_OUTCOME_TAXONOMY)
+        sections.append(
+            "   When the outcome is unclear, prefer `submitted` for "
+            "hearings with deferred decisions, `continued` for "
+            "postponements, and `other` as a last resort.\n\n"
+        )
+
+    if missing_motion_type:
+        sections.append("- **motion_type** - The motion being ruled on, using EXACTLY one of:\n")
+        sections.append(_STRICT_MOTION_TYPE_TAXONOMY)
+        sections.append(
+            "   If the ruling mentions multiple motions, use the PRIMARY "
+            "motion being ruled on.  Use `other` only when none of the "
+            "specific values fit.\n\n"
+        )
+
+    skeleton_keys: list[str] = []
+    if missing_outcome:
+        skeleton_keys.append('  "outcome": "..."')
+    if missing_motion_type:
+        skeleton_keys.append('  "motion_type": "..."')
+    skeleton = "{\n" + ",\n".join(skeleton_keys) + "\n}" if skeleton_keys else "{}"
+
+    sections.append(
+        "## Output format\n\nRespond with ONLY a JSON object containing "
+        "ONLY the field(s) listed above, no other text:\n\n"
+    )
+    sections.append(skeleton)
+
+    return ("".join(sections), skeleton)
+
+
+def enrich_ruling_strict_retry(
+    ruling_text: str,
+    *,
+    missing_outcome: bool,
+    missing_motion_type: bool,
+    provider: str = "google",
+    model: str | None = None,
+    client: object | None = None,
+) -> LlmEnrichmentResult | None:
+    """Stronger second-pass enrichment that re-asks for specific missing fields.
+
+    Invoked by the worker after the primary ``enrich_ruling_with_retry`` call
+    when ``outcome`` and / or ``motion_type`` came back null on substantive
+    ruling text (#3991).  The prompt explicitly names the fields the prior
+    pass missed and instructs the LLM to pick the closest taxonomy value
+    rather than returning null.
+
+    Parameters
+    ----------
+    ruling_text : str
+        Plain text of the ruling, already transcribed.
+    missing_outcome : bool
+        Whether the prior pass left ``outcome`` null.
+    missing_motion_type : bool
+        Whether the prior pass left ``motion_type`` null.
+    provider : str
+        LLM provider — ``"google"`` or ``"anthropic"``.  Same as the prior
+        pass so the same model sees the same text.
+    model : str | None
+        Model ID override.  ``None`` uses the provider default.
+    client : object | None
+        Pre-created provider client for connection reuse.
+
+    Returns
+    -------
+    LlmEnrichmentResult | None
+        A result with whichever fields the LLM populated.  May still have
+        ``None`` for one or both target fields if the LLM remained
+        non-committal.  Returns ``None`` only on LLM API call failure
+        (``call_llm`` returned ``None``).  Does NOT raise on JSON parse
+        failure — returns an empty ``LlmEnrichmentResult`` so the caller
+        can record diagnostic markers without crashing.
+
+    Notes
+    -----
+    Single LLM call by design — the budget for retries already lives in
+    ``enrich_ruling_with_retry``.  This pass is one additional decisive
+    attempt, not a retry loop.  When ``missing_outcome=False`` AND
+    ``missing_motion_type=False``, the function short-circuits with an
+    empty result (no LLM call).  Empty / whitespace ruling text also
+    short-circuits (matches ``enrich_ruling`` behavior).
+    """
+    if not missing_outcome and not missing_motion_type:
+        # Nothing to ask about — short-circuit so callers can pass through
+        # without inspecting flags.
+        return LlmEnrichmentResult()
+
+    if not ruling_text or not ruling_text.strip():
+        logger.warning("llm_enrichment.strict_retry_empty_ruling_text")
+        return LlmEnrichmentResult()
+
+    system_prompt, _ = _build_strict_retry_prompt(
+        missing_outcome=missing_outcome,
+        missing_motion_type=missing_motion_type,
+    )
+
+    response = call_llm(
+        system_prompt,
+        ruling_text,
+        provider=provider,
+        model=model,
+        client=client,
+        max_tokens=512,
+    )
+
+    if response is None:
+        logger.warning("llm_enrichment.strict_retry_llm_call_failed")
+        return None
+
+    _log_token_usage(response)
+
+    parsed = _parse_response(response.text)
+    if parsed is None:
+        # JSON parse failed — return an empty result so the caller can record
+        # a diagnostic marker without raising.
+        logger.warning("llm_enrichment.strict_retry_json_parse_failed")
+        return LlmEnrichmentResult()
+
+    return parsed
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -126,6 +126,19 @@ _ENRICHMENT_NO_EXTRACTION_TAG = "llm_enrichment_no_extraction"
 _ENRICHMENT_ERRORED_TAG = "llm_enrichment_errored"
 _ENRICHMENT_SKIPPED_NO_TEXT_TAG = "llm_enrichment_skipped_no_text"
 
+# Diagnostic marker for fields populated by the strict-retry second pass
+# (#3991).  When the first ``enrich_ruling_with_retry`` call leaves outcome
+# and / or motion_type null on substantive ruling text, the worker invokes
+# ``enrich_ruling_strict_retry`` for one decisive second pass.  Fields that
+# come back from the strict retry carry this tag in extraction_methods so
+# post-deploy queries can measure how often the retry was the deciding pass.
+_ENRICHMENT_STRICT_RETRY_TAG = "llm_enrichment_strict_retry"
+
+# Minimum stripped length of ruling_text before the strict retry will run.
+# Below this gate the text is too short / fragmentary to make a confident
+# classification, and adding another LLM call is wasted budget (#3991).
+_STRICT_RETRY_MIN_TEXT_LEN = 100
+
 # ---------------------------------------------------------------------------
 # Markdown ↔ HTML/plain text for multimodal PDF extraction
 # ---------------------------------------------------------------------------
@@ -766,6 +779,15 @@ class IngestionWorker:
                 "enrichment fields may be missing"
             )
 
+        # Side-channel state for the strict-retry second pass (#3991).  When
+        # ``_llm_enrich_fields`` invokes ``enrich_ruling_strict_retry`` and
+        # populates fields, it records the field names here.  The single
+        # consumer in ``process_event`` reads this set immediately after the
+        # call and passes it to ``_apply_enrichment_result`` so those fields
+        # get the ``llm_enrichment_strict_retry`` diagnostic marker.  Reset
+        # to an empty set at the top of every ``_llm_enrich_fields`` call.
+        self._strict_retry_fields_for_last_call: set[str] = set()
+
         # Reusable httpx client for GitHub issue filing (validation gate).
         # Created lazily on first use; None means "not yet created".
         self._github_client: object | None = None
@@ -996,6 +1018,15 @@ class IngestionWorker:
         ``motion_type``, ``outcome``, ``case_title``, and ``parties`` from the
         ruling text in a single LLM call.
 
+        When the first pass leaves ``outcome`` and / or ``motion_type`` null on
+        substantive ruling text, this method invokes
+        ``enrich_ruling_strict_retry`` for one decisive second pass and merges
+        the strict-retry result into the first-pass result (#3991).  The set
+        of field names actually populated by the strict retry is recorded on
+        ``self._strict_retry_fields_for_last_call`` as a side channel so the
+        consumer in ``process_event`` can pass it to
+        ``_apply_enrichment_result`` for diagnostic-marker tagging.
+
         The import is deferred (lazy) to avoid a circular import between
         ``framework`` and ``ingestion`` packages.
 
@@ -1011,9 +1042,11 @@ class IngestionWorker:
         tuple[LlmEnrichmentResult | None, str]
             ``(result, status_tag)`` where ``status_tag`` is one of:
 
-            * ``"ok"`` — enrichment ran and returned a non-None result.
-            * ``"empty"`` — enrichment ran but the LLM returned all-None
-              fields (``enrich_ruling_with_retry`` returned ``None``).
+            * ``"ok"`` — enrichment ran and returned a non-None result (this
+              includes the case where the strict retry was the only pass to
+              produce data).
+            * ``"empty"`` — enrichment ran but neither the first pass nor any
+              strict retry returned data.
             * ``"errored"`` — ``LlmEnrichmentExhaustedError`` was raised;
               ``result`` is ``None``.  The caller decides whether to re-raise
               (single-event path) or absorb (split-loop path).
@@ -1022,6 +1055,10 @@ class IngestionWorker:
             * ``"skipped_disabled"`` — enrichment is disabled or the client
               is unavailable; enrichment was never attempted.
         """
+        # Reset side-channel state on every call so a prior call's strict-retry
+        # signal doesn't leak into this one.
+        self._strict_retry_fields_for_last_call = set()
+
         if not self._llm_enrichment_enabled:
             return None, "skipped_disabled"
 
@@ -1031,7 +1068,12 @@ class IngestionWorker:
         if not ruling_text or not ruling_text.strip():
             return None, "skipped_no_text"
 
-        from framework.llm_enrichment import LlmEnrichmentExhaustedError, enrich_ruling_with_retry
+        from framework.llm_enrichment import (
+            LlmEnrichmentExhaustedError,
+            LlmEnrichmentResult,
+            enrich_ruling_strict_retry,
+            enrich_ruling_with_retry,
+        )
 
         t0 = time.monotonic()
         try:
@@ -1053,9 +1095,74 @@ class IngestionWorker:
             return None, "errored"
         latency_ms = round((time.monotonic() - t0) * 1000)
 
+        # Strict-retry decision (#3991): when the first pass left outcome
+        # and / or motion_type null on substantive text, fire one more
+        # decisive LLM call asking specifically for the missing fields.
         if result is None:
-            # LLM responded but extracted nothing (all-None fields, e.g. text
-            # too short).  Not a transient failure — return None without retry.
+            missing_outcome = True
+            missing_motion_type = True
+        else:
+            missing_outcome = result.outcome is None
+            missing_motion_type = result.motion_type is None
+
+        text_long_enough = len(ruling_text.strip()) >= _STRICT_RETRY_MIN_TEXT_LEN
+        should_strict_retry = (missing_outcome or missing_motion_type) and text_long_enough
+
+        if should_strict_retry:
+            t_strict = time.monotonic()
+            strict_result = enrich_ruling_strict_retry(
+                ruling_text,
+                missing_outcome=missing_outcome,
+                missing_motion_type=missing_motion_type,
+                provider=self._llm_provider or "google",
+                model=self._llm_model,
+                client=self._enrichment_client,
+            )
+            strict_latency_ms = round((time.monotonic() - t_strict) * 1000)
+
+            if strict_result is not None:
+                # Merge any non-None strict-retry fields into the result.  If
+                # the first pass returned None, materialize an empty result so
+                # we have somewhere to attach merged fields.
+                if result is None:
+                    result = LlmEnrichmentResult()
+
+                merged_fields: set[str] = set()
+                if missing_outcome and strict_result.outcome is not None:
+                    result = result.model_copy(update={"outcome": strict_result.outcome})
+                    merged_fields.add("outcome")
+                if missing_motion_type and strict_result.motion_type is not None:
+                    result = result.model_copy(update={"motion_type": strict_result.motion_type})
+                    merged_fields.add("motion_type")
+
+                self._strict_retry_fields_for_last_call = merged_fields
+
+                logger.info(
+                    "LLM enrichment strict retry completed",
+                    extra={
+                        "document_id": document_id,
+                        "strict_retry_latency_ms": strict_latency_ms,
+                        "fields_populated": sorted(merged_fields),
+                        "missing_outcome": missing_outcome,
+                        "missing_motion_type": missing_motion_type,
+                    },
+                )
+            else:
+                # Strict-retry LLM call failed (call_llm returned None) — log
+                # and continue with the original first-pass result.  Do not
+                # raise; first-pass result (possibly None) is still valid.
+                logger.warning(
+                    "LLM enrichment strict retry returned None — continuing with first-pass result",
+                    extra={
+                        "document_id": document_id,
+                        "strict_retry_latency_ms": strict_latency_ms,
+                    },
+                )
+
+        if result is None:
+            # Neither the first pass nor (if invoked) the strict retry
+            # produced data.  Not a transient failure — return None without
+            # bubbling up an exception.
             logger.info(
                 "LLM enrichment completed with empty result",
                 extra={
@@ -1063,6 +1170,19 @@ class IngestionWorker:
                     "enrichment_latency_ms": latency_ms,
                 },
             )
+            return None, "empty"
+
+        # Confirm post-strict-retry result has at least one populated field.
+        # If both passes left it entirely empty (highly unusual), surface
+        # "empty" so callers tag with the correct diagnostic marker.
+        has_data = (
+            result.case_title is not None
+            or result.motion_type is not None
+            or result.outcome is not None
+            or result.parties.plaintiffs
+            or result.parties.defendants
+        )
+        if not has_data:
             return None, "empty"
 
         logger.info(
@@ -1076,6 +1196,7 @@ class IngestionWorker:
                 "outcome": result.outcome,
                 "plaintiff_count": len(result.parties.plaintiffs),
                 "defendant_count": len(result.parties.defendants),
+                "strict_retry_fields": sorted(self._strict_retry_fields_for_last_call),
             },
         )
 
@@ -1090,6 +1211,7 @@ class IngestionWorker:
         motion_type: str | None,
         case_title: str | None,
         parties_data: list[dict[str, str]],
+        strict_retry_fields: set[str] | None = None,
     ) -> tuple[
         str | None,
         str | None,
@@ -1132,6 +1254,14 @@ class IngestionWorker:
             * ``"skipped_disabled"`` → no diagnostic marker (enrichment intentionally off)
         outcome, motion_type, case_title, parties_data :
             Current values to merge into.
+        strict_retry_fields :
+            Optional set of field names (``"outcome"``, ``"motion_type"``)
+            that were populated by the strict-retry second pass (#3991).
+            Fields named here are tagged with ``_ENRICHMENT_STRICT_RETRY_TAG``
+            instead of the regular ``_ENRICHMENT_METHOD_TAG`` when assigning
+            to the methods dict.  Defaults to ``None`` / empty set, in which
+            case behavior matches pre-#3991 (every populated field uses
+            the regular ``llm_enrichment`` tag).
 
         Returns
         -------
@@ -1152,6 +1282,11 @@ class IngestionWorker:
         """
         methods: dict[str, str] = {}
         method_tag = _ENRICHMENT_METHOD_TAG
+        retry_fields = strict_retry_fields or set()
+
+        def _tag_for(field_name: str) -> str:
+            """Return the populated-field tag for ``field_name`` (#3991)."""
+            return _ENRICHMENT_STRICT_RETRY_TAG if field_name in retry_fields else method_tag
 
         # Map status_tag to the diagnostic marker for fields that remain None.
         # "skipped_disabled" means enrichment was intentionally off — no marker.
@@ -1190,19 +1325,22 @@ class IngestionWorker:
 
         if outcome is None and enrichment_result.outcome is not None:
             outcome = enrichment_result.outcome
-            methods["outcome"] = method_tag
+            methods["outcome"] = _tag_for("outcome")
         elif outcome is None and _failure_marker is not None:
             # Enrichment ran (ok) but did not return this field.
             methods["outcome"] = _failure_marker
 
         if motion_type is None and enrichment_result.motion_type is not None:
             motion_type = enrichment_result.motion_type
-            methods["motion_type"] = method_tag
+            methods["motion_type"] = _tag_for("motion_type")
         elif motion_type is None and _failure_marker is not None:
             methods["motion_type"] = _failure_marker
 
         if not case_title and enrichment_result.case_title is not None:
             case_title = enrichment_result.case_title
+            # case_title never comes from the strict retry — that pass only
+            # asks for outcome / motion_type — so the regular tag always
+            # applies here regardless of strict_retry_fields contents.
             methods["case_title"] = method_tag
         elif not case_title and _failure_marker is not None:
             methods["case_title"] = _failure_marker
@@ -1217,6 +1355,8 @@ class IngestionWorker:
                 parties_data.append({"name": name, "role": "plaintiff"})
             for name in enrichment_result.parties.defendants:
                 parties_data.append({"name": name, "role": "defendant"})
+            # parties never comes from the strict retry either — same reason
+            # as case_title above.  Regular tag.
             methods["parties"] = method_tag
         elif not parties_data and _failure_marker is not None:
             methods["parties"] = _failure_marker
@@ -1752,6 +1892,10 @@ class IngestionWorker:
             extraction_methods.setdefault("motion_type", "skipped_bad_split_fragment")
         if enrichment_fields_missing:
             enrichment_result, enrich_status = self._llm_enrich_fields(ruling_text, document_id)
+            # Capture the strict-retry side-channel state immediately after
+            # the call so it isn't reset by any future _llm_enrich_fields
+            # invocation in this same process_event flow (#3991).
+            strict_retry_fields = set(self._strict_retry_fields_for_last_call)
             (
                 outcome,
                 motion_type,
@@ -1765,6 +1909,7 @@ class IngestionWorker:
                 motion_type=motion_type,
                 case_title=case_title,
                 parties_data=parties_data,
+                strict_retry_fields=strict_retry_fields,
             )
             extraction_methods.update(enrichment_methods)
             if enrich_status == "errored":

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -7296,3 +7296,385 @@ def test_multimodal_case_number_miss_telemetry_db_error_swallowed() -> None:
     assert any(
         "ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql
     ), "Inner except must execute ROLLBACK TO SAVEPOINT when INSERT raises (#3729)."
+
+
+# ---------------------------------------------------------------------------
+# Strict-retry second pass for null-outcome / null-motion_type rulings (#3991)
+# ---------------------------------------------------------------------------
+#
+# When the first ``enrich_ruling_with_retry`` call leaves outcome and / or
+# motion_type null on substantive ruling text, the worker invokes
+# ``enrich_ruling_strict_retry`` for one decisive second pass.  Fields that
+# come back from the strict retry are tagged with the new
+# ``llm_enrichment_strict_retry`` diagnostic marker so post-deploy queries
+# can measure how often the retry was the deciding pass.
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_calls_strict_retry_when_first_pass_empty(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """When the first pass returns empty, the strict retry runs and fills outcome (#3991)."""
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    # First pass returns all-None — wrapper surfaces this as None.
+    mock_enrich_ruling.return_value = LlmEnrichmentResult()
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    # Patch the strict-retry function imported inside _llm_enrich_fields.
+    strict_retry_result = LlmEnrichmentResult(outcome="continued")
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+        return_value=strict_retry_result,
+    ) as mock_strict:
+        # Substantive text — long enough to clear the strict-retry length gate.
+        result, status = worker._llm_enrich_fields(
+            "Plaintiff to give notice. Before the Court is a Demurrer by defendant. "
+            "The Court will CONTINUE the hearing as set forth herein. "
+            "The matter is continued to a future date.",
+            "doc-strict-1",
+        )
+
+    assert result is not None
+    assert result.outcome == "continued"
+    assert status == "ok"
+    mock_strict.assert_called_once()
+    # The strict retry should have been called with missing_outcome=True.
+    call_kwargs = mock_strict.call_args.kwargs
+    assert call_kwargs.get("missing_outcome") is True
+    # And the worker should have recorded which fields the strict retry filled.
+    assert worker._strict_retry_fields_for_last_call == {"outcome"}
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_calls_strict_retry_when_outcome_missing_only(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """First pass returns case_title but not outcome — strict retry fills outcome (#3991)."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    # First pass got case_title and parties but not outcome / motion_type.
+    mock_enrich_ruling.return_value = LlmEnrichmentResult(
+        case_title="Smith v. Jones",
+        motion_type=None,
+        outcome=None,
+        parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+    )
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    strict_retry_result = LlmEnrichmentResult(outcome="granted", motion_type="demurrer")
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+        return_value=strict_retry_result,
+    ) as mock_strict:
+        result, status = worker._llm_enrich_fields(
+            "The demurrer to the second amended complaint is sustained without leave to amend. "
+            "The Court finds the complaint fails to state a claim upon which relief can be granted "
+            "as alleged.",
+            "doc-strict-2",
+        )
+
+    assert result is not None
+    # Original fields preserved.
+    assert result.case_title == "Smith v. Jones"
+    # Strict-retry fields merged in.
+    assert result.outcome == "granted"
+    assert result.motion_type == "demurrer"
+    assert status == "ok"
+    mock_strict.assert_called_once()
+    call_kwargs = mock_strict.call_args.kwargs
+    assert call_kwargs.get("missing_outcome") is True
+    assert call_kwargs.get("missing_motion_type") is True
+    assert worker._strict_retry_fields_for_last_call == {"outcome", "motion_type"}
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_skips_strict_retry_when_text_too_short(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """Strict retry is skipped when ruling_text.strip() is < 100 chars (#3991)."""
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    mock_enrich_ruling.return_value = LlmEnrichmentResult()
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+    ) as mock_strict:
+        # Short text — under 100 chars.
+        result, status = worker._llm_enrich_fields("Short.", "doc-strict-3")
+
+    assert result is None
+    assert status == "empty"
+    mock_strict.assert_not_called()
+    assert worker._strict_retry_fields_for_last_call == set()
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_skips_strict_retry_when_first_pass_succeeded_fully(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """Strict retry is skipped when first pass populated outcome AND motion_type (#3991)."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    mock_enrich_ruling.return_value = LlmEnrichmentResult(
+        case_title="Smith v. Jones",
+        motion_type="msj",
+        outcome="granted",
+        parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+    )
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+    ) as mock_strict:
+        result, status = worker._llm_enrich_fields(
+            "Defendant's motion for summary judgment is GRANTED. "
+            "Plaintiff fails to raise a triable issue of material fact regarding the "
+            "negligence claim alleged in the first cause of action.",
+            "doc-strict-4",
+        )
+
+    assert result is not None
+    assert result.outcome == "granted"
+    assert result.motion_type == "msj"
+    assert status == "ok"
+    mock_strict.assert_not_called()
+    assert worker._strict_retry_fields_for_last_call == set()
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_strict_retry_returns_none_does_not_crash(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """If the strict-retry LLM call fails (returns None), worker continues gracefully (#3991)."""
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    mock_enrich_ruling.return_value = LlmEnrichmentResult()
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+        return_value=None,
+    ):
+        result, status = worker._llm_enrich_fields(
+            "Substantive ruling text that exceeds the 100-char gate so the strict retry runs. "
+            "The motion is something but the LLM is being non-committal again.",
+            "doc-strict-5",
+        )
+
+    # First pass was empty, strict retry returned None — overall result is still None / empty.
+    assert result is None
+    assert status == "empty"
+    assert worker._strict_retry_fields_for_last_call == set()
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_strict_retry_partial_outcome_only(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """Strict retry returns only outcome — motion_type stays null (#3991)."""
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    mock_enrich_ruling.return_value = LlmEnrichmentResult()
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    strict_retry_result = LlmEnrichmentResult(outcome="continued", motion_type=None)
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+        return_value=strict_retry_result,
+    ):
+        result, status = worker._llm_enrich_fields(
+            "Substantive ruling text that exceeds the 100-char gate so the strict retry runs. "
+            "The hearing is continued to next month.",
+            "doc-strict-6",
+        )
+
+    assert result is not None
+    assert result.outcome == "continued"
+    assert result.motion_type is None
+    assert status == "ok"
+    # Only outcome was filled by the strict retry.
+    assert worker._strict_retry_fields_for_last_call == {"outcome"}
+
+
+def test_apply_enrichment_result_tags_strict_retry_fields_with_strict_retry_marker() -> None:
+    """When fields came from strict retry, methods dict uses llm_enrichment_strict_retry (#3991)."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+    from ingestion.worker import IngestionWorker
+
+    # The enrichment result has outcome + motion_type populated, but those came
+    # from the strict retry pass — so they should carry the new diagnostic tag.
+    enrichment = LlmEnrichmentResult(
+        case_title="Smith v. Jones",  # came from first pass
+        motion_type="demurrer",  # came from strict retry
+        outcome="granted",  # came from strict retry
+        parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),  # first pass
+    )
+
+    _, _, _, _, methods = IngestionWorker._apply_enrichment_result(
+        enrichment,
+        status_tag="ok",
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        parties_data=[],
+        strict_retry_fields={"outcome", "motion_type"},
+    )
+
+    # outcome and motion_type came from strict retry — new diagnostic tag.
+    assert methods["outcome"] == "llm_enrichment_strict_retry"
+    assert methods["motion_type"] == "llm_enrichment_strict_retry"
+    # case_title and parties came from the first-pass enrichment — original tag.
+    assert methods["case_title"] == "llm_enrichment"
+    assert methods["parties"] == "llm_enrichment"
+
+
+def test_apply_enrichment_result_strict_retry_fields_default_none_unchanged_behavior() -> None:
+    """When strict_retry_fields is None / omitted, behavior matches pre-#3991 (no new tags)."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+    from ingestion.worker import IngestionWorker
+
+    enrichment = LlmEnrichmentResult(
+        case_title="Smith v. Jones",
+        motion_type="msj",
+        outcome="granted",
+        parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+    )
+
+    _, _, _, _, methods = IngestionWorker._apply_enrichment_result(
+        enrichment,
+        status_tag="ok",
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        parties_data=[],
+        # strict_retry_fields not passed — defaults to None.
+    )
+
+    # Default behavior: every field gets the original llm_enrichment tag.
+    assert methods["outcome"] == "llm_enrichment"
+    assert methods["motion_type"] == "llm_enrichment"
+    assert methods["case_title"] == "llm_enrichment"
+    assert methods["parties"] == "llm_enrichment"
+
+
+def test_apply_enrichment_result_strict_retry_fields_empty_set_unchanged_behavior() -> None:
+    """An empty strict_retry_fields set behaves the same as None — no new tags."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+    from ingestion.worker import IngestionWorker
+
+    enrichment = LlmEnrichmentResult(
+        case_title="Smith v. Jones",
+        motion_type="msj",
+        outcome="granted",
+        parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+    )
+
+    _, _, _, _, methods = IngestionWorker._apply_enrichment_result(
+        enrichment,
+        status_tag="ok",
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        parties_data=[],
+        strict_retry_fields=set(),
+    )
+
+    assert methods["outcome"] == "llm_enrichment"
+    assert methods["motion_type"] == "llm_enrichment"
+
+
+def test_apply_enrichment_result_strict_retry_only_outcome_field_tagged() -> None:
+    """Only fields named in strict_retry_fields get the new tag — others stay llm_enrichment."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+    from ingestion.worker import IngestionWorker
+
+    enrichment = LlmEnrichmentResult(
+        case_title="Smith v. Jones",
+        motion_type="msj",  # came from first pass
+        outcome="continued",  # came from strict retry
+        parties=EnrichmentParties(plaintiffs=["Smith"], defendants=["Jones"]),
+    )
+
+    _, _, _, _, methods = IngestionWorker._apply_enrichment_result(
+        enrichment,
+        status_tag="ok",
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        parties_data=[],
+        strict_retry_fields={"outcome"},
+    )
+
+    assert methods["outcome"] == "llm_enrichment_strict_retry"
+    assert methods["motion_type"] == "llm_enrichment"
+    assert methods["case_title"] == "llm_enrichment"
+    assert methods["parties"] == "llm_enrichment"
+
+
+def test_strict_retry_tag_constant_is_exported_from_worker() -> None:
+    """The new diagnostic marker constant exists and matches the documented value (#3991)."""
+    from ingestion.worker import _ENRICHMENT_STRICT_RETRY_TAG
+
+    assert _ENRICHMENT_STRICT_RETRY_TAG == "llm_enrichment_strict_retry"
+
+
+@patch("framework.llm_enrichment.enrich_ruling")
+def test_llm_enrich_fields_returns_empty_when_first_pass_has_data_but_strict_retry_yields_none(
+    mock_enrich_ruling: MagicMock,
+) -> None:
+    """Defensive guard: even if first pass returns a 'has data' marker but no real fields and
+    strict-retry yields None, function returns ('empty') rather than asserting on partial data.
+
+    This covers the post-merge has_data check at worker.py — the path where the first pass
+    returned an empty result object (rare in practice, but the assertion guards correctness).
+    """
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    # Workaround for the upstream contract: enrich_ruling_with_retry returns
+    # None when result has no data — which means we'd need to construct a
+    # ruling_text that's substantive (>= 100 chars) and where both passes
+    # come back with no fields.  Easiest path: mock both layers.
+    mock_enrich_ruling.return_value = LlmEnrichmentResult()  # all-None first pass
+
+    worker, _ = _make_worker()
+    worker._llm_enrichment_enabled = True
+    worker._enrichment_client = MagicMock()
+
+    # Strict retry returns LlmEnrichmentResult with all-None — possible if the
+    # second pass LLM also remained non-committal AND neither field gets merged
+    # (because both strict_result.outcome and strict_result.motion_type are None).
+    strict_result = LlmEnrichmentResult()
+    with patch(
+        "framework.llm_enrichment.enrich_ruling_strict_retry",
+        return_value=strict_result,
+    ):
+        result, status = worker._llm_enrich_fields(
+            "Substantive ruling text exceeding the 100-char gate so the strict retry runs. "
+            "Both LLM passes are non-committal and return no fields whatsoever.",
+            "doc-strict-no-data",
+        )
+
+    # Both passes left every field None — function reports empty.
+    assert result is None
+    assert status == "empty"
+    assert worker._strict_retry_fields_for_last_call == set()

--- a/packages/scraper-framework/tests/test_llm_enrichment.py
+++ b/packages/scraper-framework/tests/test_llm_enrichment.py
@@ -25,6 +25,7 @@ from framework.llm_enrichment import (
     OutcomeType,
     _parse_response,
     enrich_ruling,
+    enrich_ruling_strict_retry,
 )
 
 # ---------------------------------------------------------------------------
@@ -542,3 +543,214 @@ class TestPromptContent:
         """Prompt should note that sustained demurrer = granted, overruled = denied."""
         assert "sustained" in ENRICHMENT_SYSTEM_PROMPT.lower()
         assert "overruled" in ENRICHMENT_SYSTEM_PROMPT.lower()
+
+    def test_prompt_includes_relaxed_null_policy(self) -> None:
+        """Prompt should explicitly limit null returns to fragmentary text (#3991)."""
+        # The phrase doesn't have to be verbatim, but the intent must show up:
+        # null is reserved for empty / fragmentary text, not "uncertain".
+        text = ENRICHMENT_SYSTEM_PROMPT.lower()
+        assert "null" in text
+        # At least one of these decisive-classification cues must appear.
+        assert (
+            "best-fitting" in text
+            or "best fitting" in text
+            or "do not return null" in text
+            or "rather than returning null" in text
+            or "rather than null" in text
+        ), (
+            "Prompt must instruct the LLM to prefer a taxonomy value over null "
+            "when the text describes a ruling."
+        )
+
+
+# ---------------------------------------------------------------------------
+# enrich_ruling_strict_retry — stronger second-pass enrichment for #3991
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichRulingStrictRetry:
+    """Tests for the enrich_ruling_strict_retry() function added by #3991.
+
+    The strict-retry pass is invoked by the worker AFTER the first
+    ``enrich_ruling_with_retry`` call when ``outcome`` and/or ``motion_type``
+    came back null on substantive ruling text.  The function makes ONE
+    additional LLM call with a more decisive prompt asking specifically for
+    those fields.
+    """
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_returns_outcome_when_first_pass_empty(self, mock_call_llm: MagicMock) -> None:
+        """Strict retry returns a result with outcome when first pass missed it."""
+        mock_call_llm.return_value = _make_llm_response(json.dumps({"outcome": "continued"}))
+
+        result = enrich_ruling_strict_retry(
+            "Plaintiff to give notice. Will CONTINUE the hearing as set forth herein.",
+            missing_outcome=True,
+            missing_motion_type=False,
+        )
+
+        assert result is not None
+        assert result.outcome == "continued"
+        mock_call_llm.assert_called_once()
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_returns_motion_type_only(self, mock_call_llm: MagicMock) -> None:
+        """Strict retry can request just motion_type and parse it out."""
+        mock_call_llm.return_value = _make_llm_response(json.dumps({"motion_type": "demurrer"}))
+
+        result = enrich_ruling_strict_retry(
+            "The demurrer to the second amended complaint is sustained without leave to amend.",
+            missing_outcome=False,
+            missing_motion_type=True,
+        )
+
+        assert result is not None
+        assert result.motion_type == "demurrer"
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_returns_both_outcome_and_motion_type(self, mock_call_llm: MagicMock) -> None:
+        """Strict retry can return both fields when both are missing."""
+        mock_call_llm.return_value = _make_llm_response(
+            json.dumps({"outcome": "granted", "motion_type": "msj"})
+        )
+
+        result = enrich_ruling_strict_retry(
+            "Defendant's motion for summary judgment is GRANTED.",
+            missing_outcome=True,
+            missing_motion_type=True,
+        )
+
+        assert result is not None
+        assert result.outcome == "granted"
+        assert result.motion_type == "msj"
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_returns_none_on_llm_api_failure(self, mock_call_llm: MagicMock) -> None:
+        """LLM API failure (None response) returns None."""
+        mock_call_llm.return_value = None
+
+        result = enrich_ruling_strict_retry(
+            "Some ruling text that's substantive.",
+            missing_outcome=True,
+            missing_motion_type=True,
+        )
+
+        assert result is None
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_handles_json_parse_failure(self, mock_call_llm: MagicMock) -> None:
+        """Malformed JSON returns LlmEnrichmentResult with all-None fields (no raise)."""
+        mock_call_llm.return_value = _make_llm_response("not json at all")
+
+        result = enrich_ruling_strict_retry(
+            "Some ruling text that's substantive.",
+            missing_outcome=True,
+            missing_motion_type=False,
+        )
+
+        # Function MUST NOT raise on JSON parse failure — it returns an empty
+        # LlmEnrichmentResult so the caller can record diagnostic markers
+        # without crashing the worker.
+        assert result is not None
+        assert result.outcome is None
+        assert result.motion_type is None
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_taxonomy_validated_on_uppercase_input(self, mock_call_llm: MagicMock) -> None:
+        """Pydantic validators normalize taxonomy values from the LLM."""
+        mock_call_llm.return_value = _make_llm_response(json.dumps({"outcome": "GRANTED"}))
+
+        result = enrich_ruling_strict_retry(
+            "The motion is GRANTED.",
+            missing_outcome=True,
+            missing_motion_type=False,
+        )
+
+        assert result is not None
+        # Lowercased to canonical taxonomy value.
+        assert result.outcome == "granted"
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_taxonomy_unknown_outcome_mapped_to_other(self, mock_call_llm: MagicMock) -> None:
+        """Unknown taxonomy values are mapped to 'other' by the validator."""
+        mock_call_llm.return_value = _make_llm_response(json.dumps({"outcome": "withdrawn"}))
+
+        result = enrich_ruling_strict_retry(
+            "Motion withdrawn by moving party.",
+            missing_outcome=True,
+            missing_motion_type=False,
+        )
+
+        assert result is not None
+        # "withdrawn" is not in OutcomeType — falls through to "other".
+        assert result.outcome == "other"
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_provider_and_model_passed_through(self, mock_call_llm: MagicMock) -> None:
+        """Provider and model kwargs reach call_llm so the same LLM is used."""
+        mock_call_llm.return_value = _make_llm_response(json.dumps({"outcome": "granted"}))
+        mock_client = MagicMock()
+
+        enrich_ruling_strict_retry(
+            "The motion is GRANTED.",
+            missing_outcome=True,
+            missing_motion_type=False,
+            provider="anthropic",
+            model="claude-haiku-4-5-20251001",
+            client=mock_client,
+        )
+
+        call_kwargs = mock_call_llm.call_args
+        assert call_kwargs.kwargs["provider"] == "anthropic"
+        assert call_kwargs.kwargs["model"] == "claude-haiku-4-5-20251001"
+        assert call_kwargs.kwargs["client"] is mock_client
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_empty_ruling_text_does_not_call_llm(self, mock_call_llm: MagicMock) -> None:
+        """Empty / whitespace text returns an empty result without an LLM call."""
+        result = enrich_ruling_strict_retry(
+            "",
+            missing_outcome=True,
+            missing_motion_type=True,
+        )
+
+        assert result is not None
+        assert result.outcome is None
+        assert result.motion_type is None
+        mock_call_llm.assert_not_called()
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_no_missing_fields_short_circuits(self, mock_call_llm: MagicMock) -> None:
+        """If neither field is flagged missing, no LLM call is made."""
+        result = enrich_ruling_strict_retry(
+            "Some substantive ruling text.",
+            missing_outcome=False,
+            missing_motion_type=False,
+        )
+
+        # No work to do — function returns an empty result and skips the LLM.
+        assert result is not None
+        assert result.outcome is None
+        assert result.motion_type is None
+        mock_call_llm.assert_not_called()
+
+    @patch("framework.llm_enrichment.call_llm")
+    def test_prompt_lists_missing_fields(self, mock_call_llm: MagicMock) -> None:
+        """The strict-retry prompt names which fields the prior pass missed."""
+        mock_call_llm.return_value = _make_llm_response(json.dumps({"outcome": "granted"}))
+
+        enrich_ruling_strict_retry(
+            "The motion is GRANTED.",
+            missing_outcome=True,
+            missing_motion_type=False,
+        )
+
+        # Inspect the system prompt that was passed.
+        args, kwargs = mock_call_llm.call_args
+        # call_llm signature: call_llm(system_prompt, user_message, ...)
+        system_prompt = args[0] if args else kwargs.get("system_prompt", "")
+        # Prompt must mention the field that was missing.
+        assert "outcome" in system_prompt.lower()
+        # And must include the outcome taxonomy so the LLM can pick.
+        assert "continued" in system_prompt.lower()
+        assert "granted" in system_prompt.lower()

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -7720,6 +7720,252 @@ class TestApplyLlmEnrichment:
         assert "motion_type" not in methods
 
 
+class TestApplyLlmEnrichmentStrictRetry:
+    """Strict-retry second pass for null outcome / motion_type rulings (#3991)."""
+
+    def _make_enrichment_result(
+        self,
+        *,
+        case_title: str | None = None,
+        motion_type: str | None = None,
+        outcome: str | None = None,
+        plaintiffs: list[str] | None = None,
+        defendants: list[str] | None = None,
+    ) -> Any:
+        from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+        return LlmEnrichmentResult(
+            case_title=case_title,
+            motion_type=motion_type,
+            outcome=outcome,
+            parties=EnrichmentParties(
+                plaintiffs=plaintiffs or [],
+                defendants=defendants or [],
+            ),
+        )
+
+    def _make_extracted(
+        self,
+        *,
+        ruling_text: str | None = (
+            "Plaintiff to give notice. The Court finds the motion supported "
+            "and well-taken. The matter is continued to a future date for "
+            "further consideration as set forth herein."
+        ),
+        outcome: str | None = None,
+        motion_type: str | None = None,
+        case_title: str | None = None,
+        parties: list | None = None,
+    ) -> dict:
+        return {
+            "ruling_text": ruling_text,
+            "case_number": "30-2024-01234567",
+            "case_title": case_title,
+            "case_type": None,
+            "judge_name": "Judge Smith",
+            "outcome": outcome,
+            "motion_type": motion_type,
+            "department": "C1",
+            "parties": parties if parties is not None else [],
+            "hearing_date": date(2026, 3, 5),
+            "extraction_methods": {"_all": "multimodal"},
+            "llm_skipped": False,
+            "llm_outcome": "multimodal_success",
+            "ruling_index": 0,
+            "split_document_id": "test-doc-id",
+            "is_split": False,
+        }
+
+    def test_strict_retry_called_when_first_pass_returns_none(self) -> None:
+        """When first pass returns None, strict retry runs and fills outcome (#3991)."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+        strict = self._make_enrichment_result(outcome="continued")
+
+        with (
+            patch.object(reingest, "enrich_ruling_with_retry", return_value=None),
+            patch.object(
+                reingest,
+                "enrich_ruling_strict_retry",
+                return_value=strict,
+            ) as mock_strict,
+        ):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-strict-1",
+            )
+
+        mock_strict.assert_called_once()
+        # Outcome was populated by the strict retry — verify the value AND
+        # the new diagnostic marker.
+        assert extracted["outcome"] == "continued"
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment_strict_retry"
+
+    def test_strict_retry_called_when_outcome_missing_only(self) -> None:
+        """First pass returns case_title, strict retry fills outcome (#3991)."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+        first = self._make_enrichment_result(
+            case_title="Smith v. Jones",
+            plaintiffs=["Smith"],
+            defendants=["Jones"],
+        )
+        strict = self._make_enrichment_result(outcome="granted", motion_type="demurrer")
+
+        with (
+            patch.object(reingest, "enrich_ruling_with_retry", return_value=first),
+            patch.object(
+                reingest,
+                "enrich_ruling_strict_retry",
+                return_value=strict,
+            ) as mock_strict,
+        ):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-strict-2",
+            )
+
+        mock_strict.assert_called_once()
+        call_kwargs = mock_strict.call_args.kwargs
+        assert call_kwargs["missing_outcome"] is True
+        assert call_kwargs["missing_motion_type"] is True
+        # Both outcome and motion_type were filled by the strict retry.
+        assert extracted["outcome"] == "granted"
+        assert extracted["motion_type"] == "demurrer"
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment_strict_retry"
+        assert methods["motion_type"] == "llm_enrichment_strict_retry"
+        # case_title was filled by the first pass — regular tag.
+        assert extracted["case_title"] == "Smith v. Jones"
+        assert methods["case_title"] == "llm_enrichment"
+
+    def test_strict_retry_skipped_when_text_too_short(self) -> None:
+        """Strict retry doesn't run on < 100-char text (#3991)."""
+        extracted = self._make_extracted(ruling_text="Short.")
+        mock_client = MagicMock()
+
+        with (
+            patch.object(reingest, "enrich_ruling_with_retry", return_value=None),
+            patch.object(
+                reingest,
+                "enrich_ruling_strict_retry",
+            ) as mock_strict,
+        ):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-strict-3",
+            )
+
+        mock_strict.assert_not_called()
+        # Empty marker is recorded since first pass returned None and strict
+        # retry was skipped.
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment_empty"
+
+    def test_strict_retry_skipped_when_first_pass_filled_both(self) -> None:
+        """Strict retry doesn't run when first pass returned outcome AND motion_type."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+        first = self._make_enrichment_result(
+            case_title="Smith v. Jones",
+            motion_type="msj",
+            outcome="granted",
+            plaintiffs=["Smith"],
+            defendants=["Jones"],
+        )
+
+        with (
+            patch.object(reingest, "enrich_ruling_with_retry", return_value=first),
+            patch.object(
+                reingest,
+                "enrich_ruling_strict_retry",
+            ) as mock_strict,
+        ):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-strict-4",
+            )
+
+        mock_strict.assert_not_called()
+        # Both fields came from the first pass — regular tag.
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment"
+        assert methods["motion_type"] == "llm_enrichment"
+
+    def test_strict_retry_returns_none_falls_back_to_empty_marker(self) -> None:
+        """If strict retry LLM call fails (None), markers fall back to empty (#3991)."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+
+        with (
+            patch.object(reingest, "enrich_ruling_with_retry", return_value=None),
+            patch.object(
+                reingest,
+                "enrich_ruling_strict_retry",
+                return_value=None,
+            ),
+        ):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-strict-5",
+            )
+
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment_empty"
+        assert methods["motion_type"] == "llm_enrichment_empty"
+
+    def test_strict_retry_partial_only_outcome_no_extraction_marker_for_motion_type(
+        self,
+    ) -> None:
+        """Strict retry returns outcome but not motion_type — motion_type still null."""
+        extracted = self._make_extracted()
+        mock_client = MagicMock()
+        strict = self._make_enrichment_result(outcome="continued", motion_type=None)
+
+        with (
+            patch.object(reingest, "enrich_ruling_with_retry", return_value=None),
+            patch.object(
+                reingest,
+                "enrich_ruling_strict_retry",
+                return_value=strict,
+            ),
+        ):
+            reingest._apply_llm_enrichment(
+                extracted,
+                llm_client=mock_client,
+                llm_provider="google",
+                llm_model=None,
+                document_id="doc-strict-6",
+            )
+
+        # outcome filled by strict retry.
+        assert extracted["outcome"] == "continued"
+        # motion_type still None in extracted.
+        assert extracted.get("motion_type") is None
+        methods = extracted["extraction_methods"]
+        assert methods["outcome"] == "llm_enrichment_strict_retry"
+        # motion_type field went through the merge but neither pass produced
+        # a value — since the merged result HAS data (outcome non-null), the
+        # script's no-extraction marker fires for motion_type.
+        assert methods["motion_type"] == "llm_enrichment_no_extraction"
+
+
 class TestReparseMultimodalCallsEnrichment:
     """Integration: ``_reparse_document_multimodal`` wires enrichment in (#2406)."""
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -172,7 +172,12 @@ import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
 from framework.extraction_config import get_county_extraction_config  # noqa: E402
-from framework.llm_enrichment import LlmEnrichmentExhaustedError, enrich_ruling_with_retry  # noqa: E402
+from framework.llm_enrichment import (  # noqa: E402
+    LlmEnrichmentExhaustedError,
+    LlmEnrichmentResult,
+    enrich_ruling_strict_retry,
+    enrich_ruling_with_retry,
+)
 from framework.llm_extractor import LlmExtractor  # noqa: E402
 from framework.llm_schema import ExtractedRuling  # noqa: E402
 from framework.logging import configure_structlog  # noqa: E402
@@ -1434,6 +1439,12 @@ def _full_reparse_document(
     return results
 
 
+# Minimum stripped length of ruling_text before the strict-retry second
+# pass will run.  Mirrors ``ingestion.worker._STRICT_RETRY_MIN_TEXT_LEN``
+# (#3991) — keep both values in sync.
+_STRICT_RETRY_MIN_TEXT_LEN = 100
+
+
 def _apply_llm_enrichment(
     extracted: dict,
     *,
@@ -1499,9 +1510,13 @@ def _apply_llm_enrichment(
         if not extracted.get("outcome"):
             extraction_methods.setdefault("outcome", "llm_enrichment_skipped_no_text")
         if not extracted.get("motion_type"):
-            extraction_methods.setdefault("motion_type", "llm_enrichment_skipped_no_text")
+            extraction_methods.setdefault(
+                "motion_type", "llm_enrichment_skipped_no_text"
+            )
         if not extracted.get("case_title"):
-            extraction_methods.setdefault("case_title", "llm_enrichment_skipped_no_text")
+            extraction_methods.setdefault(
+                "case_title", "llm_enrichment_skipped_no_text"
+            )
         if not extracted.get("parties"):
             extraction_methods.setdefault("parties", "llm_enrichment_skipped_no_text")
         return
@@ -1540,9 +1555,62 @@ def _apply_llm_enrichment(
             extraction_methods.setdefault("parties", "llm_enrichment_errored")
         raise
 
+    # Strict-retry second pass (#3991): when the first pass leaves outcome
+    # and / or motion_type null on substantive ruling text, fire one more
+    # decisive LLM call asking specifically for the missing fields.  Mirrors
+    # ``ingestion.worker._llm_enrich_fields``.  ``strict_retry_fields``
+    # tracks which fields were filled by the strict retry so the diagnostic
+    # marker can be set correctly downstream.
+    strict_retry_fields: set[str] = set()
     if result is None:
-        # LLM responded but extracted nothing (all-None fields).  Not a
-        # transient failure — record diagnostic markers and return.
+        first_missing_outcome = True
+        first_missing_motion_type = True
+    else:
+        first_missing_outcome = result.outcome is None and not has_outcome
+        first_missing_motion_type = result.motion_type is None and not has_motion_type
+
+    text_long_enough = len(ruling_text.strip()) >= _STRICT_RETRY_MIN_TEXT_LEN
+    should_strict_retry = (
+        first_missing_outcome or first_missing_motion_type
+    ) and text_long_enough
+
+    if should_strict_retry:
+        strict_result = enrich_ruling_strict_retry(
+            ruling_text,
+            missing_outcome=first_missing_outcome,
+            missing_motion_type=first_missing_motion_type,
+            provider=llm_provider or "google",
+            model=llm_model,
+            client=llm_client,
+        )
+        if strict_result is not None:
+            if result is None:
+                result = LlmEnrichmentResult()
+            if first_missing_outcome and strict_result.outcome is not None:
+                result = result.model_copy(update={"outcome": strict_result.outcome})
+                strict_retry_fields.add("outcome")
+            if first_missing_motion_type and strict_result.motion_type is not None:
+                result = result.model_copy(
+                    update={"motion_type": strict_result.motion_type}
+                )
+                strict_retry_fields.add("motion_type")
+            logger.info(
+                "LLM enrichment strict retry completed",
+                document_id=document_id,
+                fields_populated=sorted(strict_retry_fields),
+                missing_outcome=first_missing_outcome,
+                missing_motion_type=first_missing_motion_type,
+            )
+        else:
+            logger.warning(
+                "LLM enrichment strict retry returned None — continuing with first-pass result",
+                document_id=document_id,
+            )
+
+    if result is None:
+        # LLM responded but extracted nothing (all-None fields), and the
+        # strict-retry pass either was skipped (text too short) or also
+        # returned nothing.  Record diagnostic markers and return.
         logger.info(
             "LLM enrichment returned empty result — no fields populated",
             document_id=document_id,
@@ -1559,14 +1627,22 @@ def _apply_llm_enrichment(
 
     if not has_outcome and result.outcome is not None:
         extracted["outcome"] = result.outcome
-        extraction_methods["outcome"] = "llm_enrichment"
+        extraction_methods["outcome"] = (
+            "llm_enrichment_strict_retry"
+            if "outcome" in strict_retry_fields
+            else "llm_enrichment"
+        )
     elif not has_outcome:
         # Enrichment ran successfully but did not return this field.
         extraction_methods.setdefault("outcome", "llm_enrichment_no_extraction")
 
     if not has_motion_type and result.motion_type is not None:
         extracted["motion_type"] = result.motion_type
-        extraction_methods["motion_type"] = "llm_enrichment"
+        extraction_methods["motion_type"] = (
+            "llm_enrichment_strict_retry"
+            if "motion_type" in strict_retry_fields
+            else "llm_enrichment"
+        )
     elif not has_motion_type:
         extraction_methods.setdefault("motion_type", "llm_enrichment_no_extraction")
 


### PR DESCRIPTION
## Summary

Adds a strict-retry second pass to the LLM enrichment pipeline so substantive Orange (and other CA county) rulings stop landing with null `outcome` and `motion_type`. Targets the dominant failure modes from #3992's marker breakdown — `llm_enrichment_empty` (70% of `outcome` failures) and `llm_enrichment_no_extraction` (65% of `motion_type` failures) — without touching the retry budget (errored = 0). The strict retry is one decisive call with a relaxed-null-policy prompt; populated fields carry a new `llm_enrichment_strict_retry` diagnostic marker for post-deploy measurement.

Closes #3991

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] After dev deploy, run targeted reingest of the 13 PDFs in #3991's body via `scripts/reingest_from_s3.py` and check a representative sample for non-null `outcome` (AC3).
- [ ] Run the AC2 query on dev DB and confirm Orange last-7d `outcome IS NULL AND length(ruling_text) > 200` count drops below the pre-fix baseline of 690 rulings / 238 PDFs.
- [ ] Spot-check a CloudWatch query against `/ecs/judgemind-ingestion-worker-dev` for the new `llm_enrichment_strict_retry` marker to confirm the retry path is firing and resolving fields.
- [ ] Verification evidence posted on issue (see A.8).
