### PR TITLE
fix(devops): add invoked scripts to deploy-{scraper,api}.yml paths filters (#4073)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -13,6 +13,11 @@ on:
       # action. Changes to the shared script must trigger this deploy so the
       # fix is exercised against a real rollout on its own PR (see #2592).
       - "scripts/wait-for-rollout.sh"
+      # scripts/ecs-render-task-def.sh is invoked transitively by the
+      # ecs-deploy composite action (.github/actions/ecs-deploy/action.yml).
+      # Same shared-script convention — a regression there silently breaks
+      # every API deploy's task-def render. See #4073.
+      - "scripts/ecs-render-task-def.sh"
   workflow_dispatch:
     inputs:
       image_tag:

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -17,6 +17,19 @@ on:
       # must trigger this deploy so regressions surface on the PR that
       # introduces them, not on the next unrelated deploy (see #2608/#2592).
       - "scripts/ecs-post-deploy-healthcheck.sh"
+      # scripts/check-ingestion-worker-task-def-fingerprint.sh is invoked
+      # by the post-deploy-health-check job's drift gate (#4044). Same
+      # paths-filter contract as wait-for-rollout.sh / ecs-post-deploy-healthcheck.sh
+      # — a regression in the canonicalize() filter (e.g. #4057) would
+      # otherwise only surface on the next *unrelated* scraper PR's deploy,
+      # blinding every scraper deploy's drift gate in the meantime
+      # (see #4073/#2608/#2592).
+      - "scripts/check-ingestion-worker-task-def-fingerprint.sh"
+      # scripts/ecs-render-task-def.sh is invoked transitively by the
+      # ecs-deploy composite action (.github/actions/ecs-deploy/action.yml).
+      # Same shared-script convention — a regression there silently breaks
+      # every scraper deploy's task-def render. See #4073.
+      - "scripts/ecs-render-task-def.sh"
   workflow_dispatch:
     inputs:
       image_tag:


### PR DESCRIPTION
## Summary

Adds the missing invoked scripts to `deploy-scraper.yml` and `deploy-api.yml`'s `on.push.paths` filters so changes to those scripts trigger the corresponding deploy on their own PR (instead of riding an unrelated future PR). Same shared-script convention as #2592 / #2608.

- `scripts/check-ingestion-worker-task-def-fingerprint.sh` → `deploy-scraper.yml` (the original gap, the #4044 drift gate's script).
- `scripts/ecs-render-task-def.sh` → `deploy-scraper.yml` AND `deploy-api.yml` (audit finding — invoked transitively by the `ecs-deploy` composite action, missing from both).

`deploy-production.yml` is `workflow_dispatch`-only (no `paths:` filter), so AC #2 is N/A there.

Closes #4073

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] On merge, `deploy-scraper.yml` triggers for the merge commit (the merge SHA touches `.github/workflows/deploy-scraper.yml`, which has always been in the filter — exercising the broader filter end-to-end). **Verified**: run [25401540406](https://github.com/judgemind/judgemind/actions/runs/25401540406) ran on merge SHA `c2c433f1`, all 4 jobs green including Post-Deploy Ingestion Worker Health Check (the job that invokes the newly-listed fingerprint script).
- [x] Verification evidence posted on issue (per /task A.8) — observe the workflow runs triggered by this PR's merge SHA.
