### PR TITLE
fix(dx): drop obsolete graphql repo-root install in CI graphql-query-check (#4089)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1395,6 +1395,15 @@ jobs:
   # ---------------------------------------------------------------
   # GraphQL query validation: frontend queries must match API schema
   # ---------------------------------------------------------------
+  # Install graphql via packages/web/ so this CI step exercises the same
+  # ESM-resolution path local users hit via `npm run check` from
+  # packages/web/. The previous repo-root `npm install --no-save graphql@^16.8`
+  # workaround dates from when the validator lived at repo-root scripts/ and
+  # relied on NODE_PATH (Node 20 only). #4093 / #4098 relocated the validator
+  # to packages/web/scripts/ where ESM resolution finds graphql at
+  # packages/web/node_modules/graphql naturally — no NODE_PATH, no Node 24
+  # branch. Keeping the repo-root install would silently mask a future
+  # regression that re-breaks the local-dev path (#4089).
   graphql-query-check:
     runs-on: ubuntu-latest
     steps:
@@ -1402,8 +1411,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
-      - name: Install graphql package
-        run: npm install --no-save graphql@^16.8
+      - name: Install web dependencies (provides packages/web/node_modules/graphql)
+        run: npm --prefix packages/web ci
       - name: Validate frontend GraphQL queries against API schema
         run: scripts/check-graphql-queries.sh
 

--- a/scripts/check-graphql-queries.sh
+++ b/scripts/check-graphql-queries.sh
@@ -53,11 +53,13 @@ fi
 # The validator imports `graphql` via ESM. Node's ESM resolver anchors the
 # lookup at the importer's URL (`packages/web/scripts/validate-graphql-queries.mjs`)
 # and walks UP the directory tree looking for `node_modules/graphql`. NODE_PATH
-# is a CommonJS-only knob and is ignored by ESM (#4093). The two paths that
-# satisfy this resolver:
-#   1. Local dev: `npm install` in packages/web/ → packages/web/node_modules/graphql
-#   2. CI: `npm install --no-save graphql@^16.8` at repo root → <repo>/node_modules/graphql
-# Either is fine; we only need to verify at least one exists so the failure
+# is a CommonJS-only knob and is ignored by ESM (#4093). The canonical path that
+# satisfies this resolver is `npm install` in packages/web/, which populates
+# packages/web/node_modules/graphql. A repo-root `<repo>/node_modules/graphql`
+# also resolves (the walk reaches it from packages/web/scripts/) and is kept as
+# a fallback for the scripts-tests Python shard, which installs graphql at the
+# repo root via `npm install --no-save graphql@^16.8` (.github/workflows/ci.yml
+# `scripts-tests` job). We only need to verify at least one exists so the failure
 # mode is a friendly error rather than Node's raw stack trace.
 if [ ! -d "$REPO_ROOT/packages/web/node_modules/graphql" ] && \
    [ ! -d "$REPO_ROOT/node_modules/graphql" ]; then
@@ -65,8 +67,7 @@ if [ ! -d "$REPO_ROOT/packages/web/node_modules/graphql" ] && \
     echo "  Looked for it at:"
     echo "    $REPO_ROOT/packages/web/node_modules/graphql"
     echo "    $REPO_ROOT/node_modules/graphql"
-    echo "  Fix (local): cd packages/web && npm install"
-    echo "  Fix (CI):    npm install --no-save graphql@^16.8  # at repo root"
+    echo "  Fix: cd packages/web && npm install"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Drop the obsolete `npm install --no-save graphql@^16.8` repo-root workaround from CI's `graphql-query-check` job. #4098 (closing #4093) relocated the validator to `packages/web/scripts/validate-graphql-queries.mjs` where Node's ESM resolver finds `graphql` at `packages/web/node_modules/graphql` naturally — the repo-root install in CI is now dead code and silently masks any future regression to the local-dev path. Switch CI to `npm --prefix packages/web ci` so the CI step exercises the same resolution path local users hit via `npm run check` from `packages/web/`. Also tidy the script's error hint.

The local-dev "AC#1" claim from #4089 (`npm run check` works on Node 24 without manual repo-root install) was already satisfied by #4098 — verified locally on Node 24 in this worktree before any code change. The remaining residual was the obsolete CI workaround, which this PR removes.

Closes #4089

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green (`graphql-query-check` job uses the new install path)

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow + script comment only). Verification gate is "CI green using the new install path."
