### PR TITLE
fix(dx): relocate validate-graphql-queries to packages/web/scripts (#4093)

### DIFF
--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -192,6 +192,8 @@ For `packages/web/`, also run `npm run build`. The same diff coverage and floor 
 
 `packages/web/` also has `npm run check` — covers hardcoded-colors, apollo-keyfields, and graphql-queries, the CI hygiene guards that fail fast. Run it before pushing large frontend changes.
 
+The graphql-queries guard is implemented as `scripts/check-graphql-queries.sh` (bash wrapper) → `packages/web/scripts/validate-graphql-queries.mjs` (Node ESM validator). The validator lives under `packages/web/scripts/` rather than the top-level `scripts/` dir on purpose: `import 'graphql'` is resolved by Node's ESM loader by walking up from the importer's URL, so locating the validator inside `packages/web/` lets the loader find `packages/web/node_modules/graphql` after a vanilla `npm install` in `packages/web/` — no NODE_PATH tricks or repo-root install required. CI's `graphql-query-check` job continues to install the package via `npm install --no-save graphql@^16.8` at repo root, which the resolver also finds by walking further up. See #4093.
+
 ### Terraform (from `infra/terraform/`)
 
 ```

--- a/packages/web/scripts/validate-graphql-queries.mjs
+++ b/packages/web/scripts/validate-graphql-queries.mjs
@@ -8,8 +8,16 @@
  * Uses the `graphql` npm package for proper schema parsing and query validation.
  * Does not require running the API server.
  *
+ * **Why this lives under packages/web/scripts/ rather than the top-level scripts/ dir.**
+ * Node's ESM resolver anchors `import 'graphql'` to the importer's URL and walks up
+ * looking for `node_modules/graphql`. With the validator at
+ * `packages/web/scripts/validate-graphql-queries.mjs`, the resolver finds
+ * `packages/web/node_modules/graphql` after `npm install` in `packages/web/` — no
+ * NODE_PATH or repo-root install required. (NODE_PATH is a CommonJS-only knob;
+ * ESM ignores it. See #4093.)
+ *
  * Usage:
- *   node scripts/validate-graphql-queries.mjs [repo-root]
+ *   node packages/web/scripts/validate-graphql-queries.mjs [repo-root]
  *
  * Exit codes:
  *   0 — All queries are valid.

--- a/scripts/check-graphql-queries.sh
+++ b/scripts/check-graphql-queries.sh
@@ -25,7 +25,7 @@ REPO_ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 
 SCHEMA_FILE="$REPO_ROOT/packages/api/src/graphql/schema.ts"
 WEB_SRC_DIR="$REPO_ROOT/packages/web/src"
-VALIDATOR_SCRIPT="$REPO_ROOT/scripts/validate-graphql-queries.mjs"
+VALIDATOR_SCRIPT="$REPO_ROOT/packages/web/scripts/validate-graphql-queries.mjs"
 
 # ─── Verify files exist ──────────────────────────────────────────────
 if [ ! -f "$SCHEMA_FILE" ]; then
@@ -49,38 +49,25 @@ if ! command -v node > /dev/null 2>&1; then
     exit 1
 fi
 
-# ─── Resolve graphql package from known locations ────────────────────
-# If NODE_PATH is already set (e.g., by CI or tests), use it.
-# Otherwise, look for the graphql package relative to the script's
-# actual location (which may differ from REPO_ROOT in tests).
-if [ -z "${NODE_PATH:-}" ]; then
-    SCRIPT_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-    NODE_PATH_CANDIDATES=(
-        "$REPO_ROOT/packages/web/node_modules"
-        "$REPO_ROOT/packages/api/node_modules"
-        "$REPO_ROOT/node_modules"
-        "$SCRIPT_REPO_ROOT/packages/web/node_modules"
-        "$SCRIPT_REPO_ROOT/packages/api/node_modules"
-        "$SCRIPT_REPO_ROOT/node_modules"
-    )
-
-    RESOLVED_NODE_PATH=""
-    for candidate in "${NODE_PATH_CANDIDATES[@]}"; do
-        if [ -d "$candidate/graphql" ]; then
-            RESOLVED_NODE_PATH="$candidate"
-            break
-        fi
-    done
-
-    if [ -z "$RESOLVED_NODE_PATH" ]; then
-        echo "ERROR: Cannot find 'graphql' npm package."
-        echo "  Checked: ${NODE_PATH_CANDIDATES[*]}"
-        echo "  Fix: Run 'npm install' in packages/web/ or packages/api/,"
-        echo "       or 'npm install graphql' in the repo root."
-        exit 1
-    fi
-
-    export NODE_PATH="$RESOLVED_NODE_PATH"
+# ─── Verify the graphql npm package is resolvable from the validator ─
+# The validator imports `graphql` via ESM. Node's ESM resolver anchors the
+# lookup at the importer's URL (`packages/web/scripts/validate-graphql-queries.mjs`)
+# and walks UP the directory tree looking for `node_modules/graphql`. NODE_PATH
+# is a CommonJS-only knob and is ignored by ESM (#4093). The two paths that
+# satisfy this resolver:
+#   1. Local dev: `npm install` in packages/web/ → packages/web/node_modules/graphql
+#   2. CI: `npm install --no-save graphql@^16.8` at repo root → <repo>/node_modules/graphql
+# Either is fine; we only need to verify at least one exists so the failure
+# mode is a friendly error rather than Node's raw stack trace.
+if [ ! -d "$REPO_ROOT/packages/web/node_modules/graphql" ] && \
+   [ ! -d "$REPO_ROOT/node_modules/graphql" ]; then
+    echo "ERROR: Cannot find 'graphql' npm package."
+    echo "  Looked for it at:"
+    echo "    $REPO_ROOT/packages/web/node_modules/graphql"
+    echo "    $REPO_ROOT/node_modules/graphql"
+    echo "  Fix (local): cd packages/web && npm install"
+    echo "  Fix (CI):    npm install --no-save graphql@^16.8  # at repo root"
+    exit 1
 fi
 
 # ─── Run the Node.js validator ───────────────────────────────────────

--- a/scripts/tests/test_check_graphql_queries.sh
+++ b/scripts/tests/test_check_graphql_queries.sh
@@ -17,7 +17,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CHECK_SCRIPT="$SCRIPT_DIR/check-graphql-queries.sh"
+VALIDATOR_SCRIPT="$REPO_ROOT/packages/web/scripts/validate-graphql-queries.mjs"
 FAILURES=0
 TESTS=0
 
@@ -28,14 +30,28 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Set up the directory structure the script expects
+# Set up the directory structure the script expects.
+#
+# IMPORTANT: ESM resolution for `import 'graphql'` walks UP from the validator's
+# file URL. To exercise that path realistically, we symlink the validator at
+# `$TMPDIR_TEST/packages/web/scripts/` AND symlink real `node_modules/`
+# directories from the host repo so the resolver finds the package. (#4093)
 setup_repo() {
     rm -rf "$TMPDIR_TEST"/*
     mkdir -p "$TMPDIR_TEST/packages/api/src/graphql"
     mkdir -p "$TMPDIR_TEST/packages/web/src/app"
-    mkdir -p "$TMPDIR_TEST/scripts"
-    # Symlink the validator script so it can be found
-    ln -sf "$SCRIPT_DIR/validate-graphql-queries.mjs" "$TMPDIR_TEST/scripts/validate-graphql-queries.mjs"
+    mkdir -p "$TMPDIR_TEST/packages/web/scripts"
+    # Symlink the validator script at the new location so check-graphql-queries.sh
+    # finds it under $REPO_ROOT/packages/web/scripts/.
+    ln -sf "$VALIDATOR_SCRIPT" "$TMPDIR_TEST/packages/web/scripts/validate-graphql-queries.mjs"
+    # Make the `graphql` npm package resolvable from the validator. Prefer the
+    # host repo's packages/web/node_modules/, fall back to the host repo's
+    # top-level node_modules/ (CI installs it there via npm install --no-save).
+    if [ -d "$REPO_ROOT/packages/web/node_modules" ]; then
+        ln -sf "$REPO_ROOT/packages/web/node_modules" "$TMPDIR_TEST/packages/web/node_modules"
+    elif [ -d "$REPO_ROOT/node_modules" ]; then
+        ln -sf "$REPO_ROOT/node_modules" "$TMPDIR_TEST/node_modules"
+    fi
 }
 
 # Write a schema.ts file with the given SDL content
@@ -489,6 +505,69 @@ write_query_file "app/DispatcherPage.tsx" '
   }
 '
 assert_fails "Module schema still surfaces invalid fields"
+
+# ─── Test 17: Regression for #4093 — packages/web/node_modules/graphql alone is sufficient ─
+# The previous validator lived at scripts/validate-graphql-queries.mjs and relied
+# on NODE_PATH to resolve the `graphql` package. ESM ignores NODE_PATH, so when
+# only packages/web/node_modules/graphql/ existed (the local-dev path),
+# `npm run check` failed with ERR_MODULE_NOT_FOUND. The fix (#4093) moved the
+# validator to packages/web/scripts/ so ESM's natural upward resolution finds
+# the package. Verify that even when packages/web/node_modules is the *only*
+# place graphql lives — i.e. no top-level node_modules — the check still passes.
+TESTS=$((TESTS + 1))
+TMPDIR_LOCAL=$(mktemp -d)
+local_cleanup() {
+    rm -rf "$TMPDIR_LOCAL"
+}
+mkdir -p "$TMPDIR_LOCAL/packages/api/src/graphql"
+mkdir -p "$TMPDIR_LOCAL/packages/web/src/app"
+mkdir -p "$TMPDIR_LOCAL/packages/web/scripts"
+# Validator at the new location.
+ln -sf "$VALIDATOR_SCRIPT" "$TMPDIR_LOCAL/packages/web/scripts/validate-graphql-queries.mjs"
+# Schema and a valid query.
+cat > "$TMPDIR_LOCAL/packages/api/src/graphql/schema.ts" <<'SCHEMA_EOF'
+export const typeDefs = `#graphql
+  type Query {
+    health: String!
+  }
+`;
+SCHEMA_EOF
+cat > "$TMPDIR_LOCAL/packages/web/src/app/Page.tsx" <<'QUERY_EOF'
+import { gql } from '@apollo/client';
+const Q = gql`
+  query Health {
+    health
+  }
+`;
+QUERY_EOF
+# Crucially, only symlink packages/web/node_modules — NOT a top-level
+# node_modules. This locks in the local-dev layout where the prior bug fired.
+if [ -d "$REPO_ROOT/packages/web/node_modules/graphql" ]; then
+    ln -sf "$REPO_ROOT/packages/web/node_modules" "$TMPDIR_LOCAL/packages/web/node_modules"
+elif [ -d "$REPO_ROOT/node_modules/graphql" ]; then
+    # CI runs `npm install --no-save graphql@^16.8` at repo root and does NOT
+    # populate packages/web/node_modules. In that environment we still want to
+    # exercise the same code path: place a node_modules fixture at the
+    # packages/web/ level by symlinking the host's root node_modules.
+    ln -sf "$REPO_ROOT/node_modules" "$TMPDIR_LOCAL/packages/web/node_modules"
+else
+    echo "FAIL: Test 17 setup — neither packages/web/node_modules/graphql nor"
+    echo "      node_modules/graphql exists at REPO_ROOT=$REPO_ROOT. Run npm"
+    echo "      install in packages/web/ before invoking this test."
+    FAILURES=$((FAILURES + 1))
+    local_cleanup
+    # fall through to summary
+fi
+if [ -L "$TMPDIR_LOCAL/packages/web/node_modules" ]; then
+    if "$CHECK_SCRIPT" "$TMPDIR_LOCAL" > /dev/null 2>&1; then
+        echo "PASS: #4093 — validator resolves graphql via packages/web/node_modules only"
+    else
+        echo "FAIL: #4093 — validator could not resolve graphql with only"
+        echo "      packages/web/node_modules populated (this is the regression)."
+        FAILURES=$((FAILURES + 1))
+    fi
+fi
+local_cleanup
 
 # ─── Summary ──────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Move `validate-graphql-queries.mjs` from `scripts/` to `packages/web/scripts/` so Node's ESM resolver finds the `graphql` npm package via its natural upward walk from `packages/web/node_modules/`. Replaces the dead `NODE_PATH` dance in `scripts/check-graphql-queries.sh` (NODE_PATH is CommonJS-only and ignored by ESM imports) with a friendly preflight check, and adds a regression test that locks in the local-dev layout. CI's `graphql-query-check` job is unchanged.

Closes #4093

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling fix; the affected scripts run only at pre-push and CI time)
- [x] Verification evidence posted on issue (see A.8)
