### PR TITLE
perf(web): trim polled recentCompletions to row-essential fields (#4064)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -197,7 +197,16 @@ export function RecentCompletionRow({
   // prop so we fall back to `Date.now()`.
   const effectiveNowMs = nowMs ?? Date.now();
   const endedMs = Date.parse(completion.endedAt);
-  const startedMs = Date.parse(completion.startedAt);
+  // Issue #4064: `startedAt` is undefined on rows fetched via the
+  // polled `DISPATCHER_STATE_QUERY` (omitted from the slim selection).
+  // `Date.parse(undefined)` is NaN, so the explicit guard collapses
+  // the polled-row path to "no Start row in tooltip" via the
+  // `Number.isFinite(startedMs)` check below — equivalent to the prior
+  // unparseable-timestamp behaviour, no rendering regression.
+  const startedMs =
+    completion.startedAt !== undefined
+      ? Date.parse(completion.startedAt)
+      : Number.NaN;
   const relativeTime = Number.isFinite(endedMs)
     ? formatRelativeTime(endedMs, effectiveNowMs)
     : null;
@@ -305,6 +314,13 @@ export function RecentCompletionRow({
  * agent" from "no metering signal on this row" (e.g. a pre-migration-31
  * agent, or every phase crashed before emitting a JSON envelope).
  *
+ * Issue #4064: `costUsd` and `totalTokens` may be `undefined` on rows
+ * fetched via the polled `DISPATCHER_STATE_QUERY` (the polled
+ * selection no longer requests these fields). Both `null` and
+ * `undefined` are treated as "no signal" — the footnote disappears
+ * on the polled row and reappears in the expand-on-click dialog where
+ * the rich `DISPATCHER_QUEUE_FULL_QUERY` selection still populates them.
+ *
  * Design choices:
  * - Cost is formatted with 2 decimals when ≥ $1, 4 decimals otherwise —
  *   a cheap haiku verify phase lands at ~$0.0008 and would round to
@@ -315,16 +331,16 @@ export function RecentCompletionRow({
  *   documented on `totalCostUsd`.
  */
 function formatCostFootnote(
-  costUsd: number | null,
-  totalTokens: number | null,
+  costUsd: number | null | undefined,
+  totalTokens: number | null | undefined,
 ): string | null {
-  if (costUsd === null && totalTokens === null) return null;
+  if (costUsd == null && totalTokens == null) return null;
   const parts: string[] = [];
-  if (costUsd !== null) {
+  if (costUsd != null) {
     const decimals = Math.abs(costUsd) >= 1 ? 2 : 4;
     parts.push(`~$${costUsd.toFixed(decimals)}`);
   }
-  if (totalTokens !== null) {
+  if (totalTokens != null) {
     parts.push(formatTokenCount(totalTokens));
   }
   return `(${parts.join(', ')})`;

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -31,6 +31,26 @@
  * which fires once on dashboard mount and is refetched explicitly by
  * the `dispatcherSetConfig` mutation's `refetchQueries` so the displayed
  * value stays in sync without a manual page reload.
+ *
+ * Polled-query slim — `recentCompletions` (issue #4064): the polled
+ * `recentCompletions` block originally selected 14 fields; under the
+ * 10× list-of-objects multiplier this contributed the third-largest
+ * chunk of the 1355-unit cost. Trimmed to the eight fields
+ * `RecentCompletionRow` actually reads to render the visible row layout
+ * — `agentId` (key), the unified `(issue, priority, [PR,] title)`
+ * prefix (`issueNumber` / `issueTitle` / `priority` / `prNumber`),
+ * the OutcomePill `status` driver, the relative-time cell's `endedAt`,
+ * and `failureSummary` (which re-skins the pill to gray ↺ for
+ * infra-preempted rows). Detail-only fields (`startedAt` for the
+ * Start/Duration tooltip, `totalTokens` / `totalCostUsd` for the cost
+ * footnote, and the four milestone columns `mergedAt` / `verifiedAt` /
+ * `verifySkipReason` / `retroedAt` that drive the green-vs-amber-✓
+ * "shipped but bookkeeping incomplete" pill nuance) ride exclusively
+ * on `DISPATCHER_QUEUE_FULL_QUERY` — fired on dialog open, not in the
+ * 2s poll path. The polled row degrades gracefully: succeeded rows
+ * render plain green ✓ instead of the amber-✓ incomplete variant; the
+ * cost footnote and start/duration tooltip are absent. The full
+ * milestone breakdown still renders inside the expand-on-click dialog.
  */
 import { gql } from '@apollo/client';
 
@@ -99,16 +119,9 @@ export const DISPATCHER_STATE_QUERY = gql`
         issueTitle
         priority
         status
-        startedAt
         endedAt
         prNumber
-        totalTokens
-        totalCostUsd
         failureSummary
-        mergedAt
-        verifiedAt
-        verifySkipReason
-        retroedAt
       }
       recentCompletionsCount
       spawnFrozenUntil
@@ -342,19 +355,36 @@ export interface RecentCompletion {
   status: string;
   /** Timestamp the agent claimed the issue (`dispatcher.agents.started_at`).
    * Non-nullable on the API side. Issue #3024 — paired with `endedAt` for
-   * the Start/Duration/End hover tooltip in the Recently completed panel. */
-  startedAt: string;
+   * the Start/Duration/End hover tooltip in the Recently completed panel.
+   *
+   * Issue #4064: may be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (which no longer selects `startedAt`).
+   * The render code in `RecentCompletionRow` already handles missing
+   * `startedAt` defensively — `Date.parse(undefined)` returns NaN,
+   * `Number.isFinite(NaN)` is false, the tooltip falls back to the
+   * single-line end-time string. Always populated on rows fetched via
+   * `DISPATCHER_QUEUE_FULL_QUERY`. */
+  startedAt?: string;
   endedAt: string;
   prNumber: number | null;
   /** Sum of input+output tokens across every phase the agent ran
    * (#2869). Null when no phase row has recorded usage — rendered as
-   * "no cost data" rather than a misleading 0. */
-  totalTokens: number | null;
+   * "no cost data" rather than a misleading 0.
+   *
+   * Issue #4064: may also be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (which no longer selects `totalTokens`);
+   * the cost footnote is absent on the polled row and reappears in the
+   * expand-on-click dialog. `formatCostFootnote` treats undefined and
+   * null identically. */
+  totalTokens?: number | null;
   /** Sum of `cost_usd` across every phase the agent ran (#2869). Null
    * when no phase row has recorded usage.
    *
-   * WARNING: list-price estimate, NOT Max plan-adjusted. */
-  totalCostUsd: number | null;
+   * WARNING: list-price estimate, NOT Max plan-adjusted.
+   *
+   * Issue #4064: may also be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (same rationale as `totalTokens`). */
+  totalCostUsd?: number | null;
   /** One-line "what happened" string for failure terminals (`failed`,
    * `crashed`, `plan_blocked`). Populated at terminal-time by the
    * daemon from `failures.category` + `phase` + stderr tail, then
@@ -363,29 +393,47 @@ export interface RecentCompletion {
    * Null for `succeeded` / `needs_review` rows and for historical rows
    * that pre-date migration 33. Rendered as a tooltip on the outcome
    * glyph in the `Recently completed` panel — no always-visible second
-   * line. Issue #2900. */
+   * line. Issue #2900.
+   *
+   * Issue #4064: kept on the polled `DISPATCHER_STATE_QUERY` selection
+   * because the `OutcomePill` infra-preempted re-skin (gray ↺) keys off
+   * a `failureSummary` exact-match against `INFRA_PREEMPTED_SUMMARIES`. */
   failureSummary: string | null;
   /** Timestamp the PR squash-merge was observed by the daemon. Paired
    * with the `status='succeeded'` flip at merge time — `mergedAt != null`
    * is the canonical "shipped" signal. Null on rows that never merged
    * (push failed, CI red after retries, etc.) and on pre-migration-35
-   * historical rows. Issue #2953. */
-  mergedAt: string | null;
+   * historical rows. Issue #2953.
+   *
+   * Issue #4064: may also be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (the polled row falls back to the
+   * status-only OutcomePill path; the milestone-completeness path runs
+   * only for rows fetched via `DISPATCHER_QUEUE_FULL_QUERY`). */
+  mergedAt?: string | null;
   /** Timestamp the verify phase completed with verdict=VERIFIED. Null
    * when verify was intentionally skipped (see `verifySkipReason`),
    * when verify crashed mid-phase, or for pre-migration-35 rows.
-   * Issue #2953. */
-  verifiedAt: string | null;
+   * Issue #2953.
+   *
+   * Issue #4064: may also be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (same rationale as `mergedAt`). */
+  verifiedAt?: string | null;
   /** Non-null when verify was intentionally skipped. Today the only
    * written value is `"self_deploy"` (dispatcher-self-PR touches
    * `scripts/dispatcher/`). A merged row with a non-null skip reason
    * counts as fully-shipped (green ✓) — skipping is not a regression.
-   * Issue #2953. */
-  verifySkipReason: string | null;
+   * Issue #2953.
+   *
+   * Issue #4064: may also be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (same rationale as `mergedAt`). */
+  verifySkipReason?: string | null;
   /** Timestamp the retro phase completed (reached PHASE_RETRO_DONE).
    * Null when retro crashed, when the worktree was already gone at
-   * retro time, or for pre-migration-35 rows. Issue #2953. */
-  retroedAt: string | null;
+   * retro time, or for pre-migration-35 rows. Issue #2953.
+   *
+   * Issue #4064: may also be `undefined` on rows fetched via the polled
+   * `DISPATCHER_STATE_QUERY` (same rationale as `mergedAt`). */
+  retroedAt?: string | null;
 }
 
 export interface DispatcherConfigEntry {

--- a/packages/web/tests/dispatcher-polled-query-shape.test.ts
+++ b/packages/web/tests/dispatcher-polled-query-shape.test.ts
@@ -91,3 +91,117 @@ describe('DISPATCHER_QUEUE_FULL_QUERY — dialog query still selects title', () 
     }
   });
 });
+
+/**
+ * Regression test for issue #4064.
+ *
+ * The polled `DISPATCHER_STATE_QUERY.recentCompletions` block originally
+ * selected 14 fields. Combined with the 10× list-of-objects multiplier
+ * applied by `graphql-validation-complexity`, this contributed the
+ * third-largest chunk of the 1355-unit query cost (cap is 1000).
+ *
+ * The fix in this PR trims the polled selection to the row-essential
+ * fields only — the eight needed by `RecentCompletionRow` to render
+ * the visible row layout (outcome pill, issue link, priority badge,
+ * PR link, title, "Nh ago" relative time). Detail-only fields
+ * (`startedAt` for the Start/Duration tooltip, the per-phase token /
+ * cost footnote, and the milestone columns that drive the green vs.
+ * amber ✓ pill nuance) are dropped from the polled path and continue
+ * to ride on the existing `DISPATCHER_QUEUE_FULL_QUERY` (fired only
+ * when the operator opens the expand-on-click dialog).
+ *
+ * If a future change re-adds any of the dropped fields inside the
+ * polled query's `recentCompletions` selection, this test fails and
+ * forces an explicit decision about the cost regression.
+ */
+describe('DISPATCHER_STATE_QUERY — recentCompletions polled shape (issue #4064)', () => {
+  const printed = print(DISPATCHER_STATE_QUERY);
+
+  it('selects exactly one `recentCompletions { ... }` block', () => {
+    const bodies = selectionBodiesFor(printed, 'recentCompletions');
+    expect(bodies).toHaveLength(1);
+  });
+
+  it('keeps row-essential fields in the polled `recentCompletions` selection', () => {
+    // The eight fields the visible row in `RecentCompletionRow` reads
+    // directly: agent identity (key), unified `(issue, priority, [PR,]
+    // title)` prefix, the OutcomePill `status` driver, the relative-time
+    // cell's `endedAt`, and the `failureSummary` that re-skins the pill
+    // to gray ↺ for infra-preempted rows (`dispatcher restarted` /
+    // `manually stopped`).
+    const bodies = selectionBodiesFor(printed, 'recentCompletions');
+    expect(bodies).toHaveLength(1);
+    const body = bodies[0];
+    for (const field of [
+      'agentId',
+      'issueNumber',
+      'issueTitle',
+      'priority',
+      'status',
+      'endedAt',
+      'prNumber',
+      'failureSummary',
+    ]) {
+      expect(body).toMatch(new RegExp(`\\b${field}\\b`));
+    }
+  });
+
+  it('omits detail-only fields from the polled `recentCompletions` selection', () => {
+    // These are surfaced via `DISPATCHER_QUEUE_FULL_QUERY` when the
+    // operator opens the expand-on-click dialog. Keeping them out of
+    // the 2s-polled query is what brings the polled cost back under
+    // the #4003 1000-cap.
+    //
+    // - `startedAt` → tooltip-only (Start/Duration/End hover); the
+    //   visible "Nh ago" cell is computed from `endedAt` alone.
+    // - `totalTokens` / `totalCostUsd` → cost footnote on the row;
+    //   absent from polled so the footnote silently drops, restored
+    //   on dialog open.
+    // - `mergedAt` / `verifiedAt` / `verifySkipReason` / `retroedAt`
+    //   → milestone tooltip + the green-vs-amber-✓ "shipped but
+    //   bookkeeping incomplete" colour nuance. Polled rows fall back
+    //   to the base status pill (green ✓ for succeeded, etc.); the
+    //   full milestone breakdown still renders in the dialog row.
+    const bodies = selectionBodiesFor(printed, 'recentCompletions');
+    expect(bodies).toHaveLength(1);
+    const body = bodies[0];
+    for (const field of [
+      'startedAt',
+      'totalTokens',
+      'totalCostUsd',
+      'mergedAt',
+      'verifiedAt',
+      'verifySkipReason',
+      'retroedAt',
+    ]) {
+      expect(body).not.toMatch(new RegExp(`\\b${field}\\b`));
+    }
+  });
+});
+
+describe('DISPATCHER_QUEUE_FULL_QUERY — dialog completions still rich (issue #4064)', () => {
+  const printed = print(DISPATCHER_QUEUE_FULL_QUERY);
+
+  it('keeps detail fields inside the dialog `completions` selection', () => {
+    // AC3 regression guard: the expand-on-click dialog is the place
+    // detail fields live now. If a future cleanup also strips them
+    // from this query, the dialog row silently loses the cost
+    // footnote, milestone tooltip, and start/duration tooltip — fail
+    // loudly here instead.
+    const bodies = selectionBodiesFor(printed, 'completions');
+    expect(bodies.length).toBeGreaterThan(0);
+    for (const body of bodies) {
+      for (const field of [
+        'totalTokens',
+        'totalCostUsd',
+        'failureSummary',
+        'mergedAt',
+        'verifiedAt',
+        'verifySkipReason',
+        'retroedAt',
+      ]) {
+        expect(body).toMatch(new RegExp(`\\b${field}\\b`));
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Trim `DISPATCHER_STATE_QUERY.recentCompletions` from 14 fields to 8 row-essential fields. The seven detail-only fields (`startedAt`, `totalTokens`, `totalCostUsd`, `mergedAt`, `verifiedAt`, `verifySkipReason`, `retroedAt`) ride exclusively on the existing `DISPATCHER_QUEUE_FULL_QUERY` — fired only on dialog open, not in the 2s poll path. Combined with #4062 and #4063, this brings the polled cost from 1105 to 1035 (-70 units). Residual ~35-unit overhang tracked in #4100.

Closes #4064

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (1509 web tests, including 8 in `dispatcher-polled-query-shape.test.ts`)
- [x] CI green

### Post-deploy verification
- [x] CloudWatch on `/ecs/judgemind-api-dev`: cost dropped from 1105 → 1035 at the deploy boundary (verified — see verification evidence comment on #4064). Residual gap to 1000 cap tracked in #4100.
- [x] Deployed Vercel bundle confirmed: polled `recentCompletions` selection has 8 row-essential fields, dialog `completions` selection still has all 14 detail fields.
- [x] Verification evidence posted on issue #4064.
