### PR TITLE
fix(ingestion): thread --bust-llm-cache through reingest prefix mode (#4049)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -677,6 +677,7 @@ class IngestionWorker:
         llm_provider: str | None = None,
         llm_model: str | None = None,
         llm_timeout: float | None = 60.0,
+        bust_llm_cache: bool = False,
     ) -> None:
         self._redis = redis_client
         self._pg_dsn = pg_dsn
@@ -684,6 +685,18 @@ class IngestionWorker:
         self._conn: psycopg.Connection | None = None
         self._s3_client = s3_client
         self._archive_bucket = archive_bucket
+        # When True, every LlmExtractor this worker constructs (multimodal +
+        # framework) is created with ``bust_cache=True``, so cache reads are
+        # skipped on every extraction call.  Cache *writes* still happen, so
+        # subsequent runs without the flag benefit from the fresh extraction.
+        # This is required by the ``reingest_from_s3.py --prefix
+        # --bust-llm-cache`` re-extract path (#4049): split-child documents
+        # cannot be re-extracted via DB-row mode (the ``is_split_child_id``
+        # guard correctly skips them to prevent the #2416 exponential
+        # explosion), so the only path to replay a fresh extraction onto an
+        # already-split parent PDF is the prefix-mode worker re-running over
+        # the parent S3 key with cache reads disabled.
+        self._bust_llm_cache: bool = bust_llm_cache
         self._indexer = IndexingConsumer(
             opensearch_client=opensearch_client,
             s3_client=s3_client,
@@ -835,8 +848,16 @@ class IngestionWorker:
         """
         if self._framework_extractor is None:
             try:
-                self._framework_extractor = LlmExtractor()
-                logger.info("Initialized framework LlmExtractor for LLM extraction path")
+                # ``bust_cache=self._bust_llm_cache`` propagates the worker's
+                # cache-bust intent into every extraction call this instance
+                # makes (#4049).
+                self._framework_extractor = LlmExtractor(
+                    bust_cache=self._bust_llm_cache,
+                )
+                logger.info(
+                    "Initialized framework LlmExtractor for LLM extraction path",
+                    extra={"bust_cache": self._bust_llm_cache},
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to initialize LlmExtractor — LLM extraction path unavailable: %s",
@@ -882,11 +903,18 @@ class IngestionWorker:
             # No county-specific token limit — use the legacy single-slot
             # cache, created with the LlmExtractor default of 4,096 tokens.
             try:
+                # ``bust_cache=self._bust_llm_cache`` propagates the worker's
+                # cache-bust intent into every multimodal extraction call
+                # (#4049).
                 self._multimodal_extractor = LlmExtractor(
                     provider="google",
                     model="gemini-2.5-flash-lite",
+                    bust_cache=self._bust_llm_cache,
                 )
-                logger.info("Initialized multimodal LlmExtractor (Google Flash Lite)")
+                logger.info(
+                    "Initialized multimodal LlmExtractor (Google Flash Lite)",
+                    extra={"bust_cache": self._bust_llm_cache},
+                )
             except Exception as exc:
                 logger.warning(
                     "Failed to initialize multimodal LlmExtractor — PDF extraction unavailable: %s",
@@ -898,15 +926,22 @@ class IngestionWorker:
         cache_key = max_output_tokens
         if cache_key not in self._multimodal_extractors:
             try:
+                # ``bust_cache=self._bust_llm_cache`` propagates the worker's
+                # cache-bust intent into every multimodal extraction call
+                # (#4049).
                 extractor = LlmExtractor(
                     provider="google",
                     model="gemini-2.5-flash-lite",
                     max_output_tokens=max_output_tokens,
+                    bust_cache=self._bust_llm_cache,
                 )
                 self._multimodal_extractors[cache_key] = extractor
                 logger.info(
                     "Initialized multimodal LlmExtractor (Google Flash Lite)",
-                    extra={"max_output_tokens": max_output_tokens},
+                    extra={
+                        "max_output_tokens": max_output_tokens,
+                        "bust_cache": self._bust_llm_cache,
+                    },
                 )
             except Exception as exc:
                 logger.warning(

--- a/packages/scraper-framework/tests/test_ingestion_worker_bust_cache.py
+++ b/packages/scraper-framework/tests/test_ingestion_worker_bust_cache.py
@@ -1,0 +1,158 @@
+"""Tests for IngestionWorker ``bust_llm_cache`` propagation (#4049).
+
+When the worker is constructed with ``bust_llm_cache=True``, every
+``LlmExtractor`` it lazy-creates (multimodal + framework) must be created
+with ``bust_cache=True`` so cache reads are skipped on every extraction
+call.  This is the only path through which already-split parent PDFs (whose
+split-child rows live in ``derived.documents``) can be re-extracted with a
+fresh LLM call — DB-row mode (``--multimodal --bust-llm-cache``) skips
+split-child rows via the ``is_split_child_id`` guard to avoid the #2416
+exponential explosion, leaving prefix-mode the sole avenue once a parent
+has been split.
+
+Tests use ``unittest.mock.patch`` to replace ``LlmExtractor`` at the
+worker module's import site so no Google API key is required and no real
+extractor is instantiated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ingestion.worker import IngestionWorker
+
+
+def _make_worker(*, bust_llm_cache: bool = False) -> IngestionWorker:
+    """Construct an IngestionWorker with mocked external clients.
+
+    Mirrors the helper in ``test_ingestion_worker.py`` but does NOT stub
+    out ``_get_framework_extractor`` — these tests need to exercise the
+    real lazy-init code path.
+    """
+    redis_mock = MagicMock()
+    os_mock = MagicMock()
+    s3_mock = MagicMock()
+    os_mock.indices.exists.return_value = False
+
+    return IngestionWorker(
+        redis_client=redis_mock,
+        pg_dsn="postgresql://localhost/test",
+        opensearch_client=os_mock,
+        s3_client=s3_mock,
+        archive_bucket="test-bucket",
+        bust_llm_cache=bust_llm_cache,
+    )
+
+
+class TestBustLlmCacheStorage:
+    """The constructor must record ``bust_llm_cache`` for later use."""
+
+    def test_default_is_false(self) -> None:
+        worker = _make_worker()
+        assert worker._bust_llm_cache is False
+
+    def test_explicit_true_is_stored(self) -> None:
+        worker = _make_worker(bust_llm_cache=True)
+        assert worker._bust_llm_cache is True
+
+    def test_explicit_false_is_stored(self) -> None:
+        worker = _make_worker(bust_llm_cache=False)
+        assert worker._bust_llm_cache is False
+
+
+class TestMultimodalExtractorBustCachePropagation:
+    """``_get_multimodal_extractor`` must construct LlmExtractor with
+    ``bust_cache=self._bust_llm_cache`` in both legacy and per-token-limit
+    code paths."""
+
+    def test_per_token_limit_path_propagates_true(self) -> None:
+        worker = _make_worker(bust_llm_cache=True)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            mock_extractor_cls.return_value = MagicMock()
+            worker._get_multimodal_extractor(max_output_tokens=32768)
+        mock_extractor_cls.assert_called_once()
+        kwargs = mock_extractor_cls.call_args.kwargs
+        assert kwargs.get("bust_cache") is True
+        assert kwargs.get("provider") == "google"
+        assert kwargs.get("model") == "gemini-2.5-flash-lite"
+        assert kwargs.get("max_output_tokens") == 32768
+
+    def test_per_token_limit_path_propagates_false(self) -> None:
+        worker = _make_worker(bust_llm_cache=False)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            mock_extractor_cls.return_value = MagicMock()
+            worker._get_multimodal_extractor(max_output_tokens=32768)
+        mock_extractor_cls.assert_called_once()
+        kwargs = mock_extractor_cls.call_args.kwargs
+        assert kwargs.get("bust_cache") is False
+
+    def test_legacy_single_slot_path_propagates_true(self) -> None:
+        """The ``max_output_tokens=None`` branch (legacy single-slot cache)
+        must also propagate ``bust_cache``."""
+        worker = _make_worker(bust_llm_cache=True)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            mock_extractor_cls.return_value = MagicMock()
+            worker._get_multimodal_extractor()  # max_output_tokens=None
+        mock_extractor_cls.assert_called_once()
+        kwargs = mock_extractor_cls.call_args.kwargs
+        assert kwargs.get("bust_cache") is True
+        assert kwargs.get("provider") == "google"
+        assert kwargs.get("model") == "gemini-2.5-flash-lite"
+
+    def test_legacy_single_slot_path_propagates_false(self) -> None:
+        worker = _make_worker(bust_llm_cache=False)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            mock_extractor_cls.return_value = MagicMock()
+            worker._get_multimodal_extractor()
+        mock_extractor_cls.assert_called_once()
+        kwargs = mock_extractor_cls.call_args.kwargs
+        assert kwargs.get("bust_cache") is False
+
+    def test_per_token_limit_cache_stable_across_calls(self) -> None:
+        """The per-token-limit cache must reuse the same instance on the
+        second call — only the first call constructs the LlmExtractor.
+        ``bust_cache`` is captured at construction time."""
+        worker = _make_worker(bust_llm_cache=True)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            instance = MagicMock()
+            mock_extractor_cls.return_value = instance
+            first = worker._get_multimodal_extractor(max_output_tokens=32768)
+            second = worker._get_multimodal_extractor(max_output_tokens=32768)
+        assert first is second
+        assert mock_extractor_cls.call_count == 1
+
+
+class TestFrameworkExtractorBustCachePropagation:
+    """``_get_framework_extractor`` must construct LlmExtractor with
+    ``bust_cache=self._bust_llm_cache``."""
+
+    def test_propagates_true(self) -> None:
+        worker = _make_worker(bust_llm_cache=True)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            mock_extractor_cls.return_value = MagicMock()
+            worker._get_framework_extractor()
+        mock_extractor_cls.assert_called_once()
+        kwargs = mock_extractor_cls.call_args.kwargs
+        assert kwargs.get("bust_cache") is True
+
+    def test_propagates_false(self) -> None:
+        worker = _make_worker(bust_llm_cache=False)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            mock_extractor_cls.return_value = MagicMock()
+            worker._get_framework_extractor()
+        mock_extractor_cls.assert_called_once()
+        kwargs = mock_extractor_cls.call_args.kwargs
+        assert kwargs.get("bust_cache") is False
+
+    def test_lazy_init_caches_instance(self) -> None:
+        """The framework extractor is lazy-init'd once and reused.  A
+        second ``_get_framework_extractor`` call must return the same
+        instance without reconstructing."""
+        worker = _make_worker(bust_llm_cache=True)
+        with patch("ingestion.worker.LlmExtractor") as mock_extractor_cls:
+            instance = MagicMock()
+            mock_extractor_cls.return_value = instance
+            first = worker._get_framework_extractor()
+            second = worker._get_framework_extractor()
+        assert first is second
+        assert mock_extractor_cls.call_count == 1

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -491,9 +491,12 @@ class TestMultimodalExtractorInit:
 
             result = worker._get_multimodal_extractor()
             assert result is mock_instance
+            # ``bust_cache`` is propagated from ``self._bust_llm_cache``,
+            # which defaults to False in this fixture.  See #4049.
             mock_cls.assert_called_once_with(
                 provider="google",
                 model="gemini-2.5-flash-lite",
+                bust_cache=False,
             )
 
     def test_lazy_init_caches(self) -> None:
@@ -534,10 +537,13 @@ class TestMultimodalExtractorInit:
 
             result = worker._get_multimodal_extractor(max_output_tokens=32768)
             assert result is mock_instance
+            # ``bust_cache`` is propagated from ``self._bust_llm_cache``,
+            # which defaults to False in this fixture.  See #4049.
             mock_cls.assert_called_once_with(
                 provider="google",
                 model="gemini-2.5-flash-lite",
                 max_output_tokens=32768,
+                bust_cache=False,
             )
 
     def test_different_max_output_tokens_gets_separate_instances(self) -> None:

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -11724,3 +11724,249 @@ class TestMultimodalReingestPerChildExhaustion:
 
         # All 3 children must land — no re-raise.
         assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# #4049 — bust_llm_cache propagation through prefix mode.
+#
+# DB-row reingest (--multimodal --bust-llm-cache) correctly skips split-child
+# rows via the is_split_child_id guard at scripts/reingest_from_s3.py:2245-2253
+# to prevent the #2416 exponential explosion.  Once a parent PDF has been
+# split, the *only* path to re-extract those children with a fresh LLM call
+# is to re-process the parent S3 key in prefix mode with bust_llm_cache=True.
+# These tests verify the plumbing: --bust-llm-cache reaches the worker,
+# which in turn constructs LlmExtractor with bust_cache=True.
+# ---------------------------------------------------------------------------
+
+
+class TestProcessPrefixDocumentBustCachePropagation:
+    """``_process_prefix_document(bust_llm_cache=True)`` must construct
+    ``IngestionWorker`` with ``bust_llm_cache=True``."""
+
+    def _build_key(self, content: bytes) -> str:
+        """Build a content-addressed S3 key whose embedded hash matches
+        ``content``.  Avoids triggering the hash-mismatch warning path so
+        the test focuses on the bust_llm_cache plumbing only."""
+        return f"federal/federal/courtlistener/raw/{hashlib.sha256(content).hexdigest()}.html"
+
+    def test_propagates_true_to_worker_constructor(self) -> None:
+        content = b"<html>ok</html>"
+        key = self._build_key(content)
+        mock_s3 = MagicMock()
+        body = MagicMock()
+        body.read.return_value = content
+        mock_s3.get_object.return_value = {"Body": body}
+
+        mock_worker = MagicMock()
+        mock_worker_cls = MagicMock(return_value=mock_worker)
+
+        # Clear cached worker to force re-creation.
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        with (
+            patch("framework.s3_cache.make_s3_client", return_value=mock_s3),
+            patch("ingestion.worker.IngestionWorker", mock_worker_cls),
+            patch("redis.Redis.from_url", return_value=MagicMock()),
+        ):
+            result = reingest._process_prefix_document(
+                key,
+                "test-bucket",
+                "postgresql://test",
+                "redis://localhost:6379",
+                "",
+                bust_llm_cache=True,
+            )
+
+        assert result["status"] == "ok"
+        mock_worker_cls.assert_called_once()
+        assert mock_worker_cls.call_args.kwargs.get("bust_llm_cache") is True
+
+    def test_default_is_false(self) -> None:
+        """Calling ``_process_prefix_document`` without the new kwarg keeps
+        the live worker cache semantics — backward-compatible default."""
+        content = b"<html>also ok</html>"
+        key = self._build_key(content)
+        mock_s3 = MagicMock()
+        body = MagicMock()
+        body.read.return_value = content
+        mock_s3.get_object.return_value = {"Body": body}
+
+        mock_worker = MagicMock()
+        mock_worker_cls = MagicMock(return_value=mock_worker)
+
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        with (
+            patch("framework.s3_cache.make_s3_client", return_value=mock_s3),
+            patch("ingestion.worker.IngestionWorker", mock_worker_cls),
+            patch("redis.Redis.from_url", return_value=MagicMock()),
+        ):
+            reingest._process_prefix_document(
+                key,
+                "test-bucket",
+                "postgresql://test",
+                "redis://localhost:6379",
+                "",
+            )
+
+        mock_worker_cls.assert_called_once()
+        assert mock_worker_cls.call_args.kwargs.get("bust_llm_cache") is False
+
+
+class TestRunReingestFromPrefixBustCachePropagation:
+    """``run_reingest_from_prefix(bust_llm_cache=True)`` must propagate the
+    flag into every ``_process_prefix_document`` invocation submitted to
+    the process pool."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_propagates_true_to_each_submit(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = [
+            {
+                "state": "Federal",
+                "county": "Federal",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
+                "timezone": "America/Los_Angeles",
+            }
+        ]
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {"federal-federal": "court-id-1"}
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future1 = MagicMock()
+        future1.result.return_value = {"status": "ok", "hash_mismatch": False}
+        future2 = MagicMock()
+        future2.result.return_value = {"status": "ok", "hash_mismatch": False}
+        pool.submit.side_effect = [future1, future2]
+
+        with patch("reingest_from_s3.as_completed", return_value=[future1, future2]):
+            reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+                bust_llm_cache=True,
+            )
+
+        assert pool.submit.call_count == 2
+        # Every submit must include bust_llm_cache=True as the trailing
+        # positional arg passed to _process_prefix_document.
+        for call in pool.submit.call_args_list:
+            assert call.args[0] is reingest._process_prefix_document
+            # Positional args: (fn, key, bucket, database_url, redis_url, os_url, bust_llm_cache)
+            assert call.args[6] is True
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_default_is_false(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """Backward-compatibility: omitting ``bust_llm_cache`` from
+        ``run_reingest_from_prefix`` keeps the worker's default cache
+        semantics (cache reads enabled)."""
+        keys = ["federal/federal/courtlistener/raw/ccc333.html"]
+        mock_list.return_value = keys
+        mock_discover.return_value = [
+            {
+                "state": "Federal",
+                "county": "Federal",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
+                "timezone": "America/Los_Angeles",
+            }
+        ]
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {"federal-federal": "court-id-1"}
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future = MagicMock()
+        future.result.return_value = {"status": "ok", "hash_mismatch": False}
+        pool.submit.return_value = future
+
+        with patch("reingest_from_s3.as_completed", return_value=[future]):
+            reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=1,
+            )
+
+        assert pool.submit.call_count == 1
+        call = pool.submit.call_args_list[0]
+        assert call.args[6] is False
+
+
+class TestSplitChildGuardUntouched:
+    """Regression guard: the ``is_split_child_id`` skip at
+    ``scripts/reingest_from_s3.py:2245-2253`` must remain in place so the
+    DB-row ``--multimodal`` mode does NOT regress on the #2416 exponential
+    explosion.  This test reads the source code directly and asserts the
+    guard text is unchanged in shape.
+    """
+
+    def test_guard_present_in_source(self) -> None:
+        source_path = os.path.join(_SCRIPTS_DIR, "reingest_from_s3.py")
+        with open(source_path, encoding="utf-8") as fh:
+            source = fh.read()
+        # The guard's distinguishing line must remain present.
+        assert "Skipping split-child document in re-split mode" in source, (
+            "is_split_child_id guard removed — #2416 regression risk."
+        )
+        assert "is_split_child_id(doc_id_str, content_hash)" in source, (
+            "is_split_child_id guard signature changed — verify #4049 plumbing "
+            "did not regress the DB-row multimodal mode."
+        )

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -3032,11 +3032,25 @@ def _process_prefix_document(
     database_url: str,
     redis_url: str,
     os_url: str,
+    bust_llm_cache: bool = False,
 ) -> dict[str, Any]:
     """Process a single S3 object through the ingestion pipeline.
 
     Creates its own DB connection, Redis client, and IngestionWorker.
     Designed for ProcessPoolExecutor — each call is fully independent.
+
+    Parameters
+    ----------
+    bust_llm_cache:
+        When True, the per-process ``IngestionWorker`` is constructed with
+        ``bust_llm_cache=True`` so every ``LlmExtractor`` it creates skips
+        cache reads.  This is the only path through which already-split
+        documents (parents whose split-child rows live in
+        ``derived.documents``) can be re-extracted with a fresh LLM call —
+        DB-row mode (``--multimodal --bust-llm-cache``) correctly skips
+        split-child rows to avoid the #2416 exponential explosion, leaving
+        prefix-mode the sole avenue once a parent has been split.  See
+        #4049.
 
     Returns a dict with:
       - ``status``: ``"ok"``, ``"skip"``, or ``"error"``
@@ -3122,12 +3136,17 @@ def _process_prefix_document(
         else:
             os_client = MagicMock()
         s3_for_worker = _make_s3()
+        # ``bust_llm_cache=...`` propagates the operator's --bust-llm-cache
+        # flag through this worker into every ``LlmExtractor`` it creates
+        # (multimodal + framework).  This is the only way to re-extract
+        # already-split parent PDFs with a fresh LLM call — see #4049.
         worker = IngestionWorker(
             redis_client=rc,
             pg_dsn=database_url,
             opensearch_client=os_client,
             s3_client=s3_for_worker,
             archive_bucket=bucket,
+            bust_llm_cache=bust_llm_cache,
         )
         _process_prefix_document._worker = worker  # type: ignore[attr-defined]
 
@@ -3146,6 +3165,7 @@ def run_reingest_from_prefix(
     concurrency: int = 10,
     limit: int | None = None,
     dry_run: bool = False,
+    bust_llm_cache: bool = False,
 ) -> dict[str, Any]:
     """Scan S3 by key prefix and ingest documents not in the DB.
 
@@ -3167,6 +3187,15 @@ def run_reingest_from_prefix(
         Maximum number of documents to process.
     dry_run:
         If True, list keys and seed courts but skip document processing.
+    bust_llm_cache:
+        If True, the per-process ``IngestionWorker`` is constructed with
+        ``bust_llm_cache=True`` so every ``LlmExtractor`` it builds skips
+        cache reads.  Required to re-extract documents whose parent PDF has
+        already been split into per-ruling child rows: DB-row mode (the
+        ``--multimodal`` path) correctly skips split-child rows via the
+        ``is_split_child_id`` guard to avoid the #2416 exponential
+        explosion, so the prefix path is the only avenue once a parent has
+        been split.  See #4049.
 
     Returns
     -------
@@ -3254,6 +3283,7 @@ def run_reingest_from_prefix(
                 database_url,
                 redis_url,
                 os_url,
+                bust_llm_cache,
             ): key
             for key in keys
         }
@@ -3816,7 +3846,11 @@ def main() -> None:
             "(e.g. dead-lettered events). Lists S3 objects under the prefix, "
             "seeds court records, and processes each document through the "
             "ingestion pipeline via IngestionWorker.process_event(). "
-            "Example: --prefix federal/"
+            "Example: --prefix federal/. "
+            "Combine with --bust-llm-cache to re-extract already-split "
+            "documents (the only path once parent PDFs have produced "
+            "split-child rows; DB-row mode skips them to avoid #2416). "
+            "See #4049."
         ),
     )
     parser.add_argument(
@@ -3880,6 +3914,7 @@ def main() -> None:
             concurrency=args.concurrency,
             limit=args.limit,
             dry_run=args.dry_run,
+            bust_llm_cache=args.bust_llm_cache,
         )
         logger.info(
             "Prefix reingest complete",


### PR DESCRIPTION
## Summary

Threads `bust_llm_cache` from `scripts/reingest_from_s3.py --prefix --bust-llm-cache` through `run_reingest_from_prefix` → `_process_prefix_document` → `IngestionWorker.__init__` → `LlmExtractor(bust_cache=...)`. Fixes the gap where already-split parent PDFs (whose split-child rows live in `derived.documents`) could not be re-extracted with a fresh LLM call: DB-row mode (`--multimodal --bust-llm-cache`) correctly skips split-child rows via the `is_split_child_id` guard at `scripts/reingest_from_s3.py:2245-2253` to avoid the #2416 exponential explosion, leaving prefix-mode the sole avenue once a parent has been split — but prefix-mode previously ignored `--bust-llm-cache` and replayed the cached extractor output. Pass-through plumbing only — no logic changes to the extractor, the worker DB-write path, or DB-row mode.

Closes #4049

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework/tests/` → 7185 passed, 3 skipped)
- [x] Diff coverage 100% on `origin/main...HEAD` (`diff-cover --fail-under=90`)
- [x] CI green

### Post-deploy verification
- [x] After `deploy-scraper.yml` ships the new ingestion-worker image to dev, confirmed task-def revision 608 is running image `3e36268` (matches merge SHA `3e362684`). The new plumbing is live on dev.
- [x] Verification evidence posted on issue #4049.

The full 765-row drain of #3855 is tracked as a follow-up post-merge — it is the live-run AC and out of scope for this PR's CI per the issue.
