### PR TITLE
feat(devops): CI guard for workflow paths-filter coverage (#4084)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1414,6 +1414,32 @@ jobs:
         run: python3 scripts/check-ci-job-skipped.py --base "origin/${{ github.event.pull_request.base.ref }}"
 
   # ---------------------------------------------------------------
+  # Workflow paths-filter coverage guard: assert every shell script
+  # invoked from a runner-side `run:` block in a deploy workflow (or
+  # composite action it references) is listed in that workflow's
+  # `paths:` filter, so changes to the shared script trigger the
+  # workflow on the PR that introduces them. Closes the recurring
+  # bug-class behind #2592, #2608, #4073, #4084 — a regression in a
+  # shared script otherwise only surfaces on the next *unrelated* PR's
+  # deploy. Runs unconditionally on every PR since the check is fast
+  # and scoping-by-paths-filter is exactly what we'd be auditing.
+  # ---------------------------------------------------------------
+  workflow-paths-filter-coverage-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install pytest
+        run: pip install pytest
+      - name: Verify workflow paths-filters cover invoked shell scripts
+        run: python3 scripts/check-workflow-paths-filter-coverage.py
+      - name: Run unit tests for the coverage check
+        run: pytest tests/test_check_workflow_paths_filter_coverage.py -v
+
+  # ---------------------------------------------------------------
   # Preflight hook test suite: runs when .claude/hooks/ changes (#2408)
   # ---------------------------------------------------------------
   preflight-hook-test:
@@ -1588,7 +1614,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,12 +13,18 @@ on:
       # path on its own merge — otherwise regressions surface on the
       # next unrelated apply.
       - "scripts/wait-for-rollout.sh"
+      # scripts/check-no-nonascii-tf-descriptions.sh is invoked by the
+      # `Check no non-ASCII in tf descriptions` step. Same paths-filter
+      # contract — a regression in the hygiene check would otherwise
+      # only surface on the next unrelated terraform PR (see #4084).
+      - "scripts/check-no-nonascii-tf-descriptions.sh"
   pull_request:
     branches: [main]
     paths:
       - "infra/terraform/**"
       - ".github/workflows/terraform.yml"
       - "scripts/wait-for-rollout.sh"
+      - "scripts/check-no-nonascii-tf-descriptions.sh"
 
 jobs:
   terraform:

--- a/scripts/check-workflow-paths-filter-coverage.py
+++ b/scripts/check-workflow-paths-filter-coverage.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check-workflow-paths-filter-coverage.py — Verify that every shell script
+invoked from the runner inside a GitHub Actions workflow (or a composite
+action it references) is present in that workflow's `paths:` filter, so
+changes to the shared script trigger the workflow on the PR that
+introduces them.
+
+Motivation (#4084)
+------------------
+Issue #4073 / PR #4077 fixed two instances of the same bug shape: a
+shell script invoked from a deploy workflow was missing from the
+workflow's `on.push.paths:` filter. A regression in the script only
+surfaces on the next *unrelated* workflow run — blinding the gate in
+the meantime. The convention has been applied four times so far
+(#2592 wait-for-rollout, #2608 ecs-post-deploy-healthcheck, #4073 the
+two scripts in PR #4077). This check enforces it structurally.
+
+What the check does
+-------------------
+1. Walk every workflow file under ``.github/workflows/*.yml`` (and
+   ``*.yaml``).
+2. For each workflow with at least one ``paths:`` filter (under
+   ``on.push`` or ``on.pull_request``), extract the positive and
+   negative path entries.
+3. Find every ``run:`` block in the workflow body. For each composite
+   action referenced via ``uses: ./.github/actions/<name>``, also
+   scan that action's ``run:`` blocks.
+4. In each ``run:`` block, find every reference matching
+   ``scripts/<path>.(sh|py)`` — those are runner-side script
+   invocations. Strings inside ``with:`` blocks are NOT scanned (a
+   ``command:`` input to ``ecs-oneshot`` runs *inside* the launched
+   container, not on the runner — so it's intentionally excluded).
+5. For each found script, assert it matches at least one positive
+   glob in EVERY ``paths:`` filter present in the workflow, and is
+   NOT excluded by a negative entry.
+6. Report violations and exit 1; exit 0 if all clean.
+
+Glob syntax: GitHub Actions uses picomatch globs. Reuses the same
+glob_to_regex() convention as ``check-ci-job-skipped.py``.
+
+Usage
+-----
+    scripts/check-workflow-paths-filter-coverage.py
+    scripts/check-workflow-paths-filter-coverage.py --repo-root /path
+    scripts/check-workflow-paths-filter-coverage.py --workflows-dir DIR
+                                                    --actions-dir DIR
+
+Exit codes
+----------
+    0 — All clean: every runner-side script invocation is covered
+        by the workflow's ``paths:`` filter.
+    1 — One or more workflows have a runner-side script invocation
+        missing from a ``paths:`` filter.
+    2 — Script error (cannot parse a workflow file, missing dir,
+        etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+# -----------------------------------------------------------------------------
+# Glob matching (GitHub Actions / dorny/paths-filter / picomatch syntax)
+# -----------------------------------------------------------------------------
+# GitHub Actions paths filter uses picomatch globs:
+#   - ``**`` matches any sequence (including zero or more directory
+#     boundaries).
+#   - ``*`` matches any character except ``/``.
+#   - ``?`` matches a single character except ``/``.
+#   - Other chars are literal.
+#
+# This is the same convention used by ``check-ci-job-skipped.py``; the
+# glob_to_regex implementation is intentionally a near-copy so the
+# behavior stays consistent.
+
+
+def glob_to_regex(glob: str) -> re.Pattern[str]:
+    """Convert a picomatch-ish glob to a compiled regex anchored to full path."""
+    glob = glob.strip().strip("'\"")
+
+    out: list[str] = []
+    i = 0
+    n = len(glob)
+    while i < n:
+        c = glob[i]
+        if c == "*":
+            # Look for `**` (optionally followed by `/`)
+            if i + 1 < n and glob[i + 1] == "*":
+                # `**/` matches any sequence of dirs including none
+                if i + 2 < n and glob[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                    continue
+                # `/**` at end or elsewhere: match anything (incl empty).
+                out.append(".*")
+                i += 2
+                continue
+            # Single `*`: match anything except slash.
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c in r".+^$()[]{}|\\":
+            out.append(re.escape(c))
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+
+    pattern = "^" + "".join(out) + "$"
+    return re.compile(pattern)
+
+
+def path_matches_any(path: str, compiled_globs: list[re.Pattern[str]]) -> bool:
+    for pat in compiled_globs:
+        if pat.match(path):
+            return True
+    return False
+
+
+# -----------------------------------------------------------------------------
+# Workflow / action YAML parsing (line-oriented; no PyYAML dep needed)
+# -----------------------------------------------------------------------------
+#
+# We only need three kinds of structure out of these files:
+#
+#   1. The ``on.push.paths`` and ``on.pull_request.paths`` lists. Each
+#      entry is a YAML list element ``- '...'`` or ``- "..."`` or
+#      ``- ...``; a leading ``!`` marks a negative (exclusion) entry.
+#
+#   2. The text of every ``run:`` block — both single-line ``run: foo``
+#      and multi-line ``run: |``-style folded scalars. We need the
+#      content to grep for ``scripts/...`` references.
+#
+#   3. The list of composite actions referenced via
+#      ``uses: ./.github/actions/<name>`` (and the ``with:`` block
+#      following each, which we DO NOT include in the runner-side
+#      run-block content because ``with:`` values are inputs to the
+#      action, not commands executed on the runner).
+#
+# The parser is a small line-level state machine. It does not aim to
+# handle every YAML edge case — only the structures actually used in
+# this repo's workflows. ``check-ci-job-skipped.py`` follows the same
+# pattern for ``ci.yml``, and the constraint has held up well.
+
+
+# A `run: |` block-scalar header (multi-line). Indent of the colon-bearing
+# line determines where the block content begins (one level deeper).
+# Both forms are accepted:
+#   `<indent>run: |`                            (mapping form)
+#   `<indent>- run: |`                          (list-item form)
+RUN_BLOCK_RE = re.compile(r"^(\s*(?:-\s+)?)run:\s*\|[\s+\-]*\s*$")
+# A `run: <single-line-command>` — captures the command portion. Same
+# list-item-or-mapping leading allowance.
+RUN_INLINE_RE = re.compile(r"^(\s*(?:-\s+)?)run:\s+([^|>].*)$")
+# A `uses: ./.github/actions/<name>` reference — captures the action path.
+USES_LOCAL_ACTION_RE = re.compile(
+    r"^\s*(?:-\s+)?uses:\s+(\./\.github/actions/[A-Za-z0-9_\-./]+)\s*$"
+)
+# An entry inside a paths-filter list: `- '<glob>'` or `- "<glob>"` or `- <glob>`.
+PATH_ENTRY_RE = re.compile(r"^(\s*)-\s+(.+?)\s*$")
+
+
+@dataclass
+class WorkflowPaths:
+    """Paths-filter content under one of ``on.push.paths`` or ``on.pull_request.paths``."""
+
+    trigger: str  # "push" or "pull_request"
+    positives: list[str] = field(default_factory=list)
+    negatives: list[str] = field(default_factory=list)
+
+    def is_covered(self, script_path: str) -> bool:
+        """Return True if ``script_path`` is covered by this filter.
+
+        Coverage = matches at least one positive glob AND does not
+        match any negative glob.
+        """
+        pos = [glob_to_regex(g) for g in self.positives]
+        neg = [glob_to_regex(g) for g in self.negatives]
+        if not path_matches_any(script_path, pos):
+            return False
+        if path_matches_any(script_path, neg):
+            return False
+        return True
+
+
+@dataclass
+class RunBlock:
+    """A runner-side ``run:`` block — text content + source location."""
+
+    file_path: Path  # the workflow or action file the block lives in
+    line_number: int  # 1-indexed line where the `run:` keyword appears
+    content: str  # the block's actual command text (joined lines)
+
+
+@dataclass
+class WorkflowFile:
+    """Parsed view of a single workflow file."""
+
+    path: Path
+    paths_filters: list[WorkflowPaths]
+    run_blocks: list[RunBlock]
+    composite_actions: list[Path]  # absolute paths to local action.yml files
+
+
+def parse_yaml_file(
+    path: Path,
+    repo_root: Path,
+    is_workflow: bool,
+) -> WorkflowFile:
+    """Parse a workflow or action file into a WorkflowFile structure.
+
+    For composite-action files (is_workflow=False) we only collect
+    ``run:`` blocks and nested ``uses:`` — paths_filters is empty.
+    """
+    text = path.read_text()
+    lines = text.splitlines()
+
+    paths_filters: list[WorkflowPaths] = []
+    run_blocks: list[RunBlock] = []
+    composite_actions: list[Path] = []
+
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        stripped = line.strip()
+
+        # `run: |` — multi-line block scalar
+        m_run_block = RUN_BLOCK_RE.match(line)
+        if m_run_block:
+            run_indent = len(m_run_block.group(1))
+            block_lines: list[str] = []
+            j = i + 1
+            block_indent: int | None = None
+            while j < n:
+                bl = lines[j]
+                # Empty / blank lines belong to the block (they're inside the scalar).
+                if not bl.strip():
+                    block_lines.append("")
+                    j += 1
+                    continue
+                bl_indent = len(bl) - len(bl.lstrip(" "))
+                if bl_indent <= run_indent:
+                    break
+                if block_indent is None:
+                    block_indent = bl_indent
+                block_lines.append(bl)
+                j += 1
+            run_blocks.append(
+                RunBlock(
+                    file_path=path, line_number=i + 1, content="\n".join(block_lines)
+                )
+            )
+            i = j
+            continue
+
+        # `run: <single line command>` — single-line invocation
+        m_run_inline = RUN_INLINE_RE.match(line)
+        if m_run_inline:
+            content = m_run_inline.group(2)
+            run_blocks.append(
+                RunBlock(file_path=path, line_number=i + 1, content=content)
+            )
+            i += 1
+            continue
+
+        # `uses: ./.github/actions/<name>` — collect for later recursion
+        m_uses = USES_LOCAL_ACTION_RE.match(line)
+        if m_uses:
+            # m_uses.group(1) is like "./.github/actions/myaction".
+            # ``Path("./.github/actions/...")`` simplifies the leading
+            # `./` automatically, so a plain join with repo_root works.
+            ref = m_uses.group(1)
+            if ref.startswith("./"):
+                ref = ref[2:]
+            action_dir = repo_root / ref
+            # Try common filenames: action.yml then action.yaml
+            for fname in ("action.yml", "action.yaml"):
+                candidate = action_dir / fname
+                if candidate.is_file():
+                    composite_actions.append(candidate.resolve())
+                    break
+            i += 1
+            continue
+
+        # `on:` block — only relevant for workflow files
+        if is_workflow and stripped == "on:":
+            paths_filters.extend(_parse_on_block(lines, i))
+            # _parse_on_block doesn't advance — let outer loop continue.
+            # The block content is parsed inline; we just keep walking.
+            i += 1
+            continue
+
+        i += 1
+
+    return WorkflowFile(
+        path=path,
+        paths_filters=paths_filters,
+        run_blocks=run_blocks,
+        composite_actions=composite_actions,
+    )
+
+
+def _parse_on_block(lines: list[str], on_line_idx: int) -> list[WorkflowPaths]:
+    """Parse the ``on:`` block starting at ``on_line_idx`` and return
+    paths-filter entries for triggers we care about (``push``, ``pull_request``).
+
+    The block ends when we encounter a top-level (zero-indent) line.
+    Within the block, each trigger header is at indent 2:
+        on:
+          push:
+            branches: [main]
+            paths:
+              - 'foo/**'
+          pull_request:
+            paths:
+              - 'foo/**'
+    We support both ``paths:`` (global to the trigger) and the
+    occasional ``branches:`` interleaving.
+    """
+    out: list[WorkflowPaths] = []
+    n = len(lines)
+    # The ``on:`` line itself.
+    # Walk subsequent lines as long as they are indented OR blank.
+    # Track when we enter a trigger sub-block (`push:` or `pull_request:`).
+    current_trigger: str | None = None
+    # Indent of the trigger header line (e.g. `  push:` -> 2).
+    trigger_indent: int | None = None
+    i = on_line_idx + 1
+    while i < n:
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        leading = len(line) - len(line.lstrip(" "))
+        if leading == 0:
+            # Left the on: block.
+            break
+
+        # Trigger header at indent 2 or deeper-but-shallowest level
+        m_trigger = re.match(
+            r"^(\s+)(push|pull_request|workflow_dispatch|schedule):\s*$", line
+        )
+        if m_trigger and (
+            trigger_indent is None or len(m_trigger.group(1)) <= trigger_indent
+        ):
+            current_trigger = m_trigger.group(2)
+            trigger_indent = len(m_trigger.group(1))
+            i += 1
+            continue
+
+        # `paths:` block under the current trigger
+        if current_trigger in ("push", "pull_request") and re.match(
+            r"^\s+paths:\s*$", line
+        ):
+            paths_indent = len(line) - len(line.lstrip(" "))
+            wp = WorkflowPaths(trigger=current_trigger)
+            j = i + 1
+            while j < n:
+                pl = lines[j]
+                if not pl.strip():
+                    j += 1
+                    continue
+                pl_indent = len(pl) - len(pl.lstrip(" "))
+                if pl_indent <= paths_indent:
+                    break
+                m_entry = PATH_ENTRY_RE.match(pl)
+                if m_entry:
+                    val = m_entry.group(2).strip()
+                    # Strip wrapping quotes
+                    if (val.startswith("'") and val.endswith("'")) or (
+                        val.startswith('"') and val.endswith('"')
+                    ):
+                        val = val[1:-1]
+                    if val.startswith("!"):
+                        wp.negatives.append(val[1:])
+                    else:
+                        wp.positives.append(val)
+                j += 1
+            out.append(wp)
+            i = j
+            continue
+
+        i += 1
+
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Script-invocation extraction
+# -----------------------------------------------------------------------------
+# We look for tokens of the form ``scripts/<path>.(sh|py)`` inside ``run:``
+# block content. The token may appear in many forms:
+#
+#   bash scripts/foo.sh
+#   python3 scripts/foo.py
+#   "${GITHUB_WORKSPACE}/scripts/foo.sh"
+#   ./scripts/foo.sh
+#   scripts/foo.sh --some-flag
+#
+# All of them have the literal substring ``scripts/<path>``. The regex
+# below captures the bare path component, with a leading word boundary
+# (or path-prefix character) to avoid matching things like
+# ``packages/scripts/...`` or ``my-scripts/foo.sh``.
+#
+# Extensions: ``.sh`` and ``.py`` cover every shared-script case in the
+# current workflows. ``.mjs`` (e.g. ``scripts/seed-and-migrate.mjs``)
+# always runs *inside* the container — it's the value of a
+# ``command:`` input to the ecs-oneshot action — so it's intentionally
+# excluded; if a future workflow invokes a ``.mjs`` script directly on
+# the runner, we'll add it here.
+#
+# Distinguishing top-level ``scripts/`` vs nested ``packages/scripts/``:
+#
+#   `bash scripts/foo.sh`               — match
+#   `"${GITHUB_WORKSPACE}/scripts/foo.sh"` — match (via `}/`)
+#   `./scripts/foo.sh`                  — match (via `./`)
+#   `packages/scripts/foo.sh`           — DO NOT match (alphabetic
+#                                          char before the `/`).
+#
+# Both "good" cases above have the immediately-preceding character of
+# ``scripts/`` be ``/``. The "bad" case also has ``/`` immediately
+# before. We disambiguate by what's BEFORE that slash: if it's a
+# ``}``, ``.``, or non-word char, it's a substitution / dot-slash, NOT
+# a path component. If it's a word char (letter/digit/_/-), it's
+# nested.
+#
+# Two-arm regex:
+#   1. ``(?<![A-Za-z0-9_\-/])scripts/...`` — covers leads like start
+#      of line, whitespace, quotes, ``;`` ``&`` ``(``.
+#   2. ``(?<=[}.])/(scripts/...)`` — covers ``}/scripts/`` and
+#      ``./scripts/`` cases where a ``/`` is permitted because of
+#      the preceding char.
+SCRIPT_REF_RE = re.compile(
+    r"(?:"
+    r"(?<![A-Za-z0-9_\-/])(?P<a>scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))"
+    r"|"
+    r"(?<=[})\.])/(?P<b>scripts/[A-Za-z0-9_\-./]+\.(?:sh|py))"
+    r")"
+)
+
+
+def find_script_invocations(content: str) -> list[str]:
+    """Return the list of ``scripts/...`` references found in ``content``.
+
+    Filters comment-only lines (lines whose first non-whitespace char
+    is ``#``) since those are documentation, not invocations.
+    Deduplicates while preserving order of first appearance.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in content.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        for m in SCRIPT_REF_RE.finditer(line):
+            ref = m.group("a") or m.group("b")
+            if ref and ref not in seen:
+                seen.add(ref)
+                out.append(ref)
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Main check
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class Violation:
+    workflow: Path
+    trigger: str  # "push" or "pull_request"
+    script_path: str
+    invocation_file: Path  # workflow itself, OR a composite action it uses
+    invocation_line: int
+
+
+def check_workflow(
+    wf: WorkflowFile,
+    repo_root: Path,
+    workflow_files: dict[Path, WorkflowFile],
+    action_files: dict[Path, WorkflowFile],
+) -> list[Violation]:
+    """Return list of violations for this workflow."""
+    if not wf.paths_filters:
+        return []  # workflow_dispatch-only / no path gating
+
+    # Collect all run-block references in the workflow itself.
+    invocations: list[tuple[str, Path, int]] = []
+    for rb in wf.run_blocks:
+        for ref in find_script_invocations(rb.content):
+            invocations.append((ref, rb.file_path, rb.line_number))
+
+    # Recursively collect from composite actions (one level — actions
+    # don't typically reference other local actions in this repo).
+    seen_actions: set[Path] = set()
+    pending = list(wf.composite_actions)
+    while pending:
+        action_path = pending.pop()
+        if action_path in seen_actions:
+            continue
+        seen_actions.add(action_path)
+        action = action_files.get(action_path)
+        if action is None:
+            continue
+        for rb in action.run_blocks:
+            for ref in find_script_invocations(rb.content):
+                invocations.append((ref, rb.file_path, rb.line_number))
+        # Composite actions can `uses:` other composite actions.
+        for sub in action.composite_actions:
+            if sub not in seen_actions:
+                pending.append(sub)
+
+    # Validate each invocation against EVERY paths filter on the workflow.
+    violations: list[Violation] = []
+    for script_path, inv_file, inv_line in invocations:
+        for pf in wf.paths_filters:
+            if not pf.is_covered(script_path):
+                violations.append(
+                    Violation(
+                        workflow=wf.path,
+                        trigger=pf.trigger,
+                        script_path=script_path,
+                        invocation_file=inv_file,
+                        invocation_line=inv_line,
+                    )
+                )
+    return violations
+
+
+def gather_files(
+    workflows_dir: Path,
+    actions_dir: Path,
+    repo_root: Path,
+) -> tuple[dict[Path, WorkflowFile], dict[Path, WorkflowFile]]:
+    workflows: dict[Path, WorkflowFile] = {}
+    if workflows_dir.is_dir():
+        for f in sorted(workflows_dir.iterdir()):
+            if f.is_file() and f.suffix in (".yml", ".yaml"):
+                resolved = f.resolve()
+                workflows[resolved] = parse_yaml_file(
+                    resolved, repo_root, is_workflow=True
+                )
+
+    actions: dict[Path, WorkflowFile] = {}
+    if actions_dir.is_dir():
+        for action_dir in sorted(actions_dir.iterdir()):
+            if not action_dir.is_dir():
+                continue
+            for fname in ("action.yml", "action.yaml"):
+                candidate = action_dir / fname
+                if candidate.is_file():
+                    resolved = candidate.resolve()
+                    actions[resolved] = parse_yaml_file(
+                        resolved, repo_root, is_workflow=False
+                    )
+                    break
+
+    return workflows, actions
+
+
+def format_violation(v: Violation, repo_root: Path) -> str:
+    workflow_rel = _rel(v.workflow, repo_root)
+    invocation_rel = _rel(v.invocation_file, repo_root)
+    return (
+        f"  {workflow_rel} (on.{v.trigger}.paths):\n"
+        f"    invokes  {v.script_path}\n"
+        f"    via      {invocation_rel}:{v.invocation_line}\n"
+        f"    but      {v.script_path} is NOT in the {v.trigger}-paths filter\n"
+    )
+
+
+def _rel(p: Path, repo_root: Path) -> str:
+    try:
+        return str(p.relative_to(repo_root))
+    except ValueError:
+        return str(p)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Verify that every shell script invoked from a runner-side "
+            "run: block in a GitHub Actions workflow (or composite action "
+            "it references) is present in the workflow's paths: filter."
+        )
+    )
+    ap.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root (default: auto-detect from this script's location).",
+    )
+    ap.add_argument(
+        "--workflows-dir",
+        default=None,
+        help="Override workflows dir (default: <repo-root>/.github/workflows).",
+    )
+    ap.add_argument(
+        "--actions-dir",
+        default=None,
+        help="Override composite-actions dir (default: <repo-root>/.github/actions).",
+    )
+    args = ap.parse_args()
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        # scripts/check-workflow-paths-filter-coverage.py -> two parents up.
+        repo_root = Path(__file__).resolve().parent.parent
+
+    workflows_dir = (
+        Path(args.workflows_dir)
+        if args.workflows_dir
+        else repo_root / ".github" / "workflows"
+    )
+    actions_dir = (
+        Path(args.actions_dir)
+        if args.actions_dir
+        else repo_root / ".github" / "actions"
+    )
+
+    if not workflows_dir.is_dir():
+        print(f"ERROR: workflows dir not found: {workflows_dir}", file=sys.stderr)
+        return 2
+
+    try:
+        workflows, actions = gather_files(workflows_dir, actions_dir, repo_root)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: failed to parse workflow files: {exc}", file=sys.stderr)
+        return 2
+
+    all_violations: list[Violation] = []
+    for wf in workflows.values():
+        all_violations.extend(check_workflow(wf, repo_root, workflows, actions))
+
+    if not all_violations:
+        return 0
+
+    print(
+        "check-workflow-paths-filter-coverage: "
+        "one or more workflows invoke a shell script that is NOT in their paths: filter.",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    # Group by workflow + script for readability.
+    seen: set[tuple[str, str, str]] = set()
+    for v in all_violations:
+        key = (str(v.workflow), v.trigger, v.script_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        print(format_violation(v, repo_root), file=sys.stderr)
+    print(
+        "Fix: add an entry for the script under the workflow's "
+        "on.<trigger>.paths block.\n"
+        "See https://github.com/judgemind/judgemind/issues/4084 for background "
+        "(and #4073, #2592, #2608 for prior instances).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-workflow-paths-filter-coverage.sh
+++ b/scripts/check-workflow-paths-filter-coverage.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# check-workflow-paths-filter-coverage.sh — Thin wrapper for
+# check-workflow-paths-filter-coverage.py.
+#
+# Verifies that every shell script invoked from the runner inside a
+# GitHub Actions workflow (or a composite action it references) is
+# present in that workflow's `paths:` filter, so changes to the shared
+# script trigger the workflow on the PR that introduces them.
+#
+# Passes all args through to the Python script — see that file for
+# flags and exit codes (#4084).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-workflow-paths-filter-coverage.py" "$@"

--- a/tests/test_check_workflow_paths_filter_coverage.py
+++ b/tests/test_check_workflow_paths_filter_coverage.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-workflow-paths-filter-coverage.py (#4084).
+
+Each test builds a synthetic .github/workflows/ + .github/actions/ tree
+under tmp_path, runs the script, and asserts the exit code and output.
+
+Fixture coverage (per issue #4084 acceptance criteria):
+  1. in-paths-direct
+       Workflow's run: block invokes scripts/foo.sh; foo.sh is in
+       on.push.paths — exit 0.
+  2. in-paths-via-composite-action
+       Workflow uses ./.github/actions/myaction; the action's run:
+       block invokes scripts/foo.sh; foo.sh is in on.push.paths
+       — exit 0.
+  3. missing-direct
+       Workflow's run: block invokes scripts/foo.sh; foo.sh is NOT
+       in on.push.paths — exit 1, error message names foo.sh.
+  4. missing-via-composite
+       Workflow uses a composite action that invokes scripts/foo.sh;
+       foo.sh is NOT in on.push.paths — exit 1.
+  5. in-Docker-container-invocation
+       Workflow uses ecs-oneshot composite with
+       command: '["node", "scripts/seed.mjs"]' under with: — that
+       runs *inside* a Docker container, not on the runner, so the
+       check should NOT flag scripts/seed.mjs even though it's not
+       in on.push.paths. Exit 0.
+
+Run from the repo root:
+    pytest tests/test_check_workflow_paths_filter_coverage.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check-workflow-paths-filter-coverage.py"
+
+
+# ---------------------------------------------------------------------------
+# Module loading (script has hyphens in its name → load via importlib)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def module():
+    spec = importlib.util.spec_from_file_location(
+        "check_workflow_paths_filter_coverage", SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["check_workflow_paths_filter_coverage"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create the .github tree and return (repo_root, workflows_dir, actions_dir)."""
+    repo_root = tmp_path / "repo"
+    workflows_dir = repo_root / ".github" / "workflows"
+    actions_dir = repo_root / ".github" / "actions"
+    workflows_dir.mkdir(parents=True)
+    actions_dir.mkdir(parents=True)
+    return repo_root, workflows_dir, actions_dir
+
+
+def _run_script(repo_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo-root",
+            str(repo_root),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fixture tests (the five cases listed in #4084 AC #3)
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureCases:
+    def test_in_paths_direct_passes(self, tmp_path: Path) -> None:
+        """1. Script invoked directly + present in paths → exit 0."""
+        repo_root, workflows_dir, _ = _make_repo(tmp_path)
+        (workflows_dir / "deploy.yml").write_text(
+            "name: Deploy\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "      - 'scripts/foo.sh'\n"
+            "jobs:\n"
+            "  deploy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: bash scripts/foo.sh\n"
+        )
+        result = _run_script(repo_root)
+        assert result.returncode == 0, (
+            f"expected exit 0, got {result.returncode}\nstderr={result.stderr!r}"
+        )
+
+    def test_in_paths_via_composite_action_passes(self, tmp_path: Path) -> None:
+        """2. Script invoked via composite action + present in paths → exit 0."""
+        repo_root, workflows_dir, actions_dir = _make_repo(tmp_path)
+        (workflows_dir / "deploy.yml").write_text(
+            "name: Deploy\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "      - 'scripts/foo.sh'\n"
+            "      - '.github/actions/myaction/**'\n"
+            "jobs:\n"
+            "  deploy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: ./.github/actions/myaction\n"
+        )
+        action_dir = actions_dir / "myaction"
+        action_dir.mkdir()
+        (action_dir / "action.yml").write_text(
+            "name: My Action\n"
+            "runs:\n"
+            "  using: composite\n"
+            "  steps:\n"
+            "    - shell: bash\n"
+            "      run: |\n"
+            "        ${GITHUB_WORKSPACE}/scripts/foo.sh\n"
+        )
+        result = _run_script(repo_root)
+        assert result.returncode == 0, (
+            f"expected exit 0, got {result.returncode}\nstderr={result.stderr!r}"
+        )
+
+    def test_missing_direct_fails(self, tmp_path: Path) -> None:
+        """3. Script invoked directly + missing from paths → exit 1, names script."""
+        repo_root, workflows_dir, _ = _make_repo(tmp_path)
+        (workflows_dir / "deploy.yml").write_text(
+            "name: Deploy\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "jobs:\n"
+            "  deploy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: bash scripts/foo.sh\n"
+        )
+        result = _run_script(repo_root)
+        assert result.returncode == 1, (
+            f"expected exit 1, got {result.returncode}\n"
+            f"stdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+        assert "scripts/foo.sh" in result.stderr
+        assert "deploy.yml" in result.stderr
+
+    def test_missing_via_composite_fails(self, tmp_path: Path) -> None:
+        """4. Script invoked via composite + missing from paths → exit 1."""
+        repo_root, workflows_dir, actions_dir = _make_repo(tmp_path)
+        (workflows_dir / "deploy.yml").write_text(
+            "name: Deploy\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "      - '.github/actions/myaction/**'\n"
+            "jobs:\n"
+            "  deploy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: ./.github/actions/myaction\n"
+        )
+        action_dir = actions_dir / "myaction"
+        action_dir.mkdir()
+        (action_dir / "action.yml").write_text(
+            "name: My Action\n"
+            "runs:\n"
+            "  using: composite\n"
+            "  steps:\n"
+            "    - shell: bash\n"
+            "      run: |\n"
+            "        ${GITHUB_WORKSPACE}/scripts/foo.sh\n"
+        )
+        result = _run_script(repo_root)
+        assert result.returncode == 1, (
+            f"expected exit 1, got {result.returncode}\nstderr={result.stderr!r}"
+        )
+        assert "scripts/foo.sh" in result.stderr
+        # Violation should reference the composite action's location
+        assert "myaction/action.yml" in result.stderr
+
+    def test_in_docker_container_invocation_ignored(self, tmp_path: Path) -> None:
+        """5. Script in `command:` input (runs inside container) → not flagged → exit 0.
+
+        The ecs-oneshot composite action takes a ``command`` input and
+        passes it as ``aws ecs register-task-definition --command``;
+        the script runs *inside* the launched ECS container, not on
+        the GitHub Actions runner. The check must not flag it even
+        though the script is not in the paths filter.
+        """
+        repo_root, workflows_dir, actions_dir = _make_repo(tmp_path)
+        (workflows_dir / "deploy.yml").write_text(
+            "name: Deploy\n"
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "      - '.github/actions/ecs-oneshot/**'\n"
+            "jobs:\n"
+            "  deploy:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: ./.github/actions/ecs-oneshot\n"
+            "        with:\n"
+            '          command: \'["node", "scripts/seed.mjs"]\'\n'
+        )
+        action_dir = actions_dir / "ecs-oneshot"
+        action_dir.mkdir()
+        # Action body does NOT itself invoke any scripts/ — `command:`
+        # is forwarded to ECS register-task-definition, not executed
+        # on the runner.
+        (action_dir / "action.yml").write_text(
+            "name: ECS Oneshot\n"
+            "inputs:\n"
+            "  command:\n"
+            "    required: true\n"
+            "runs:\n"
+            "  using: composite\n"
+            "  steps:\n"
+            "    - shell: bash\n"
+            "      env:\n"
+            "        COMMAND: ${{ inputs.command }}\n"
+            "      run: |\n"
+            '        aws ecs register-task-definition --command "$COMMAND"\n'
+        )
+        result = _run_script(repo_root)
+        assert result.returncode == 0, (
+            f"expected exit 0 (in-container script must be ignored), "
+            f"got {result.returncode}\n"
+            f"stdout={result.stdout!r}\n"
+            f"stderr={result.stderr!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests on the parser/glob helpers
+# ---------------------------------------------------------------------------
+
+
+class TestGlobToRegex:
+    def test_recursive_doublestar(self, module) -> None:
+        pat = module.glob_to_regex("packages/**")
+        assert pat.match("packages/a/b/c.py")
+        assert pat.match("packages/")
+        assert not pat.match("scripts/foo.sh")
+
+    def test_exact_path(self, module) -> None:
+        pat = module.glob_to_regex("scripts/foo.sh")
+        assert pat.match("scripts/foo.sh")
+        assert not pat.match("scripts/foo.shell")
+        assert not pat.match("scripts/sub/foo.sh")
+
+    def test_negation_handled_by_caller(self, module) -> None:
+        # The glob_to_regex helper itself does NOT handle leading `!`;
+        # WorkflowPaths separates positives from negatives. Documented
+        # so a future refactor doesn't change the contract.
+        pat = module.glob_to_regex("scripts/foo.sh")
+        assert pat.match("scripts/foo.sh")
+
+
+class TestFindScriptInvocations:
+    def test_finds_bash_script(self, module) -> None:
+        refs = module.find_script_invocations("bash scripts/foo.sh")
+        assert refs == ["scripts/foo.sh"]
+
+    def test_finds_python_script(self, module) -> None:
+        refs = module.find_script_invocations("python3 scripts/check.py --flag")
+        assert refs == ["scripts/check.py"]
+
+    def test_finds_workspace_prefixed(self, module) -> None:
+        refs = module.find_script_invocations('"${GITHUB_WORKSPACE}/scripts/wait.sh"')
+        assert refs == ["scripts/wait.sh"]
+
+    def test_dedupes_repeated_refs(self, module) -> None:
+        refs = module.find_script_invocations("scripts/foo.sh\nscripts/foo.sh --flag\n")
+        assert refs == ["scripts/foo.sh"]
+
+    def test_skips_comment_lines(self, module) -> None:
+        refs = module.find_script_invocations(
+            "# scripts/foo.sh is a doc reference\necho hello\n"
+        )
+        assert refs == []
+
+    def test_does_not_match_packages_scripts_subpath(self, module) -> None:
+        # `packages/scripts/foo.sh` is not the same as `scripts/foo.sh`.
+        refs = module.find_script_invocations("ls packages/scripts/foo.sh")
+        assert "packages/scripts/foo.sh" not in refs
+        # Nor should it match scripts/foo.sh by accident.
+        assert refs == []
+
+    def test_handles_multiple_per_line(self, module) -> None:
+        refs = module.find_script_invocations("scripts/a.sh && scripts/b.sh")
+        assert refs == ["scripts/a.sh", "scripts/b.sh"]
+
+
+class TestPathsFilterParse:
+    def test_extracts_positives_and_negatives(self, module, tmp_path: Path) -> None:
+        wf_path = tmp_path / "wf.yml"
+        wf_path.write_text(
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "      - 'scripts/foo.sh'\n"
+            "      - '!scripts/foo/**'\n"
+            "jobs:\n"
+            "  x:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n"
+        )
+        parsed = module.parse_yaml_file(wf_path, tmp_path, is_workflow=True)
+        assert len(parsed.paths_filters) == 1
+        pf = parsed.paths_filters[0]
+        assert pf.trigger == "push"
+        assert pf.positives == ["packages/**", "scripts/foo.sh"]
+        assert pf.negatives == ["scripts/foo/**"]
+
+    def test_extracts_both_push_and_pull_request(self, module, tmp_path: Path) -> None:
+        wf_path = tmp_path / "wf.yml"
+        wf_path.write_text(
+            "on:\n"
+            "  push:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "  pull_request:\n"
+            "    branches: [main]\n"
+            "    paths:\n"
+            "      - 'packages/**'\n"
+            "      - 'tests/**'\n"
+            "jobs:\n"
+            "  x:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: echo hi\n"
+        )
+        parsed = module.parse_yaml_file(wf_path, tmp_path, is_workflow=True)
+        triggers = sorted(pf.trigger for pf in parsed.paths_filters)
+        assert triggers == ["pull_request", "push"]
+
+    def test_workflow_dispatch_only_yields_no_filters(
+        self, module, tmp_path: Path
+    ) -> None:
+        wf_path = tmp_path / "wf.yml"
+        wf_path.write_text(
+            "on:\n"
+            "  workflow_dispatch:\n"
+            "jobs:\n"
+            "  x:\n"
+            "    runs-on: ubuntu-latest\n"
+            "    steps:\n"
+            "      - run: bash scripts/foo.sh\n"
+        )
+        parsed = module.parse_yaml_file(wf_path, tmp_path, is_workflow=True)
+        assert parsed.paths_filters == []
+
+
+class TestRunBlockExtraction:
+    def test_extracts_multiline_run_block(self, module, tmp_path: Path) -> None:
+        wf_path = tmp_path / "wf.yml"
+        wf_path.write_text(
+            "jobs:\n"
+            "  x:\n"
+            "    steps:\n"
+            "      - run: |\n"
+            "          line1\n"
+            "          scripts/foo.sh\n"
+            "          line3\n"
+        )
+        parsed = module.parse_yaml_file(wf_path, tmp_path, is_workflow=False)
+        assert len(parsed.run_blocks) == 1
+        assert "scripts/foo.sh" in parsed.run_blocks[0].content
+
+    def test_extracts_single_line_run(self, module, tmp_path: Path) -> None:
+        wf_path = tmp_path / "wf.yml"
+        wf_path.write_text(
+            "jobs:\n  x:\n    steps:\n      - run: bash scripts/foo.sh --flag\n"
+        )
+        parsed = module.parse_yaml_file(wf_path, tmp_path, is_workflow=False)
+        assert len(parsed.run_blocks) == 1
+        assert "scripts/foo.sh" in parsed.run_blocks[0].content
+
+    def test_does_not_capture_with_block_command(self, module, tmp_path: Path) -> None:
+        """`with: command:` parameters are NOT run blocks."""
+        wf_path = tmp_path / "wf.yml"
+        wf_path.write_text(
+            "jobs:\n"
+            "  x:\n"
+            "    steps:\n"
+            "      - uses: ./.github/actions/oneshot\n"
+            "        with:\n"
+            '          command: \'["node", "scripts/seed.mjs"]\'\n'
+        )
+        parsed = module.parse_yaml_file(wf_path, tmp_path, is_workflow=False)
+        # The `with:` block is not a run block; no run_blocks should be
+        # captured.
+        assert parsed.run_blocks == []
+
+
+# ---------------------------------------------------------------------------
+# AC #1: the check exits 0 against the live repo on main post-#4077
+# ---------------------------------------------------------------------------
+
+
+class TestRealRepoIsClean:
+    """Run the check against the actual repo and assert exit 0.
+
+    This is the live verification of AC #1: "exits 0 on main post-#4077
+    (current state has zero violations)". It also runs every PR going
+    forward, so a future PR that adds a runner-side script invocation
+    without updating paths will fail this test.
+    """
+
+    def test_exit_zero_on_real_repo(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--repo-root", str(REPO_ROOT)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert result.returncode == 0, (
+            "check-workflow-paths-filter-coverage found violations on "
+            "the current tree. Add the missing scripts to the workflow's "
+            "on.<trigger>.paths filter, or pass --workflows-dir to "
+            "exclude a non-applicable workflow.\n"
+            f"stderr:\n{result.stderr}"
+        )


### PR DESCRIPTION
## Summary

Adds `scripts/check-workflow-paths-filter-coverage.{py,sh}` — a CI hygiene check that asserts every shell script invoked from a runner-side `run:` block in a deploy workflow (or a composite action it references) is listed in that workflow's `paths:` filter. Wired into `ci.yml` as `workflow-paths-filter-coverage-check`. Closes the recurring bug-class behind #2592, #2608, #4073 — a regression in a shared script otherwise only surfaces on the next *unrelated* deploy.

The check's first run surfaced one real violation that PR #4077's audit didn't catch: `terraform.yml` invokes `scripts/check-no-nonascii-tf-descriptions.sh` from a runner-side step but the script was missing from both `on.push.paths` and `on.pull_request.paths`. Same PR fixes it inline.

Closes #4084

## Synthetic-failure demo (per AC #2)

A temp deploy-scraper.yml that invokes `scripts/foo.sh` without listing it produces this output:

```
exit_code: 1
=== stderr ===
check-workflow-paths-filter-coverage: one or more workflows invoke a shell script that is NOT in their paths: filter.

  .github/workflows/deploy-scraper.yml (on.push.paths):
    invokes  scripts/foo.sh
    via      .github/workflows/deploy-scraper.yml:14
    but      scripts/foo.sh is NOT in the push-paths filter

Fix: add an entry for the script under the workflow's on.<trigger>.paths block.
See https://github.com/judgemind/judgemind/issues/4084 for background (and #4073, #2592, #2608 for prior instances).
```

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest tests/test_check_workflow_paths_filter_coverage.py -v` → 22 passed in 0.21s)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check + workflow YAML edits only). Verification is the green CI run on this PR itself: the new `workflow-paths-filter-coverage-check` job exercised the static check + 22-test pytest suite end-to-end (concluded SUCCESS).
- [x] Verification evidence posted on issue (see A.8) — CI-run-link comment with the green `workflow-paths-filter-coverage-check` job result.
