### PR TITLE
fix(scripts): wait-for-ci.sh canonical-merge-gate fast-path (#4069)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -626,7 +626,7 @@ Use `scripts/wait-for-ci.sh` as the canonical PR CI gate:
 scripts/wait-for-ci.sh <PR-N>
 ```
 
-This polls the check-runs API with `filter=latest` (deduplicates re-runs) and exits 0 only when `ci-passed` is success, no check has failed, and `mergeStateStatus` is CLEAN or UNSTABLE. Exit 1 = failure, Exit 2 = timeout.
+This polls the check-runs API with `filter=latest` (deduplicates re-runs) and exits 0 via either of two paths: (a) the canonical-merge-gate fast-path — `mergeable == MERGEABLE`, any `ci-passed` entry is `success`, no latest check has failed — fires immediately even if stale `in_progress` entries from a superseded CI run linger in the response (#4069); (b) the all-checks-complete fallback — `pending == 0`, `ci-passed` is `success`, no failures, `mergeStateStatus` is `CLEAN` or `UNSTABLE` — fires when CI legitimately drains to zero pending. Stdout names the path explicitly with `canonical merge gate green` or `all checks complete`. Exit 1 = failure, Exit 2 = timeout.
 
 For workflow-run-level watching (deploy workflows in §A.8), `gh run watch` stays as the fallback:
 

--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -67,6 +67,7 @@ fail() {
 #   - `gh pr view ... --json headRefOid`  → canned SHA from SHA_RESPONSE env
 #   - `gh api repos/.../check-runs...`   → next response from $RESPONSES_DIR/NN.json
 #   - `gh pr view ... --json mergeStateStatus` → canned status from MERGE_STATE_RESPONSE env
+#   - `gh pr view ... --json mergeable` → canned status from MERGEABLE_RESPONSE env
 #
 # Usage: setup_mock_gh <tmpdir>
 setup_mock_gh() {
@@ -84,10 +85,14 @@ RESPONSES_DIR="${RESPONSES_DIR:?RESPONSES_DIR required}"
 CALL_COUNTER_FILE="${CALL_COUNTER_FILE:?CALL_COUNTER_FILE required}"
 SHA_RESPONSE="${SHA_RESPONSE:-deadbeefdeadbeef}"
 MERGE_STATE_RESPONSE="${MERGE_STATE_RESPONSE:-CLEAN}"
+MERGEABLE_RESPONSE="${MERGEABLE_RESPONSE:-MERGEABLE}"
 
 ARGS="$*"
 
 # Route: pr view ... headRefOid — return canned SHA (plain string, like gh -q output).
+# Note: order matters — match `mergeStateStatus` before `mergeable` because the
+# substring `mergeable` appears within `mergeStateStatus` patterns in some gh
+# JSON enum outputs.
 case "$ARGS" in
     *"headRefOid"*)
         printf '%s\n' "$SHA_RESPONSE"
@@ -95,6 +100,10 @@ case "$ARGS" in
         ;;
     *"mergeStateStatus"*)
         printf '%s\n' "$MERGE_STATE_RESPONSE"
+        exit 0
+        ;;
+    *"mergeable"*)
+        printf '%s\n' "$MERGEABLE_RESPONSE"
         exit 0
         ;;
     *"check-runs"*)
@@ -146,6 +155,7 @@ run_script() {
     CALL_COUNTER_FILE="$tmpdir/counter" \
     SHA_RESPONSE="${SHA_RESPONSE:-deadbeefdeadbeef}" \
     MERGE_STATE_RESPONSE="${MERGE_STATE_RESPONSE:-CLEAN}" \
+    MERGEABLE_RESPONSE="${MERGEABLE_RESPONSE:-MERGEABLE}" \
         "$SCRIPT_UNDER_TEST" "$@"
 }
 
@@ -190,10 +200,62 @@ write_failure_response() {
 JSON
 }
 
+# Write a check-runs response that simulates the #4069 wedge: ci-passed has
+# a completed=success entry, but two unrelated check-runs from a SUPERSEDED
+# CI run on the same SHA still show as in_progress. Without the canonical
+# fast-path, pending=2 keeps the script polling forever even though the
+# canonical merge gate is satisfied.
+write_stale_pending_with_success_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",                "status": "completed",  "conclusion": "success", "details_url": "https://example.com/lint"},
+    {"name": "unit-tests",          "status": "completed",  "conclusion": "success", "details_url": "https://example.com/unit"},
+    {"name": "ci-passed",           "status": "completed",  "conclusion": "success", "details_url": "https://example.com/ci"},
+    {"name": "Vercel-stale",        "status": "in_progress","conclusion": null,      "details_url": "https://example.com/vercel-stale"},
+    {"name": "Smoke-Test-stale",    "status": "in_progress","conclusion": null,      "details_url": "https://example.com/smoke-stale"}
+  ]
+}
+JSON
+}
+
+# Write a check-runs response where ci-passed is still in_progress (no
+# success entry yet) and there are no failures — the script must NOT
+# exit via the fast-path, even if mergeable=MERGEABLE.
+write_in_progress_ci_passed_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",       "status": "completed",  "conclusion": "success", "details_url": "https://example.com/lint"},
+    {"name": "ci-passed",  "status": "in_progress","conclusion": null,      "details_url": "https://example.com/ci"}
+  ]
+}
+JSON
+}
+
+# Write a check-runs response with TWO ci-passed entries (re-run + superseded).
+# This exercises the multi-entry jq selector that was the #4069 root cause.
+write_double_ci_passed_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",       "status": "completed", "conclusion": "success", "details_url": "https://example.com/lint"},
+    {"name": "ci-passed",  "status": "completed", "conclusion": "success", "details_url": "https://example.com/ci-rerun"},
+    {"name": "ci-passed",  "status": "in_progress","conclusion": null,     "details_url": "https://example.com/ci-superseded"}
+  ]
+}
+JSON
+}
+
 # ── Tests ──────────────────────────────────────────────────────────────────
 
 # Test 1: Happy path — first poll in-progress, second poll all success + ci-passed,
-# then mergeStateStatus=CLEAN. Expect exit 0.
+# then mergeable=MERGEABLE. Expect exit 0 via the canonical-merge-gate fast-path
+# (the second-priority all-checks-complete path also satisfies but the fast-path
+# fires first when mergeable resolves cleanly).
 test_happy_path() {
     local tmpdir
     tmpdir=$(make_temp_dir)
@@ -202,7 +264,7 @@ test_happy_path() {
 
     local output exit_code
     exit_code=0
-    output=$(MERGE_STATE_RESPONSE=CLEAN \
+    output=$(MERGE_STATE_RESPONSE=CLEAN MERGEABLE_RESPONSE=MERGEABLE \
         run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
 
     if [ "$exit_code" -eq 0 ]; then
@@ -211,10 +273,10 @@ test_happy_path() {
         fail "happy_path: exits 0 on success" "exit=$exit_code output=$output"
     fi
 
-    if echo "$output" | grep -q "CI passed"; then
-        pass "happy_path: emits success message"
+    if echo "$output" | grep -qE "canonical merge gate green|all checks complete"; then
+        pass "happy_path: emits a success message"
     else
-        fail "happy_path: emits success message" "output=$output"
+        fail "happy_path: emits a success message" "output=$output"
     fi
 }
 
@@ -303,6 +365,159 @@ test_help() {
     fi
 }
 
+# Test 6 (#4069 regression): canonical-merge-gate fast-path. The mock returns
+# ci-passed=success + 2 stale in_progress entries (pending=2) on EVERY poll,
+# i.e. the same wedge state observed on PR #4059. With mergeable=MERGEABLE,
+# the script must exit 0 in well under 60s with the substring
+# `canonical merge gate green` on stdout — proving the fast-path bypasses
+# the stale pending counts.
+test_canonical_gate_fastpath_with_stale_pending() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_stale_pending_with_success_response "$tmpdir/responses/01.json"
+
+    local output exit_code start_ts end_ts elapsed
+    exit_code=0
+    start_ts=$(date +%s)
+    output=$(MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=UNSTABLE \
+        run_script "$tmpdir" 42 --poll-interval 1 --timeout-secs 30 2>&1) || exit_code=$?
+    end_ts=$(date +%s)
+    elapsed=$((end_ts - start_ts))
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "canonical_gate_fastpath: exits 0 even with pending=2 from superseded run"
+    else
+        fail "canonical_gate_fastpath: exits 0 even with pending=2 from superseded run" "exit=$exit_code output=$output"
+    fi
+
+    if [ "$elapsed" -lt 10 ]; then
+        pass "canonical_gate_fastpath: exits in <10s (actual: ${elapsed}s)"
+    else
+        fail "canonical_gate_fastpath: exits in <10s" "elapsed=${elapsed}s — fast-path must not wait for pending to drain"
+    fi
+
+    if echo "$output" | grep -q "canonical merge gate green"; then
+        pass "canonical_gate_fastpath: stdout contains 'canonical merge gate green'"
+    else
+        fail "canonical_gate_fastpath: stdout contains 'canonical merge gate green'" "output=$output"
+    fi
+}
+
+# Test 7: All-checks-complete fallback path. When mergeable cannot be resolved
+# (UNKNOWN) but pending=0 + ci-passed=success + mergeStateStatus=CLEAN, the
+# script must still exit 0 via the fallback path with `all checks complete`.
+test_all_checks_complete_path() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_all_success_response "$tmpdir/responses/01.json"
+
+    local output exit_code
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=UNKNOWN MERGE_STATE_RESPONSE=CLEAN \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 30 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "all_checks_complete_path: exits 0 when pending=0 and mergeable=UNKNOWN"
+    else
+        fail "all_checks_complete_path: exits 0 when pending=0 and mergeable=UNKNOWN" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "all checks complete"; then
+        pass "all_checks_complete_path: stdout contains 'all checks complete'"
+    else
+        fail "all_checks_complete_path: stdout contains 'all checks complete'" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "canonical merge gate green"; then
+        fail "all_checks_complete_path: stdout must NOT contain 'canonical merge gate green' when fast-path was bypassed" "output=$output"
+    else
+        pass "all_checks_complete_path: stdout does not falsely claim canonical merge gate"
+    fi
+}
+
+# Test 8 (#4069 regression): ci-passed still in_progress must not trigger
+# the fast-path even when mergeable=MERGEABLE. The script must keep polling
+# (and ultimately time out under a short --timeout-secs).
+test_no_regression_in_progress_ci_passed() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_in_progress_ci_passed_response "$tmpdir/responses/01.json"
+
+    local output exit_code
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=CLEAN \
+        run_script "$tmpdir" 42 --poll-interval 1 --timeout-secs 2 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 2 ]; then
+        pass "no_regression_in_progress_ci_passed: times out (exit 2) when ci-passed is still in_progress"
+    else
+        fail "no_regression_in_progress_ci_passed: times out (exit 2) when ci-passed is still in_progress" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "canonical merge gate green"; then
+        fail "no_regression_in_progress_ci_passed: must NOT exit via fast-path when ci-passed is in_progress" "output=$output"
+    else
+        pass "no_regression_in_progress_ci_passed: does not falsely trigger fast-path"
+    fi
+}
+
+# Test 9 (#4069 regression): ci-passed has a failure before any success on the
+# same SHA. The early-failure path must still fire (exit 1) and the fast-path
+# must NOT swallow the failure even with mergeable=MERGEABLE (which GitHub
+# would not actually return in this state, but defense-in-depth).
+test_no_regression_failure_short_circuits_fastpath() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_response "$tmpdir/responses/01.json" "web-tests"
+
+    local output exit_code
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=CLEAN \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 30 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "no_regression_failure_short_circuits_fastpath: exits 1 on failure even with mergeable=MERGEABLE"
+    else
+        fail "no_regression_failure_short_circuits_fastpath: exits 1 on failure even with mergeable=MERGEABLE" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "canonical merge gate green"; then
+        fail "no_regression_failure_short_circuits_fastpath: fast-path must not fire when there is any latest failure" "output=$output"
+    else
+        pass "no_regression_failure_short_circuits_fastpath: fast-path correctly suppressed by failure"
+    fi
+}
+
+# Test 10 (#4069 root cause): when the filter=latest response contains TWO
+# ci-passed entries (re-run + superseded), the success-detection logic must
+# treat it as success — not silently break on multi-line jq output. This is
+# the exact condition that wedged wait-for-ci.sh on PR #4059.
+test_double_ci_passed_entries_resolves_success() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_double_ci_passed_response "$tmpdir/responses/01.json"
+
+    local output exit_code start_ts end_ts elapsed
+    exit_code=0
+    start_ts=$(date +%s)
+    output=$(MERGEABLE_RESPONSE=MERGEABLE \
+        run_script "$tmpdir" 42 --poll-interval 1 --timeout-secs 30 2>&1) || exit_code=$?
+    end_ts=$(date +%s)
+    elapsed=$((end_ts - start_ts))
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "double_ci_passed_entries: exits 0 when one of two ci-passed entries is success"
+    else
+        fail "double_ci_passed_entries: exits 0 when one of two ci-passed entries is success" "exit=$exit_code output=$output"
+    fi
+
+    if [ "$elapsed" -lt 10 ]; then
+        pass "double_ci_passed_entries: exits in <10s (actual: ${elapsed}s)"
+    else
+        fail "double_ci_passed_entries: exits in <10s" "elapsed=${elapsed}s"
+    fi
+}
+
 # ── Run all tests ──────────────────────────────────────────────────────────
 
 test_happy_path
@@ -310,6 +525,11 @@ test_early_failure
 test_timeout
 test_missing_pr_arg
 test_help
+test_canonical_gate_fastpath_with_stale_pending
+test_all_checks_complete_path
+test_no_regression_in_progress_ci_passed
+test_no_regression_failure_short_circuits_fastpath
+test_double_ci_passed_entries_resolves_success
 
 echo ""
 echo "────────────────────────────────────────────"

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -55,9 +55,19 @@
 #   --help              Print this help and exit 0
 #
 # Exit codes:
-#   0 — Success: ci-passed check has conclusion=success, no other latest check
-#       has conclusion=failure/timed_out/action_required/cancelled, AND
-#       mergeStateStatus is CLEAN or UNSTABLE.
+#   0 — Success. Reached via one of two paths, in priority order:
+#       (a) **Canonical-merge-gate fast-path** (#4069): `mergeable == MERGEABLE`,
+#           any `ci-passed` entry in the filter=latest response has
+#           conclusion=success, and no latest check has conclusion=
+#           failure/timed_out/action_required/cancelled. Stdout names this
+#           path explicitly with the substring `canonical merge gate green`.
+#           This path exits immediately even if filter=latest still surfaces
+#           in_progress entries from a superseded CI run on the same SHA —
+#           the same gate documented in `docs/agent/code-standards.md`
+#           §"Interpreting mergeStateStatus (UNSTABLE-but-green)".
+#       (b) **All-checks-complete path:** filter=latest shows pending=0,
+#           ci-passed=success, no failures, and mergeStateStatus is CLEAN or
+#           UNSTABLE. Stdout names this path with `all checks complete`.
 #   1 — Early failure: one or more checks have a failed conclusion. Prints the
 #       failed check names and their details_url.
 #   2 — Timeout: --timeout-secs elapsed without reaching a terminal state.
@@ -171,15 +181,45 @@ while true; do
         exit 1
     fi
 
-    # Check for success: ci-passed is success and no failures.
-    CI_PASSED_CONCLUSION=$(echo "$CHECK_RUNS_JSON" | jq -r '.[] | select(.name == "ci-passed") | .conclusion // ""')
+    # Determine whether `ci-passed` succeeded on its latest run. Use `any(...)`
+    # rather than `select(...) | .conclusion` because filter=latest dedupes
+    # within a workflow run but NOT across workflow re-runs on the same SHA —
+    # a re-run plus a superseded run can leave two `ci-passed` entries in the
+    # response, which would make a single jq `select()` print two lines and
+    # silently break the equality check that follows (#4069 root cause). The
+    # `any` form returns a single boolean string.
+    CI_PASSED_SUCCESS=$(echo "$CHECK_RUNS_JSON" | jq -r '[.[] | select(.name == "ci-passed")] | any(.conclusion == "success")')
+    CI_PASSED_CONCLUSION=$(echo "$CHECK_RUNS_JSON" | jq -r '[.[] | select(.name == "ci-passed") | .conclusion] | (.[0] // "")')
 
-    if [ "$CI_PASSED_CONCLUSION" = "success" ] && [ "$FAILED_COUNT" -eq 0 ]; then
+    # ── Canonical-merge-gate fast-path (#4069) ───────────────────────────────
+    # Mirrors `docs/agent/code-standards.md` §"Interpreting mergeStateStatus
+    # (UNSTABLE-but-green)" and the `/task` skill's §A.7 merge gate. When
+    # `mergeable == MERGEABLE`, the required `ci-passed` check is success on
+    # its latest run, and no latest check is a hard failure, the PR is safe
+    # to merge regardless of any pending entries left over from a superseded
+    # CI run on the same SHA. Exit immediately so callers don't burn the full
+    # timeout watching phantom in_progress rows that will never complete.
+    if [ "$CI_PASSED_SUCCESS" = "true" ] && [ "$FAILED_COUNT" -eq 0 ]; then
+        MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable -q .mergeable 2>/dev/null || echo "UNKNOWN")
+        if [ "$MERGEABLE" = "MERGEABLE" ]; then
+            echo ""
+            echo "[${ELAPSED}s] canonical merge gate green — exiting (mergeable=MERGEABLE, ci-passed=success, failed=0; pending=${PENDING_COUNT} ignored as superseded)."
+            exit 0
+        fi
+    fi
+
+    # ── Existing all-checks-complete path ────────────────────────────────────
+    # When pending=0, every check has a terminal conclusion. Combined with
+    # ci-passed=success and a CLEAN/UNSTABLE mergeStateStatus, this is the
+    # original safe-to-merge signal. Kept as a fallback for the case where
+    # `mergeable` cannot be resolved (UNKNOWN, API error) so the script still
+    # exits when CI legitimately drained to zero pending.
+    if [ "$CI_PASSED_SUCCESS" = "true" ] && [ "$FAILED_COUNT" -eq 0 ] && [ "$PENDING_COUNT" -eq 0 ]; then
         # Secondary guard: verify mergeStateStatus is CLEAN or UNSTABLE.
         MERGE_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus -q .mergeStateStatus)
         if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
             echo ""
-            echo "CI passed after ${ELAPSED}s. ci-passed=success, mergeStateStatus=${MERGE_STATE}."
+            echo "[${ELAPSED}s] all checks complete — CI passed (ci-passed=success, mergeStateStatus=${MERGE_STATE})."
             exit 0
         else
             echo "  ci-passed=success but mergeStateStatus=${MERGE_STATE}, still waiting..."


### PR DESCRIPTION
## Summary

Adds a canonical-merge-gate fast-path to `scripts/wait-for-ci.sh` so it exits 0 immediately when `mergeable == MERGEABLE`, any `ci-passed` entry on the filter=latest response is `success`, and no latest check is a hard failure — even if the response still surfaces stale `in_progress` entries from a superseded CI run on the same SHA. Also fixes the underlying `select(.name == "ci-passed") | .conclusion // ""` jq selector that silently broke (multi-line output) when a re-run + superseded run produced two `ci-passed` entries — the actual root cause behind the >20-minute wedge observed on PR #4059.

Closes #4069

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_wait_for_ci.sh` — 22/22 locally, +5 new regression tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling script + its unit tests + a SKILL.md docstring update only). The script runs only in operator/Claude Code agent contexts and has no production deploy path. Live exercise of the fast-path on this PR's own CI run is documented in the verification-evidence comment.
- [x] Verification evidence posted on issue (see A.8)
