### PR TITLE
infra(api): CloudWatch alarm on polled dispatcherState query cost (#4110)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -490,6 +490,40 @@ aws cloudwatch get-metric-data --region us-west-2 \
 
 If a future investigation genuinely requires per-task-ARN metrics (to disambiguate two concurrent oneshots within the same family), toggle the setting to `enhanced` on a targeted basis — expect a billing uptick proportional to concurrent task count.
 
+### CloudWatch Alarms (dev)
+
+Alarms wired through Terraform — `enable_alerts = true` on each module gates whether the alarm resources are created. `alert_sns_topic_arn` is `module.compute.alerts_topic_arn` (the same SNS topic surfaces in Telegram and the `/admin/dispatcher` cockpit).
+
+| Alarm name prefix | Module | Source | Fires when |
+|---|---|---|---|
+| `judgemind-api-5xx-` | `api-service` | `AWS/ApplicationELB` `HTTPCode_Target_5XX_Count` | API 5xx error count > threshold in 5 min |
+| `judgemind-api-4xx-spike-` | `api-service` | `AWS/ApplicationELB` `HTTPCode_Target_4XX_Count` | API 4xx error count > threshold in 5 min |
+| `judgemind-api-latency-p99-` | `api-service` | `AWS/ApplicationELB` `TargetResponseTime` (p99) | API p99 latency > threshold for 2 consecutive 5-min periods |
+| `judgemind-api-unhealthy-hosts-` | `api-service` | `AWS/ApplicationELB` `UnHealthyHostCount` | ALB target group has unhealthy hosts |
+| `dispatcher-polled-cost-` | `api-service` | log metric filter on `/ecs/judgemind-api-${env}` matching `{ $.msg = "graphql.cost.breakdown" }`, namespace `Judgemind/API`, metric `PolledQueryCost` | Cockpit's polled `dispatcherState` query cost > 900 (cap 1000) in 3 of last 5 minutes — pre-cap early warning, see #4110 |
+| `judgemind-dispatcher-heartbeat-stale-` | `dispatcher-daemon` | `Judgemind/Dispatcher` `HeartbeatStale` | Daemon heartbeat hasn't advanced in `heartbeat_stale_seconds` |
+| `judgemind-dispatcher-stuck-timeout-repeated-` | `dispatcher-daemon` | log metric filter on `stuck_timeout_repeated` events | Same agent hits `stuck_timeout` twice within the configured window |
+| `judgemind-dispatcher-diagnoser-fallback-spike-` | `dispatcher-daemon` | log metric filter on `diagnoser_fallback` events | Diagnoser fell back to mechanical escalation `>= diagnoser_fallback_threshold` times in the configured window |
+| `judgemind-dispatcher-list-advanceable-failed-` | `dispatcher-daemon` | log metric filter on `_list_advanceable_agents` exceptions | Supervisor tick raised an unhandled exception |
+| `judgemind-dispatcher-recover-scan-failed-` | `dispatcher-daemon` | log metric filter on `_recover_scan` exceptions | Supervisor tick raised an unhandled exception |
+| `judgemind-dispatcher-resume-scan-failed-` | `dispatcher-daemon` | log metric filter on `_resume_scan` exceptions | Supervisor tick raised an unhandled exception |
+| `judgemind-dispatcher-observe-external-terminal-failed-` | `dispatcher-daemon` | log metric filter on `_observe_external_terminal` exceptions | Supervisor tick raised an unhandled exception |
+| `judgemind-dispatcher-reap-agent-tasks-select-failed-` | `dispatcher-daemon` | log metric filter on `_reap_agent_tasks` exceptions | Supervisor tick raised an unhandled exception |
+
+Confirm an alarm exists / inspect its config:
+
+```
+aws cloudwatch describe-alarms --region us-west-2 \
+  --alarm-name-prefix dispatcher-polled-cost
+```
+
+Confirm a metric filter exists / inspect its pattern:
+
+```
+aws logs describe-metric-filters --region us-west-2 \
+  --log-group-name /ecs/judgemind-api-dev
+```
+
 ### Dev DB Connection Budget
 
 The dev RDS instance (`judgemind-dev`) runs on **`db.t4g.small`** (2 GB RAM).  PostgreSQL 16's `max_connections` is derived from the instance-class memory via the formula `LEAST({DBInstanceClassMemory/9531392}, 5000)` — on `db.t4g.small` this resolves to roughly **~170 connections**.  Reserved slots:

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -578,3 +578,71 @@ resource "aws_cloudwatch_metric_alarm" "api_unhealthy_hosts" {
   alarm_actions = [var.alert_sns_topic_arn]
   ok_actions    = [var.alert_sns_topic_arn]
 }
+
+# ─── Polled dispatcherState query cost — pre-cap alarm (#4110) ─────────────────
+#
+# The cockpit's polled `dispatcherState` query has crossed the 1000-unit
+# complexity cap four times in 30 days (#4062, #4063, #4064, #4100), each
+# time discovered only after operators noticed the cockpit going blank or
+# HTTP 400s in CloudWatch. The `costBreakdownPlugin` from #4100 logs a
+# `graphql.cost.breakdown` line with the total cost whenever a request
+# crosses the 800-unit early-warning band. This alarm watches that signal
+# and fires while the cockpit still works (cost > 900, 100-unit buffer
+# below the 1000 cap), so the next slim trim PR can be filed proactively
+# instead of as an emergency.
+#
+# Metric design:
+# - Pattern matches the structured Pino log shape: top-level `msg` field
+#   is "graphql.cost.breakdown" (set by the second positional arg to
+#   `app.log.info(entry, 'graphql.cost.breakdown')` in packages/api/src/app.ts).
+# - Value extracted from `$.cost` (top-level numeric in the entry object).
+# - Statistic `Maximum` over a 60-second period: each 1-min bin reports
+#   the highest observed cost. Sum would conflate distinct queries;
+#   Average would dilute a real regression with cheap parallel queries.
+# - 5-min evaluation window (5 × 60s) with `datapoints_to_alarm = 3` —
+#   3-of-5 minutes seeing max cost > 900 is a sustained trend, not a
+#   single noisy poll. The dispatcher polls every 2s so each 1-min bin
+#   has ~30 samples to draw the Maximum from.
+# - `treat_missing_data = "notBreaching"` so cost-quiet windows (cockpit
+#   not loaded by anyone) do not flap the alarm.
+#
+# Dev-only by design: production traffic on this query is operator-only
+# and the cap surfaces immediately as a blank cockpit, which is its own
+# alarm (#4110 Out of Scope).
+
+resource "aws_cloudwatch_log_metric_filter" "polled_query_cost" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "judgemind-api-polled-query-cost-${var.environment}"
+  pattern        = "{ $.msg = \"graphql.cost.breakdown\" }"
+  log_group_name = aws_cloudwatch_log_group.api.name
+
+  metric_transformation {
+    name          = "PolledQueryCost"
+    namespace     = "Judgemind/API"
+    value         = "$.cost"
+    default_value = null
+    unit          = "None"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "polled_query_cost" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "dispatcher-polled-cost-${var.environment}"
+  alarm_description = "Polled dispatcherState query cost crossed ${var.polled_query_cost_threshold} (cap 1000) in ${var.polled_query_cost_datapoints_to_alarm} of the last ${var.polled_query_cost_evaluation_periods} minutes (${var.environment}). The cockpit still works at this level — file a slim trim PR before the next field add pushes us over. See #4110."
+
+  namespace   = "Judgemind/API"
+  metric_name = "PolledQueryCost"
+  statistic   = "Maximum"
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.polled_query_cost_threshold
+  period              = 60
+  evaluation_periods  = var.polled_query_cost_evaluation_periods
+  datapoints_to_alarm = var.polled_query_cost_datapoints_to_alarm
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/api-service/variables.tf
+++ b/infra/terraform/modules/api-service/variables.tf
@@ -168,3 +168,23 @@ variable "unhealthy_host_threshold" {
   type        = number
   default     = 0
 }
+
+# ─── Polled dispatcherState query cost alarm (#4110) ─────────────────────────
+
+variable "polled_query_cost_threshold" {
+  description = "Cost threshold (in graphql-validation-complexity units) above which the polled-query-cost alarm fires. The cap is 1000; the cost-breakdown logger emits at >= 800. 900 leaves a 100-unit buffer between the early-warning emit and the cap so the alarm fires while the cockpit still works."
+  type        = number
+  default     = 900
+}
+
+variable "polled_query_cost_evaluation_periods" {
+  description = "Number of consecutive 60-second periods evaluated for the polled-query-cost alarm. Default 5 (5-min window)."
+  type        = number
+  default     = 5
+}
+
+variable "polled_query_cost_datapoints_to_alarm" {
+  description = "Number of evaluation periods within polled_query_cost_evaluation_periods that must breach the threshold to alarm. 3-of-5 default avoids flapping on a single noisy poll while still firing on a sustained trend."
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
## Summary

Add a CloudWatch metric filter + alarm on the polled `dispatcherState` query cost so the next time it creeps toward the 1000-cap, an alert fires *before* HTTP 400s start hitting cockpit users. Pattern matches the `graphql.cost.breakdown` log emission from #4100; threshold of 900 leaves a 100-unit buffer below the cap so the alarm fires while the cockpit still works.

Closes #4110.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`infra-validate` + `Validate and Plan` SUCCESS; non-touched-package suites SKIPPED)
- [x] CI green (`ci-passed` SUCCESS; `Check major pages` CANCELLED = non-required Vercel smoke-test concurrency cancellation)

### Post-deploy verification
- [x] `aws logs describe-metric-filters --log-group-name /ecs/judgemind-api-dev` shows `judgemind-api-polled-query-cost-dev` filter with pattern `{ $.msg = "graphql.cost.breakdown" }` and value `$.cost`.
- [x] `aws cloudwatch describe-alarms --alarm-name-prefix dispatcher-polled-cost` shows the alarm with `Threshold=900`, `EvaluationPeriods=5`, `DatapointsToAlarm=3`, `Period=60`, `Statistic=Maximum`, `ComparisonOperator=GreaterThanThreshold`.
- [x] `aws cloudwatch describe-alarms --alarm-name-prefix dispatcher-polled-cost --query 'MetricAlarms[].AlarmActions'` shows the dispatcher alerts SNS topic ARN (`arn:aws:sns:us-west-2:155326049300:judgemind-scraper-alerts-dev`).
- [x] Verification evidence posted on issue (see #4110).
