### PR TITLE
fix(ingestion): reingest honors ExtractionMethod.NONE (#4056)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3562,6 +3562,285 @@ class TestFullReparseDocumentScraperIdFallback:
 
 
 # ---------------------------------------------------------------------------
+# ExtractionMethod.NONE short-circuit (#4056)
+#
+# scripts/reingest_from_s3.py historically only consulted
+# get_county_extraction_config to read ``max_output_tokens`` (#2355) and ran
+# the LLM regardless of the configured ``method``.  That mismatch caused
+# ``ExtractionMethod.NONE`` counties (Federal CourtListener clusters, #3967)
+# to be re-run through the CA-tuned LLM prompt during reingest, producing
+# truncation, JSON-parse errors, and field contamination that blocked
+# #3978's federal cleanup pass.  These tests pin the new guard.
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentExtractionMethodNone:
+    """LLM short-circuit when the county/scraper config returns NONE (#4056)."""
+
+    def _federal_doc_meta(self, **overrides: Any) -> dict:
+        meta = {
+            "document_id": str(_DOC_ID_1),
+            "state": "Federal",
+            "county": "Federal",
+            "court_name": "Court of Appeals for the Ninth Circuit",
+            "source_url": "https://www.courtlistener.com/opinion/abc/",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "fedabc",
+            "format": "html",
+            "case_number": "24-1234",
+            "case_title": "United States v. Doe",
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "courtlistener",
+            "s3_key": "federal/test.html",
+            "s3_bucket": "test-bucket",
+        }
+        meta.update(overrides)
+        return meta
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_reparse_document_skips_llm_when_config_none(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Federal docs (ExtractionMethod.NONE) must not invoke extract_fields_llm.
+
+        The (FEDERAL, FEDERAL) county registers ``ExtractionMethod.NONE`` in
+        ``framework/extraction_config.py``.  Reingest must honor that and
+        skip the LLM call entirely — running the CA-tuned LLM prompt over
+        federal opinion text causes the truncation/JSON-parse failures
+        documented in #3967 / #4056.
+        """
+        raw = b"<html>federal opinion text - judges named in cluster metadata</html>"
+        client = MagicMock()
+        result = reingest._reparse_document(
+            raw,
+            "courtlistener",
+            self._federal_doc_meta(case_number=None, case_title=None),
+            llm_client=client,
+        )
+
+        mock_llm.assert_not_called()
+        assert result["llm_skipped"] is True
+        assert result["llm_outcome"] == "skipped_none"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_reparse_document_skips_llm_even_with_force_llm(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """``force_llm=True`` must not override an ExtractionMethod.NONE config.
+
+        The whole point of the NONE registration is that the LLM prompt
+        produces wrong/contaminated output for this county.  ``force_llm``
+        was originally meant for selective re-extraction on counties that
+        *do* support LLM — applying it to NONE-configured counties would
+        re-introduce the exact contamination class #3967 documented.
+        """
+        raw = b"<html>federal opinion text</html>"
+        client = MagicMock()
+        result = reingest._reparse_document(
+            raw,
+            "courtlistener",
+            self._federal_doc_meta(case_number=None),
+            llm_client=client,
+            force_llm=True,
+        )
+
+        mock_llm.assert_not_called()
+        assert result["llm_outcome"] == "skipped_none"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_reparse_document_runs_llm_for_non_none_county(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Non-NONE counties must continue to invoke extract_fields_llm.
+
+        Pins the negative case so the new guard cannot accidentally break
+        LA / Riverside / SF / etc.  ``unknown-scraper`` + ``CA / Los
+        Angeles`` is not registered in ``_COUNTY_CONFIGS`` so
+        ``get_county_extraction_config`` returns ``None`` and the LLM
+        path runs as before.
+        """
+        from ingestion.llm_extract import LLMExtractionResult
+
+        mock_llm.return_value = LLMExtractionResult(
+            judge_name=None,
+            hearing_date=None,
+            department=None,
+            case_count=0,
+            rulings=[],
+        )
+        meta = {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Los Angeles",
+            "court_name": "Los Angeles Superior Court",
+            "source_url": "https://court.example.com/ruling",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": None,
+            "case_title": None,
+            "hearing_date": None,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "unknown-scraper",
+            "s3_key": "docs/test.html",
+            "s3_bucket": "test-bucket",
+        }
+
+        client = MagicMock()
+        reingest._reparse_document(
+            b"<html>ruling text</html>", "unknown-scraper", meta, llm_client=client
+        )
+
+        mock_llm.assert_called_once()
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_reparse_document_skips_llm_for_sd_calendar_scraper_override(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Scraper-level NONE overrides (e.g. ca-sd-calendar) are also honored.
+
+        The ``_SCRAPER_CONFIGS`` table in ``extraction_config.py`` maps the
+        ``ca-sd-calendar`` scraper_id to ``ExtractionMethod.NONE`` even
+        though its parent county (CA / San Diego) is configured for LLM.
+        Reingest must respect the scraper-level override.
+        """
+        meta = {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "San Diego",
+            "court_name": "Superior Court of California, San Diego",
+            "source_url": "",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "sd123",
+            "format": "html",
+            "case_number": "37-2024-00021082-CL-CL-CTL",
+            "case_title": None,
+            "hearing_date": None,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-sd-calendar",
+            "s3_key": "ca/san_diego/superior_court/raw/abc.html",
+            "s3_bucket": "test-bucket",
+        }
+        # Make sure the scraper is not registered so parse_document doesn't run.
+        reingest._SCRAPER_REGISTRY.pop("ca-sd-calendar", None)
+
+        raw = b"<html>calendar HTML</html>"
+        client = MagicMock()
+        result = reingest._reparse_document(raw, "ca-sd-calendar", meta, llm_client=client)
+
+        mock_llm.assert_not_called()
+        assert result["llm_outcome"] == "skipped_none"
+
+
+class TestFullReparseDocumentExtractionMethodNone:
+    """LLM short-circuit in _full_reparse_document for NONE-configured counties (#4056)."""
+
+    def _federal_doc_meta(self, **overrides: Any) -> dict:
+        meta = {
+            "document_id": str(_DOC_ID_1),
+            "state": "Federal",
+            "county": "Federal",
+            "court_name": "Court of Appeals for the Ninth Circuit",
+            "source_url": "https://www.courtlistener.com/opinion/abc/",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "fedabc",
+            "format": "html",
+            "case_number": "24-1234",
+            "case_title": "United States v. Doe",
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "courtlistener",
+            "s3_key": "federal/test.html",
+            "s3_bucket": "test-bucket",
+        }
+        meta.update(overrides)
+        return meta
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_full_reparse_document_skips_llm_for_federal(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """``--full-reparse`` on a Federal doc must not invoke extract_fields_llm.
+
+        ``_full_reparse_document`` delegates to ``_reparse_document`` for
+        scrapers without a split function.  The ExtractionMethod.NONE
+        guard at the top of ``_full_reparse_document`` (and the matching
+        guard in the inner ``_reparse_document``) ensure the LLM is
+        skipped regardless of which split path is taken.
+        """
+        raw = b"<html>federal opinion text</html>"
+        client = MagicMock()
+
+        # Make sure no split function is registered (matches reality for
+        # the courtlistener scraper).
+        reingest._SPLIT_REGISTRY.pop("courtlistener", None)
+        reingest._LLM_SPLIT_REGISTRY.pop("courtlistener", None)
+
+        results = reingest._full_reparse_document(
+            raw,
+            "courtlistener",
+            self._federal_doc_meta(case_number=None, case_title=None),
+            llm_client=client,
+        )
+
+        mock_llm.assert_not_called()
+        assert isinstance(results, list)
+        assert len(results) == 1
+        assert results[0]["llm_skipped"] is True
+        assert results[0]["llm_outcome"] == "skipped_none"
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch("reingest_from_s3.extract_fields_llm")
+    def test_full_reparse_document_skips_llm_split_for_none_config(
+        self,
+        mock_llm: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """The NONE guard short-circuits *before* the llm_split_fn runs.
+
+        Defense in depth: even if a future scraper registered under an
+        ExtractionMethod.NONE county had an llm_split_fn entry, the guard
+        at the top of ``_full_reparse_document`` would skip it.  We
+        simulate that by registering a mock llm_split_fn for the
+        ``courtlistener`` scraper and asserting the mock was not called.
+        """
+        mock_llm_split = MagicMock()
+        reingest._LLM_SPLIT_REGISTRY["courtlistener"] = mock_llm_split
+        try:
+            raw = b"<html>federal opinion text</html>"
+            client = MagicMock()
+            results = reingest._full_reparse_document(
+                raw,
+                "courtlistener",
+                self._federal_doc_meta(case_number=None),
+                llm_client=client,
+            )
+
+            mock_llm.assert_not_called()
+            mock_llm_split.assert_not_called()
+            assert len(results) == 1
+            assert results[0]["llm_outcome"] == "skipped_none"
+        finally:
+            reingest._LLM_SPLIT_REGISTRY.pop("courtlistener", None)
+
+
+# ---------------------------------------------------------------------------
 # LLM extraction in reingest_batch — llm_client passthrough
 # ---------------------------------------------------------------------------
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -54,6 +54,18 @@ the live worker path — known divergences have been resolved.
     case row.  The LLM always wins when it produces a case_number, so
     the fixed-point risk that affected ``case_title`` does not apply.
 
+-   ``_reparse_document`` and ``_full_reparse_document`` now honor
+    ``ExtractionMethod.NONE`` (#4056).  Previously, the script consulted
+    ``get_county_extraction_config`` only to read ``max_output_tokens``
+    (#2355) and ran the LLM regardless of the configured ``method``.
+    That mismatch caused NONE-configured counties (Federal CourtListener
+    clusters, #3967; San Diego calendar override, #2331) to be re-run
+    through the CA-tuned LLM prompt during reingest, producing
+    truncation, JSON-parse errors, and field contamination.  Both reparse
+    entry points now skip ``extract_fields_llm`` (and any registered
+    ``llm_split_fn``) when the lookup returns ``ExtractionMethod.NONE``,
+    matching the live worker guard at ``worker.py:1719-1732``.
+
 For cleanup of corrupted ``derived.*`` state, prefer ``rebuild_db.py
 --county <name>`` over reingest — rebuild walks S3 directly and does not
 touch existing ``cases.*`` rows when the split set changes across runs.
@@ -171,7 +183,10 @@ import boto3  # noqa: E402
 import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
-from framework.extraction_config import get_county_extraction_config  # noqa: E402
+from framework.extraction_config import (  # noqa: E402
+    ExtractionMethod,
+    get_county_extraction_config,
+)
 from framework.llm_enrichment import (  # noqa: E402
     LlmEnrichmentExhaustedError,
     LlmEnrichmentResult,
@@ -850,7 +865,12 @@ def _reparse_document(
     Extraction priority per field:
       1. Scraper ``parse_document()`` (highest priority).
       2. LLM extraction via ``extract_fields_llm()`` (if *llm_client*
-         is provided and fields are missing, or *force_llm* is True).
+         is provided and fields are missing, or *force_llm* is True),
+         **unless** the (state, county, scraper_id) lookup in
+         ``framework.extraction_config`` returns ``ExtractionMethod.NONE``.
+         NONE-configured counties (e.g. Federal CourtListener clusters,
+         San Diego calendar) ship complete scraper-populated fields and
+         the CA-tuned LLM prompt corrupts them — see #4056.
       3. Regex fallback (lowest priority).
 
     For PDF documents, extracts text via pdfplumber in a subprocess with
@@ -858,8 +878,11 @@ def _reparse_document(
 
     Returns a dict of extracted fields plus an ``extraction_methods`` dict
     recording which method populated each field, and an ``llm_skipped``
-    boolean indicating whether LLM extraction was skipped because all
-    fields were already populated.
+    boolean indicating whether LLM extraction was skipped (because all
+    fields were already populated, or because the county is registered
+    with ``ExtractionMethod.NONE``).  ``llm_outcome`` distinguishes the
+    two: ``"skipped"`` for the all-fields-present path and
+    ``"skipped_none"`` for the NONE-config short-circuit.
     """
     _load_scraper_registry()
 
@@ -1000,7 +1023,33 @@ def _reparse_document(
     # ------------------------------------------------------------------
     llm_skipped = False
     llm_outcome = "not_attempted"
-    if llm_client is not None:
+
+    # Short-circuit LLM extraction when the county/scraper is registered
+    # with ``ExtractionMethod.NONE`` (#4056).  The live worker path honors
+    # this in ``ingestion.worker._extract_fields`` (worker.py L1719-1732),
+    # but the reingest path historically only consulted the county config
+    # for ``max_output_tokens`` (#2355) and ran the LLM regardless of the
+    # configured method.  That mismatch caused ``ExtractionMethod.NONE``
+    # counties (e.g. Federal CourtListener clusters, #3967) to be re-run
+    # through the CA-tuned LLM prompt during reingest, producing
+    # truncation, JSON-parse errors, and field contamination that
+    # blocked #3978's federal cleanup pass.
+    _ext_config = get_county_extraction_config(
+        doc_meta.get("state", ""),
+        doc_meta.get("county", ""),
+        scraper_id=scraper_id,
+    )
+    if _ext_config is not None and _ext_config.method == ExtractionMethod.NONE:
+        logger.info(
+            "Skipping LLM extraction — county uses ExtractionMethod.NONE",
+            document_id=doc_meta["document_id"],
+            state=doc_meta.get("state"),
+            county=doc_meta.get("county"),
+            scraper_id=scraper_id,
+        )
+        llm_skipped = True
+        llm_outcome = "skipped_none"
+    elif llm_client is not None:
         missing_fields = [
             f
             for f in (
@@ -1190,6 +1239,38 @@ def _full_reparse_document(
       - ``is_split``: bool — True if this came from splitting
     """
     _load_scraper_registry()
+
+    # Short-circuit the LLM-based split path when the county/scraper is
+    # registered with ``ExtractionMethod.NONE`` (#4056).  Even though the
+    # downstream ``_reparse_document`` path also guards LLM extraction, an
+    # ``llm_split_fn`` registered for a NONE-configured scraper would still
+    # invoke an LLM here.  No NONE-registered scraper has an llm_split_fn
+    # today, but the explicit guard makes the contract self-documenting and
+    # protects future scrapers from regressing the federal cleanup case.
+    _ext_config = get_county_extraction_config(
+        doc_meta.get("state", ""),
+        doc_meta.get("county", ""),
+        scraper_id=scraper_id,
+    )
+    if _ext_config is not None and _ext_config.method == ExtractionMethod.NONE:
+        result = _reparse_document(
+            raw_content,
+            scraper_id,
+            doc_meta,
+            pdf_timeout=pdf_timeout,
+            llm_client=llm_client,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            llm_timeout=llm_timeout,
+            force_llm=force_llm,
+            token_tracker=token_tracker,
+            force_retranscribe=force_retranscribe,
+            bust_llm_cache=bust_llm_cache,
+        )
+        result["ruling_index"] = 0
+        result["split_document_id"] = doc_meta["document_id"]
+        result["is_split"] = False
+        return [result]
 
     split_fn = _SPLIT_REGISTRY.get(scraper_id)
     llm_split_fn = _LLM_SPLIT_REGISTRY.get(scraper_id)


### PR DESCRIPTION
## Summary

`scripts/reingest_from_s3.py` historically consulted `get_county_extraction_config` only to read `max_output_tokens` (#2355) and ran the LLM regardless of the configured `method`. That mismatch caused `ExtractionMethod.NONE` counties — Federal CourtListener clusters (#3967) and the `ca-sd-calendar` scraper override (#2331) — to be re-run through the CA-tuned LLM prompt during reingest, producing truncation, JSON-parse errors, and field contamination that blocked #3978's federal cleanup pass.

Both `_reparse_document` and `_full_reparse_document` now skip `extract_fields_llm` (and any registered `llm_split_fn`) when the lookup returns `ExtractionMethod.NONE`, matching the live-worker guard at `ingestion.worker._extract_fields` (worker.py L1719-1732). Six regression tests cover positive Federal/SD-calendar cases, the `force_llm`-still-skips invariant, the negative non-NONE case, and the defense-in-depth `llm_split_fn` skip.

Closes #4056

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A for this PR — verification via #3978's reingest run, per the issue's AC #3 ("post-deploy, part of #3978's verification, not this PR's gate"). This PR's gate is unit-test coverage of the new guard.
- [ ] Verification evidence posted on issue (see A.8)
