### PR TITLE
fix(scraping): label slash and month-name date branches in _parse_header_date (#3601)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -4192,19 +4192,54 @@ def _append_ruling_from_case(
 def _parse_header_date(info: str) -> str | None:
     """Extract a hearing date from a page-header string, returning ISO YYYY-MM-DD.
 
-    Tries three patterns in priority order so that the existing ISO path
-    wins over ambiguous slash or month-name matches (#3559):
+    Tries patterns in priority order so labeled dates always beat bare dates,
+    preventing dual-date headers like ``Filed 1/15/2024 — Hearing Date 3/16/2026``
+    from selecting the filed date instead of the hearing date (#3601). The
+    bare-format fallbacks remain so OC multimodal headers like ``March 16, 2026``
+    on a line by themselves continue to parse (#3559):
 
-    1. ``Hearing Date: YYYY-MM-DD`` — explicit ISO label (existing behaviour).
-    2. Month-name: ``March 16, 2026`` — common in OC multimodal PDFs.
-    3. Slash: ``3/16/2026`` or ``03/16/2026`` — alternate courts.
+    1. Labeled ISO: ``Hearing Date: 2026-03-16`` — highest priority.
+    2. Labeled slash: ``Hearing Date: 3/16/2026`` — beats any bare slash earlier in the header.
+    3. Labeled month-name: ``Hearing Date: March 16, 2026`` — beats any bare month-name earlier.
+    4. Bare month-name: ``March 16, 2026`` — fallback for OC multimodal PDFs (#3559).
+    5. Bare slash: ``3/16/2026`` or ``03/16/2026`` — fallback for alternate courts.
+
+    The label alternation covers the known set: "Hearing Date", "Calendar Date",
+    "Date". Filed/effective/recording stamps are not in this set, so a header that
+    contains both a stamp and a labeled hearing date will pick the hearing date.
     """
-    # 1. Existing ISO path — must remain the highest-priority match.
-    m = re.search(r"Hearing Date:\s*(\d{4}-\d{2}-\d{2})", info)
+    # Common label prefix used by branches 1-3 below. Allow optional ":" plus
+    # whitespace so headers that omit the colon (e.g. "Hearing Date 3/16/2026")
+    # still match. Matches case-insensitively.
+    label_prefix = r"(?:Hearing Date|Calendar Date|Date)[:\s]+"
+
+    # 1. Labeled ISO path — must remain the highest-priority match.
+    m = re.search(label_prefix + r"(\d{4}-\d{2}-\d{2})", info, re.IGNORECASE)
     if m:
         return m.group(1)
 
-    # 2. Month-name format, e.g. "March 16, 2026".
+    # 2. Labeled slash format, e.g. "Hearing Date: 3/16/2026".
+    m = re.search(label_prefix + r"(\d{1,2}/\d{1,2}/\d{4})", info, re.IGNORECASE)
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%m/%d/%Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 3. Labeled month-name format, e.g. "Hearing Date: March 16, 2026".
+    m = re.search(
+        label_prefix + r"((?:January|February|March|April|May|June|July|August|September|"
+        r"October|November|December)\s+\d{1,2},\s*\d{4})",
+        info,
+        re.IGNORECASE,
+    )
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%B %d, %Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 4. Bare month-name format, e.g. "March 16, 2026" — fallback for OC PDFs.
     m = re.search(
         r"\b((?:January|February|March|April|May|June|July|August|September|"
         r"October|November|December)\s+\d{1,2},\s*\d{4})\b",
@@ -4216,7 +4251,7 @@ def _parse_header_date(info: str) -> str | None:
         except ValueError:
             pass
 
-    # 3. Slash format, e.g. "3/16/2026" or "03/16/2026".
+    # 5. Bare slash format, e.g. "3/16/2026" or "03/16/2026".
     m = re.search(r"\b(\d{1,2}/\d{1,2}/\d{4})\b", info)
     if m:
         try:

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1111,6 +1111,46 @@ class TestJoinPageRows:
         """
         assert _parse_header_date("13/05/2026") is None
 
+    def test_parse_header_date_labeled_slash_beats_bare_filed_stamp(self) -> None:
+        """Labeled slash date wins over a bare slash date earlier in the header (#3601).
+
+        Headers like "Filed 1/15/2024 — Hearing Date 3/16/2026" must return the
+        labeled hearing date, not the unlabeled filed-date stamp.
+        """
+        header = "Filed 1/15/2024 — Hearing Date 3/16/2026"
+        assert _parse_header_date(header) == "2026-03-16"
+
+    def test_parse_header_date_labeled_month_name_beats_bare_filed_stamp(self) -> None:
+        """Labeled month-name date wins over a bare month-name earlier in the header (#3601).
+
+        Headers like "Filed January 15, 2024 — Hearing Date March 16, 2026" must
+        return the labeled hearing date, not the unlabeled filed-date stamp.
+        """
+        header = "Filed January 15, 2024 — Hearing Date March 16, 2026"
+        assert _parse_header_date(header) == "2026-03-16"
+
+    def test_parse_header_date_labeled_slash_no_colon(self) -> None:
+        """Labeled slash format works without an explicit colon (#3601).
+
+        Real-world OC headers sometimes render the label as "Hearing Date"
+        followed by whitespace and the date, with no colon between them.
+        """
+        assert _parse_header_date("Hearing Date 3/16/2026") == "2026-03-16"
+
+    def test_parse_header_date_calendar_date_label(self) -> None:
+        """The "Calendar Date" label is also recognized (#3601)."""
+        assert _parse_header_date("Calendar Date: 3/16/2026") == "2026-03-16"
+
+    def test_parse_header_date_labeled_iso_still_wins_over_bare_slash(self) -> None:
+        """A labeled ISO date beats any earlier bare slash date in the header (#3601).
+
+        The ISO branch was already labeled (#3559), but in a dual-format header
+        like "Filed 1/15/2024 — Hearing Date: 2026-03-16" the labeled ISO must
+        still win — confirming the priority ordering is correct.
+        """
+        header = "Filed 1/15/2024 — Hearing Date: 2026-03-16"
+        assert _parse_header_date(header) == "2026-03-16"
+
     def test_metadata_fallback_judge_via_permissive_scan(self) -> None:
         """Permissive second pass picks up judge name from a non-header row (#3722).
 


### PR DESCRIPTION
## Summary

Fixed `_parse_header_date()` so labeled hearing-date patterns (ISO, slash, month-name) always beat bare dates. Headers like `Filed 1/15/2024 — Hearing Date 3/16/2026` now return `2026-03-16` instead of incorrectly returning `2024-01-15`. Bare-format fallbacks remain so OC multimodal headers (#3559) continue to parse.

Closes #3601

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (internal scraper-framework parser fix; verified by 5 new regression tests + 7179 existing tests passing)
