### PR TITLE
perf(ingestion): line-anchor LA judge regex to fix O(n^2) blowup (#4104)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -840,10 +840,19 @@ def normalize_motion_type(motion_type: str) -> str | None:
 
 _JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
     # LA: "William A. Crowfoot Judge of the Superior Court" (now case-insensitive
-    # to also match "JARED D. MOSES JUDGE OF THE SUPERIOR COURT")
+    # to also match "JARED D. MOSES JUDGE OF THE SUPERIOR COURT").
+    #
+    # Pattern is line-anchored (^ with MULTILINE) and bounded to 80 chars to
+    # prevent catastrophic-backtracking-like quadratic blowup on long opinion
+    # text.  The pre-fix unanchored, unbounded variant
+    # `([^\n]+?)\s+Judge of the Superior Court` cost O(n^2) per call on input
+    # without the literal substring (15+ seconds on a 50KB federal opinion;
+    # see #4104).  Anchoring to the start of a line and capping the capture at
+    # 80 characters bounds the work to O(n) and matches all real LA judge
+    # signatures, which always start on their own line.
     re.compile(
-        r"([^\n]+?)\s+Judge of the Superior Court",
-        re.IGNORECASE,
+        r"^([^\n]{1,80}?)\s+Judge of the Superior Court",
+        re.IGNORECASE | re.MULTILINE,
     ),
     # SB: "Department S22 - Judge Bobby P. Luna"
     re.compile(

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -372,6 +372,81 @@ class TestExtractJudgeName:
         result = extract_judge_name(text)
         assert result == "Arthur Hester III"
 
+    # --- Performance regression tests (#4104) ---
+
+    def test_no_quadratic_blowup_on_long_no_match_input(self) -> None:
+        """Regression: extract_judge_name must complete in bounded time on
+        long opinion text that contains no matchable judge signature (#4104).
+
+        Pre-fix, the LA `([^\\n]+?)\\s+Judge of the Superior Court` pattern with
+        re.IGNORECASE cost O(n^2) per call.  On a 50KB synthetic federal
+        opinion (no LA signature, lots of capitalized prose), the call took
+        15+ seconds — driving reingest_from_s3.py CPU-bound at ~1 doc/min.
+
+        Post-fix, anchoring to start-of-line plus a bounded capture forces
+        O(n) behavior. 100ms is generous headroom over the actual sub-10ms
+        cost on modern hardware.
+        """
+        import time
+
+        # Federal-opinion-shaped text without any LA judge signature.
+        paragraph = (
+            "The Court has considered Plaintiff's Motion for Summary Judgment "
+            "filed pursuant to Federal Rule of Civil Procedure 56. As the "
+            "Ninth Circuit held in Smith v. Jones, 123 F.3d 456, 459 (9th Cir. "
+            "2018), summary judgment is appropriate when the moving party has "
+            "shown there is no genuine dispute as to any material fact. See "
+            "also Anderson v. Liberty Lobby, Inc., 477 U.S. 242, 248 (1986); "
+            "Celotex Corp. v. Catrett, 477 U.S. 317, 322 (1986). Defendant "
+            "Acme Industries, A California Corporation, opposes the Motion. "
+            "The Court finds that Plaintiff has met its burden under Federal "
+            "Rule of Evidence 401. United States District Court for the "
+            "Southern District of California considered the matter on January "
+            "5, 2026 at 1:30 PM. "
+        )
+        # Build ~100KB of synthetic opinion text.
+        text = (paragraph * ((100 * 1024) // len(paragraph) + 1))[: 100 * 1024]
+        assert len(text) >= 100 * 1024
+
+        start = time.perf_counter()
+        result = extract_judge_name(text)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+        assert result is None, "Synthetic federal text contains no LA judge"
+        assert elapsed_ms < 100.0, (
+            f"extract_judge_name took {elapsed_ms:.1f}ms on 100KB of federal-"
+            f"opinion-shaped text — quadratic regression in pattern[0] suspected."
+        )
+
+    def test_no_quadratic_blowup_on_long_with_match_input(self) -> None:
+        """Same as above but WITH a real LA judge signature appended (#4104).
+
+        Pre-fix, even with the signature present, the unanchored lazy capture
+        explored quadratic backtracks before settling on the match. Post-fix,
+        the line anchor lets the engine seek directly to the match.
+        """
+        import time
+
+        paragraph = (
+            "The Court has considered Plaintiff's Motion for Summary Judgment "
+            "filed pursuant to Federal Rule of Civil Procedure 56. As the "
+            "Ninth Circuit held in Smith v. Jones, 123 F.3d 456, 459 (9th Cir. "
+            "2018), summary judgment is appropriate when the moving party has "
+            "shown there is no genuine dispute as to any material fact. "
+        )
+        text = (paragraph * ((100 * 1024) // len(paragraph) + 1))[: 100 * 1024]
+        text += "\nWilliam A. Crowfoot Judge of the Superior Court\n"
+
+        start = time.perf_counter()
+        result = extract_judge_name(text)
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+
+        assert result == "William A. Crowfoot"
+        assert elapsed_ms < 100.0, (
+            f"extract_judge_name took {elapsed_ms:.1f}ms on 100KB+match text — "
+            f"quadratic regression in pattern[0] suspected."
+        )
+
 
 # ---------------------------------------------------------------------------
 # _looks_like_person_name validation


### PR DESCRIPTION
## Summary

Line-anchor the LA "Judge of the Superior Court" regex to fix an O(n^2) blowup that drove `scripts/reingest_from_s3.py --county Federal` to ~1 doc/min on Federal opinion text (50-200KB per doc). Post-fix, the pattern runs in <2ms on a 100KB synthetic federal opinion vs. >15s pre-fix.

Closes #4104

## Root cause

`_JUDGE_NAME_PATTERNS[0]` (`packages/scraper-framework/src/ingestion/extract.py:844`):

```python
re.compile(
    r"([^\n]+?)\s+Judge of the Superior Court",
    re.IGNORECASE,
)
```

The lazy `[^\n]+?` capture, combined with `re.IGNORECASE` and no leading literal anchor, forces the engine to start from every position in the input and expand the capture one character at a time when the literal anchor is absent. This is **quadratic** in input length (not exponential nested-quantifier backtracking — the issue body's hypothesis was wrong about which pattern but right about the symptom).

Per-pattern timing on synthetic federal-opinion text (no LA signature):

| Input | Pre-fix | Post-fix |
|---|---|---|
| 1KB | 6.21 ms | 0.02 ms |
| 5KB | 154.11 ms | 0.08 ms |
| 10KB | 637.93 ms | 0.18 ms |
| 50KB | >15000 ms (timeout) | 0.78 ms |
| 100KB | >15000 ms (timeout) | 1.74 ms |

The other 8 judge patterns ran in microseconds — they each have leading literal anchors (`Department`, `Hon`, `Judge`, `JUDICIAL`, `Presiding`) that let the engine seek directly to candidate positions.

## Fix

Anchor pattern[0] to start-of-line (`^` with `re.MULTILINE`) and bound the lazy capture to 80 chars:

```python
re.compile(
    r"^([^\n]{1,80}?)\s+Judge of the Superior Court",
    re.IGNORECASE | re.MULTILINE,
)
```

All 9 existing pattern[0] test cases still pass — including multi-line LA cases like `"JARED D. MOSES\nJUDGE OF THE SUPERIOR COURT"` and `"The motion is GRANTED.\nJames I. Montgomery Judge of the Superior Court"`, which work because `\s+` matches the newline between name and suffix.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county Federal --limit 50` completes in < 2 minutes (acceptance criterion #1) — **2.18s** on oneshot `4437f5f7`
- [x] Verification evidence posted on issue (see A.8)
