### PR TITLE
perf(dispatcher): batch orphan-PR resurrection sweep gh calls (#3407)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1644,6 +1644,20 @@ ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS = 3
 #: append-only audit + bookkeeping marker.
 PHASE_RESURRECTED_FOR_ORPHAN_PR = "resurrected_for_orphan_pr"
 
+#: Maximum number of orphan-PR candidates the resurrection sweep
+#: examines per supervisor tick (#3407). The pre-fix sweep iterated
+#: every ``status='failed' AND pr_number IS NOT NULL`` row from the
+#: 24h lookback window — typically 20-30 rows in production — and
+#: issued one ``gh pr view`` subprocess per row, taking ~27s per tick
+#: (threshold 10s). Capping the candidate set bounds worst-case
+#: latency: the SELECT order is ``ended_at DESC`` so the most-recent
+#: failures (most likely to still be transient and resurrectable)
+#: stay in scope. Older rows beyond the cap are operator-attention
+#: territory anyway. Combined with the batched GraphQL fetch in
+#: :meth:`_fetch_pr_status_batch` this drops the sweep from N
+#: subprocess calls to one.
+MAX_ORPHAN_PR_BATCH_SIZE = 30
+
 #: Which failure categories auto-create a retry marker (tier 1 per
 #: spec §8 table). ``subprocess_turn_limit`` (tier 2) and
 #: ``subprocess_auth_fail`` (halt — no retry) are intentionally
@@ -1735,6 +1749,95 @@ def _stderr_tail(stderr: str | bytes | None) -> str:
     if len(stderr) <= STRUCTURED_LOG_STDERR_MAX:
         return stderr
     return stderr[-STRUCTURED_LOG_STDERR_MAX:]
+
+
+def _normalize_graphql_pr_payload(node: dict[str, Any]) -> dict[str, Any]:
+    """Translate a ``pullRequest(number:N)`` GraphQL node into the dict
+    shape :meth:`_fetch_pr_status` returns from ``gh pr view --json``.
+
+    The orphan-PR resurrection sweep's classifier
+    (``phase_transitions._ci_rollup_state`` via
+    :func:`phase_transitions.transition_from_awaiting_ci`) consumes the
+    ``gh pr view`` shape — a flat list of dicts under the
+    ``statusCheckRollup`` key, each with ``status`` / ``conclusion`` for
+    CheckRun-typed checks and ``state`` for legacy StatusContext-typed
+    checks. The GraphQL ``commits(last:1).statusCheckRollup.contexts.nodes``
+    response wraps those same checks in a deeper shape with
+    ``__typename`` discrimination. This helper flattens the GraphQL
+    nodes into the gh-pr-view shape so downstream code (and existing
+    tests) keeps working without two parallel classifiers.
+
+    Issue #3407.
+
+    Returns a dict with these keys (all best-effort — missing fields
+    map to ``None`` so the classifier's defensive checks still apply):
+
+    * ``state`` — ``"OPEN"`` / ``"MERGED"`` / ``"CLOSED"``
+    * ``mergeable`` — ``"MERGEABLE"`` / ``"CONFLICTING"`` / ``"UNKNOWN"``
+    * ``mergeStateStatus`` — ``"CLEAN"`` / ``"UNSTABLE"`` / ``"DIRTY"`` / ``"UNKNOWN"`` / ...
+    * ``mergedAt`` — ISO timestamp string or ``None``
+    * ``headRefOid`` — head SHA string or ``None``
+    * ``mergeCommit`` — ``{"oid": "..."}`` or ``None``
+    * ``statusCheckRollup`` — list of ``{"status", "conclusion", "name"}``
+      (CheckRun) or ``{"state", "context"}`` (StatusContext) dicts.
+    """
+    out: dict[str, Any] = {
+        "state": node.get("state"),
+        "mergeable": node.get("mergeable"),
+        "mergeStateStatus": node.get("mergeStateStatus"),
+        "mergedAt": node.get("mergedAt"),
+        "headRefOid": node.get("headRefOid"),
+    }
+
+    # mergeCommit is nested in GraphQL — flatten to {"oid": ...} or None.
+    merge_commit = node.get("mergeCommit")
+    if isinstance(merge_commit, dict) and merge_commit.get("oid"):
+        out["mergeCommit"] = {"oid": merge_commit["oid"]}
+    else:
+        out["mergeCommit"] = None
+
+    # Flatten commits(last:1).statusCheckRollup.contexts.nodes — convert
+    # each context into the gh-pr-view shape the classifier expects.
+    rollup: list[dict[str, Any]] = []
+    commits_field = node.get("commits") or {}
+    commits_nodes = (
+        commits_field.get("nodes") if isinstance(commits_field, dict) else None
+    )
+    if isinstance(commits_nodes, list) and commits_nodes:
+        commit = (
+            commits_nodes[0].get("commit")
+            if isinstance(commits_nodes[0], dict)
+            else None
+        )
+        if isinstance(commit, dict):
+            rollup_obj = commit.get("statusCheckRollup")
+            if isinstance(rollup_obj, dict):
+                contexts = rollup_obj.get("contexts") or {}
+                ctx_nodes = (
+                    contexts.get("nodes") if isinstance(contexts, dict) else None
+                )
+                if isinstance(ctx_nodes, list):
+                    for ctx in ctx_nodes:
+                        if not isinstance(ctx, dict):
+                            continue
+                        typename = ctx.get("__typename")
+                        if typename == "CheckRun":
+                            rollup.append(
+                                {
+                                    "status": ctx.get("status"),
+                                    "conclusion": ctx.get("conclusion"),
+                                    "name": ctx.get("name"),
+                                }
+                            )
+                        elif typename == "StatusContext":
+                            rollup.append(
+                                {
+                                    "state": ctx.get("state"),
+                                    "context": ctx.get("context"),
+                                }
+                            )
+    out["statusCheckRollup"] = rollup
+    return out
 
 
 def _extract_botocore_error_code(exc: Exception) -> str:
@@ -14025,6 +14128,15 @@ class DispatcherDaemon:
         supervisor-tick log summary). Per-row failures (PR fetch
         timeout, DB write error) are logged and swallowed so one bad
         row cannot stall the sweep or the tick.
+
+        **Performance (#3407):** the candidate set is capped at
+        :data:`MAX_ORPHAN_PR_BATCH_SIZE` *after* the budget filter, and
+        the remaining PRs are fetched in a single batched GraphQL call
+        via :meth:`_fetch_pr_status_batch`. This drops the sweep from
+        N sequential ``gh pr view`` subprocesses to one — measured at
+        ~27s/tick (threshold 10s) before the fix. Any candidates beyond
+        the cap emit ``orphan_pr_resurrection_skipped`` with reason
+        ``batch_cap_exceeded`` so CloudWatch retains the audit trail.
         """
         assert self._conn is not None, "connect() must run before resurrection sweep"
 
@@ -14032,20 +14144,19 @@ class DispatcherDaemon:
         if not candidates:
             return 0
 
-        resurrected = 0
+        # Phase 1: filter by budget. Skipping budget-exhausted /
+        # count-failed rows BEFORE the PR-status fetch keeps the
+        # GraphQL query short and avoids burning rate on PRs we
+        # already know we can't resurrect.
+        eligible: list[dict[str, Any]] = []
         for row in candidates:
             agent_id = row["agent_id"]
             pr_number = row["pr_number"]
             issue_number = row["issue_number"]
 
-            # Budget check — count past resurrections for this agent_id
-            # via the phase_transitions audit log. This avoids needing
-            # a new schema column for the counter (#3399 is pure code).
             past_attempts = self._count_orphan_pr_resurrections(agent_id)
             if past_attempts is None:
                 # DB read failed — skip rather than grant a free pass.
-                # Checked BEFORE _fetch_pr_status to avoid a wasted gh
-                # API call when we already know we can't proceed safely.
                 self._log.info(
                     "daemon.orphan_pr_resurrection_skipped",
                     extra={
@@ -14074,12 +14185,60 @@ class DispatcherDaemon:
                 )
                 continue
 
-            # PR-state guard. Re-uses the same classifier as the
-            # awaiting_ci handler so the gate is consistent — if the
-            # PR isn't currently green-and-mergeable, don't resurrect.
-            pr_status = self._fetch_pr_status(pr_number)
+            eligible.append(
+                {
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "issue_number": issue_number,
+                    "past_attempts": past_attempts,
+                }
+            )
+
+        if not eligible:
+            return 0
+
+        # Phase 2: cap the set so a 100-row backlog can't burn the tick.
+        # The SELECT in :meth:`_list_orphan_pr_failed_agents` already
+        # ordered by ``ended_at DESC`` so most-recent failures (most
+        # likely to still be transient and resurrectable) stay in scope.
+        # Anything beyond the cap is operator-attention territory —
+        # autonomous resurrection isn't going to help.
+        if len(eligible) > MAX_ORPHAN_PR_BATCH_SIZE:
+            for skipped in eligible[MAX_ORPHAN_PR_BATCH_SIZE:]:
+                self._log.info(
+                    "daemon.orphan_pr_resurrection_skipped",
+                    extra={
+                        "event": "orphan_pr_resurrection_skipped",
+                        "run_id": self._run_id,
+                        "agent_id": skipped["agent_id"],
+                        "pr_number": skipped["pr_number"],
+                        "issue_number": skipped["issue_number"],
+                        "reason": "batch_cap_exceeded",
+                        "max_batch_size": MAX_ORPHAN_PR_BATCH_SIZE,
+                    },
+                )
+            eligible = eligible[:MAX_ORPHAN_PR_BATCH_SIZE]
+
+        # Phase 3: ONE batched GraphQL call for all remaining PR numbers.
+        # _fetch_pr_status_batch returns ``{pr_number: payload | None}``
+        # — None means the alias resolved to null OR the whole batch
+        # failed (transient gh / GraphQL flake).
+        pr_numbers = [row["pr_number"] for row in eligible]
+        pr_status_by_number = self._fetch_pr_status_batch(pr_numbers)
+
+        # Phase 4: per-row classification + DB write. No subprocess
+        # calls happen in this loop — the heavy work is already done.
+        resurrected = 0
+        for row in eligible:
+            agent_id = row["agent_id"]
+            pr_number = row["pr_number"]
+            issue_number = row["issue_number"]
+            past_attempts = row["past_attempts"]
+
+            pr_status = pr_status_by_number.get(pr_number)
             if pr_status is None:
-                # Transient gh failure — log and skip; next tick re-tries.
+                # Transient gh failure or alias-null — log and skip; next
+                # tick re-tries with a fresh batch.
                 self._log.info(
                     "daemon.orphan_pr_resurrection_skipped",
                     extra={
@@ -14909,6 +15068,136 @@ class DispatcherDaemon:
                 },
             )
             return None
+
+    def _fetch_pr_status_batch(
+        self, pr_numbers: list[int]
+    ) -> dict[int, dict[str, Any] | None]:
+        """Fetch combined check rollup + merge state for many PRs in one
+        GraphQL call (#3407).
+
+        The orphan-PR resurrection sweep used to call :meth:`_fetch_pr_status`
+        once per candidate, which translated to N sequential ``gh pr view``
+        subprocesses per supervisor tick. Production load (20-30 candidates
+        in the 24h lookback) drove that sweep to ~27s per tick (threshold
+        10s) and burned ~50min/hour of supervisor time on what is supposed
+        to be a ~1s housekeeping step. This batched helper issues a single
+        ``gh api graphql`` call with one aliased ``pullRequest(number:N)``
+        node per PR, mirroring the pattern in :meth:`_fetch_blocker_titles`.
+
+        Each PR resolves to either:
+
+        * a parsed dict shaped like the per-call :meth:`_fetch_pr_status`
+          payload (``statusCheckRollup``, ``mergeable``, ``mergeStateStatus``,
+          ``state``, ``mergedAt``, ``headRefOid``, ``mergeCommit``), OR
+        * ``None`` if the alias resolved to ``null`` (PR doesn't exist in
+          the repo, scope mismatch) or the whole batch failed.
+
+        On a transient failure (timeout, gh missing, empty stdout, missing
+        ``data.repository``) every key in the returned dict is ``None`` —
+        the caller treats that as "skip these candidates this tick" the
+        same way the per-call helper handles a flake.
+
+        Empty input returns ``{}`` without issuing a subprocess. Inputs
+        beyond GitHub's 500-node GraphQL limit are bounded by the caller
+        (see :data:`MAX_ORPHAN_PR_BATCH_SIZE`).
+        """
+        if not pr_numbers:
+            return {}
+
+        # Sort for deterministic alias ordering so unit tests can assert
+        # on the generated query without depending on input order.
+        capped = sorted(set(pr_numbers))
+
+        # Parse owner/name from "owner/repo" config value (mirrors the
+        # split in _fetch_blocker_titles).
+        repo_parts = self._cfg.github_repo.split("/", 1)
+        owner = repo_parts[0]
+        name = repo_parts[1] if len(repo_parts) > 1 else ""
+
+        # Build a single GraphQL query with one aliased pullRequest field
+        # per PR number. The ``statusCheckRollup`` shape mirrors the
+        # ``gh pr view --json statusCheckRollup`` output so the same
+        # phase_transitions._ci_rollup_state classifier accepts both.
+        # ``commits(last:1).statusCheckRollup.contexts.nodes`` returns the
+        # individual check runs / status contexts; we flatten them client
+        # side into the gh-pr-view-shaped ``statusCheckRollup`` list.
+        alias_fields = " ".join(
+            f"pr{n}: pullRequest(number: {n}) {{ "
+            f"number state mergeable mergeStateStatus mergedAt "
+            f"headRefOid "
+            f"mergeCommit {{ oid }} "
+            f"commits(last: 1) {{ nodes {{ commit {{ "
+            f"statusCheckRollup {{ contexts(first: 100) {{ nodes {{ "
+            f"__typename "
+            f"... on CheckRun {{ name status conclusion }} "
+            f"... on StatusContext {{ context state }} "
+            f"}} }} }} }} }} }} "
+            f"}}"
+            for n in capped
+        )
+        query = (
+            f'query {{ repository(owner:"{owner}", name:"{name}") '
+            f"{{ {alias_fields} }} }}"
+        )
+
+        cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+
+        # Hot-path: the supervisor tick blocks on this, so route through
+        # _subprocess_with_retry for the same 1s+2s backoff envelope the
+        # per-call _fetch_pr_status uses. The retry helper treats every
+        # non-zero exit as transient — acceptable here because the
+        # orphan-PR PRs are all author=daemon and a partial-error response
+        # (one of N PRs missing) is genuinely worth retrying. Compare to
+        # _fetch_blocker_titles which bypasses the retry helper because
+        # mixed-issue/PR batches deterministically partial-error.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="pr_view_batch",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"pr_count": len(capped)},
+        )
+        if not outcome["ok"]:
+            return {n: None for n in capped}
+
+        result = outcome["result"]
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            self._log.warning(
+                "daemon.pr_view_batch_invalid_json",
+                extra={
+                    "event": "pr_view_batch_invalid_json",
+                    "run_id": self._run_id,
+                    "pr_count": len(capped),
+                },
+            )
+            return {n: None for n in capped}
+
+        repo_data = (
+            payload.get("data", {}).get("repository")
+            if isinstance(payload, dict)
+            else None
+        )
+        if not isinstance(repo_data, dict):
+            self._log.warning(
+                "daemon.pr_view_batch_missing_data",
+                extra={
+                    "event": "pr_view_batch_missing_data",
+                    "run_id": self._run_id,
+                    "pr_count": len(capped),
+                },
+            )
+            return {n: None for n in capped}
+
+        out: dict[int, dict[str, Any] | None] = {}
+        for n in capped:
+            node = repo_data.get(f"pr{n}")
+            if not isinstance(node, dict):
+                # PR doesn't exist (e.g. number was deleted) or scope mismatch.
+                out[n] = None
+                continue
+            out[n] = _normalize_graphql_pr_payload(node)
+        return out
 
     @staticmethod
     def _pr_observed_as_merged(pr_status: dict[str, Any] | None) -> bool:

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
@@ -30,6 +30,7 @@ GitHub / DB writes.
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from datetime import UTC, datetime, timedelta
@@ -231,9 +232,12 @@ class TestResurrectionHappyPath:
         # _count_orphan_pr_resurrections fetchone — 0 prior attempts.
         conn.cursor_instance.fetch_queue.append((0,))
 
-        # Stub _fetch_pr_status to return the canonical green payload.
-        # PR #3391 is the live test case from the issue body.
-        d._fetch_pr_status = lambda pr: _pr_status_green()  # type: ignore[method-assign]
+        # Stub _fetch_pr_status_batch to return the canonical green
+        # payload for every requested PR (#3407 batched-fetch). PR
+        # #3391 is the live test case from the issue body.
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_green() for pr in prs
+        }
 
         n = d._resurrect_orphan_pr_agents()
 
@@ -287,7 +291,9 @@ class TestResurrectionNegativePaths:
         conn.cursor_instance.fetchall_queue.append([("agent-closed", 999, 100)])
         conn.cursor_instance.fetch_queue.append((0,))
         # Closed/declined PRs come back as mergeable != 'MERGEABLE'.
-        d._fetch_pr_status = lambda pr: _pr_status_closed()  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_closed() for pr in prs
+        }
 
         n = d._resurrect_orphan_pr_agents()
 
@@ -319,7 +325,9 @@ class TestResurrectionNegativePaths:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue.append([("agent-dirty", 888, 200)])
         conn.cursor_instance.fetch_queue.append((0,))
-        d._fetch_pr_status = lambda pr: _pr_status_dirty()  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_dirty() for pr in prs
+        }
 
         n = d._resurrect_orphan_pr_agents()
 
@@ -352,7 +360,9 @@ class TestResurrectionNegativePaths:
             "headRefOid": "head-sha",
             "mergeCommit": None,
         }
-        d._fetch_pr_status = lambda pr: unknown_payload  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: unknown_payload for pr in prs
+        }
 
         n = d._resurrect_orphan_pr_agents()
 
@@ -367,7 +377,9 @@ class TestResurrectionNegativePaths:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue.append([("agent-pending", 777, 300)])
         conn.cursor_instance.fetch_queue.append((0,))
-        d._fetch_pr_status = lambda pr: _pr_status_pending()  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_pending() for pr in prs
+        }
 
         n = d._resurrect_orphan_pr_agents()
 
@@ -380,8 +392,9 @@ class TestResurrectionNegativePaths:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue.append([("agent-pr-view-fail", 666, 400)])
         conn.cursor_instance.fetch_queue.append((0,))
-        # _fetch_pr_status returns None on transient gh failure.
-        d._fetch_pr_status = lambda pr: None  # type: ignore[method-assign]
+        # _fetch_pr_status_batch returns ``{pr: None}`` on transient
+        # gh / GraphQL failure (#3407).
+        d._fetch_pr_status_batch = lambda prs: {pr: None for pr in prs}  # type: ignore[method-assign]
 
         n = d._resurrect_orphan_pr_agents()
 
@@ -407,20 +420,26 @@ class TestResurrectionNegativePaths:
             (daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS,)
         )
 
-        # Sentinel: _fetch_pr_status must NOT be called when budget
-        # check short-circuits. (Saves a gh API call.)
-        called: list[int] = []
+        # Sentinel: _fetch_pr_status_batch must NOT receive the
+        # budget-exhausted PR (saves it from the GraphQL alias list).
+        called: list[list[int]] = []
 
-        def boom(pr: int) -> dict[str, Any]:
-            called.append(pr)
-            return _pr_status_green()
+        def boom(prs: list[int]) -> dict[int, dict[str, Any] | None]:
+            called.append(list(prs))
+            return {pr: _pr_status_green() for pr in prs}
 
-        d._fetch_pr_status = boom  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = boom  # type: ignore[method-assign]
 
         n = d._resurrect_orphan_pr_agents()
 
         assert n == 0
-        assert called == [], "_fetch_pr_status should not be called past budget"
+        # _fetch_pr_status_batch is either skipped entirely (no
+        # eligible candidates) OR receives a list NOT containing
+        # the budget-exhausted PR. Either is acceptable.
+        for invocation in called:
+            assert 555 not in invocation, (
+                "budget-exhausted PR must NOT be in batched fetch"
+            )
         skipped = handler.events("orphan_pr_resurrection_skipped")
         assert skipped, "expected orphan_pr_resurrection_skipped"
         assert skipped[0].reason == "budget_exhausted"
@@ -429,10 +448,10 @@ class TestResurrectionNegativePaths:
 
     def test_count_failed_skips_candidate_no_resurrection(self, tmp_path: Path) -> None:
         """When _count_orphan_pr_resurrections returns None (DB error),
-        the candidate must be skipped without calling _fetch_pr_status
-        (no wasted gh API call) and without any resurrection DB write.
-        A distinct orphan_pr_resurrection_skipped event with
-        reason='count_failed' must be logged (#3427).
+        the candidate must be skipped without batch-fetching its PR
+        status (no wasted GraphQL call) and without any resurrection
+        DB write. A distinct orphan_pr_resurrection_skipped event with
+        reason='count_failed' must be logged (#3427, #3407).
         """
         d, conn, handler = _make_daemon(tmp_path)
 
@@ -442,21 +461,23 @@ class TestResurrectionNegativePaths:
         # Force _count_orphan_pr_resurrections to return None.
         d._count_orphan_pr_resurrections = lambda agent_id: None  # type: ignore[method-assign]
 
-        # Sentinel: _fetch_pr_status must NOT be called.
-        pr_status_calls: list[int] = []
+        # Sentinel: _fetch_pr_status_batch must NOT include the
+        # count-failed PR.
+        pr_status_calls: list[list[int]] = []
 
-        def fetch_pr_sentinel(pr: int) -> dict[str, Any]:
-            pr_status_calls.append(pr)
-            return _pr_status_green()
+        def fetch_pr_sentinel(prs: list[int]) -> dict[int, dict[str, Any] | None]:
+            pr_status_calls.append(list(prs))
+            return {pr: _pr_status_green() for pr in prs}
 
-        d._fetch_pr_status = fetch_pr_sentinel  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = fetch_pr_sentinel  # type: ignore[method-assign]
 
         n = d._resurrect_orphan_pr_agents()
 
         assert n == 0, "no resurrection expected"
-        assert pr_status_calls == [], (
-            "_fetch_pr_status must NOT be called on count_failed"
-        )
+        for invocation in pr_status_calls:
+            assert 444 not in invocation, (
+                "_fetch_pr_status_batch must NOT include count_failed PR"
+            )
         # No resurrection event.
         assert handler.events("agent_resurrected_for_orphan_pr") == []
         # Distinct skip event with count_failed reason.
@@ -476,14 +497,20 @@ class TestResurrectionNegativePaths:
         # SELECT returns no rows.
         conn.cursor_instance.fetchall_queue.append([])
 
-        # Sentinel: _fetch_pr_status must NOT be called.
-        called: list[int] = []
-        d._fetch_pr_status = lambda pr: called.append(pr) or None  # type: ignore[method-assign]
+        # Sentinel: _fetch_pr_status_batch must NOT be called when
+        # there are no candidates.
+        called: list[list[int]] = []
+
+        def fetch_sentinel(prs: list[int]) -> dict[int, dict[str, Any] | None]:
+            called.append(list(prs))
+            return {}
+
+        d._fetch_pr_status_batch = fetch_sentinel  # type: ignore[method-assign]
 
         n = d._resurrect_orphan_pr_agents()
 
         assert n == 0
-        assert called == []
+        assert called == [], "_fetch_pr_status_batch must NOT be called"
         assert handler.events("agent_resurrected_for_orphan_pr") == []
         assert handler.events("orphan_pr_resurrection_skipped") == []
 
@@ -769,3 +796,515 @@ class TestDbErrorPaths:
 
         assert rows == []
         assert handler.events("orphan_pr_list_failed")
+
+
+# --------------------------------------------------------------------------
+# Issue #3407 — batched gh pr view + candidate cap
+# --------------------------------------------------------------------------
+
+
+class TestBatchedFetchInvariants:
+    """The orphan-PR resurrection sweep must issue ONE batched fetch
+    per supervisor tick instead of N per-PR ``gh pr view`` calls. The
+    pre-fix sweep took ~27s/tick at the 24h-lookback default with
+    20-30 candidates; one batched GraphQL roundtrip is the surgical
+    fix described in the issue body's "fix shape #1".
+    """
+
+    def test_constant_max_orphan_pr_batch_size(self) -> None:
+        # Candidate cap must exist and be a sensible bound — small
+        # enough to keep the GraphQL query under GitHub's 500-node
+        # limit (one alias per PR), large enough to absorb the
+        # observed 20-30-row 24h-lookback steady state.
+        assert daemon.MAX_ORPHAN_PR_BATCH_SIZE >= 20
+        assert daemon.MAX_ORPHAN_PR_BATCH_SIZE <= 100
+
+    def test_batched_fetch_called_exactly_once_per_sweep(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        # 5 eligible candidates — the batched contract is "one
+        # invocation regardless of N".
+        rows = [(f"agent-{i}", 1000 + i, 2000 + i) for i in range(5)]
+        conn.cursor_instance.fetchall_queue.append(rows)
+        # 5 budget-count fetchones, all 0.
+        for _ in range(5):
+            conn.cursor_instance.fetch_queue.append((0,))
+
+        invocations: list[list[int]] = []
+
+        def batched_fetch(prs: list[int]) -> dict[int, dict[str, Any] | None]:
+            invocations.append(list(prs))
+            # All green — every candidate resurrects.
+            return {pr: _pr_status_green() for pr in prs}
+
+        d._fetch_pr_status_batch = batched_fetch  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 5, "all five candidates should resurrect"
+        assert len(invocations) == 1, (
+            "batched fetch must be called once per sweep, not N times"
+        )
+        assert sorted(invocations[0]) == [1000, 1001, 1002, 1003, 1004]
+
+    def test_per_call_fetch_pr_status_not_invoked_in_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        """Sentinel — :meth:`_fetch_pr_status` (the per-call helper)
+        must not be reachable from the resurrection sweep after the
+        #3407 batched-fetch refactor. Calling the per-call helper
+        would spawn one ``gh pr view`` subprocess per candidate, which
+        is exactly the failure mode the issue describes."""
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        rows = [(f"agent-{i}", 5000 + i, 6000 + i) for i in range(3)]
+        conn.cursor_instance.fetchall_queue.append(rows)
+        for _ in range(3):
+            conn.cursor_instance.fetch_queue.append((0,))
+
+        per_call_invocations: list[int] = []
+
+        def boom_per_call(pr_number: int) -> dict[str, Any] | None:
+            per_call_invocations.append(pr_number)
+            return _pr_status_green()
+
+        d._fetch_pr_status = boom_per_call  # type: ignore[method-assign]
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_green() for pr in prs
+        }
+
+        d._resurrect_orphan_pr_agents()
+
+        assert per_call_invocations == [], (
+            "_fetch_pr_status MUST NOT be called from the sweep — "
+            "use _fetch_pr_status_batch instead"
+        )
+
+    def test_30_candidate_sweep_completes_under_5s(self, tmp_path: Path) -> None:
+        """Acceptance criterion #3 from issue #3407: simulate 30
+        candidate orphan-PR rows; sweep completes within 5s with
+        mocked gh calls.
+
+        The pre-fix sweep was ~27s for ~25 rows (one ``gh pr view``
+        per row at ~1s wall-clock). After the refactor a single
+        mocked batched fetch returns instantly, so the realistic
+        expectation is sub-100ms — but the AC's 5s threshold is the
+        operator-visible bound the supervisor tick must stay under.
+        """
+        import time as _time  # local import to keep test isolation
+
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        n_candidates = 30
+        rows = [(f"agent-{i}", 7000 + i, 8000 + i) for i in range(n_candidates)]
+        conn.cursor_instance.fetchall_queue.append(rows)
+        for _ in range(n_candidates):
+            conn.cursor_instance.fetch_queue.append((0,))
+
+        # All-green batched response. The real call would issue one
+        # GraphQL HTTP request — about 200-400ms in production. The
+        # test mocks it as instant.
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_green() for pr in prs
+        }
+
+        start = _time.monotonic()
+        n = d._resurrect_orphan_pr_agents()
+        elapsed = _time.monotonic() - start
+
+        assert n == n_candidates, "all 30 candidates should resurrect"
+        # 5s threshold from the issue's AC. The actual measured time
+        # should be well under 1s; the threshold provides headroom for
+        # CI-runner noise without being so loose it permits a regression.
+        assert elapsed < 5.0, f"30-candidate sweep took {elapsed:.2f}s — exceeds 5s AC"
+
+
+class TestBatchCapEnforcement:
+    """When the candidate set is larger than
+    :data:`MAX_ORPHAN_PR_BATCH_SIZE`, the sweep must drop the excess
+    rows (with an audit log line per drop) rather than letting the
+    GraphQL alias list grow unboundedly. The SELECT order
+    (``ended_at DESC``) keeps the most-recent failures in scope."""
+
+    def test_excess_candidates_emit_batch_cap_exceeded_skip(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # 5 over the cap — these should be skipped with the new reason.
+        n_candidates = daemon.MAX_ORPHAN_PR_BATCH_SIZE + 5
+        rows = [(f"agent-{i}", 9000 + i, 10000 + i) for i in range(n_candidates)]
+        conn.cursor_instance.fetchall_queue.append(rows)
+        for _ in range(n_candidates):
+            conn.cursor_instance.fetch_queue.append((0,))
+
+        d._fetch_pr_status_batch = lambda prs: {  # type: ignore[method-assign]
+            pr: _pr_status_green() for pr in prs
+        }
+
+        n = d._resurrect_orphan_pr_agents()
+
+        # Only the first MAX_ORPHAN_PR_BATCH_SIZE rows resurrected.
+        assert n == daemon.MAX_ORPHAN_PR_BATCH_SIZE
+        # The 5 excess rows each get a skip-event with the new reason.
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        cap_skips = [
+            s for s in skipped if getattr(s, "reason", None) == "batch_cap_exceeded"
+        ]
+        assert len(cap_skips) == 5, (
+            f"expected 5 batch_cap_exceeded skips, got {len(cap_skips)}"
+        )
+        # The CloudWatch event carries max_batch_size for operator
+        # readability so they can check the cap from the log alone.
+        assert cap_skips[0].max_batch_size == daemon.MAX_ORPHAN_PR_BATCH_SIZE
+
+    def test_batched_fetch_receives_at_most_max_batch_size_prs(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        n_candidates = daemon.MAX_ORPHAN_PR_BATCH_SIZE + 10
+        rows = [(f"agent-{i}", 11000 + i, 12000 + i) for i in range(n_candidates)]
+        conn.cursor_instance.fetchall_queue.append(rows)
+        for _ in range(n_candidates):
+            conn.cursor_instance.fetch_queue.append((0,))
+
+        invocations: list[list[int]] = []
+
+        def batched_fetch(prs: list[int]) -> dict[int, dict[str, Any] | None]:
+            invocations.append(list(prs))
+            return {pr: _pr_status_green() for pr in prs}
+
+        d._fetch_pr_status_batch = batched_fetch  # type: ignore[method-assign]
+
+        d._resurrect_orphan_pr_agents()
+
+        assert len(invocations) == 1
+        # The batched fetch sees only the first cap-many PRs.
+        assert len(invocations[0]) == daemon.MAX_ORPHAN_PR_BATCH_SIZE
+
+
+# --------------------------------------------------------------------------
+# _fetch_pr_status_batch — single subprocess, GraphQL shape, normalization
+# --------------------------------------------------------------------------
+
+
+class TestFetchPrStatusBatch:
+    def test_empty_input_returns_empty_dict_no_subprocess(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        # Sentinel: no subprocess wrapper invoked when input is empty.
+        d._subprocess_with_retry = lambda *_a, **_k: (_ for _ in ()).throw(  # type: ignore[method-assign]
+            AssertionError("subprocess must NOT be called for empty input")
+        )
+
+        result = d._fetch_pr_status_batch([])
+
+        assert result == {}
+
+    def test_single_subprocess_for_many_prs(self, tmp_path: Path) -> None:
+        """The whole point of #3407 — one subprocess call regardless
+        of PR count."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        invocations: list[list[str]] = []
+
+        # Build a synthetic GraphQL response for 25 PRs.
+        pr_numbers = list(range(100, 125))
+
+        def fake_run(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            invocations.append(cmd)
+            assert event_name == "pr_view_batch", "uses dedicated event name"
+            # Build a fake gh api graphql response.
+            repo_data = {}
+            for n in pr_numbers:
+                repo_data[f"pr{n}"] = {
+                    "number": n,
+                    "state": "OPEN",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "mergedAt": None,
+                    "headRefOid": f"sha-{n}",
+                    "mergeCommit": None,
+                    "commits": {
+                        "nodes": [
+                            {
+                                "commit": {
+                                    "statusCheckRollup": {
+                                        "contexts": {
+                                            "nodes": [
+                                                {
+                                                    "__typename": "CheckRun",
+                                                    "name": "ci-passed",
+                                                    "status": "COMPLETED",
+                                                    "conclusion": "SUCCESS",
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                }
+            payload = {"data": {"repository": repo_data}}
+
+            class _Result:
+                stdout = json.dumps(payload)
+
+            return {"ok": True, "result": _Result(), "attempts": 1}
+
+        d._subprocess_with_retry = fake_run  # type: ignore[method-assign]
+
+        result = d._fetch_pr_status_batch(pr_numbers)
+
+        # ONE subprocess invocation regardless of N.
+        assert len(invocations) == 1
+        # The cmd is a `gh api graphql` invocation with a query
+        # containing one alias per PR.
+        cmd = invocations[0]
+        assert cmd[:3] == ["gh", "api", "graphql"]
+        assert cmd[3] == "-f"
+        query = cmd[4].removeprefix("query=")
+        for n in pr_numbers:
+            assert f"pr{n}: pullRequest(number: {n})" in query
+
+        # Per-PR shape mirrors `_fetch_pr_status` so the existing
+        # classifier (transition_from_awaiting_ci) consumes it
+        # without changes.
+        assert set(result.keys()) == set(pr_numbers)
+        for n in pr_numbers:
+            payload = result[n]
+            assert payload is not None
+            assert payload["state"] == "OPEN"
+            assert payload["mergeable"] == "MERGEABLE"
+            assert payload["mergeStateStatus"] == "CLEAN"
+            # CheckRun translated to gh-pr-view shape.
+            assert payload["statusCheckRollup"] == [
+                {"name": "ci-passed", "status": "COMPLETED", "conclusion": "SUCCESS"}
+            ]
+
+    def test_subprocess_failure_returns_all_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        # _subprocess_with_retry returns ok=False on exhausted retries.
+        d._subprocess_with_retry = lambda *_a, **_k: {  # type: ignore[method-assign]
+            "ok": False,
+            "reason": "timeout",
+            "stderr_tail": "",
+            "exit_code": None,
+            "attempts": 3,
+        }
+
+        result = d._fetch_pr_status_batch([100, 200, 300])
+
+        assert result == {100: None, 200: None, 300: None}
+
+    def test_unparseable_json_returns_all_none(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        class _Result:
+            stdout = "{not json"
+
+        d._subprocess_with_retry = lambda *_a, **_k: {  # type: ignore[method-assign]
+            "ok": True,
+            "result": _Result(),
+            "attempts": 1,
+        }
+
+        result = d._fetch_pr_status_batch([100, 200])
+
+        assert result == {100: None, 200: None}
+        assert handler.events("pr_view_batch_invalid_json")
+
+    def test_missing_repository_data_returns_all_none(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        class _Result:
+            # Valid JSON but no data.repository — treated as transient
+            # like in _fetch_blocker_titles.
+            stdout = json.dumps({"data": {}})
+
+        d._subprocess_with_retry = lambda *_a, **_k: {  # type: ignore[method-assign]
+            "ok": True,
+            "result": _Result(),
+            "attempts": 1,
+        }
+
+        result = d._fetch_pr_status_batch([100, 200])
+
+        assert result == {100: None, 200: None}
+        assert handler.events("pr_view_batch_missing_data")
+
+    def test_alias_null_for_one_pr_returns_none_for_only_that_pr(
+        self, tmp_path: Path
+    ) -> None:
+        """A specific PR may have been deleted; the alias resolves to
+        null while the rest of the batch returns valid data. The
+        deleted PR's slot must be ``None``; the others must carry
+        their normalized payloads."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        class _Result:
+            stdout = json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pr100": None,  # deleted
+                            "pr200": {
+                                "number": 200,
+                                "state": "OPEN",
+                                "mergeable": "MERGEABLE",
+                                "mergeStateStatus": "CLEAN",
+                                "mergedAt": None,
+                                "headRefOid": "sha-200",
+                                "mergeCommit": None,
+                                "commits": {
+                                    "nodes": [
+                                        {
+                                            "commit": {
+                                                "statusCheckRollup": {
+                                                    "contexts": {
+                                                        "nodes": [
+                                                            {
+                                                                "__typename": "CheckRun",
+                                                                "name": "ci-passed",
+                                                                "status": "COMPLETED",
+                                                                "conclusion": "SUCCESS",
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                            },
+                        }
+                    }
+                }
+            )
+
+        d._subprocess_with_retry = lambda *_a, **_k: {  # type: ignore[method-assign]
+            "ok": True,
+            "result": _Result(),
+            "attempts": 1,
+        }
+
+        result = d._fetch_pr_status_batch([100, 200])
+
+        assert result[100] is None
+        assert result[200] is not None
+        assert result[200]["state"] == "OPEN"
+
+
+class TestNormalizeGraphqlPrPayload:
+    """Direct tests for the GraphQL-to-gh-pr-view shape normalizer.
+    Both CheckRun and StatusContext discriminator paths must round-
+    trip through the same gh-pr-view-shaped output the existing
+    classifier consumes."""
+
+    def test_check_run_node_normalized(self) -> None:
+        node = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "mergedAt": None,
+            "headRefOid": "head-sha",
+            "mergeCommit": None,
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "statusCheckRollup": {
+                                "contexts": {
+                                    "nodes": [
+                                        {
+                                            "__typename": "CheckRun",
+                                            "name": "ci-passed",
+                                            "status": "COMPLETED",
+                                            "conclusion": "SUCCESS",
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+        }
+        out = daemon._normalize_graphql_pr_payload(node)
+        assert out["state"] == "OPEN"
+        assert out["mergeable"] == "MERGEABLE"
+        assert out["mergeStateStatus"] == "CLEAN"
+        assert out["mergeCommit"] is None
+        assert out["statusCheckRollup"] == [
+            {"name": "ci-passed", "status": "COMPLETED", "conclusion": "SUCCESS"}
+        ]
+
+    def test_status_context_node_normalized(self) -> None:
+        node = {
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "mergedAt": None,
+            "headRefOid": "head-sha",
+            "mergeCommit": None,
+            "commits": {
+                "nodes": [
+                    {
+                        "commit": {
+                            "statusCheckRollup": {
+                                "contexts": {
+                                    "nodes": [
+                                        {
+                                            "__typename": "StatusContext",
+                                            "context": "vercel/preview",
+                                            "state": "SUCCESS",
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+        }
+        out = daemon._normalize_graphql_pr_payload(node)
+        assert out["statusCheckRollup"] == [
+            {"context": "vercel/preview", "state": "SUCCESS"}
+        ]
+
+    def test_merge_commit_oid_normalized(self) -> None:
+        node = {
+            "state": "MERGED",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "mergedAt": "2026-04-26T03:00:00Z",
+            "headRefOid": "head-sha",
+            "mergeCommit": {"oid": "merge-sha"},
+            "commits": {"nodes": []},
+        }
+        out = daemon._normalize_graphql_pr_payload(node)
+        assert out["mergeCommit"] == {"oid": "merge-sha"}
+        assert out["state"] == "MERGED"
+        assert out["mergedAt"] == "2026-04-26T03:00:00Z"
+        # Empty commits.nodes → empty rollup, NOT a crash.
+        assert out["statusCheckRollup"] == []
+
+    def test_missing_fields_default_to_none_or_empty(self) -> None:
+        # Defensive — GraphQL may omit fields under transient errors.
+        out = daemon._normalize_graphql_pr_payload({})
+        assert out["state"] is None
+        assert out["mergeable"] is None
+        assert out["mergeStateStatus"] is None
+        assert out["mergedAt"] is None
+        assert out["headRefOid"] is None
+        assert out["mergeCommit"] is None
+        assert out["statusCheckRollup"] == []


### PR DESCRIPTION
## Summary

Batches the orphan-PR resurrection sweep's `gh pr view` calls into a single GraphQL roundtrip and caps the candidate set at 30 — drops the supervisor sub-step from ~27s/tick (threshold 10s) to ~one-GraphQL-call worth of wall-clock.

Closes #3407

## What changed

- New module-level constant `MAX_ORPHAN_PR_BATCH_SIZE = 30` caps the per-tick candidate set.
- New method `_fetch_pr_status_batch(pr_numbers)` issues one `gh api graphql` call with one aliased `pullRequest(number:N)` field per PR, mirroring the existing `_fetch_blocker_titles` pattern.
- New helper `_normalize_graphql_pr_payload` flattens the GraphQL `commits.statusCheckRollup.contexts.nodes` response (with CheckRun / StatusContext typename discrimination) back into the gh-pr-view shape the existing classifier consumes — no second classifier needed.
- `_resurrect_orphan_pr_agents` refactored into 4 phases: (1) budget filter, (2) candidate cap with `batch_cap_exceeded` skip event for any drops, (3) ONE batched fetch, (4) classify + write per row.
- Per-row classification (`transition_from_awaiting_ci`) and DB writes (`_mark_agent_resurrected_for_orphan_pr`) unchanged — every existing skip-reason event still fires on the same conditions.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/`) — 2158 passed, 1 skipped
- [x] CI green

### Post-deploy verification
- [x] CloudWatch query for `event="supervisor_tick_slow_orphan_pr_resurrect"` returns zero hits over 60min after deploy lands.
- [x] Verification evidence posted on issue (see A.8)

## Notes

- The claim-path helper `_orphan_pr_recovery_pending` still uses the per-call `_fetch_pr_status` — that path checks ONE issue per scheduler tick and is already optimal. Only the sweep needed batching.
- Did not introduce a TTL cache (issue's fix shape #2) or a worker thread (#3) — batching alone solves the problem cleanly. Tightening the lookback to 6h (#4 sub-bullet) is unnecessary given the candidate-set cap; the cap keeps `ORDER BY ended_at DESC`'s 30 most-recent rows in scope, which is exactly what we want.
