### PR TITLE
refactor(ingestion): extract decide_extraction_strategy helper (#4081)

### DIFF
--- a/packages/scraper-framework/src/framework/extraction_config.py
+++ b/packages/scraper-framework/src/framework/extraction_config.py
@@ -235,3 +235,156 @@ def get_county_extraction_config(
     if scraper_id and scraper_id in _SCRAPER_CONFIGS:
         return _SCRAPER_CONFIGS[scraper_id]
     return _COUNTY_CONFIGS.get((state.upper(), county.upper()))
+
+
+# ---------------------------------------------------------------------------
+# Extraction strategy — single source of truth for worker + reingest gates
+# ---------------------------------------------------------------------------
+# The ingestion worker (``packages/scraper-framework/src/ingestion/worker.py``)
+# and the reingest path (``scripts/reingest_from_s3.py``) both decide:
+#
+#   - Should the framework LLM be skipped entirely? (``ExtractionMethod.NONE``)
+#   - Should the multimodal extractor handle this document? (raw-PDF + per-page
+#     images, ``ExtractionMethod.MULTIMODAL``)
+#   - Which provider/model/system_prompt should the text LLM call use?
+#   - What max_output_tokens cap applies?
+#   - What max_chars_per_chunk cap applies?
+#
+# Historically each path consulted ``get_county_extraction_config`` inline and
+# spelled the gate logic out itself.  When ``ExtractionMethod`` gained the
+# ``NONE`` value the worker honored it but reingest did not — producing the
+# divergence pattern in #2490, #2501, #2502, #2521, #4056.  The Option A
+# parity test in ``tests/test_worker_reingest_parity.py`` (#4071) was the
+# preventative; this helper is the structural fix described in #4081 (Option B).
+#
+# Both paths now call ``decide_extraction_strategy(...)`` once and read the
+# resulting ``ExtractionStrategy`` fields.  Adding a new ``ExtractionMethod``
+# value or a new ``CountyExtractionConfig`` field updates both paths in one
+# place — the divergence pattern becomes structurally impossible.
+#
+# Default semantics for unconfigured (state, county, scraper_id) tuples
+# preserve the worker's pre-refactor behavior:
+#
+#   - ``skip_llm = False``      — run framework extraction
+#   - ``use_multimodal = True`` — allow multimodal when a raw PDF is present
+#                                  (worker.py L1738 default-multimodal path)
+#   - ``max_output_tokens = 4096`` — framework default (#2355)
+#   - ``system_prompt = None``  — caller falls back to ``EXTRACTION_SYSTEM_PROMPT``
+#   - ``provider = None``       — caller uses framework-default provider
+#   - ``model = None``          — caller uses provider-default model
+#   - ``max_chars_per_chunk = None`` — caller uses ``LlmExtractor`` default
+
+_DEFAULT_MAX_OUTPUT_TOKENS = 4096
+
+
+@dataclass(frozen=True)
+class ExtractionStrategy:
+    """Per-document extraction decision derived from county+scraper config.
+
+    All fields are populated to concrete values where possible; ``None``
+    means "use the framework/extractor default" so callers do not need to
+    re-derive defaults.
+
+    Attributes:
+        skip_llm: True when ``ExtractionMethod.NONE`` is configured —
+            short-circuit framework LLM extraction entirely.  The scraper
+            populates all fields itself (e.g. SD calendar HTML, Federal
+            CourtListener clusters).
+        use_multimodal: True when ``ExtractionMethod.MULTIMODAL`` is
+            configured OR no config exists for the (state, county,
+            scraper_id) tuple.  Worker uses this to decide whether to
+            download the raw PDF from S3 and route to the per-page
+            multimodal extractor.  Reingest's ``_reparse_document`` does
+            not have a multimodal sub-path today, so the flag is
+            informational there — but exposing it keeps the strategy
+            self-describing for future reingest enhancements.
+        max_output_tokens: Per-call max output tokens for the LLM.
+            Defaults to ``4096`` when no override is configured (#2355).
+        system_prompt: County-specific system prompt, or ``None`` to use
+            the framework default ``EXTRACTION_SYSTEM_PROMPT``.
+        provider: ``"anthropic"`` or ``"google"``, or ``None`` to use
+            the framework default (Anthropic).
+        model: Provider-specific model id, or ``None`` to use the
+            provider default.
+        max_chars_per_chunk: Per-chunk character cap for chunked
+            extraction.  ``None`` falls back to the ``LlmExtractor``
+            default (80,000).
+    """
+
+    skip_llm: bool
+    use_multimodal: bool
+    max_output_tokens: int
+    system_prompt: str | None
+    provider: str | None
+    model: str | None
+    max_chars_per_chunk: int | None
+
+
+def decide_extraction_strategy(
+    state: str,
+    county: str,
+    *,
+    scraper_id: str | None = None,
+    has_raw_pdf: bool = False,  # noqa: ARG001 — reserved for future selectors
+) -> ExtractionStrategy:
+    """Resolve the extraction strategy for a (state, county, scraper_id) tuple.
+
+    Single source of truth for both ``ingestion.worker`` and
+    ``scripts/reingest_from_s3.py``.  See module docstring for the full
+    divergence-history rationale.
+
+    Parameters
+    ----------
+    state : str
+        Two-letter state code (e.g. ``"CA"``).
+    county : str
+        County name (e.g. ``"Riverside"``).
+    scraper_id : str | None
+        Optional scraper ID for scraper-level overrides.  Same lookup
+        precedence as ``get_county_extraction_config``.
+    has_raw_pdf : bool
+        Whether the caller currently has the document's raw PDF bytes
+        in hand.  Reserved for future per-document multimodal selectors;
+        not consulted today.  Accepted as a keyword argument so the
+        helper signature does not need to change when a future
+        ``ExtractionMethod`` adds a raw-PDF dependency.
+
+    Returns
+    -------
+    ExtractionStrategy
+        Populated strategy with concrete defaults — callers do not need
+        to re-derive the 4096 default or the multimodal default branch.
+    """
+    config = get_county_extraction_config(state, county, scraper_id=scraper_id)
+
+    if config is None:
+        # No config — preserve worker.py's pre-refactor default behavior:
+        # multimodal is allowed (worker.py L1738), framework default
+        # 4096-token cap, no county prompt, default provider/model.
+        return ExtractionStrategy(
+            skip_llm=False,
+            use_multimodal=True,
+            max_output_tokens=_DEFAULT_MAX_OUTPUT_TOKENS,
+            system_prompt=None,
+            provider=None,
+            model=None,
+            max_chars_per_chunk=None,
+        )
+
+    skip_llm = config.method == ExtractionMethod.NONE
+    use_multimodal = config.method == ExtractionMethod.MULTIMODAL
+    max_output_tokens = (
+        config.max_output_tokens
+        if config.max_output_tokens is not None
+        else _DEFAULT_MAX_OUTPUT_TOKENS
+    )
+
+    return ExtractionStrategy(
+        skip_llm=skip_llm,
+        use_multimodal=use_multimodal,
+        max_output_tokens=max_output_tokens,
+        system_prompt=config.system_prompt,
+        provider=config.provider,
+        model=config.model,
+        max_chars_per_chunk=config.max_chars_per_chunk,
+    )

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1664,6 +1664,19 @@ class IngestionWorker:
         source_url: str = event_data.get("source_url", "")
         scraper_id: str = event_data.get("scraper_id", "")
 
+        # Resolve the extraction strategy once for this event (#4081).
+        # Single source of truth shared with scripts/reingest_from_s3.py — both
+        # paths read ``strategy.skip_llm`` / ``use_multimodal`` /
+        # ``max_output_tokens`` / ``system_prompt`` / ``provider`` / ``model``
+        # / ``max_chars_per_chunk`` instead of re-deriving the gate logic from
+        # ``CountyExtractionConfig`` inline.  This closes the divergence
+        # pattern catalogued in #2490, #2501, #2502, #2521, #4056 — adding a
+        # new ``ExtractionMethod`` value or ``CountyExtractionConfig`` field
+        # now updates both paths in one place.
+        from framework.extraction_config import decide_extraction_strategy
+
+        strategy = decide_extraction_strategy(state, county, scraper_id=scraper_id)
+
         # Pipeline branch — non-ruling scrapers (#3688).
         # The ca-governor-appointments scraper emits judge-bio press releases
         # that share the CapturedDocument shape but are NOT rulings. Without
@@ -1727,16 +1740,10 @@ class IngestionWorker:
         # For MULTIMODAL counties, download the original PDF from S3 so
         # the multimodal path can send page images to the LLM.
         if raw_pdf_bytes is None and content_format == "pdf" and s3_key:
-            from framework.extraction_config import (
-                ExtractionMethod,
-                get_county_extraction_config,
-            )
-
-            county_config = get_county_extraction_config(state, county, scraper_id=scraper_id)
-            needs_multimodal = (
-                county_config is not None and county_config.method == ExtractionMethod.MULTIMODAL
-            ) or county_config is None  # unconfigured counties default to multimodal
-            if needs_multimodal:
+            # ``strategy.use_multimodal`` is True for ExtractionMethod.MULTIMODAL
+            # AND for unconfigured counties (the helper preserves the worker's
+            # pre-refactor default-multimodal behavior, #4081).
+            if strategy.use_multimodal:
                 raw_pdf_bytes = self._fetch_raw_pdf_from_s3(s3_key, s3_bucket, document_id)
 
         # ------------------------------------------------------------------
@@ -1821,16 +1828,14 @@ class IngestionWorker:
         # already populated by the scraper — skip per-field LLM extraction.
         # This handles scrapers like SD calendar where structured HTML is
         # fully parsed and the LLM would produce wrong results (#2331).
+        # ``strategy.skip_llm`` is the single-source-of-truth flag (#4081),
+        # populated identically for the reingest path.
         is_extraction_none = False
-        if not is_llm_extracted:
-            from framework.extraction_config import ExtractionMethod, get_county_extraction_config
-
-            _ext_config = get_county_extraction_config(state, county, scraper_id=scraper_id)
-            if _ext_config is not None and _ext_config.method == ExtractionMethod.NONE:
-                is_extraction_none = True
-                for field in EXTRACTABLE_FIELDS:
-                    if event_data.get(field):
-                        extraction_methods[field] = "scraper"
+        if not is_llm_extracted and strategy.skip_llm:
+            is_extraction_none = True
+            for field in EXTRACTABLE_FIELDS:
+                if event_data.get(field):
+                    extraction_methods[field] = "scraper"
 
         # ------------------------------------------------------------------
         # LLM extraction — primary method for missing fields
@@ -1846,13 +1851,12 @@ class IngestionWorker:
                 "judge_name": event_data.get("judge_name"),
                 "department": event_data.get("department"),
             }
-            # Look up county-specific max_output_tokens (#2355).
+            # County-specific max_output_tokens (#2355).
             # Large-document counties (e.g. Santa Clara, 130K+ chars) need
             # more than the default 4096 output tokens to avoid truncated JSON.
-            from framework.extraction_config import get_county_extraction_config as _get_cc
-
-            _cc = _get_cc(state, county)
-            _llm_max_tokens = _cc.max_output_tokens if _cc and _cc.max_output_tokens else 4096
+            # ``strategy.max_output_tokens`` already resolves to 4096 when no
+            # county override is configured (#4081).
+            _llm_max_tokens = strategy.max_output_tokens
 
             t0 = time.monotonic()
             llm_result = extract_fields_llm(
@@ -3048,22 +3052,24 @@ class IngestionWorker:
         extracted_rulings = None
         extraction_method = "llm"  # Track which path was used for logging.
 
-        # Check if the county/scraper has a configured extraction method (#2271, #2331).
-        # Counties with ExtractionMethod.LLM (e.g. Ventura) have custom
-        # text-based prompts that extract structured fields including outcome.
-        # The multimodal per-page extraction does NOT extract outcome or
-        # motion_type, so using it for LLM-configured counties causes field
-        # regressions.  Only use multimodal for counties explicitly configured
-        # as ExtractionMethod.MULTIMODAL (e.g. Orange County).
-        # Counties/scrapers with ExtractionMethod.NONE skip framework extraction
-        # entirely (e.g. SD calendar — structured HTML already fully parsed).
-        from framework.extraction_config import ExtractionMethod, get_county_extraction_config
+        # Resolve the extraction strategy once (#4081).  Counties with
+        # ExtractionMethod.LLM (e.g. Ventura) have custom text-based prompts
+        # that extract structured fields including outcome.  The multimodal
+        # per-page extraction does NOT extract outcome or motion_type, so
+        # using it for LLM-configured counties causes field regressions
+        # (#2271, #2331).  Only use multimodal when ``strategy.use_multimodal``
+        # is True — that is, ExtractionMethod.MULTIMODAL counties (e.g.
+        # Orange) and unconfigured counties (default behavior).  Counties
+        # with ExtractionMethod.NONE (``strategy.skip_llm``) skip framework
+        # extraction entirely (e.g. SD calendar — structured HTML already
+        # fully parsed).
+        from framework.extraction_config import decide_extraction_strategy
 
         event_scraper_id: str = event_data.get("scraper_id", "")
-        county_config = get_county_extraction_config(state, county, scraper_id=event_scraper_id)
+        strategy = decide_extraction_strategy(state, county, scraper_id=event_scraper_id)
 
         # NONE means the scraper handles everything — no framework extraction.
-        if county_config is not None and county_config.method == ExtractionMethod.NONE:
+        if strategy.skip_llm:
             logger.debug(
                 "Skipping framework extraction — scraper/county uses ExtractionMethod.NONE",
                 extra={
@@ -3074,20 +3080,18 @@ class IngestionWorker:
             )
             return False
 
-        use_multimodal = (
-            county_config is not None and county_config.method == ExtractionMethod.MULTIMODAL
-        ) or county_config is None  # Default: allow multimodal for unconfigured counties
+        use_multimodal = strategy.use_multimodal
 
         # Multimodal path: per-page image extraction from raw PDF (#1590).
         # Only used when the county is configured for multimodal extraction
         # or has no specific config (default behavior).
         if raw_pdf_bytes is not None and use_multimodal:
-            # Pass the county's multimodal max_output_tokens (if configured)
-            # so dense multi-case pages don't truncate the LLM JSON response
-            # at the default 4,096 tokens (#2369).
-            mm_max_output_tokens: int | None = (
-                county_config.max_output_tokens if county_config is not None else None
-            )
+            # ``strategy.max_output_tokens`` already resolves to 4096 when no
+            # county override is configured (#4081), and to the override
+            # value (e.g. 32768 for Orange) when present — so dense
+            # multi-case pages don't truncate the LLM JSON response at the
+            # default 4,096 tokens (#2369).
+            mm_max_output_tokens: int = strategy.max_output_tokens
             multimodal_extractor = self._get_multimodal_extractor(
                 max_output_tokens=mm_max_output_tokens,
             )
@@ -3133,27 +3137,26 @@ class IngestionWorker:
         if extracted_rulings is None and ruling_text:
             extraction_method = "llm"  # Falling back to text-based.
 
-            # Check for county/scraper-specific extraction config (#1728, #2331).
-            from framework.extraction_config import get_county_extraction_config
+            # County/scraper-specific extraction config (#1728, #2331), now
+            # resolved through the shared strategy helper (#4081).
+            county_prompt: str | None = strategy.system_prompt
 
-            county_config = get_county_extraction_config(state, county, scraper_id=event_scraper_id)
-            county_prompt: str | None = None
-
-            if county_config and county_config.provider:
+            if strategy.provider:
                 # County has a custom provider — use a dedicated extractor.
+                # ``_get_county_extractor`` accepts ``max_output_tokens=None``
+                # to mean "use the LlmExtractor default", but the strategy
+                # already resolved 4096 for that case — pass it through.
                 extractor = self._get_county_extractor(
-                    county_config.provider,
-                    county_config.model,
-                    county_config.max_output_tokens,
-                    county_config.max_chars_per_chunk,
+                    strategy.provider,
+                    strategy.model,
+                    strategy.max_output_tokens,
+                    strategy.max_chars_per_chunk,
                 )
-                county_prompt = county_config.system_prompt
                 if county_prompt:
                     extraction_method = "llm_county"
             else:
                 extractor = self._get_framework_extractor()
-                if county_config and county_config.system_prompt:
-                    county_prompt = county_config.system_prompt
+                if county_prompt:
                     extraction_method = "llm_county"
 
             if extractor is None:

--- a/packages/scraper-framework/tests/test_extraction_strategy.py
+++ b/packages/scraper-framework/tests/test_extraction_strategy.py
@@ -1,0 +1,283 @@
+"""Unit tests for ``framework.extraction_config.decide_extraction_strategy``.
+
+Validates the structural-fix helper introduced in #4081 — the single
+source of truth consulted by both ``ingestion.worker`` and
+``scripts/reingest_from_s3.py`` for "how should this document be
+extracted?".  See ``test_worker_reingest_parity.py`` for the
+cross-path live-call regression guard introduced in #4071.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.extraction_config import (
+    CountyExtractionConfig,
+    ExtractionMethod,
+    ExtractionStrategy,
+    decide_extraction_strategy,
+)
+
+# ---------------------------------------------------------------------------
+# ExtractionStrategy dataclass — shape, immutability, defaults
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionStrategyDataclass:
+    """ExtractionStrategy mirrors CountyExtractionConfig with concrete defaults."""
+
+    def test_required_fields(self) -> None:
+        """All seven fields are required positional/keyword args."""
+        strategy = ExtractionStrategy(
+            skip_llm=False,
+            use_multimodal=False,
+            max_output_tokens=4096,
+            system_prompt=None,
+            provider=None,
+            model=None,
+            max_chars_per_chunk=None,
+        )
+        assert strategy.skip_llm is False
+        assert strategy.use_multimodal is False
+        assert strategy.max_output_tokens == 4096
+        assert strategy.system_prompt is None
+        assert strategy.provider is None
+        assert strategy.model is None
+        assert strategy.max_chars_per_chunk is None
+
+    def test_frozen(self) -> None:
+        """ExtractionStrategy is frozen (immutable)."""
+        strategy = ExtractionStrategy(
+            skip_llm=False,
+            use_multimodal=False,
+            max_output_tokens=4096,
+            system_prompt=None,
+            provider=None,
+            model=None,
+            max_chars_per_chunk=None,
+        )
+        with pytest.raises(AttributeError):
+            strategy.skip_llm = True  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# decide_extraction_strategy — registry-backed cases
+# ---------------------------------------------------------------------------
+
+
+class TestDecideStrategyForRegisteredCounties:
+    """Verify strategy resolution against the live registry."""
+
+    def test_riverside_llm_strategy(self) -> None:
+        """Riverside (CA) is configured LLM with Google + 32768 tokens."""
+        strategy = decide_extraction_strategy("CA", "Riverside")
+        assert strategy.skip_llm is False
+        assert strategy.use_multimodal is False
+        assert strategy.max_output_tokens == 32768
+        assert strategy.provider == "google"
+        assert strategy.model == "gemini-2.5-flash-lite"
+        assert strategy.system_prompt is not None
+        assert strategy.max_chars_per_chunk is None
+
+    def test_orange_multimodal_strategy(self) -> None:
+        """Orange (CA) is configured MULTIMODAL — use_multimodal flips True."""
+        strategy = decide_extraction_strategy("CA", "Orange")
+        assert strategy.skip_llm is False
+        assert strategy.use_multimodal is True
+        assert strategy.max_output_tokens == 32768
+        # Orange has no provider/model override; framework default applies.
+        assert strategy.provider is None
+        assert strategy.model is None
+        assert strategy.system_prompt is None
+
+    def test_san_francisco_max_chars_per_chunk_propagated(self) -> None:
+        """SF Family Law has a 40K char per-chunk cap (#2107) — surface it."""
+        strategy = decide_extraction_strategy("CA", "San Francisco")
+        assert strategy.max_chars_per_chunk == 40_000
+        assert strategy.max_output_tokens == 32768
+        assert strategy.provider == "google"
+
+    def test_federal_skip_llm(self) -> None:
+        """Federal CourtListener is ExtractionMethod.NONE → skip_llm True (#3967, #4056)."""
+        strategy = decide_extraction_strategy("Federal", "Federal")
+        assert strategy.skip_llm is True
+        assert strategy.use_multimodal is False
+        # max_output_tokens still resolves to a concrete value — callers
+        # that ignore skip_llm and continue to the LLM call must not see
+        # ``None`` here.
+        assert strategy.max_output_tokens == 4096
+        assert strategy.system_prompt is None
+
+    def test_sd_calendar_scraper_override_skip_llm(self) -> None:
+        """SD calendar scraper override sets ExtractionMethod.NONE (#2331)."""
+        strategy = decide_extraction_strategy("CA", "San Diego", scraper_id="ca-sd-calendar")
+        assert strategy.skip_llm is True
+        assert strategy.use_multimodal is False
+
+    def test_sd_tentatives_falls_through_to_county(self) -> None:
+        """SD tentatives scraper falls through to county-level LLM config."""
+        strategy = decide_extraction_strategy("CA", "San Diego", scraper_id="ca-sd-tentatives")
+        assert strategy.skip_llm is False
+        assert strategy.use_multimodal is False
+        assert strategy.provider == "google"
+        assert strategy.system_prompt is not None
+
+    def test_rebuild_sd_synthetic_scraper_id(self) -> None:
+        """``rebuild-ca-san_diego`` synthetic scraper_id → NONE (#2447)."""
+        strategy = decide_extraction_strategy("CA", "San Diego", scraper_id="rebuild-ca-san_diego")
+        assert strategy.skip_llm is True
+
+
+# ---------------------------------------------------------------------------
+# decide_extraction_strategy — unconfigured (default) behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDecideStrategyDefaults:
+    """Verify the no-config default preserves the worker's pre-refactor behavior."""
+
+    def test_unknown_county_default_strategy(self) -> None:
+        """Unknown (state, county) → multimodal-allowed default (worker.py L1738)."""
+        strategy = decide_extraction_strategy("XX", "Nonexistent")
+        assert strategy.skip_llm is False
+        # Worker default treats unconfigured counties as multimodal-allowed
+        # so raw PDFs still get downloaded and routed through the per-page
+        # multimodal extractor.  Preserving this is critical — pre-refactor
+        # behavior is the safety contract for unmigrated counties.
+        assert strategy.use_multimodal is True
+        assert strategy.max_output_tokens == 4096  # framework default
+        assert strategy.system_prompt is None
+        assert strategy.provider is None
+        assert strategy.model is None
+        assert strategy.max_chars_per_chunk is None
+
+    def test_unknown_scraper_id_falls_through(self) -> None:
+        """An unknown scraper_id falls through to the county-level config."""
+        strategy = decide_extraction_strategy("CA", "Riverside", scraper_id="ca-totally-unknown")
+        # Same as the no-scraper_id Riverside lookup.
+        assert strategy.skip_llm is False
+        assert strategy.use_multimodal is False
+        assert strategy.provider == "google"
+
+    def test_max_output_tokens_default_when_config_lacks_override(self) -> None:
+        """A registered county without ``max_output_tokens`` falls back to 4096."""
+        # Construct an ad-hoc CountyExtractionConfig with the field missing
+        # via the registry monkey-patch path: instead of mutating _COUNTY_CONFIGS
+        # we verify the dataclass default behavior plus the helper's fallback
+        # by building one via direct construction and asserting the helper's
+        # 4096-default branch is exercised.  The default-args ExtractionStrategy
+        # produced by ``decide_extraction_strategy("XX", "Nonexistent")`` is
+        # the registry-miss case and already covers this branch.
+        strategy = decide_extraction_strategy("XX", "Nonexistent")
+        assert strategy.max_output_tokens == 4096
+
+    def test_has_raw_pdf_keyword_accepted(self) -> None:
+        """The ``has_raw_pdf`` kwarg is accepted (reserved for future selectors)."""
+        # The kwarg currently has no effect; this test pins the signature so
+        # callers can pass it without TypeError, and a future ExtractionMethod
+        # that depends on raw-PDF availability can read it.
+        s_true = decide_extraction_strategy("CA", "Riverside", has_raw_pdf=True)
+        s_false = decide_extraction_strategy("CA", "Riverside", has_raw_pdf=False)
+        assert s_true == s_false
+
+    def test_case_insensitive_lookup(self) -> None:
+        """State/county lookups are case-insensitive (matches get_county_extraction_config)."""
+        upper = decide_extraction_strategy("CA", "RIVERSIDE")
+        mixed = decide_extraction_strategy("ca", "Riverside")
+        assert upper == mixed
+        assert upper.provider == "google"
+
+
+# ---------------------------------------------------------------------------
+# CountyExtractionConfig method coverage matrix
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionMethodMatrix:
+    """Verify every ExtractionMethod value maps to the correct strategy flags."""
+
+    def test_llm_method_no_skip_no_multimodal(self) -> None:
+        """LLM method → both skip_llm and use_multimodal stay False."""
+        # Riverside is LLM-configured.
+        strategy = decide_extraction_strategy("CA", "Riverside")
+        assert strategy.skip_llm is False
+        assert strategy.use_multimodal is False
+
+    def test_multimodal_method_flips_use_multimodal(self) -> None:
+        """MULTIMODAL method → use_multimodal True, skip_llm False."""
+        strategy = decide_extraction_strategy("CA", "Orange")
+        assert strategy.use_multimodal is True
+        assert strategy.skip_llm is False
+
+    def test_none_method_flips_skip_llm(self) -> None:
+        """NONE method → skip_llm True, use_multimodal False."""
+        strategy = decide_extraction_strategy("Federal", "Federal")
+        assert strategy.skip_llm is True
+        assert strategy.use_multimodal is False
+
+    def test_methods_are_mutually_exclusive(self) -> None:
+        """No registered config produces both skip_llm and use_multimodal True."""
+        from framework.extraction_config import _COUNTY_CONFIGS, _SCRAPER_CONFIGS
+
+        # County registry — every (state, county) pair must produce a
+        # mutually-exclusive flag set.
+        for (state, county), _config in _COUNTY_CONFIGS.items():
+            strategy = decide_extraction_strategy(state, county)
+            assert not (strategy.skip_llm and strategy.use_multimodal), (
+                f"({state}, {county}) produced skip_llm AND use_multimodal — "
+                f"these flags must be mutually exclusive"
+            )
+
+        # Scraper-level registry — same invariant.
+        for scraper_id, _config in _SCRAPER_CONFIGS.items():
+            # Use a synthetic state/county; scraper override fires first.
+            strategy = decide_extraction_strategy("XX", "Synthetic", scraper_id=scraper_id)
+            assert not (strategy.skip_llm and strategy.use_multimodal), (
+                f"scraper_id={scraper_id!r} produced skip_llm AND use_multimodal"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Sanity check — the helper preserves CountyExtractionConfig fields
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyMirrorsConfig:
+    """For each registered config, the strategy mirrors its non-method fields."""
+
+    def test_riverside_strategy_mirrors_config(self) -> None:
+        """Riverside ExtractionStrategy fields equal the underlying config fields."""
+        from framework.extraction_config import get_county_extraction_config
+
+        config = get_county_extraction_config("CA", "Riverside")
+        assert config is not None  # for type narrowing
+        strategy = decide_extraction_strategy("CA", "Riverside")
+        assert strategy.system_prompt is config.system_prompt
+        assert strategy.provider == config.provider
+        assert strategy.model == config.model
+        assert strategy.max_output_tokens == config.max_output_tokens
+        assert strategy.max_chars_per_chunk == config.max_chars_per_chunk
+
+    def test_san_francisco_strategy_mirrors_config(self) -> None:
+        """San Francisco preserves max_chars_per_chunk through the helper."""
+        from framework.extraction_config import get_county_extraction_config
+
+        config = get_county_extraction_config("CA", "San Francisco")
+        assert config is not None
+        strategy = decide_extraction_strategy("CA", "San Francisco")
+        assert strategy.max_chars_per_chunk == config.max_chars_per_chunk
+
+    def test_dataclass_used_for_construction_demonstrates_defaults(self) -> None:
+        """Construct an ad-hoc CountyExtractionConfig and verify the helper
+        default-applies the framework 4096 token cap when ``max_output_tokens
+        is None``.  This guards against a regression where the helper passes
+        ``None`` straight through and downstream callers crash on a NoneType
+        comparison."""
+        # The CountyExtractionConfig defaults pin this contract; the helper
+        # must convert ``None`` to 4096.
+        default_config = CountyExtractionConfig()
+        assert default_config.method == ExtractionMethod.LLM
+        assert default_config.max_output_tokens is None
+        # Helper invocation against the unknown path uses the same code branch.
+        strategy = decide_extraction_strategy("XX", "Unconfigured")
+        assert strategy.max_output_tokens == 4096

--- a/packages/scraper-framework/tests/test_worker_reingest_parity.py
+++ b/packages/scraper-framework/tests/test_worker_reingest_parity.py
@@ -12,40 +12,41 @@ live worker correctly handled.  The pattern has now repeated five times:
 - #2521 — text-split branch had the same fixed-point pattern
 - #4056 — ``ExtractionMethod.NONE`` not honored
 
-The test is the **Option A** snapshot/regex-pair contract test described in
-issue #4071.  For each (state, county, scraper_id) case it verifies:
+After Option B (#4081) landed, both paths consume the shared
+``decide_extraction_strategy`` helper from
+``framework.extraction_config``.  The test now verifies:
 
 1. **Reingest live behavior** — ``_reparse_document`` is invoked with a
    mocked ``extract_fields_llm``; the number of times it was called matches
    the expectation derived from ``get_county_extraction_config``.  This
    catches regressions where someone deletes the NONE-skip guard from
    ``reingest_from_s3.py`` and the reingest path starts running the LLM on
-   ``ExtractionMethod.NONE`` counties.
+   ``ExtractionMethod.NONE`` counties.  This live-call check is the
+   primary regression guard — it directly observes the divergence symptom.
 
-2. **Worker source-text sentinels** — ``ingestion/worker.py`` is read as
-   text and asserted to contain a regex that matches the equivalent guard
-   (an ``is_extraction_none = True`` assignment gated on
-   ``ExtractionMethod.NONE``, plus a multimodal selector reading
-   ``ExtractionMethod.MULTIMODAL``).  This catches the symmetric
-   regression where someone deletes the guard from ``worker.py``.
+2. **Strategy-helper consumer sentinels** — both ``ingestion/worker.py``
+   and ``scripts/reingest_from_s3.py`` are read as text and asserted to
+   import ``decide_extraction_strategy`` and read ``strategy.skip_llm``.
+   The Option B refactor (#4081) made ``decide_extraction_strategy`` the
+   single source of truth for the gate logic; deleting either side's
+   call would re-open the divergence pattern.  The sentinels are kept
+   intentionally narrow — they catch deletion of the helper consumer,
+   not every possible behavior regression (the live-call check above is
+   the contract for those).
 
 The deliberate-revert verification mentioned in #4071's acceptance criterion
 is captured by the Verifies-fail-on-revert behavior of (1) — ``patch.object``
 on ``reingest.extract_fields_llm`` directly observes whether the live path
 called the LLM, so removing the NONE short-circuit from
 ``reingest_from_s3.py`` flips the call count from ``0`` to ``1`` and the
-NONE cases fail.  The (2) regex pairs likewise fail when the worker.py
-sentinel is deleted.
+NONE cases fail.  The (2) consumer sentinels likewise fail when either
+side stops calling the helper.
 
-When ``ExtractionMethod`` gains a new value or worker/reingest gains a new
-config consumer (e.g. a future ``max_chars_per_chunk`` selector), this file
-must be extended with a new ``_GUARD_PATTERNS`` entry on **both** sides.
-That is the maintenance load the issue explicitly accepted in exchange for
-the divergence-detection coverage; it is intentionally a manual edit so a
-change to one side without the other surfaces in the diff review.
-
-See #4071 for the full investigation and Option B (refactor into shared
-``decide_extraction_strategy`` helper) follow-up.
+When ``ExtractionMethod`` gains a new value or ``ExtractionStrategy``
+gains a new field, ``decide_extraction_strategy`` is the only place that
+needs to learn about it — both consumers automatically pick up the new
+field.  See #4081 for the structural fix and #4071 for the original
+divergence catalog.
 """
 
 from __future__ import annotations
@@ -109,43 +110,38 @@ _REINGEST_SRC = _REPO_ROOT / "scripts/reingest_from_s3.py"
 
 _GUARD_PATTERNS: tuple[tuple[str, str, str], ...] = (
     (
-        "extraction_method_none_skip",
-        # Worker: gates on ``method == ExtractionMethod.NONE`` and then sets
-        # ``is_extraction_none = True`` on the next non-blank line.  Match
-        # the conditional + the assignment within a tight window so a stray
-        # ``ExtractionMethod.NONE`` reference (e.g. in a doc-comment) cannot
-        # satisfy the pattern alone.
-        (
-            r"\.method\s*==\s*ExtractionMethod\.NONE\s*:"
-            r"[^\n]*\n(?:[^\n]*\n){0,3}\s*is_extraction_none\s*=\s*True"
-        ),
-        # Reingest: short-circuits when ``_ext_config.method ==
-        # ExtractionMethod.NONE``.  Single-line match.
-        r"_ext_config\.method\s*==\s*ExtractionMethod\.NONE",
+        "decide_extraction_strategy_imported",
+        # Worker: imports the helper from ``framework.extraction_config``.
+        # The Option B refactor (#4081) made this the single source of
+        # truth for the NONE / MULTIMODAL / max_output_tokens gates.
+        r"from\s+framework\.extraction_config\s+import\s+decide_extraction_strategy",
+        # Reingest: imports the helper alongside ExtractionMethod and
+        # get_county_extraction_config (the latter is still consumed by
+        # ``_full_reparse_document``, which #4081 declared out of scope).
+        r"decide_extraction_strategy",
     ),
     (
-        "extraction_method_multimodal_selector",
-        # Worker: branches on ``ExtractionMethod.MULTIMODAL`` for the
-        # raw-PDF per-page extraction path.
-        r"ExtractionMethod\.MULTIMODAL",
-        # Reingest: must import ``ExtractionMethod`` from
-        # ``framework.extraction_config`` so the NONE short-circuit (and
-        # any future MULTIMODAL-aware reingest branch) compiles.  The
-        # MULTIMODAL value is not a separate reingest path today —
-        # reingest uses the text LLM for MULTIMODAL counties because the
-        # multimodal extractor is a worker-only feature — but the paired
-        # sentinel makes a future divergence detectable.
-        r"from\s+framework\.extraction_config\s+import[^)]*ExtractionMethod",
+        "strategy_skip_llm_consumed",
+        # Worker: reads ``strategy.skip_llm`` to short-circuit the
+        # per-event NONE gate (replaces the historic
+        # ``is_extraction_none = True`` assignment) and to skip framework
+        # extraction inside ``_llm_split_document``.
+        r"strategy\.skip_llm",
+        # Reingest: reads ``strategy.skip_llm`` in ``_reparse_document``
+        # to short-circuit the LLM call.  This is the live regression
+        # site catalogued in #4056.
+        r"strategy\.skip_llm",
     ),
     (
-        "extraction_config_consulted_for_max_output_tokens",
-        # Worker: text-LLM path looks up ``<name>.max_output_tokens`` and
-        # falls back to the 4096 default (#2355).  The pattern must appear
-        # within ~120 chars so an unrelated reference plus a stray ``4096``
-        # later in the file does not produce a false match.
-        r"\.max_output_tokens[^\n]{0,120}4096",
-        # Reingest: same lookup with the same default.
-        r"\.max_output_tokens[^\n]{0,120}4096",
+        "strategy_max_output_tokens_consumed",
+        # Worker: reads ``strategy.max_output_tokens`` for the per-field
+        # LLM call (#2355) and for the multimodal extractor's per-page
+        # token cap (#2369).  No more 4096 fallback constant — the
+        # helper resolves the default.
+        r"strategy\.max_output_tokens",
+        # Reingest: reads ``strategy.max_output_tokens`` in
+        # ``_reparse_document`` for the same reason.
+        r"strategy\.max_output_tokens",
     ),
 )
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -185,6 +185,7 @@ import structlog  # noqa: E402
 
 from framework.extraction_config import (  # noqa: E402
     ExtractionMethod,
+    decide_extraction_strategy,
     get_county_extraction_config,
 )
 from framework.llm_enrichment import (  # noqa: E402
@@ -1024,22 +1025,23 @@ def _reparse_document(
     llm_skipped = False
     llm_outcome = "not_attempted"
 
-    # Short-circuit LLM extraction when the county/scraper is registered
-    # with ``ExtractionMethod.NONE`` (#4056).  The live worker path honors
-    # this in ``ingestion.worker._extract_fields`` (worker.py L1719-1732),
-    # but the reingest path historically only consulted the county config
-    # for ``max_output_tokens`` (#2355) and ran the LLM regardless of the
-    # configured method.  That mismatch caused ``ExtractionMethod.NONE``
-    # counties (e.g. Federal CourtListener clusters, #3967) to be re-run
-    # through the CA-tuned LLM prompt during reingest, producing
-    # truncation, JSON-parse errors, and field contamination that
-    # blocked #3978's federal cleanup pass.
-    _ext_config = get_county_extraction_config(
+    # Resolve the extraction strategy once and reuse below (#4081 — Option B).
+    # Single source of truth shared with ``packages/scraper-framework/src/
+    # ingestion/worker.py`` — both paths read ``strategy.skip_llm`` and
+    # ``strategy.max_output_tokens`` instead of re-deriving the gate logic
+    # from ``CountyExtractionConfig`` inline.  This closes the recurring
+    # divergence pattern (#2490, #2501, #2502, #2521, #4056).
+    strategy = decide_extraction_strategy(
         doc_meta.get("state", ""),
         doc_meta.get("county", ""),
         scraper_id=scraper_id,
     )
-    if _ext_config is not None and _ext_config.method == ExtractionMethod.NONE:
+
+    # Short-circuit LLM extraction when the county/scraper is registered
+    # with ``ExtractionMethod.NONE`` (#4056).  The live worker path honors
+    # this in ``ingestion.worker.process_event``, and now both paths read
+    # ``strategy.skip_llm`` from the same helper.
+    if strategy.skip_llm:
         logger.info(
             "Skipping LLM extraction — county uses ExtractionMethod.NONE",
             document_id=doc_meta["document_id"],
@@ -1081,17 +1083,12 @@ def _reparse_document(
             # causes output truncation).  Narrowing already happened
             # above for SD HTML pages regardless of LLM availability.
             llm_text = extracted.get("ruling_text") or text
-            # Look up county-specific max_output_tokens (#2355).
-            # Large-document counties (e.g. Santa Clara, 130K+ chars)
-            # need more than the default 4096 output tokens to avoid
-            # truncated JSON responses.
-            _cc = get_county_extraction_config(
-                doc_meta.get("state", ""),
-                doc_meta.get("county", ""),
-            )
-            _llm_max_tokens = (
-                _cc.max_output_tokens if _cc and _cc.max_output_tokens else 4096
-            )
+            # County-specific max_output_tokens (#2355) — large-document
+            # counties (e.g. Santa Clara, 130K+ chars) need more than the
+            # default 4096 output tokens to avoid truncated JSON responses.
+            # ``strategy.max_output_tokens`` already resolves to 4096 when
+            # no county override is configured (#4081).
+            _llm_max_tokens = strategy.max_output_tokens
 
             t0 = time.monotonic()
             llm_result = extract_fields_llm(


### PR DESCRIPTION
## Summary

Adds `decide_extraction_strategy(state, county, *, scraper_id, has_raw_pdf) -> ExtractionStrategy` to `framework.extraction_config` as the single source of truth for the worker + reingest extraction-method gates. Both `ingestion/worker.py` (`process_event` and `_llm_split_document`) and `scripts/reingest_from_s3.py` `_reparse_document` now consult the helper instead of consulting `get_county_extraction_config` inline — closing the divergence pattern catalogued in #2490, #2501, #2502, #2521, #4056.

`worker.py` drops from 4 inline `get_county_extraction_config` calls to 0; `_reparse_document` drops from 2 to 0. `_full_reparse_document` and `_reparse_document_multimodal` are explicitly out of scope per the issue and retain their direct registry calls (separate refactor PR).

The Option A parity test (`test_worker_reingest_parity.py`) is updated to assert the post-refactor helper-consumer contract; the live-call regression check on `_reparse_document` is preserved as the primary divergence detector.

Closes #4081

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — pure refactor with full unit-test coverage; behavior is identical to pre-refactor for every (state, county, scraper_id) tuple in the registry. The Option A parity test (live `extract_fields_llm` call-count) is the regression guard against any production divergence.
- [x] Verification evidence posted on issue (see A.8)
