### PR TITLE
feat(audit): drill into long-pole CI jobs and recommend trim/re-shard (#4070)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -245,6 +245,21 @@ Flag a finding if any of the following are true:
 - **Do NOT report trend regressions with fewer than 3 ran-samples in each half.** Tiny samples produce noisy means; the `audit_ci_health.py` script enforces a minimum of 3 samples per half before emitting a trend finding.
 - **Do NOT rely on percentage alone for small-duration jobs.** A 3-second check going to 4 seconds is +33% but not an actionable regression. The script requires BOTH a ≥20% delta AND a ≥15-second absolute delta.
 
+#### Drill-down: which step inside the slow job (issue #4070)
+
+When a job is flagged as `> 10 min` (single-job threshold), `scripts/audit_ci_health.py` automatically fetches that job's log via `gh run view --log --job=<id>`, parses `##[group]<name>` / `##[endgroup]` paired timestamps, and attaches a `drill_down` section to the finding. This is the audit's job — do **not** repeat the manual log-eyeball drill that produced #4067 by hand.
+
+The drill-down emits, per flagged job:
+
+- `slowest_steps` — the top 3 `##[group]` blocks by wall-clock, each with `name`, `seconds`, and (when an inline `~Ns` estimate exists in `.github/workflows/ci.yml` near the matrix block) `estimate_seconds` and `drift_factor`.
+- `if_split_wall_clock_seconds` — wall-clock if the slowest step were extracted into its own matrix shard: `max(slowest_step, sum_of_remaining_steps)`.
+- `split_savings_seconds` — the savings if that re-shard happened.
+- `suggested_fixes` — `trim <step>` when `drift_factor ≥ 1.5`, `split <step> into separate shard` when the slowest step accounts for ≥ 50% of the total group time AND savings ≥ 30s.
+
+The drill-down section is omitted (rather than emitted as empty) when the job's log has no `##[group]` markers — that's expected for setup-only jobs and short jobs.
+
+To opt out (e.g. ad-hoc runs that don't need the extra `gh` API calls), pass `--no-drill-down`.
+
 #### Filing issues
 
 For each threshold violation or trend regression, file a `priority/p1` `type/dx` issue with:
@@ -254,7 +269,22 @@ For each threshold violation or trend regression, file a `priority/p1` `type/dx`
 - The specific run IDs and timestamps so the issue is traceable. Paste the output of `scripts/audit_ci_health.py --json` into the issue body.
 - Suggested investigation steps: check for new heavy test files, fixture bloat, missing parallelism, runner size, or unnecessary sequential steps.
 
-**Deduplication:** Before filing, check for existing open issues related to CI performance (e.g., #1243 tracks CI runner size / test splitting). If an existing issue covers the same job or concern, note it as "skipped — duplicate of #N" rather than filing a new one. Only file a new issue if the finding is distinct from existing tracked work.
+**For single-job findings, the issue body must include the drill-down sections** (the `audit_ci_health.render_finding_issue_body(finding)` helper produces them). Specifically:
+
+- **Slowest steps inside the flagged job** — a 3-row table (Step, Measured (s), Estimate (s), Drift). Modeled on #4067's body.
+- **Estimate drift** — for each step where `drift_factor ≥ 1.5`, name the step and quote measured-vs-estimate.
+- **Re-shard math** — if the slowest step were split into its own shard, what the new wall-clock and savings would be.
+- **Suggested fixes** — the `trim` / `split` recommendations from the drill-down's `suggested_fixes`.
+
+**Deduplication:** Before filing, dedup against the **open** issues list only — pass `state: "open"` to `mcp__github__list_issues` (the script and skill never match against closed issues, since a previously-fixed-and-closed issue must NOT silence a regression on the same job; see issue #4070). The dedup key is `(job_name, slowest_step_name)`, not job name alone — two distinct slow steps inside the same job get distinct issues.
+
+If an open issue matches the (job, slowest-step) key, note the new finding as "skipped — duplicate of #N" rather than filing a new one. **Closed issues do NOT silence regressions** — if a previously-closed issue's job (and step) regresses, file a **new** issue with `Recurrence of #N` in the body. Reopened issues sit in a weird state across `gh issue list --state` filters and dispatcher queue logic, so a fresh issue with a back-link is always preferred.
+
+The `audit_ci_health.classify_finding_against_issues(finding, issues)` helper returns one of:
+
+- `DedupMatch(kind="duplicate", issue_number=N)` — open match; skip filing.
+- `DedupMatch(kind="recurrence", issue_number=N)` — closed match; file fresh with `Recurrence of #N`.
+- `DedupMatch(kind="new")` — no match; file fresh.
 
 ### 1.9 — Scripts directory hygiene
 

--- a/scripts/audit_ci_health.py
+++ b/scripts/audit_ci_health.py
@@ -37,11 +37,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 
 REPO = "judgemind/judgemind"
 WORKFLOW = "ci.yml"
@@ -52,6 +54,22 @@ TOTAL_WALL_CLOCK_THRESHOLD = 15 * 60  # 15 minutes
 TREND_PERCENT_THRESHOLD = 20.0  # +20% mean delta
 TREND_ABSOLUTE_SECONDS_THRESHOLD = 15.0  # +15s absolute delta
 MIN_SAMPLES_PER_GROUP = 3  # require ≥3 ran-samples in BOTH halves
+
+# Drill-down constants.
+DRILL_DOWN_TOP_N = 3  # report top-N slowest steps inside a flagged job
+DRIFT_FACTOR_THRESHOLD = 1.5  # measured ≥ 1.5× estimate flags drift
+# Suggest re-shard when the slowest step alone accounts for ≥ this fraction
+# of the parsed `##[group]` total. The intuition: a long pole that dominates
+# the test execution time is a great candidate for parallelism — isolating it
+# brings the post-split wall-clock down to roughly the long pole alone.
+# A balanced job (slowest step ≈ remaining steps) gains far less from
+# splitting and should not trigger the suggestion. 0.5 means "slowest step
+# accounts for at least half of the total" — generous to avoid missing real
+# wins, strict enough to filter balanced jobs.
+SPLIT_SLOWEST_DOMINANCE_THRESHOLD = 0.5
+# Belt-and-suspenders: even when dominance clears the gate, require some
+# absolute savings so we don't fire on tiny groups (e.g. slowest 10s, total 12s).
+SPLIT_SAVINGS_MIN_SECONDS = 30
 
 
 @dataclass
@@ -64,6 +82,7 @@ class JobRun:
     started_at: datetime | None
     completed_at: datetime | None
     test_step_seconds: float | None = None
+    job_id: str | None = None  # gh job databaseId; needed for log fetch
 
     @property
     def duration_seconds(self) -> float | None:
@@ -138,6 +157,7 @@ def build_runs_from_json(data: list[dict[str, Any]]) -> list[RunSummary]:
                     started_at=parse_iso(job.get("startedAt")),
                     completed_at=parse_iso(job.get("completedAt")),
                     test_step_seconds=test_step_seconds,
+                    job_id=str(job["databaseId"]) if job.get("databaseId") else None,
                 )
             )
         runs.append(RunSummary(run_id=run_id, created_at=created_at, jobs=job_runs))
@@ -200,6 +220,527 @@ def fetch_runs_via_gh(limit: int) -> list[dict[str, Any]]:
             }
         )
     return results
+
+
+# ---------------------------------------------------------------------------
+# Drill-down support — parse gh run view --log + ci.yml inline estimates so
+# audit findings carry "which step inside the slow job" plus drift / re-shard
+# recommendations. See issue #4070 for the spec.
+# ---------------------------------------------------------------------------
+
+
+# A line in `gh run view --log` looks like:
+#   <job-name>\t<step-name>\t2026-05-05T19:00:11.123Z <content>
+# or, for steps emitted with `::group::` in a shell script:
+#   <job-name>\t<step-name>\t2026-05-05T19:00:11.123Z ##[group]<group-name>
+#   <job-name>\t<step-name>\t2026-05-05T19:00:13.456Z ##[endgroup]
+# We parse `##[group]<name>` start timestamps and pair each with the next
+# `##[endgroup]` (or the next `##[group]` start, if endgroup is missing —
+# defensive against truncated logs).
+
+_GROUP_START_RE = re.compile(r"##\[group\](?P<name>.*)$")
+_GROUP_END_RE = re.compile(r"##\[endgroup\]")
+_LOG_LINE_RE = re.compile(
+    r"^(?P<job>[^\t]+)\t(?P<step>[^\t]*)\t(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s?(?P<content>.*)$"
+)
+
+
+def parse_group_durations(log_text: str) -> list[dict[str, Any]]:
+    """Parse `##[group]<name>` / `##[endgroup]` paired timestamps from a log.
+
+    Returns a list of dicts ``{"name": str, "seconds": float, "step": str}``
+    in encounter order. Each entry is the wall-clock between a `##[group]<name>`
+    line and the next `##[endgroup]` line (or, if the log is truncated, the
+    next `##[group]` line — better to undercount than crash).
+
+    Lines that do not match the expected `<job>\\t<step>\\t<ts> <content>`
+    shape are silently ignored. A log with zero `##[group]` markers returns
+    an empty list — callers should treat this as "drill-down unavailable"
+    rather than a failure.
+    """
+    durations: list[dict[str, Any]] = []
+    open_group: dict[str, Any] | None = None
+    for raw in log_text.splitlines():
+        m = _LOG_LINE_RE.match(raw)
+        if not m:
+            continue
+        ts = parse_iso(m.group("ts"))
+        if ts is None:
+            continue
+        content = m.group("content")
+        step = m.group("step")
+        start_match = _GROUP_START_RE.match(content)
+        end_match = _GROUP_END_RE.match(content)
+        if start_match:
+            # Close any prior open group as a defensive truncation guard.
+            if open_group is not None:
+                seconds = (ts - open_group["start"]).total_seconds()
+                durations.append(
+                    {
+                        "name": open_group["name"],
+                        "seconds": seconds,
+                        "step": open_group["step"],
+                    }
+                )
+            open_group = {
+                "name": start_match.group("name"),
+                "start": ts,
+                "step": step,
+            }
+        elif end_match and open_group is not None:
+            seconds = (ts - open_group["start"]).total_seconds()
+            durations.append(
+                {
+                    "name": open_group["name"],
+                    "seconds": seconds,
+                    "step": open_group["step"],
+                }
+            )
+            open_group = None
+    return durations
+
+
+# Match common inline estimate forms inside the matrix block of a job:
+#   ~275s
+#   ~275 seconds
+#   ~5 min
+#   Estimated wall-clock ~395s
+#   roughly 660s
+_ESTIMATE_RE = re.compile(
+    r"~?\s*(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>seconds?|secs?|s|minutes?|mins?|m)\b",
+    re.IGNORECASE,
+)
+
+
+def _estimate_to_seconds(value: float, unit: str) -> float:
+    u = unit.lower()
+    if u in ("s", "sec", "secs", "second", "seconds"):
+        return value
+    if u in ("m", "min", "mins", "minute", "minutes"):
+        return value * 60.0
+    return value
+
+
+def _job_name_search_terms(job_name: str) -> list[str]:
+    """Derive substring patterns that locate ``job_name`` inside ci.yml.
+
+    `gh run view --json jobs` returns the display name (e.g.
+    ``"scripts-tests (shell)"``) which never appears verbatim in ci.yml.
+    The matrix-expanded display name is ``<job-id> (<matrix-value>)``; we
+    extract the matrix value and synthesize a pattern that matches the YAML
+    matrix line (e.g. ``- shard: shell``).
+
+    Returns the patterns to try in priority order — most specific first.
+    """
+    candidates: list[str] = []
+    m = re.match(r"^(?P<base>[^ (]+)\s*\((?P<value>[^)]+)\)\s*$", job_name)
+    if m:
+        candidates.append(f"shard: {m.group('value').strip()}")
+        candidates.append(m.group("base").strip() + ":")
+    else:
+        candidates.append(f"shard: {job_name}")
+        candidates.append(job_name + ":")
+    candidates.append(job_name)
+    # De-dup while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for c in candidates:
+        if c and c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+
+
+def extract_step_estimates(ciyml_text: str, job_name: str) -> dict[str, float]:
+    """Find inline `~Ns` / `~N seconds` estimates near ``job_name`` in ci.yml.
+
+    The convention in `.github/workflows/ci.yml` is to leave a comment block
+    like::
+
+        # Shard shell: scripts/run-scripts-tests.sh only.
+        # Dominated by test_agent_runner_entrypoint.sh (~275s) and
+        # test_check_dispatcher_image_versions.sh (~58s).
+        # Estimated wall-clock ~395s. See issue #3307.
+        - shard: shell
+
+    Returns a dict mapping step/test names that appear adjacent to a numeric
+    estimate to the estimate in seconds.  We scan the comment block (any run
+    of `#`-prefixed lines) immediately preceding a line that contains the
+    job name (matrix shard line, job key, or job ``name:`` line).  Matching
+    is intentionally loose — drift detection is a heuristic, not a
+    correctness gate, so false positives just produce no drift signal.
+
+    ``job_name`` accepts the gh-display form (``"scripts-tests (shell)"``);
+    we synthesize candidate patterns via :func:`_job_name_search_terms`.
+
+    A job that has no inline estimate returns an empty dict and the caller
+    silently omits drift detection for that job.
+    """
+    estimates: dict[str, float] = {}
+    lines = ciyml_text.splitlines()
+
+    def _scan_at(i: int) -> bool:
+        """Walk up contiguous comment lines above ``lines[i]`` and harvest estimates.
+
+        Returns True iff at least one estimate was harvested.
+        """
+        comment_lines: list[str] = []
+        j = i - 1
+        while j >= 0:
+            stripped = lines[j].strip()
+            if stripped.startswith("#"):
+                comment_lines.append(stripped.lstrip("#").strip())
+                j -= 1
+            elif stripped == "":
+                break
+            else:
+                break
+        comment_lines.reverse()
+        harvested = False
+        for cl in comment_lines:
+            for m in _ESTIMATE_RE.finditer(cl):
+                value = float(m.group("value"))
+                unit = m.group("unit")
+                seconds = _estimate_to_seconds(value, unit)
+                pre = cl[: m.start()].rstrip()
+                # Try last `*.sh` / `*.py` token before the estimate (test file).
+                file_tokens = re.findall(r"[A-Za-z0-9_./-]+\.(?:sh|py)", pre)
+                if file_tokens:
+                    if estimates.setdefault(file_tokens[-1], seconds) == seconds:
+                        harvested = True
+                    continue
+                # Job-level estimate: keyed under the search pattern.
+                if (
+                    "estimated wall-clock" in cl.lower()
+                    or "estimated wall clock" in cl.lower()
+                ):
+                    if estimates.setdefault(job_name, seconds) == seconds:
+                        harvested = True
+                    continue
+        return harvested
+
+    # Try patterns in priority order; stop at the first pattern that yields
+    # any estimate (avoids false hits from less-specific patterns).
+    for pattern in _job_name_search_terms(job_name):
+        any_harvest = False
+        for i, line in enumerate(lines):
+            if pattern not in line:
+                continue
+            if _scan_at(i):
+                any_harvest = True
+                # First good hit wins; stop searching this pattern.
+                break
+        if any_harvest:
+            break
+    return estimates
+
+
+def fetch_job_log_via_gh(run_id: str, job_id: str, repo: str = REPO) -> str | None:
+    """Fetch a single job's log via `gh run view --log --job=<id>`.
+
+    Returns ``None`` if the call fails (auth, transient API error, missing
+    job).  Drill-down is best-effort — the caller silently degrades to no
+    drill-down on ``None``.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "run",
+                "view",
+                run_id,
+                "--repo",
+                repo,
+                "--log",
+                "--job",
+                str(job_id),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=180,
+        )
+        return proc.stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def compute_drill_down(
+    job: JobRun,
+    *,
+    log_text: str | None,
+    step_estimates: dict[str, float] | None = None,
+    top_n: int = DRILL_DOWN_TOP_N,
+) -> dict[str, Any] | None:
+    """Compute drill-down stats for a single job: slowest steps + re-shard math.
+
+    Returns ``None`` when the log has no parseable `##[group]` markers, so
+    callers can silently omit the drill-down rather than emit an empty
+    section. This is the §4070 backstop AC: the script must keep working on
+    short / unusual jobs that emit no markers.
+    """
+    if log_text is None:
+        return None
+    durations = parse_group_durations(log_text)
+    if not durations:
+        return None
+    # Sort all groups by duration descending.
+    sorted_groups = sorted(durations, key=lambda g: g["seconds"], reverse=True)
+    top = sorted_groups[:top_n]
+    estimates = step_estimates or {}
+    slowest_steps: list[dict[str, Any]] = []
+    for entry in top:
+        step_obj: dict[str, Any] = {
+            "name": entry["name"],
+            "seconds": round(entry["seconds"], 1),
+        }
+        # Match the entry name against the estimate dict — accept either a
+        # direct hit, or a basename hit (estimate keyed under "test_X.sh" but
+        # the group name is "scripts/tests/test_X.sh").
+        est_seconds = None
+        if entry["name"] in estimates:
+            est_seconds = estimates[entry["name"]]
+        else:
+            for key, val in estimates.items():
+                if entry["name"].endswith(key) or key.endswith(entry["name"]):
+                    est_seconds = val
+                    break
+        if est_seconds is not None and est_seconds > 0:
+            drift = entry["seconds"] / est_seconds
+            step_obj["estimate_seconds"] = round(est_seconds, 1)
+            step_obj["drift_factor"] = round(drift, 2)
+        slowest_steps.append(step_obj)
+    # Re-shard math: if we extracted the slowest step into its own shard,
+    # the remaining shard runs at sum_of_remaining_seconds; the new wall
+    # clock is max(slowest_step, sum_of_remaining).
+    total_seconds = sum(g["seconds"] for g in durations)
+    slowest_seconds = sorted_groups[0]["seconds"]
+    remaining_seconds = total_seconds - slowest_seconds
+    if_split_wall_clock = max(slowest_seconds, remaining_seconds)
+    split_savings = total_seconds - if_split_wall_clock
+    drill: dict[str, Any] = {
+        "slowest_steps": slowest_steps,
+        "if_split_wall_clock_seconds": round(if_split_wall_clock, 1),
+        "split_savings_seconds": round(split_savings, 1),
+    }
+    suggested: list[str] = []
+    # Drift suggestion: trim any step with drift ≥ DRIFT_FACTOR_THRESHOLD.
+    for step in slowest_steps:
+        if step.get("drift_factor", 0) >= DRIFT_FACTOR_THRESHOLD:
+            suggested.append(f"trim {step['name']}")
+    # Re-shard suggestion: only when the slowest step dominates the total
+    # group runtime (long-pole pattern) AND we'd save a meaningful absolute
+    # number of seconds. Balanced jobs (slowest ≈ remaining) gain less from
+    # splitting and don't warrant the suggestion.
+    if (
+        total_seconds > 0
+        and (slowest_seconds / total_seconds) >= SPLIT_SLOWEST_DOMINANCE_THRESHOLD
+        and split_savings >= SPLIT_SAVINGS_MIN_SECONDS
+    ):
+        suggested.append(f"split {slowest_steps[0]['name']} into separate shard")
+    if suggested:
+        drill["suggested_fixes"] = suggested
+    return drill
+
+
+def attach_drill_down(
+    findings: list[Finding],
+    runs: list[RunSummary],
+    *,
+    log_fetcher: Callable[[str, str], str | None] | None = None,
+    ciyml_path: Path | None = None,
+) -> None:
+    """For each single-job finding, attach a `drill_down` to its details.
+
+    ``log_fetcher`` defaults to :func:`fetch_job_log_via_gh`; tests inject a
+    fake. ``ciyml_path`` defaults to ``.github/workflows/ci.yml`` resolved
+    against the script's repo root; tests inject a fixture.
+    """
+    if log_fetcher is None:
+        log_fetcher = fetch_job_log_via_gh
+    ciyml_text = ""
+    if ciyml_path is None:
+        ciyml_path = (
+            Path(__file__).resolve().parent.parent / ".github" / "workflows" / "ci.yml"
+        )
+    try:
+        ciyml_text = ciyml_path.read_text()
+    except OSError:
+        ciyml_text = ""
+
+    # Build a quick lookup: run_id -> job_name -> JobRun.
+    by_id: dict[str, dict[str, JobRun]] = {}
+    for run in runs:
+        by_id.setdefault(run.run_id, {})
+        for j in run.jobs:
+            by_id[run.run_id][j.name] = j
+
+    for finding in findings:
+        if finding.kind != "single-job":
+            continue
+        run_id = finding.details.get("run_id")
+        job_name = finding.job_name
+        if not run_id or not job_name:
+            continue
+        job = by_id.get(str(run_id), {}).get(job_name)
+        if job is None or job.job_id is None:
+            continue
+        log_text = log_fetcher(str(run_id), job.job_id)
+        estimates = extract_step_estimates(ciyml_text, job_name) if ciyml_text else {}
+        drill = compute_drill_down(job, log_text=log_text, step_estimates=estimates)
+        if drill is not None:
+            finding.details["drill_down"] = drill
+
+
+# ---------------------------------------------------------------------------
+# Dedup helpers — match findings against existing GitHub issues.
+#
+# Spec (issue #4070):
+#   - Match OPEN issues only. A previously-closed issue must not silently
+#     suppress a regression on the same job.
+#   - Match on (job_name, slowest_step_name) when drill-down identifies a
+#     specific step; otherwise fall back to job_name alone.
+#   - When a CLOSED prior issue matches, file a fresh issue with a
+#     `Recurrence of #N` note rather than reopening or commenting.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DedupMatch:
+    """Outcome of matching a finding against existing issues."""
+
+    kind: str  # "duplicate", "recurrence", "new"
+    issue_number: int | None = None  # set for duplicate/recurrence
+
+
+def _slowest_step_from_finding(finding: Finding) -> str | None:
+    drill = finding.details.get("drill_down") or {}
+    steps = drill.get("slowest_steps") or []
+    if not steps:
+        return None
+    return steps[0].get("name")
+
+
+def _issue_matches_finding(issue: dict[str, Any], finding: Finding) -> bool:
+    """True if the issue's title/body mentions the finding's job (and step, if any)."""
+    title = issue.get("title", "") or ""
+    body = issue.get("body", "") or ""
+    haystack = f"{title}\n{body}"
+    if finding.job_name not in haystack:
+        return False
+    step = _slowest_step_from_finding(finding)
+    if step:
+        # Step-aware key: require both job and step to appear in the issue
+        # text. Two distinct slow steps in the same job get distinct issues.
+        return step in haystack
+    return True
+
+
+def classify_finding_against_issues(
+    finding: Finding, issues: list[dict[str, Any]]
+) -> DedupMatch:
+    """Return a DedupMatch indicating whether to skip / file-as-recurrence / file-fresh.
+
+    Filing rules (issue #4070):
+      * If any OPEN issue matches the (job, slowest-step) key — return
+        ``duplicate`` with the issue number; the caller skips filing.
+      * Else if any CLOSED issue matches — return ``recurrence`` with the
+        issue number; the caller files a NEW issue with a
+        ``Recurrence of #N`` line in the body.
+      * Else — return ``new``.
+    """
+    open_match: int | None = None
+    closed_match: int | None = None
+    for issue in issues:
+        if not _issue_matches_finding(issue, finding):
+            continue
+        state = (issue.get("state") or "").lower()
+        number = issue.get("number")
+        if state == "open" and open_match is None:
+            open_match = number
+        elif state == "closed" and closed_match is None:
+            closed_match = number
+    if open_match is not None:
+        return DedupMatch(kind="duplicate", issue_number=open_match)
+    if closed_match is not None:
+        return DedupMatch(kind="recurrence", issue_number=closed_match)
+    return DedupMatch(kind="new")
+
+
+def render_finding_issue_body(finding: Finding, dedup: DedupMatch | None = None) -> str:
+    """Render the issue body the /audit skill should post for a CI-health finding.
+
+    Includes the drill-down sections (`Slowest steps`, `Estimate drift`,
+    `Suggested fixes`) when the finding has a `drill_down` payload, and a
+    `Recurrence of #N` line when the dedup pass found a closed prior issue.
+    """
+    parts: list[str] = []
+    parts.append("## Found by")
+    parts.append("`/audit` skill (CI health, §1.8)")
+    parts.append("")
+    parts.append("## Finding")
+    parts.append(finding.message)
+    parts.append("")
+    drill = finding.details.get("drill_down") or {}
+    slowest = drill.get("slowest_steps") or []
+    if slowest:
+        parts.append("## Slowest steps inside the flagged job")
+        parts.append("")
+        parts.append("| Step | Measured (s) | Estimate (s) | Drift |")
+        parts.append("|---|---:|---:|---:|")
+        for step in slowest:
+            est = step.get("estimate_seconds")
+            drift = step.get("drift_factor")
+            est_cell = f"{est:.0f}" if isinstance(est, (int, float)) else "—"
+            drift_cell = f"{drift:.1f}×" if isinstance(drift, (int, float)) else "—"
+            parts.append(
+                f"| `{step['name']}` | {step['seconds']:.0f} | {est_cell} | {drift_cell} |"
+            )
+        parts.append("")
+        # Estimate drift section.
+        drifted = [
+            s
+            for s in slowest
+            if isinstance(s.get("drift_factor"), (int, float))
+            and s["drift_factor"] >= DRIFT_FACTOR_THRESHOLD
+        ]
+        if drifted:
+            parts.append("## Estimate drift")
+            parts.append("")
+            for step in drifted:
+                parts.append(
+                    f"- `{step['name']}` measured {step['seconds']:.0f}s vs. "
+                    f"~{step['estimate_seconds']:.0f}s estimate "
+                    f"({step['drift_factor']:.1f}× drift, ≥ {DRIFT_FACTOR_THRESHOLD:.1f}× threshold)"
+                )
+            parts.append("")
+        # Re-shard math.
+        if "if_split_wall_clock_seconds" in drill:
+            parts.append("## Re-shard math")
+            parts.append("")
+            parts.append(
+                f"- If `{slowest[0]['name']}` were split into its own shard, "
+                f"wall-clock would be {drill['if_split_wall_clock_seconds']:.0f}s "
+                f"(savings: {drill['split_savings_seconds']:.0f}s)."
+            )
+            parts.append("")
+        # Suggested fixes.
+        suggested = drill.get("suggested_fixes") or []
+        if suggested:
+            parts.append("## Suggested fixes")
+            parts.append("")
+            for s in suggested:
+                parts.append(f"- {s}")
+            parts.append("")
+    parts.append("## Run details")
+    parts.append("")
+    parts.append(f"- run_id: {finding.details.get('run_id', '?')}")
+    parts.append(f"- duration: {finding.details.get('seconds', '?')}s")
+    parts.append("")
+    if dedup is not None and dedup.kind == "recurrence" and dedup.issue_number:
+        parts.append(f"Recurrence of #{dedup.issue_number}.")
+        parts.append("")
+    return "\n".join(parts).rstrip() + "\n"
 
 
 def compute_threshold_findings(runs: list[RunSummary]) -> list[Finding]:
@@ -342,6 +883,27 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Read run data from JSON file (for tests / replay)",
     )
+    parser.add_argument(
+        "--no-drill-down",
+        action="store_true",
+        help="Skip per-step drill-down for jobs > 10 min "
+        "(otherwise we fetch each flagged job's log via `gh run view --log` "
+        "and parse `##[group]` markers; opt out for speed during ad-hoc runs)",
+    )
+    parser.add_argument(
+        "--ciyml",
+        type=str,
+        default=None,
+        help="Path to .github/workflows/ci.yml for inline-estimate extraction "
+        "(defaults to repo root; tests override this)",
+    )
+    parser.add_argument(
+        "--drill-down-log-file",
+        type=str,
+        default=None,
+        help="Replay a single job's log from a file rather than fetching via gh "
+        "(testing / debugging); applied to every single-job finding",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -356,6 +918,23 @@ def main(argv: list[str] | None = None) -> int:
 
     runs = build_runs_from_json(raw)
     findings = compute_threshold_findings(runs) + compute_trend_findings(runs)
+
+    if not args.no_drill_down and findings:
+        log_fetcher: Callable[[str, str], str | None] | None = None
+        if args.drill_down_log_file:
+            replay_text = Path(args.drill_down_log_file).read_text()
+
+            def _replay(_run_id: str, _job_id: str) -> str | None:
+                return replay_text
+
+            log_fetcher = _replay
+        ciyml_path = Path(args.ciyml) if args.ciyml else None
+        attach_drill_down(
+            findings,
+            runs,
+            log_fetcher=log_fetcher,
+            ciyml_path=ciyml_path,
+        )
 
     if args.json:
         payload = {
@@ -378,6 +957,21 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Findings ({len(findings)}):")
             for f in findings:
                 print(f"  [{f.kind}] {f.message}")
+                drill = f.details.get("drill_down") if hasattr(f, "details") else None
+                if drill:
+                    for step in drill.get("slowest_steps", []):
+                        drift = step.get("drift_factor")
+                        drift_str = (
+                            f" (drift {drift:.1f}× vs ~{step.get('estimate_seconds', 0):.0f}s)"
+                            if drift is not None
+                            else ""
+                        )
+                        print(
+                            f"      step '{step['name']}' "
+                            f"{step['seconds']:.0f}s{drift_str}"
+                        )
+                    if drill.get("suggested_fixes"):
+                        print(f"      suggested: {', '.join(drill['suggested_fixes'])}")
         else:
             print("No findings — CI health is within thresholds.")
 

--- a/scripts/tests/test_audit_ci_health.py
+++ b/scripts/tests/test_audit_ci_health.py
@@ -17,15 +17,27 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from audit_ci_health import (  # noqa: E402 — sys.path manipulation above
+    DRIFT_FACTOR_THRESHOLD,
     MIN_SAMPLES_PER_GROUP,
     SINGLE_JOB_SECONDS_THRESHOLD,
+    SPLIT_SAVINGS_MIN_SECONDS,
+    SPLIT_SLOWEST_DOMINANCE_THRESHOLD,
     TOTAL_WALL_CLOCK_THRESHOLD,
     TREND_ABSOLUTE_SECONDS_THRESHOLD,
     TREND_PERCENT_THRESHOLD,
+    DedupMatch,
+    Finding,
+    JobRun,
+    attach_drill_down,
     build_runs_from_json,
+    classify_finding_against_issues,
+    compute_drill_down,
     compute_threshold_findings,
     compute_trend_findings,
+    extract_step_estimates,
     main,
+    parse_group_durations,
+    render_finding_issue_body,
 )
 
 
@@ -36,6 +48,7 @@ def _make_job(
     duration_s: float,
     conclusion: str = "success",
     test_step_duration_s: float | None = None,
+    database_id: int | None = None,
 ) -> dict[str, object]:
     """Build a job-record dict matching gh run view --json jobs output."""
     t0 = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=start_offset_s)
@@ -51,13 +64,16 @@ def _make_job(
                 "completedAt": test_end.isoformat().replace("+00:00", "Z"),
             }
         )
-    return {
+    job: dict[str, object] = {
         "name": name,
         "conclusion": conclusion,
         "startedAt": t0.isoformat().replace("+00:00", "Z"),
         "completedAt": t1.isoformat().replace("+00:00", "Z"),
         "steps": steps,
     }
+    if database_id is not None:
+        job["databaseId"] = database_id
+    return job
 
 
 def _make_skipped_job(name: str) -> dict[str, object]:
@@ -324,3 +340,539 @@ class TestConstants:
 
     def test_trend_absolute_threshold_is_nonzero(self) -> None:
         assert TREND_ABSOLUTE_SECONDS_THRESHOLD > 0
+
+    def test_drill_down_constants_present(self) -> None:
+        assert DRIFT_FACTOR_THRESHOLD >= 1.0
+        assert SPLIT_SAVINGS_MIN_SECONDS > 0
+        assert 0 < SPLIT_SLOWEST_DOMINANCE_THRESHOLD < 1
+
+
+# ---------------------------------------------------------------------------
+# §4070 drill-down tests
+# ---------------------------------------------------------------------------
+
+
+def _log_line(job: str, step: str, ts: str, content: str) -> str:
+    """Build one line of `gh run view --log` output."""
+    return f"{job}\t{step}\t{ts} {content}"
+
+
+def _shell_log_fixture() -> str:
+    """A small log resembling `gh run view --log` for the shell shard.
+
+    Three `::group::test_X` runs:
+      * test_agent_runner_entrypoint.sh — 663s
+      * test_check_dispatcher_image_versions.sh — 66s
+      * test_other_quick.sh — 5s
+    """
+    job = "scripts-tests (shell)"
+    step = "Run all scripts/tests shell tests"
+    lines = [
+        _log_line(
+            job,
+            step,
+            "2026-05-05T19:00:11.000Z",
+            "##[group]scripts/tests/test_agent_runner_entrypoint.sh",
+        ),
+        _log_line(job, step, "2026-05-05T19:05:00.000Z", "PASS: t_first"),
+        _log_line(job, step, "2026-05-05T19:11:14.000Z", "##[endgroup]"),
+        _log_line(
+            job,
+            step,
+            "2026-05-05T19:11:14.500Z",
+            "##[group]scripts/tests/test_check_dispatcher_image_versions.sh",
+        ),
+        _log_line(job, step, "2026-05-05T19:12:20.500Z", "##[endgroup]"),
+        _log_line(
+            job,
+            step,
+            "2026-05-05T19:12:21.000Z",
+            "##[group]scripts/tests/test_other_quick.sh",
+        ),
+        _log_line(job, step, "2026-05-05T19:12:26.000Z", "##[endgroup]"),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+class TestParseGroupDurations:
+    def test_parses_paired_group_endgroup(self) -> None:
+        log = _shell_log_fixture()
+        groups = parse_group_durations(log)
+        names = [g["name"] for g in groups]
+        # All three test groups should appear, in encounter order.
+        assert names == [
+            "scripts/tests/test_agent_runner_entrypoint.sh",
+            "scripts/tests/test_check_dispatcher_image_versions.sh",
+            "scripts/tests/test_other_quick.sh",
+        ]
+        # Durations match the timestamps in the fixture (within ±0.5s).
+        secs = {g["name"]: g["seconds"] for g in groups}
+        assert secs["scripts/tests/test_agent_runner_entrypoint.sh"] == pytest.approx(
+            663, abs=1
+        )
+        assert secs[
+            "scripts/tests/test_check_dispatcher_image_versions.sh"
+        ] == pytest.approx(66, abs=1)
+        assert secs["scripts/tests/test_other_quick.sh"] == pytest.approx(5, abs=1)
+
+    def test_log_with_no_group_markers_returns_empty(self) -> None:
+        log = (
+            "job-x\tstep-y\t2026-05-05T19:00:00Z setup\n"
+            "job-x\tstep-y\t2026-05-05T19:00:01Z all good\n"
+        )
+        assert parse_group_durations(log) == []
+
+    def test_handles_truncated_log_open_group_at_eof(self) -> None:
+        # `##[group]` without a closing `##[endgroup]` should not crash;
+        # the open group is silently dropped (better undercount than crash).
+        log = (
+            _log_line("j", "s", "2026-05-05T00:00:00Z", "##[group]hanging-group") + "\n"
+        )
+        assert parse_group_durations(log) == []
+
+    def test_consecutive_groups_close_implicitly(self) -> None:
+        # Two `##[group]` lines in a row (missing first endgroup): the
+        # first group should be implicitly closed at the second start.
+        log = "\n".join(
+            [
+                _log_line("j", "s", "2026-05-05T00:00:00Z", "##[group]first"),
+                _log_line("j", "s", "2026-05-05T00:00:10Z", "##[group]second"),
+                _log_line("j", "s", "2026-05-05T00:00:15Z", "##[endgroup]"),
+            ]
+        )
+        groups = parse_group_durations(log)
+        assert [g["name"] for g in groups] == ["first", "second"]
+        assert groups[0]["seconds"] == pytest.approx(10, abs=1)
+        assert groups[1]["seconds"] == pytest.approx(5, abs=1)
+
+    def test_ignores_lines_without_log_prefix(self) -> None:
+        # Headers, banners, etc. without the `<job>\t<step>\t<ts> ...` shape
+        # should be ignored, not crash.
+        log = "Run started at 19:00:00\n" + _shell_log_fixture()
+        groups = parse_group_durations(log)
+        assert len(groups) == 3
+
+
+CIYML_FIXTURE = """
+  scripts-tests:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          # Shard python: pytest suites + inline shell guards.
+          # pytest-xdist parallelises the suite. Estimated wall-clock ~200s.
+          - shard: python
+          # Shard shell: scripts/run-scripts-tests.sh only.
+          # Dominated by test_agent_runner_entrypoint.sh (~275s) and
+          # test_check_dispatcher_image_versions.sh (~58s).
+          # Estimated wall-clock ~395s. See issue #3307.
+          - shard: shell
+"""
+
+
+class TestExtractStepEstimates:
+    def test_extracts_test_filename_estimates(self) -> None:
+        estimates = extract_step_estimates(CIYML_FIXTURE, "shard: shell")
+        # Test-filename keys take priority over the job-level estimate.
+        assert estimates["test_agent_runner_entrypoint.sh"] == 275.0
+        assert estimates["test_check_dispatcher_image_versions.sh"] == 58.0
+
+    def test_returns_empty_when_no_inline_estimate(self) -> None:
+        ci = """
+        - shard: never-mentioned-with-estimate
+"""
+        # No comment block above → empty dict, no crash.
+        assert extract_step_estimates(ci, "never-mentioned-with-estimate") == {}
+
+    def test_handles_minutes_unit(self) -> None:
+        ci = """
+        # Estimated wall-clock ~5 min total.
+        - shard: minute-form
+"""
+        e = extract_step_estimates(ci, "shard: minute-form")
+        # Job-level estimate keyed under the searched name.
+        assert e["shard: minute-form"] == 300.0
+
+    def test_handles_gh_display_name_form(self) -> None:
+        # `gh run view --json jobs` returns "<job-id> (<matrix-value>)";
+        # extract_step_estimates must derive `shard: <value>` to find the
+        # YAML matrix line above the comment block.
+        e = extract_step_estimates(CIYML_FIXTURE, "scripts-tests (shell)")
+        assert e["test_agent_runner_entrypoint.sh"] == 275.0
+
+
+class TestComputeDrillDown:
+    def test_returns_top3_slowest_with_estimates(self) -> None:
+        log = _shell_log_fixture()
+        estimates = {
+            "test_agent_runner_entrypoint.sh": 275.0,
+            "test_check_dispatcher_image_versions.sh": 58.0,
+        }
+        job = JobRun(
+            run_id="r1",
+            name="scripts-tests (shell)",
+            conclusion="success",
+            started_at=None,
+            completed_at=None,
+        )
+        drill = compute_drill_down(job, log_text=log, step_estimates=estimates)
+        assert drill is not None
+        names = [s["name"] for s in drill["slowest_steps"]]
+        assert names[0] == "scripts/tests/test_agent_runner_entrypoint.sh"
+        # Drift factor for the long-pole step is ~2.4× (663/275).
+        long_pole = drill["slowest_steps"][0]
+        assert long_pole["drift_factor"] == pytest.approx(2.41, abs=0.05)
+        assert long_pole["estimate_seconds"] == 275.0
+        # Re-shard math: total ~734s, isolating long pole gives wall-clock 663s
+        # (the long-pole's own seconds, since the remaining ~71s < long pole).
+        assert drill["if_split_wall_clock_seconds"] == pytest.approx(663, abs=1)
+        assert drill["split_savings_seconds"] == pytest.approx(71, abs=1)
+        # Suggested fixes include trim + split.
+        assert any(
+            "trim" in s and "test_agent_runner_entrypoint" in s
+            for s in drill["suggested_fixes"]
+        )
+        assert any("split" in s for s in drill["suggested_fixes"])
+
+    def test_returns_none_when_log_has_no_group_markers(self) -> None:
+        # §4070 backstop AC: silently omit drill-down on marker-less logs.
+        log = "job-x\tstep-y\t2026-05-05T19:00:00Z normal output line\n"
+        job = JobRun(
+            run_id="r1",
+            name="quick-job",
+            conclusion="success",
+            started_at=None,
+            completed_at=None,
+        )
+        assert compute_drill_down(job, log_text=log) is None
+
+    def test_returns_none_when_log_text_is_none(self) -> None:
+        job = JobRun(
+            run_id="r1",
+            name="job",
+            conclusion="success",
+            started_at=None,
+            completed_at=None,
+        )
+        assert compute_drill_down(job, log_text=None) is None
+
+    def test_no_split_suggestion_when_savings_below_threshold(self) -> None:
+        # Three roughly-balanced groups → splitting the slowest doesn't help.
+        log = "\n".join(
+            [
+                _log_line("j", "s", "2026-05-05T00:00:00Z", "##[group]a"),
+                _log_line("j", "s", "2026-05-05T00:01:40Z", "##[endgroup]"),
+                _log_line("j", "s", "2026-05-05T00:01:41Z", "##[group]b"),
+                _log_line("j", "s", "2026-05-05T00:03:21Z", "##[endgroup]"),
+                _log_line("j", "s", "2026-05-05T00:03:22Z", "##[group]c"),
+                _log_line("j", "s", "2026-05-05T00:05:02Z", "##[endgroup]"),
+            ]
+        )
+        job = JobRun(
+            run_id="r1",
+            name="balanced",
+            conclusion="success",
+            started_at=None,
+            completed_at=None,
+        )
+        drill = compute_drill_down(job, log_text=log)
+        assert drill is not None
+        # No split suggestion — savings would be too small.
+        assert not any("split" in s for s in drill.get("suggested_fixes") or [])
+
+
+class TestAttachDrillDown:
+    def test_attaches_drill_down_to_single_job_finding(self, tmp_path: Path) -> None:
+        ciyml = tmp_path / "ci.yml"
+        ciyml.write_text(CIYML_FIXTURE)
+        # Build a run with a > 10 min job.
+        raw = [
+            _make_run(
+                "rX",
+                "2026-05-05T19:00:00Z",
+                [
+                    _make_job(
+                        "shard: shell",
+                        start_offset_s=0,
+                        duration_s=SINGLE_JOB_SECONDS_THRESHOLD + 100,
+                        database_id=99,
+                    )
+                ],
+            )
+        ]
+        runs = build_runs_from_json(raw)
+        findings = compute_threshold_findings(runs)
+        assert findings, "expected a single-job finding above 10 min"
+        log_text = _shell_log_fixture()
+        attach_drill_down(
+            findings,
+            runs,
+            log_fetcher=lambda _r, _j: log_text,
+            ciyml_path=ciyml,
+        )
+        single_jobs = [f for f in findings if f.kind == "single-job"]
+        assert single_jobs[0].details.get("drill_down") is not None
+        drill = single_jobs[0].details["drill_down"]
+        assert (
+            drill["slowest_steps"][0]["name"]
+            == "scripts/tests/test_agent_runner_entrypoint.sh"
+        )
+
+    def test_silently_omits_when_no_log(self, tmp_path: Path) -> None:
+        ciyml = tmp_path / "ci.yml"
+        ciyml.write_text(CIYML_FIXTURE)
+        raw = [
+            _make_run(
+                "rY",
+                "2026-05-05T19:00:00Z",
+                [
+                    _make_job(
+                        "no-marker-job",
+                        start_offset_s=0,
+                        duration_s=SINGLE_JOB_SECONDS_THRESHOLD + 1,
+                        database_id=10,
+                    )
+                ],
+            )
+        ]
+        runs = build_runs_from_json(raw)
+        findings = compute_threshold_findings(runs)
+        attach_drill_down(
+            findings,
+            runs,
+            log_fetcher=lambda _r, _j: None,
+            ciyml_path=ciyml,
+        )
+        # No drill_down on the finding — graceful degradation.
+        assert "drill_down" not in findings[0].details
+
+
+class TestRenderFindingIssueBody:
+    def test_body_contains_drill_down_sections(self, tmp_path: Path) -> None:
+        ciyml = tmp_path / "ci.yml"
+        ciyml.write_text(CIYML_FIXTURE)
+        raw = [
+            _make_run(
+                "rX",
+                "2026-05-05T19:00:00Z",
+                [
+                    _make_job(
+                        "shard: shell",
+                        start_offset_s=0,
+                        duration_s=SINGLE_JOB_SECONDS_THRESHOLD + 100,
+                        database_id=99,
+                    )
+                ],
+            )
+        ]
+        runs = build_runs_from_json(raw)
+        findings = compute_threshold_findings(runs)
+        attach_drill_down(
+            findings,
+            runs,
+            log_fetcher=lambda _r, _j: _shell_log_fixture(),
+            ciyml_path=ciyml,
+        )
+        body = render_finding_issue_body(findings[0])
+        assert "Slowest steps inside the flagged job" in body
+        assert "Estimate drift" in body
+        assert "Suggested fixes" in body
+        assert "test_agent_runner_entrypoint.sh" in body
+        # 2.4× drift factor surfaces in the drift section.
+        assert "2.4×" in body or "2.41×" in body
+
+    def test_body_omits_drill_sections_when_no_drill_down(self) -> None:
+        f = Finding(
+            kind="single-job",
+            job_name="quick-job",
+            message="Job 'quick-job' took 700s",
+            details={"run_id": "r1", "seconds": 700},
+        )
+        body = render_finding_issue_body(f)
+        assert "Slowest steps" not in body
+        assert "Estimate drift" not in body
+
+    def test_body_includes_recurrence_line_for_closed_match(self) -> None:
+        f = Finding(
+            kind="single-job",
+            job_name="quick-job",
+            message="Job 'quick-job' took 700s",
+            details={"run_id": "r1", "seconds": 700},
+        )
+        body = render_finding_issue_body(
+            f, dedup=DedupMatch(kind="recurrence", issue_number=4067)
+        )
+        assert "Recurrence of #4067" in body
+
+
+class TestDedupClassification:
+    def _step_finding(self, job: str, step: str | None) -> Finding:
+        details: dict[str, object] = {"run_id": "r1", "seconds": 700}
+        if step:
+            details["drill_down"] = {
+                "slowest_steps": [{"name": step, "seconds": 663.0}],
+            }
+        return Finding(
+            kind="single-job",
+            job_name=job,
+            message=f"Job '{job}' took 700s",
+            details=details,
+        )
+
+    def test_open_match_returns_duplicate(self) -> None:
+        finding = self._step_finding("scripts-tests (shell)", "test_X.sh")
+        issues = [
+            {
+                "number": 999,
+                "state": "open",
+                "title": "perf(ci): scripts-tests (shell) too slow",
+                "body": "Inside that shard, test_X.sh is the long pole.",
+            }
+        ]
+        m = classify_finding_against_issues(finding, issues)
+        assert m.kind == "duplicate"
+        assert m.issue_number == 999
+
+    def test_closed_match_returns_recurrence(self) -> None:
+        # §4070 AC: closed issues do NOT silence regressions; they trigger
+        # a recurrence path with a `Recurrence of #N` body line.
+        finding = self._step_finding("scripts-tests (shell)", "test_X.sh")
+        issues = [
+            {
+                "number": 3313,
+                "state": "closed",
+                "title": "scripts-tests (shell) flagged > 10 min",
+                "body": "Was fixed by sharding. test_X.sh is still in the shard.",
+            }
+        ]
+        m = classify_finding_against_issues(finding, issues)
+        assert m.kind == "recurrence"
+        assert m.issue_number == 3313
+
+    def test_no_match_returns_new(self) -> None:
+        finding = self._step_finding("unique-job", "unique_test.sh")
+        m = classify_finding_against_issues(finding, [])
+        assert m.kind == "new"
+
+    def test_dedup_key_includes_step_name(self) -> None:
+        # Two findings against the same job but different slowest steps
+        # should both be treated as new — dedup key is (job, step).
+        f_a = self._step_finding("scripts-tests (shell)", "test_a.sh")
+        f_b = self._step_finding("scripts-tests (shell)", "test_b.sh")
+        issues = [
+            {
+                "number": 100,
+                "state": "open",
+                "title": "scripts-tests (shell) — test_a.sh is the long pole",
+                "body": "test_a.sh is slow.",
+            }
+        ]
+        # f_a matches the existing test_a.sh issue; f_b does not.
+        assert classify_finding_against_issues(f_a, issues).kind == "duplicate"
+        assert classify_finding_against_issues(f_b, issues).kind == "new"
+
+    def test_falls_back_to_job_name_when_no_drill_down(self) -> None:
+        # No drill_down on the finding → match on job name alone.
+        f = self._step_finding("misc-job", None)
+        issues = [
+            {
+                "number": 50,
+                "state": "open",
+                "title": "misc-job is slow",
+                "body": "see attached.",
+            }
+        ]
+        assert classify_finding_against_issues(f, issues).kind == "duplicate"
+
+    def test_open_overrides_closed_when_both_match(self) -> None:
+        f = self._step_finding("job-x", "step-y")
+        issues = [
+            {
+                "number": 1,
+                "state": "closed",
+                "title": "job-x slow (step-y)",
+                "body": "old",
+            },
+            {
+                "number": 2,
+                "state": "open",
+                "title": "job-x slow (step-y)",
+                "body": "current",
+            },
+        ]
+        m = classify_finding_against_issues(f, issues)
+        assert m.kind == "duplicate"
+        assert m.issue_number == 2
+
+
+class TestMainCliDrillDown:
+    def test_json_output_contains_drill_down(self, tmp_path: Path, capsys) -> None:
+        # Build a runs file with a > 10 min job, plus a fixture log + ci.yml.
+        runs_data: list[dict[str, object]] = [
+            _make_run(
+                "rX",
+                "2026-05-05T19:00:00Z",
+                [
+                    _make_job(
+                        "shard: shell",
+                        start_offset_s=0,
+                        duration_s=SINGLE_JOB_SECONDS_THRESHOLD + 100,
+                        database_id=99,
+                    )
+                ],
+            )
+        ]
+        runs_file = tmp_path / "runs.json"
+        runs_file.write_text(json.dumps(runs_data))
+        ciyml = tmp_path / "ci.yml"
+        ciyml.write_text(CIYML_FIXTURE)
+        log_file = tmp_path / "joblog.txt"
+        log_file.write_text(_shell_log_fixture())
+
+        rc = main(
+            [
+                "--from-file",
+                str(runs_file),
+                "--ciyml",
+                str(ciyml),
+                "--drill-down-log-file",
+                str(log_file),
+                "--json",
+            ]
+        )
+        out = capsys.readouterr().out
+        assert rc == 1
+        payload = json.loads(out)
+        single_jobs = [f for f in payload["findings"] if f["kind"] == "single-job"]
+        assert single_jobs, "expected at least one single-job finding"
+        drill = single_jobs[0]["details"].get("drill_down")
+        assert drill is not None
+        assert "slowest_steps" in drill
+        assert "if_split_wall_clock_seconds" in drill
+        assert "split_savings_seconds" in drill
+
+    def test_no_drill_down_flag_skips_drill_down(self, tmp_path: Path, capsys) -> None:
+        runs_data: list[dict[str, object]] = [
+            _make_run(
+                "rY",
+                "2026-05-05T19:00:00Z",
+                [
+                    _make_job(
+                        "slow-job",
+                        start_offset_s=0,
+                        duration_s=SINGLE_JOB_SECONDS_THRESHOLD + 1,
+                        database_id=10,
+                    )
+                ],
+            )
+        ]
+        runs_file = tmp_path / "runs.json"
+        runs_file.write_text(json.dumps(runs_data))
+        rc = main(["--from-file", str(runs_file), "--no-drill-down", "--json"])
+        out = capsys.readouterr().out
+        assert rc == 1
+        payload = json.loads(out)
+        assert payload["findings"]
+        # No drill_down attached when the flag is set.
+        assert "drill_down" not in payload["findings"][0]["details"]


### PR DESCRIPTION
## Summary

Extends `scripts/audit_ci_health.py` so the `/audit` skill's CI-health pass automatically drills into any job that exceeds the 10-minute single-job threshold — fetching the job log, parsing `##[group]` per-step markers, cross-referencing inline `~Ns` estimates in `ci.yml`, and emitting `slowest_steps` + `if_split_wall_clock_seconds` + `split_savings_seconds` + `trim` / `split` recommendations. Also hardens dedup so closed prior issues no longer silently silence regressions: dedup matches **open** issues only, the dedup key is `(job_name, slowest_step_name)`, and a closed prior match files a new issue with `Recurrence of #N`.

Closes #4070

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green (canonical merge gate; `scripts-tests (shell)` is the long-pole job we're enhancing — it's superseded by ci-passed)

### Post-deploy verification
- [x] N/A — no deployed component (audit script + SKILL.md only; the script is permanent and is invoked by the `/audit` skill on demand and on the dispatcher cadence)
