### PR TITLE
feat(ci): add redos-pattern hygiene check (#4117)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,6 +1047,19 @@ jobs:
         run: scripts/check-deprecated-models.sh
 
   # ---------------------------------------------------------------
+  # ReDoS-shaped regex guard: catch leading-lazy-quantifier shapes
+  # in re.compile(..., re.IGNORECASE) before they land.  See #4117
+  # for the check, #4104 for the production incident that motivated
+  # it (15+ seconds per call on 50KB federal opinion text).
+  # ---------------------------------------------------------------
+  redos-pattern-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Scan re.compile call sites for catastrophic-backtracking shapes
+        run: scripts/check-no-redos-pattern.sh
+
+  # ---------------------------------------------------------------
   # Hardcoded model guard: enforce model ID centralization
   # ---------------------------------------------------------------
   hardcoded-models-check:
@@ -1658,7 +1671,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-no-redos-pattern.sh
+++ b/scripts/check-no-redos-pattern.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# check-no-redos-pattern.sh — Detect ReDoS-shaped regex patterns in Python.
+#
+# Flags ``re.compile(r"<pattern>", ...re.IGNORECASE...)`` calls where
+# ``<pattern>`` begins with an unanchored lazy quantifier — i.e. the
+# pattern starts (optionally inside a wrapping group) with a wildcard
+# followed by ``+?`` or ``*?`` BEFORE any literal anchor (``^``, ``\b``,
+# ``\A``, ``\Z``, ``$``, or a literal character).
+#
+# Why this check exists
+# ---------------------
+# This shape exhibits O(n^2) per call on inputs that lack the literal
+# anchor.  Issue #4104 documented a real production incident: a leading
+# ``([^\n]+?)\s+Judge of the Superior Court`` pattern with re.IGNORECASE
+# pegged the LA scraper at 15+ seconds per 50KB federal opinion text.
+# The fix anchored the pattern at start-of-line with ``re.MULTILINE``;
+# the same anti-pattern could exist anywhere a contributor reaches for a
+# leading lazy capture as a "match anything before this literal" idiom.
+#
+# Heuristic — not perfect
+# -----------------------
+# False negatives are acceptable.  False positives can be suppressed
+# with a trailing ``# noqa: redos-pattern`` comment on the same line as
+# the ``re.compile(`` call site.  The goal is to catch the common case
+# before it lands.
+#
+# What is flagged
+# ---------------
+# A re.compile(r"...", flags) call is flagged when:
+#   1. ``re.IGNORECASE`` (or ``re.I``) is in the flags argument, AND
+#   2. The pattern string starts (after at most one opening ``(``,
+#      ``(?:``, ``(?P<name>``, ``(?=``, or ``(?!``) with a wildcard
+#      construct (``.``, ``[...]``, ``\S``, ``\W``, ``\D``) followed by
+#      ``+?`` or ``*?`` BEFORE any of these anchors:
+#        - ``^`` or ``$`` or ``\A`` or ``\Z`` or ``\b`` or ``\B``
+#        - A literal alphanumeric character (or escaped literal like
+#          ``\.``, ``\(``, ``\/``, etc.) at the top level.
+#
+# What is NOT flagged
+# -------------------
+#   - Patterns starting with ``^``, ``\b``, ``\A`` (anchored).
+#   - Patterns starting with a literal character (``Department\s+\S+?...``)
+#     — the literal acts as an effective anchor.
+#   - Patterns without ``re.IGNORECASE`` — case-sensitive scans of large
+#     inputs do not trigger the same backtracking class.
+#   - re.compile with a ``# noqa: redos-pattern`` suppression on the
+#     same line (or the line opening the call).
+#   - Files outside ``packages/`` and ``scripts/`` (the scan scope).
+#   - Files under ``scripts/archive/`` (already-run one-off scripts).
+#
+# Issue: #4117.
+#
+# Usage
+# -----
+#   scripts/check-no-redos-pattern.sh                # scan packages/ + scripts/
+#   scripts/check-no-redos-pattern.sh [path]         # scan a specific file or dir
+#
+# Exit codes
+# ----------
+#   0 — No violations found.
+#   1 — At least one violating ``re.compile`` call site detected.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ─── Determine scan targets ──────────────────────────────────────────────
+# With no argument: scan packages/ and scripts/ (the production scope).
+# With an argument: scan that path (file or directory) — used by tests.
+if [[ $# -eq 0 ]]; then
+    SCAN_TARGETS=("$REPO_ROOT/packages" "$REPO_ROOT/scripts")
+else
+    SCAN_TARGETS=("$1")
+fi
+
+# ─── Filter to existing .py paths ────────────────────────────────────────
+py_files=()
+for target in "${SCAN_TARGETS[@]}"; do
+    if [[ -f "$target" && "$target" == *.py ]]; then
+        py_files+=("$target")
+    elif [[ -d "$target" ]]; then
+        # Find every .py under the directory, excluding common vendored
+        # / generated dirs.
+        while IFS= read -r found; do
+            py_files+=("$found")
+        done < <(find "$target" \
+            -type d \( \
+                -name '.venv' -o \
+                -name '__pycache__' -o \
+                -name 'node_modules' -o \
+                -name '.git' -o \
+                -path '*/scripts/archive' \
+            \) -prune \
+            -o -type f -name '*.py' -print)
+    fi
+done
+
+if [[ ${#py_files[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+# ─── Run the AST + pattern scanner ───────────────────────────────────────
+# The Python scanner emits one line per violation in the form:
+#   <path>:<lineno>:<pattern-snippet>
+#
+# Files are passed as positional args; the scanner reads each one.
+python_output="$(python3 "$REPO_ROOT/scripts/check_no_redos_pattern.py" "${py_files[@]}")"
+
+# ─── Report violations ───────────────────────────────────────────────────
+if [[ -z "${python_output// /}" ]]; then
+    exit 0
+fi
+
+violations=0
+echo "ERROR: Found ReDoS-shaped re.compile() pattern(s) with re.IGNORECASE."
+echo ""
+echo "  These patterns start with an unanchored lazy quantifier (+? or *?)"
+echo "  before any literal anchor.  This shape exhibits O(n^2) per call"
+echo "  on inputs that lack the literal anchor — see issue #4104 for the"
+echo "  production incident."
+echo ""
+echo "  Fix options:"
+echo "    1. Anchor the pattern at start-of-line with re.MULTILINE and ^."
+echo "    2. Bound the wildcard with a {min,max} length cap."
+echo "    3. Replace with a literal-leading pattern."
+echo ""
+echo "  Suppress (false positives only):"
+echo "    re.compile(r\"...\", re.IGNORECASE)  # noqa: redos-pattern"
+echo ""
+echo "  Violating call sites:"
+echo ""
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    echo "    $entry"
+    violations=$((violations + 1))
+done <<< "$python_output"
+
+if (( violations > 0 )); then
+    echo ""
+    echo "  Found $violations occurrence(s) of leading-lazy-quantifier with re.IGNORECASE."
+    exit 1
+fi
+
+exit 0

--- a/scripts/check_no_redos_pattern.py
+++ b/scripts/check_no_redos_pattern.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check_no_redos_pattern.py — AST + regex-prefix scanner for ReDoS-shaped
+``re.compile`` patterns.
+
+Driven by ``scripts/check-no-redos-pattern.sh``.  See that wrapper for the
+full motivation and CI integration story (issue #4117).
+
+The scanner walks every ``re.compile(...)`` call in each input file and
+emits a one-line report of the form ``<path>:<lineno>:<pattern-snippet>``
+for each call that matches both:
+
+  1. The pattern string begins with an unanchored lazy quantifier
+     (``.+?``, ``.*?``, ``[...]+?``, ``[...]*?``, ``\\S+?``, ``\\W+?``, etc.),
+     optionally inside a single wrapping group ``(``, ``(?:``, ``(?P<name>``,
+     ``(?=``, or ``(?!``, BEFORE any literal anchor character.
+  2. The flags argument contains ``re.IGNORECASE`` (or ``re.I``).
+
+A leading literal anchor — ``^``, ``$``, ``\\A``, ``\\Z``, ``\\b``, ``\\B``,
+or any literal alphanumeric / escaped-literal character at the top level
+of the pattern — counts as an effective anchor and disqualifies the
+match.
+
+Suppression: if the line containing the ``re.compile(`` call (or its
+opening line in a multi-line call) has the trailing comment
+``# noqa: redos-pattern``, the call is skipped.
+
+Heuristic-level by design — false negatives are acceptable.  See issue
+#4117 for the rationale.
+
+Usage
+-----
+
+    python3 scripts/check_no_redos_pattern.py [PATH ...]
+
+Each PATH is a ``.py`` file.  The wrapper script discovers the paths.
+
+Exit codes
+----------
+
+  0 — Always.  The wrapper turns the printed-violations stream into a
+       non-zero exit.  Splitting the responsibility keeps this script's
+       output stream the single source of truth for tests and the
+       wrapper alike.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+
+# ─── Regex-string prefix classifier ───────────────────────────────────────
+# We classify the *prefix* of the pattern up to the first lazy quantifier
+# or the first literal anchor.  If the lazy quantifier wins, the pattern
+# is flagged.
+
+# Structures we strip from the very front before classifying:
+#   ( (?:  (?P<name>  (?=  (?!  (?P=name)
+# The intent: ``re.compile(r"([^\\n]+?)\\s+...")`` should be classified by
+# what comes *inside* the wrapping group, since the wrapping group itself
+# is just a no-op anchor-wise.
+_WRAP_PREFIX_RE = re.compile(
+    r"""
+    ^
+    \(                  # opening paren
+    (?:
+        \?:             # non-capturing
+      | \?P<[^>]+>      # named capture
+      | \?=             # lookahead
+      | \?!             # neg lookahead
+      | \?<=            # lookbehind
+      | \?<!            # neg lookbehind
+    )?
+    """,
+    re.VERBOSE,
+)
+
+# A "wildcard-with-lazy-quantifier" head — the bad shape we flag.
+# Matches:
+#   .+?       .*?       [...]+?      [...]*?
+#   \\S+?     \\W+?     \\D+?        \\S*?  etc.
+# Notes:
+#   - The character class ``[...]`` may contain escapes; we use a
+#     non-greedy class that disallows nested ``]``.
+#   - The wildcard MUST be followed immediately by ``+?`` or ``*?``
+#     (or ``{m,n}?`` — also lazy, also bad).
+_LAZY_HEAD_RE = re.compile(
+    r"""
+    ^
+    (?:
+        \.                              # any-char
+      | \[ (?: [^\]\\] | \\. )+ \]      # character class
+      | \\ [SsWwDd]                     # escaped wildcard
+    )
+    (?:
+        [+*] \?                         # lazy +? or *?
+      | \{ \d+ , \d* \} \?              # lazy {m,n}?
+      | \{ , \d+ \} \?                  # lazy {,n}?
+    )
+    """,
+    re.VERBOSE,
+)
+
+# A leading literal-anchor head — the safe shape we exempt.
+# Anchors:
+#   ^   $   \A   \Z   \b   \B
+# Plus any literal character (alphanumeric, space, escaped punctuation).
+# Specifically NOT exempted: ``.``, ``[``, ``\\S``, ``\\W``, ``\\D`` —
+# these are wildcards, not anchors.
+_ANCHOR_HEAD_RE = re.compile(
+    r"""
+    ^
+    (?:
+        \^                              # start-of-line / start-of-string
+      | \$                              # end-of-line / end-of-string
+      | \\A                             # start-of-string
+      | \\Z                             # end-of-string
+      | \\b                             # word boundary
+      | \\B                             # non-word boundary
+      | \\ [^SsWwDdAZbB]                # escaped literal (e.g. \., \(, \/)
+      | [A-Za-z0-9_\- ]                 # literal alphanumeric / space / hyphen
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def _pattern_is_redos_shape(pattern: str) -> bool:
+    """Return True if ``pattern`` starts with a lazy wildcard that is
+    not preceded by a literal anchor (after at most one wrapping group)."""
+
+    if not pattern:
+        return False
+
+    # Strip at most one outer group prefix so ``([^\n]+?)..`` is
+    # classified by ``[^\n]+?`` rather than the bare ``(``.
+    m = _WRAP_PREFIX_RE.match(pattern)
+    head = pattern[m.end():] if m else pattern
+
+    # If the very first construct is a literal anchor, we are safe —
+    # bail out early.
+    if _ANCHOR_HEAD_RE.match(head):
+        return False
+
+    # Otherwise: is the very first construct a wildcard with a lazy
+    # quantifier?  If yes, flag.
+    if _LAZY_HEAD_RE.match(head):
+        return True
+
+    return False
+
+
+# ─── re.IGNORECASE flag-arg detection ─────────────────────────────────────
+def _flags_have_ignorecase(node: ast.AST | None) -> bool:
+    """Return True if ``node`` (the ``flags=`` arg of re.compile) contains
+    ``re.IGNORECASE`` or ``re.I``.
+
+    Handles the common shapes:
+        re.IGNORECASE
+        re.I
+        re.IGNORECASE | re.MULTILINE
+        re.MULTILINE | re.IGNORECASE
+        re.IGNORECASE | re.DOTALL | re.MULTILINE  (any chain of |)
+    """
+    if node is None:
+        return False
+    if isinstance(node, ast.Attribute):
+        return node.attr in ("IGNORECASE", "I")
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        return _flags_have_ignorecase(node.left) or _flags_have_ignorecase(node.right)
+    return False
+
+
+# ─── Pattern-arg literal extraction ───────────────────────────────────────
+def _extract_pattern_string(node: ast.AST) -> str | None:
+    """Return the string value of a ``re.compile`` first arg if it is a
+    literal, else None.  Handles plain ``str``, raw-string-via-Constant,
+    and trivial concatenation of string literals (``"a" + "b"``).
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        # f-string: skip — we cannot statically know the value.
+        return None
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _extract_pattern_string(node.left)
+        right = _extract_pattern_string(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+# ─── Suppression marker ───────────────────────────────────────────────────
+_SUPPRESS_MARKER = "noqa: redos-pattern"
+
+
+def _is_suppressed(source_lines: list[str], call_node: ast.Call) -> bool:
+    """Return True if the call site has a ``# noqa: redos-pattern``
+    suppression on the opening line OR on any line spanned by the call."""
+    start = call_node.lineno - 1
+    end = (call_node.end_lineno or call_node.lineno) - 1
+    for idx in range(start, min(end + 1, len(source_lines))):
+        if _SUPPRESS_MARKER in source_lines[idx]:
+            return True
+    return False
+
+
+# ─── re.compile call detection ────────────────────────────────────────────
+def _is_re_compile_call(node: ast.Call) -> bool:
+    """Return True if ``node.func`` resolves to ``re.compile``."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if func.attr == "compile" and isinstance(func.value, ast.Name) and func.value.id == "re":
+            return True
+    return False
+
+
+def _flags_arg(node: ast.Call) -> ast.AST | None:
+    """Return the flags arg of an re.compile call, whether positional
+    (2nd arg) or keyword (``flags=...``).  Returns None if no flags
+    were passed."""
+    # re.compile(pattern, flags=0) — flags is the 2nd positional arg.
+    if len(node.args) >= 2:
+        return node.args[1]
+    for kw in node.keywords:
+        if kw.arg == "flags":
+            return kw.value
+    return None
+
+
+# ─── Per-file scan ────────────────────────────────────────────────────────
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (lineno, snippet) for every violating re.compile
+    call in ``path``."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Not valid Python — skip.  May be a fixture or template.
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_re_compile_call(node):
+            continue
+        if not node.args:
+            continue
+
+        flags_node = _flags_arg(node)
+        if not _flags_have_ignorecase(flags_node):
+            continue
+
+        pattern = _extract_pattern_string(node.args[0])
+        if pattern is None:
+            # Pattern is dynamic (variable, f-string, etc.) — skip.
+            continue
+
+        if not _pattern_is_redos_shape(pattern):
+            continue
+
+        if _is_suppressed(source_lines, node):
+            continue
+
+        # Truncate the pattern in the report to keep output readable.
+        snippet = pattern if len(pattern) <= 80 else pattern[:77] + "..."
+        violations.append((node.lineno, snippet))
+
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    """Print one ``<path>:<lineno>:<pattern>`` line per violation."""
+    paths = [Path(p) for p in argv[1:]]
+    for path in paths:
+        for lineno, snippet in scan_file(path):
+            print(f"{path}:{lineno}:{snippet}")
+    # Exit 0 unconditionally — the wrapper script aggregates and exits 1
+    # on non-empty output.  See module docstring.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_check_no_redos_pattern.sh
+++ b/scripts/tests/test_check_no_redos_pattern.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# test_check_no_redos_pattern.sh — Tests for check-no-redos-pattern.sh.
+#
+# Creates temporary Python files exercising both pass and fail cases
+# for the ReDoS-shaped re.compile detector (issue #4117).
+#
+# Usage:
+#   scripts/tests/test_check_no_redos_pattern.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-redos-pattern.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: The exact #4104 anti-pattern is caught ──────────────────────
+create_test_file "redos_bad.py" 'import re
+
+BAD = re.compile(
+    r"([^\n]+?)\s+Judge of the Superior Court",
+    re.IGNORECASE,
+)
+'
+assert_fails "Exact #4104 anti-pattern (lazy [^\\n]+? + IGNORECASE) is caught"
+reset_tmpdir
+
+# ─── Test 2: One-line bad form is caught ─────────────────────────────────
+create_test_file "redos_oneline.py" 'import re
+BAD = re.compile(r"([^\n]+?)\s+foo", re.IGNORECASE)
+'
+assert_fails "One-line lazy-leading pattern with IGNORECASE is caught"
+reset_tmpdir
+
+# ─── Test 3: Anchored ^ + MULTILINE is the post-fix shape (passes) ───────
+create_test_file "redos_anchored.py" 'import re
+
+GOOD = re.compile(
+    r"^([^\n]{1,80}?)\s+Judge of the Superior Court",
+    re.IGNORECASE | re.MULTILINE,
+)
+'
+assert_passes "Anchored ^ + bounded {1,80}? pattern passes (post-#4104 fix shape)"
+reset_tmpdir
+
+# ─── Test 4: Word-boundary leading anchor passes ─────────────────────────
+create_test_file "redos_wordboundary.py" 'import re
+GOOD = re.compile(r"\bmotion\s+to\s+dismiss\b", re.IGNORECASE)
+'
+assert_passes "\\b word-boundary leading anchor passes"
+reset_tmpdir
+
+# ─── Test 5: Literal-leading pattern passes ──────────────────────────────
+create_test_file "redos_literal.py" 'import re
+GOOD = re.compile(r"Department\s+\S+?\s*-\s*Judge\s+(?P<n>[^\n]+)", re.IGNORECASE)
+'
+assert_passes "Literal-leading 'Department' before lazy quantifier passes"
+reset_tmpdir
+
+# ─── Test 6: No IGNORECASE — case-sensitive — is exempt ──────────────────
+create_test_file "redos_no_ignorecase.py" 'import re
+NEUTRAL = re.compile(r"([^\n]+?)\s+foo")
+'
+assert_passes "Same shape WITHOUT IGNORECASE is not flagged (case-sensitive ok)"
+reset_tmpdir
+
+# ─── Test 7: re.I (the alias) is treated like re.IGNORECASE ──────────────
+create_test_file "redos_re_i.py" 'import re
+BAD = re.compile(r"([^\n]+?)\s+foo", re.I)
+'
+assert_fails "re.I alias (short form of IGNORECASE) is caught"
+reset_tmpdir
+
+# ─── Test 8: re.IGNORECASE | re.MULTILINE BinOp is detected ──────────────
+create_test_file "redos_or_flags.py" 'import re
+BAD = re.compile(r"([^\n]+?)\s+foo", re.IGNORECASE | re.DOTALL)
+'
+assert_fails "re.IGNORECASE | re.DOTALL flag chain is detected"
+reset_tmpdir
+
+# ─── Test 9: # noqa: redos-pattern suppression on opening line ───────────
+create_test_file "redos_suppress.py" 'import re
+# noqa for known-safe (test fixture)
+BAD = re.compile(r"([^\n]+?)\s+foo", re.IGNORECASE)  # noqa: redos-pattern
+'
+assert_passes "# noqa: redos-pattern suppression on opening line skips the check"
+reset_tmpdir
+
+# ─── Test 10: # noqa: redos-pattern on multi-line call ───────────────────
+create_test_file "redos_suppress_multiline.py" 'import re
+
+BAD = re.compile(  # noqa: redos-pattern
+    r"([^\n]+?)\s+foo",
+    re.IGNORECASE,
+)
+'
+assert_passes "# noqa: redos-pattern on multi-line call opening line skips"
+reset_tmpdir
+
+# ─── Test 11: .*? leading wildcard is also caught ────────────────────────
+create_test_file "redos_star_lazy.py" 'import re
+BAD = re.compile(r"(.*?)foo", re.IGNORECASE)
+'
+assert_fails "Leading .*? lazy quantifier is caught"
+reset_tmpdir
+
+# ─── Test 12: \\S+? leading wildcard is caught ───────────────────────────
+create_test_file "redos_S_lazy.py" 'import re
+BAD = re.compile(r"\S+?\s+foo", re.IGNORECASE)
+'
+assert_fails "Leading \\S+? lazy quantifier is caught"
+reset_tmpdir
+
+# ─── Test 13: keyword flags=re.IGNORECASE form is detected ───────────────
+create_test_file "redos_kwarg.py" 'import re
+BAD = re.compile(r"([^\n]+?)\s+foo", flags=re.IGNORECASE)
+'
+assert_fails "flags=re.IGNORECASE keyword form is detected"
+reset_tmpdir
+
+# ─── Test 14: Non-capturing group wrapper does not hide the bad shape ────
+create_test_file "redos_noncap.py" 'import re
+BAD = re.compile(r"(?:[^\n]+?)\s+foo", re.IGNORECASE)
+'
+assert_fails "Non-capturing group wrapper (?:...) does not mask the lazy head"
+reset_tmpdir
+
+# ─── Test 15: Named-capture group wrapper does not hide the bad shape ────
+create_test_file "redos_named.py" 'import re
+BAD = re.compile(r"(?P<name>[^\n]+?)\s+foo", re.IGNORECASE)
+'
+assert_fails "Named-capture (?P<name>...) wrapper does not mask the lazy head"
+reset_tmpdir
+
+# ─── Test 16: Alternation with literal alternatives passes ───────────────
+# `(foo|bar).+?baz` starts with literal alternatives so the lazy
+# quantifier is anchored.  This is borderline but acceptable for a
+# heuristic — the literal alternatives prevent unbounded backtracking
+# from the start.
+create_test_file "redos_alternation.py" 'import re
+GOOD = re.compile(r"(foo|bar).+?baz", re.IGNORECASE)
+'
+assert_passes "Literal alternation (foo|bar) before lazy quantifier passes"
+reset_tmpdir
+
+# ─── Test 17: Bounded {1,80}? quantifier passes ──────────────────────────
+# A lazy {min,max}? is still lazy — but a small max bounds the work to
+# O(n) regardless.  Still, the heuristic flags ANY leading lazy
+# wildcard without a literal anchor.  When the pattern starts with `^`
+# the bounded form is the recommended fix.
+create_test_file "redos_bounded.py" 'import re
+GOOD = re.compile(r"^[^\n]{1,80}?\s+foo", re.IGNORECASE | re.MULTILINE)
+'
+assert_passes "^-anchored bounded {1,80}? lazy passes (recommended fix)"
+reset_tmpdir
+
+# ─── Test 18: Empty / no-match files pass ────────────────────────────────
+create_test_file "redos_empty.py" 'pass
+'
+assert_passes "Python file with no re.compile calls passes"
+reset_tmpdir
+
+# ─── Test 19: Non-Python file is ignored ─────────────────────────────────
+create_test_file "redos_not_python.txt" 're.compile(r"([^\n]+?)\s+foo", re.IGNORECASE)
+'
+assert_passes "Non-.py file is not scanned"
+reset_tmpdir
+
+# ─── Test 20: Syntactically broken Python is skipped silently ────────────
+create_test_file "redos_broken.py" 'import re
+def broken(:  # syntax error
+    pass
+'
+assert_passes "Syntactically broken Python is skipped silently"
+reset_tmpdir
+
+# ─── Test 21: f-string pattern (dynamic) is skipped ──────────────────────
+# We cannot statically know the value of an f-string pattern, so the
+# scanner skips it.  False negatives are acceptable per the heuristic.
+create_test_file "redos_fstring.py" 'import re
+suffix = "foo"
+BAD = re.compile(f"([^\n]+?)\s+{suffix}", re.IGNORECASE)
+'
+assert_passes "f-string pattern is skipped (dynamic — heuristic accepts FN)"
+reset_tmpdir
+
+# ─── Test 22: Variable pattern (dynamic) is skipped ──────────────────────
+create_test_file "redos_var.py" 'import re
+PATTERN = r"([^\n]+?)\s+foo"
+BAD = re.compile(PATTERN, re.IGNORECASE)
+'
+assert_passes "Variable pattern is skipped (dynamic — heuristic accepts FN)"
+reset_tmpdir
+
+# ─── Test 23: scripts/archive/ subdir is excluded ────────────────────────
+# Archived one-off scripts (already run, kept for posterity) are out of
+# scope — the bug class only matters for active code paths.
+mkdir -p "$TMPDIR_TEST/scripts/archive"
+printf 'import re\nBAD = re.compile(r"([^\\n]+?)\\s+foo", re.IGNORECASE)\n' \
+    > "$TMPDIR_TEST/scripts/archive/old_backfill.py"
+assert_passes "scripts/archive/ subdir is excluded from the scan"
+reset_tmpdir
+
+# ─── Test 24: .venv/ subdir is excluded ──────────────────────────────────
+mkdir -p "$TMPDIR_TEST/.venv/lib/python3.12/site-packages"
+printf 'import re\nBAD = re.compile(r"([^\\n]+?)\\s+foo", re.IGNORECASE)\n' \
+    > "$TMPDIR_TEST/.venv/lib/python3.12/site-packages/vendored.py"
+assert_passes ".venv/ subdir is excluded from the scan"
+reset_tmpdir
+
+# ─── Test 25: Multiple violations across files are all reported ──────────
+# Two files, each with one violation — the wrapper script must flag
+# the whole run as failed.
+create_test_file "v1.py" 'import re
+A = re.compile(r"([^\n]+?)\s+foo", re.IGNORECASE)
+'
+create_test_file "v2.py" 'import re
+B = re.compile(r"(.*?)bar", re.IGNORECASE)
+'
+assert_fails "Multiple violations across multiple files are all reported"
+reset_tmpdir
+
+# ─── Test 26: Direct file-path argument works ────────────────────────────
+# The wrapper accepts a file path directly (used by some CI configs).
+TESTS=$((TESTS + 1))
+single_file="$TMPDIR_TEST/single.py"
+mkdir -p "$TMPDIR_TEST"
+printf 'import re\nBAD = re.compile(r"([^\\n]+?)\\s+foo", re.IGNORECASE)\n' \
+    > "$single_file"
+if "$CHECK_SCRIPT" "$single_file" > /dev/null 2>&1; then
+    echo "FAIL: Direct .py file path argument detects violations (expected failure, got success)"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: Direct .py file path argument detects violations"
+fi
+reset_tmpdir
+
+# ─── Test 27: No self-match on ci.yml step name ──────────────────────────
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-redos-pattern.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI hygiene guard `scripts/check-no-redos-pattern.sh` that detects ReDoS-shaped `re.compile()` call sites — those starting with an unanchored lazy quantifier (`+?` / `*?` / `{m,n}?`) before any literal anchor when `re.IGNORECASE` is set. This is the exact shape that caused the #4104 LA-judge production CPU peg (15+ seconds per 50KB federal opinion).

The check uses a Python AST walker (`scripts/check_no_redos_pattern.py`) for `re.compile` call detection + a regex-prefix classifier for the leading-lazy-quantifier shape. Heuristic-level by design (false negatives acceptable, false positives suppressed via `# noqa: redos-pattern` on the call-site line). Wired as standalone `redos-pattern-check` job in `ci.yml` and into `ci-passed.needs`.

Closes #4117

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_no_redos_pattern.sh` — 27 tests, all pass locally)
- [x] CI green (incl. new `redos-pattern-check` job)

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check only; runs in GitHub Actions, no service code path).
