### PR TITLE
fix(dispatcher): replace BSD-broken date +%s%3N with python3-backed _ms_now (#4099)

### DIFF
--- a/scripts/dispatcher/agent_runner_run_claude_phase.sh
+++ b/scripts/dispatcher/agent_runner_run_claude_phase.sh
@@ -61,6 +61,48 @@ if ! declare -F die >/dev/null 2>&1; then
     }
 fi
 
+# ── _ms_now() — portable epoch-milliseconds helper (#4099) ──────────────────
+#
+# GNU ``date -u +%s%3N`` returns epoch-seconds + 3-digit nanoseconds (i.e.
+# milliseconds). BSD ``date`` (macOS) does NOT support the ``%N`` format
+# specifier — it silently emits a literal ``N`` appended to the seconds
+# (e.g. ``17780132253N``). The ``2>/dev/null || printf 'unknown'`` fallback
+# the helper used to wrap around ``date -u +%s%3N`` does NOT trip on this
+# case, because BSD date exits 0 with the malformed token. The literal ``N``
+# then poisons the downstream ``$((end - start))`` arithmetic with
+# ``value too great for base (error token is "17780132253N")``, which under
+# ``set -e`` aborts ``scripts/tests/test_agent_runner_entrypoint.sh`` on
+# macOS bash 3.2 — blocking any /task agent on a Mac from running the
+# entrypoint test suite locally.
+#
+# Fix: route through python3, which is already a hard dependency of the
+# entrypoint (used for the phase-transition shims) and which produces a
+# clean integer milliseconds value on every supported platform. The
+# fallback to ``printf 'unknown'`` is preserved for the unlikely case
+# where ``python3`` is absent so the existing ``unknown``-handling branch
+# in ``run_claude_phase`` (and the T3778 test) still has a code path to
+# exercise.
+#
+# Bash 3.2 compatible — no associative arrays, no ``${EPOCHREALTIME}`` (bash 5+).
+#
+# Output contract: prints either a positive integer (epoch milliseconds) or
+# the literal string ``unknown``. Validate python3's stdout is a non-empty
+# digit string before accepting it — a stubbed python3 (e.g. tests that
+# replace python3 with ``#!/usr/bin/env bash\nexit 0\n``) returns rc=0
+# with empty stdout, which would otherwise leak the empty string into the
+# downstream ``$((end - start))`` arithmetic. Validating here keeps the
+# ``unknown`` branch in ``run_claude_phase`` as the only path that
+# produces non-numeric output.
+_ms_now() {
+    local _ms_now_out
+    _ms_now_out=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null) \
+        || _ms_now_out=""
+    case "$_ms_now_out" in
+        ''|*[!0-9]*) printf 'unknown' ;;
+        *)           printf '%s' "$_ms_now_out" ;;
+    esac
+}
+
 # ── Per-phase claude -p timeout constants ───────────────────────────────────
 #
 # Each phase has its own wall-clock cap so ralph (the long-tail phase)
@@ -245,7 +287,9 @@ run_claude_phase() {
     # name appears in the constants block above as a comment anchor
     # for the test_per_phase_timeout.py static lints.
     _phase_timeout=$(claude_phase_timeout_seconds_by_phase "$_phase")
-    _phase_start_ms=$(date -u +%s%3N 2>/dev/null || printf 'unknown')
+    # #4099: route through ``_ms_now`` (python3-backed) so macOS BSD date
+    # doesn't silently emit ``17780132253N`` — see helper docstring above.
+    _phase_start_ms=$(_ms_now)
     set +e
     (
         cd "$REPO_ROOT" || exit 127
@@ -269,7 +313,8 @@ run_claude_phase() {
     )
     _rc=$?
     set -e
-    _phase_end_ms=$(date -u +%s%3N 2>/dev/null || printf 'unknown')
+    # #4099: see ``_ms_now`` helper above — replaces ``date -u +%s%3N``.
+    _phase_end_ms=$(_ms_now)
     if [[ "$_phase_start_ms" == 'unknown' || "$_phase_end_ms" == 'unknown' ]]; then
         _phase_duration_ms='unknown'
     else

--- a/scripts/dispatcher/tests/test_agent_runner_run_claude_phase.sh
+++ b/scripts/dispatcher/tests/test_agent_runner_run_claude_phase.sh
@@ -67,9 +67,16 @@ if [[ ! -f "$HELPER" ]]; then
 fi
 pass "helper script $HELPER exists"
 
-# ── Sourceability: sourcing defines all 5 functions ──────────────────────────
+# ── Sourceability: sourcing defines all named functions ─────────────────────
 
-for fn in write_phase_input read_phase_output phase_to_skill run_claude_phase \
+# #4099: ``_ms_now`` is the helper's portable epoch-ms shim, used by
+# ``run_claude_phase`` for ``_phase_start_ms`` / ``_phase_end_ms``. The
+# previous in-line ``date -u +%s%3N`` pattern silently emitted a literal
+# ``N`` on macOS BSD date (e.g. ``17780132253N``), poisoning the
+# downstream ``$((end - start))`` arithmetic with
+# ``value too great for base``. Listing ``_ms_now`` here so a future
+# refactor that drops or renames the helper trips this static lint.
+for fn in _ms_now write_phase_input read_phase_output phase_to_skill run_claude_phase \
           claude_phase_timeout_seconds_by_phase; do
     if ! ( set +u; source "$HELPER"; type "$fn" >/dev/null 2>&1 ); then
         fail "helper defines $fn" \
@@ -80,6 +87,84 @@ for fn in write_phase_input read_phase_output phase_to_skill run_claude_phase \
     fi
     pass "helper defines $fn function"
 done
+
+# ── #4099 regression: _ms_now produces clean integer (no trailing N) ────────
+#
+# The bug being prevented: GNU date format ``+%s%3N`` is unsupported on
+# macOS BSD date, which silently emits a literal ``N`` appended to the
+# seconds value. The helper routes through python3 to avoid the BSD/GNU
+# split. Verify the function returns either a non-negative integer or
+# the literal 'unknown' fallback (no other strings are valid).
+ms_now_output=$(
+    set +u
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _ms_now
+)
+if [[ "$ms_now_output" =~ ^[0-9]+$ ]] || [[ "$ms_now_output" == 'unknown' ]]; then
+    pass "_ms_now returns integer ms or 'unknown' (#4099 — got '$ms_now_output')"
+else
+    fail "_ms_now returns integer ms or 'unknown' (#4099)" \
+        "expected ^[0-9]+$ or 'unknown', got '$ms_now_output'"
+fi
+
+# ── #4099 regression: arithmetic on _ms_now output succeeds under set -e ────
+#
+# The original failure mode: ``$((end_ms - start_ms))`` aborted under
+# ``set -e`` when start/end carried the literal ``N`` token. Verify the
+# arithmetic shape from ``run_claude_phase`` succeeds end-to-end with
+# the new ``_ms_now`` helper.
+arithmetic_ok=$(
+    set -e
+    set +u
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _start=$(_ms_now)
+    _end=$(_ms_now)
+    if [[ "$_start" == 'unknown' || "$_end" == 'unknown' ]]; then
+        printf 'fallback'
+    else
+        _delta=$((_end - _start))
+        if (( _delta >= 0 )); then
+            printf 'ok'
+        else
+            printf 'negative'
+        fi
+    fi
+)
+if [[ "$arithmetic_ok" == 'ok' ]] || [[ "$arithmetic_ok" == 'fallback' ]]; then
+    pass "_ms_now output supports \$((end - start)) arithmetic under set -e (#4099 — '$arithmetic_ok')"
+else
+    fail "_ms_now output supports \$((end - start)) arithmetic under set -e (#4099)" \
+        "expected 'ok' or 'fallback', got '$arithmetic_ok'"
+fi
+
+# ── #4099 regression: stubbed python3 (rc=0, empty stdout) → 'unknown' ──────
+#
+# Tests in this very repo stub python3 with ``#!/usr/bin/env bash\nexit 0\n``
+# to keep the PHASE_INPUT_SHIM lookup from blocking the dispatch path. A
+# naive ``python3 -c ... 2>/dev/null || printf 'unknown'`` would NOT trip
+# the fallback (rc=0 with empty stdout is treated as success), leaking the
+# empty string into the downstream ``$((end - start))`` arithmetic. The
+# helper validates the captured stdout is a non-empty digit string and
+# falls back to 'unknown' otherwise. Verify the fallback fires.
+broken_stub_tmp=$(mktemp -d)
+TEMP_DIRS+=("$broken_stub_tmp")
+printf '#!/usr/bin/env bash\nexit 0\n' > "$broken_stub_tmp/python3"
+chmod +x "$broken_stub_tmp/python3"
+broken_stub_output=$(
+    set +u
+    export PATH="$broken_stub_tmp:$PATH"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _ms_now
+)
+if [[ "$broken_stub_output" == 'unknown' ]]; then
+    pass "_ms_now falls back to 'unknown' when python3 returns rc=0 with empty stdout (#4099)"
+else
+    fail "_ms_now falls back to 'unknown' when python3 returns rc=0 with empty stdout (#4099)" \
+        "expected 'unknown', got '$broken_stub_output'"
+fi
 
 # ── phase_to_skill: phase name → skill suffix mapping ────────────────────────
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -3661,9 +3661,14 @@ for fn in db_exec db_query_one log persist_phase_output \
     ' "$ENTRYPOINT" >> "$t41_funcs"
 done
 
-# #3775: the following 5 functions were extracted from the entrypoint to
+# #3775: the following functions were extracted from the entrypoint to
 # the sourceable helper agent_runner_run_claude_phase.sh. Read from HELPER.
-for fn in claude_phase_timeout_seconds_by_phase \
+# #4099: ``_ms_now`` is a HELPER-resident function used by
+# ``run_claude_phase`` for portable epoch-ms timing. Must be extracted
+# into the fixture or the sourced ``run_claude_phase`` body fails with
+# ``_ms_now: command not found`` on every invocation.
+for fn in _ms_now \
+          claude_phase_timeout_seconds_by_phase \
           run_claude_phase \
           write_phase_input \
           phase_to_skill \
@@ -4183,9 +4188,14 @@ for fn in db_exec db_query_one log persist_phase_output \
     ' "$ENTRYPOINT" >> "$t44_funcs"
 done
 
-# #3775: the following 5 functions were extracted from the entrypoint to
+# #3775: the following functions were extracted from the entrypoint to
 # the sourceable helper agent_runner_run_claude_phase.sh. Read from HELPER.
-for fn in phase_to_skill \
+# #4099: ``_ms_now`` is a HELPER-resident function used by
+# ``run_claude_phase`` for portable epoch-ms timing. Must be extracted
+# into the fixture or the sourced ``run_claude_phase`` body fails with
+# ``_ms_now: command not found`` on every invocation.
+for fn in _ms_now \
+          phase_to_skill \
           read_phase_output \
           write_phase_input \
           claude_phase_timeout_seconds_by_phase \
@@ -5706,9 +5716,14 @@ for fn in db_exec db_query_one log persist_phase_output \
     ' "$ENTRYPOINT" >> "$t58_funcs"
 done
 
-# #3775: the following 5 functions were extracted from the entrypoint to
+# #3775: the following functions were extracted from the entrypoint to
 # the sourceable helper agent_runner_run_claude_phase.sh. Read from HELPER.
-for fn in phase_to_skill \
+# #4099: ``_ms_now`` is a HELPER-resident function used by
+# ``run_claude_phase`` for portable epoch-ms timing. Must be extracted
+# into the fixture or the sourced ``run_claude_phase`` body fails with
+# ``_ms_now: command not found`` on every invocation.
+for fn in _ms_now \
+          phase_to_skill \
           read_phase_output \
           write_phase_input \
           claude_phase_timeout_seconds_by_phase \


### PR DESCRIPTION
## Summary

Fix the macOS BSD `date -u +%s%3N` portability bug that aborts `scripts/tests/test_agent_runner_entrypoint.sh` under `set -e` with `value too great for base (error token is "17780132253N")`. Replaces the two `date -u +%s%3N` call sites in `scripts/dispatcher/agent_runner_run_claude_phase.sh` with a portable `_ms_now()` helper that delegates to `python3` (already a hard dep) and falls back to `'unknown'` when python3 is absent or returns garbage.

Closes #4099

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts-tests (shell-slow)` on Linux still passes (no regression to GNU-date path)

### Post-deploy verification
- [x] N/A — no deployed component (dispatcher helper script change; the dispatcher daemon will pick up the fix on its next deploy via the standard deploy-dispatcher workflow). The PR's primary user is the /task agent operator on macOS, who can now run `bash scripts/tests/test_agent_runner_entrypoint.sh` locally without hitting the arithmetic abort.
- [x] Verified on macOS Darwin 25.3.0 bash 3.2.57: 288 PASS / 2 FAIL (both pre-existing, unrelated), **0 occurrences of "value too great for base"**.

### Verification on macOS bash 3.2 (issue body's primary AC)

```
$ grep -n "%s%3N" scripts/dispatcher/agent_runner_run_claude_phase.sh
66:# GNU ``date -u +%s%3N`` returns epoch-seconds + 3-digit nanoseconds (i.e.
70:# the helper used to wrap around ``date -u +%s%3N`` does NOT trip on this
302:    # #4099: see ``_ms_now`` helper above — replaces ``date -u +%s%3N``.
```

Only docstring/comment hits — no executable invocations remain.

```
$ bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ bash scripts/tests/test_agent_runner_entrypoint.sh > /tmp/out.txt 2>&1; echo $?
2

$ grep -c '^PASS:' /tmp/out.txt
288

$ grep -c '^FAIL:' /tmp/out.txt
2

$ grep -c 'value too great for base' /tmp/out.txt
0
```

The exit code 2 + 2 FAILs are pre-existing macOS portability gaps (T58 syntax error at `2>&1` standalone line, `timeout` command unavailable on BSD, `/private/var/...` symlink canonicalization in #3547). All independent of #4099 — filed as retro follow-ups.
