### PR TITLE
fix(web): drop blockedBy.title from polled dispatcher dashboard query (#4062)

### DIFF
--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -9,6 +9,19 @@
  * Apollo `keyFields` for these types live in `apollo-client.ts`
  * (`DispatcherRun`, `DispatcherFailure`, `PhaseTransition`,
  * `DispatcherCommandResult`, and `keyFields: false` for `DispatcherState`).
+ *
+ * Polled-query complexity contract (issue #4062 — followup to the #4003
+ * GraphQL DoS hardening that capped per-query cost at 1000):
+ * `DISPATCHER_STATE_QUERY` is fired every 2s by the cockpit, so it must
+ * stay well below the 1000-cost cap. The biggest amplifier in this query
+ * shape is list-of-objects-containing-a-list — the polled `blockedBy`
+ * selections inside `queueReady` and `queueBlocked` therefore request
+ * ONLY `number`. Blocker titles are populated only when the operator
+ * opens the expand-on-click full-list dialog, which uses the separate
+ * `DISPATCHER_QUEUE_FULL_QUERY` below (fires once per dialog open, not
+ * polled). The render layer's `formatBlockerTooltip` already falls back
+ * to `#N` alone when `BlockerRef.title` is null/undefined, so the polled
+ * tooltip degrades gracefully — full titles still appear in the dialog.
  */
 import { gql } from '@apollo/client';
 
@@ -58,7 +71,6 @@ export const DISPATCHER_STATE_QUERY = gql`
         createdAt
         blockedBy {
           number
-          title
         }
         cooldownSecondsRemaining
       }
@@ -70,7 +82,6 @@ export const DISPATCHER_STATE_QUERY = gql`
         createdAt
         blockedBy {
           number
-          title
         }
       }
       recentCompletions {
@@ -254,10 +265,21 @@ export interface DispatcherFailure {
  *
  * Apollo `keyFields: ['number']` is registered in `apollo-client.ts` so
  * Apollo normalises distinct BlockerRef entries correctly.
+ *
+ * Title selection (issue #4062): only `DISPATCHER_QUEUE_FULL_QUERY`
+ * (the expand-on-click dialog) selects `title`. The polled
+ * `DISPATCHER_STATE_QUERY` selects only `number` to keep query cost
+ * under the 1000-cap from #4003. Render code that consumes
+ * `BlockerRef.title` MUST tolerate `undefined` as well as `null` — see
+ * `formatBlockerTooltip` in `QueuePanel.tsx` for the canonical fallback
+ * (renders `#N` alone when the title is missing).
  */
 export interface BlockerRef {
   number: number;
-  title: string | null;
+  /** May be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (which selects only `number`). Always either
+   * a string or `null` on rows fetched via `DISPATCHER_QUEUE_FULL_QUERY`. */
+  title?: string | null;
 }
 
 export interface QueueItem {

--- a/packages/web/tests/dispatcher-polled-query-shape.test.ts
+++ b/packages/web/tests/dispatcher-polled-query-shape.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { print } from 'graphql';
+import {
+  DISPATCHER_STATE_QUERY,
+  DISPATCHER_QUEUE_FULL_QUERY,
+} from '../src/lib/dispatcher-queries';
+
+/**
+ * Regression test for issue #4062.
+ *
+ * The polled `DISPATCHER_STATE_QUERY` is fired every 2s by the cockpit
+ * dashboard. The #4003 GraphQL DoS hardening introduced a per-query
+ * complexity cap of 1000, which the dashboard query was exceeding
+ * (cost: 1355). The biggest single contributor to that cost was the
+ * nested `blockedBy { number title }` selection inside the two queue
+ * lists — `graphql-validation-complexity` multiplies cost for each list
+ * nesting level, and list-of-objects-containing-a-list is the most
+ * expensive shape.
+ *
+ * The fix in this PR drops `blockedBy.title` from the polled query and
+ * keeps only `blockedBy.number`. Blocker titles remain on the
+ * expand-on-click `DISPATCHER_QUEUE_FULL_QUERY`, which fires only on
+ * dialog open (not in the poll path).
+ *
+ * If a future change re-adds `title` inside the polled query's
+ * `blockedBy` selections, this test fails and forces an explicit
+ * decision about the cost regression.
+ */
+
+/**
+ * Extract every selection-set body that follows the regex pattern
+ * `<fieldName> { ... }` in the printed query, with the `{ ... }` matched
+ * non-greedily on a per-block basis.
+ *
+ * Returns the contents of every `<fieldName> { ... }` block, in source
+ * order. Nested braces inside the field block (e.g. another nested
+ * selection) are not expected for the leaf-list shapes we inspect here
+ * (`blockedBy` in the polled query has only scalar fields), so a simple
+ * non-greedy match is sufficient.
+ */
+function selectionBodiesFor(query: string, fieldName: string): string[] {
+  const re = new RegExp(`${fieldName}\\s*\\{([^{}]*)\\}`, 'g');
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(query)) !== null) {
+    out.push(m[1]);
+  }
+  return out;
+}
+
+describe('DISPATCHER_STATE_QUERY — polled query shape (issue #4062)', () => {
+  const printed = print(DISPATCHER_STATE_QUERY);
+
+  it('is the expected operation', () => {
+    expect(printed).toMatch(/query\s+DispatcherState\b/);
+  });
+
+  it('selects blockedBy in both queueReady and queueBlocked', () => {
+    // Sanity: we expect exactly two `blockedBy { ... }` blocks in the
+    // polled query — one inside queueReady, one inside queueBlocked.
+    const bodies = selectionBodiesFor(printed, 'blockedBy');
+    expect(bodies).toHaveLength(2);
+  });
+
+  it('omits `title` from every `blockedBy` selection in the polled query', () => {
+    // AC5 (regression): a frontend-side test asserts the polled query
+    // string does not contain `title` inside the two `blockedBy`
+    // selections. The polled query only renders `#N` count info; full
+    // titles are populated via DISPATCHER_QUEUE_FULL_QUERY.
+    const bodies = selectionBodiesFor(printed, 'blockedBy');
+    for (const body of bodies) {
+      expect(body).toMatch(/\bnumber\b/);
+      expect(body).not.toMatch(/\btitle\b/);
+    }
+  });
+});
+
+describe('DISPATCHER_QUEUE_FULL_QUERY — dialog query still selects title', () => {
+  const printed = print(DISPATCHER_QUEUE_FULL_QUERY);
+
+  it('keeps `title` inside the dialog query `blockedBy` selection', () => {
+    // AC4 (regression guard the other way): the expand-on-click dialog
+    // continues to surface blocker titles. If a future cleanup also
+    // strips `title` from this query, the dialog tooltip silently loses
+    // information — fail loudly here instead.
+    const bodies = selectionBodiesFor(printed, 'blockedBy');
+    expect(bodies.length).toBeGreaterThan(0);
+    for (const body of bodies) {
+      expect(body).toMatch(/\btitle\b/);
+      expect(body).toMatch(/\bnumber\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The polled `DISPATCHER_STATE_QUERY` cost was 1355, exceeding the 1000 GraphQL complexity cap added in #4003 — every poll on `/admin/dispatcher` was being rejected with HTTP 400. The biggest single contributor was the nested `blockedBy { number title }` selection inside both `queueReady` and `queueBlocked` (list-of-objects-containing-a-list is the most expensive shape under `graphql-validation-complexity`'s per-list-nesting multiplier). Drops `title` from both polled `blockedBy` selections; the expand-on-click `DISPATCHER_QUEUE_FULL_QUERY` keeps `blockedBy { number title }` so the dialog tooltip still shows full blocker titles.

Closes #4062

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Polled `dispatcherState` cost dropped 1355 → 1155 (CloudWatch verified — see issue verification evidence comment)
- [ ] `/admin/dispatcher` renders without HTTP 400 (NOT met — 1155 still > 1000 cap; sibling follow-ups #4085 and #4086 file the remaining fixes)
- [x] Verification evidence posted on issue (#4062 comment)
