### PR TITLE
fix(ingestion): map DB 'txt' format to ContentFormat.TEXT in reingest_from_s3 (#4122)

### DIFF
--- a/packages/scraper-framework/src/framework/models.py
+++ b/packages/scraper-framework/src/framework/models.py
@@ -36,6 +36,39 @@ class ContentFormat(StrEnum):
     DOCX = "docx"
     TEXT = "text"
 
+    @classmethod
+    def from_db_value(cls, db_value: str) -> ContentFormat:
+        """Map ``derived.documents.format`` enum values to ``ContentFormat`` members.
+
+        DB enum (``packages/api/migrations/1_initial-schema.sql``):
+            ``('html', 'pdf', 'docx', 'txt')``
+        Python enum (this class):
+            ``HTML='html'``, ``PDF='pdf'``, ``DOCX='docx'``, ``TEXT='text'``
+
+        The DB stores ``'txt'`` while the Python enum spells the textual
+        format ``'text'``.  The bare ``ContentFormat(<db value>)`` constructor
+        therefore raises ``ValueError`` for every ``'txt'`` row — the failure
+        mode that produced #4122 (silently swallowed by reingest_from_s3.py's
+        ``except Exception:`` block, masking 98% of Federal CourtListener
+        documents from the case-title mapper fix in #3970).
+
+        This helper is the single sanctioned bridge between the two value
+        sets and is one-way: it accepts only DB enum values, not Python enum
+        values.  Round-tripping ``'text'`` through here intentionally raises
+        ``ValueError`` so a future "make it bidirectional" refactor cannot
+        silently re-introduce the original bug class.
+        """
+        mapping = {
+            "html": cls.HTML,
+            "pdf": cls.PDF,
+            "docx": cls.DOCX,
+            "txt": cls.TEXT,
+        }
+        try:
+            return mapping[db_value]
+        except KeyError as exc:
+            raise ValueError(f"{db_value!r} is not a valid derived.documents.format value") from exc
+
 
 # ---------------------------------------------------------------------------
 # Scraper configuration

--- a/packages/scraper-framework/tests/test_models.py
+++ b/packages/scraper-framework/tests/test_models.py
@@ -1,0 +1,59 @@
+"""Tests for framework.models — focused on enum helpers shared by the
+ingestion pipeline and the reingest-from-S3 script.
+
+Regression coverage for #4122: the DB ``derived.documents.format`` enum
+stores ``'txt'``, but the Python ``ContentFormat`` enum spells it
+``'text'``.  ``ContentFormat.from_db_value`` is the single helper that
+bridges the two; the script-side fix at
+``scripts/reingest_from_s3.py`` calls it at three sites that previously
+raised ``ValueError`` for every Federal CourtListener ``.txt``
+document.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.models import ContentFormat
+
+
+class TestContentFormatFromDbValue:
+    """``ContentFormat.from_db_value`` maps DB enum values to enum members.
+
+    The DB ``document_format`` enum (``packages/api/migrations/1_initial-schema.sql``
+    line 166) is ``('html', 'pdf', 'docx', 'txt')``; the Python enum uses
+    ``'text'`` for the textual format.  This helper is the only sanctioned
+    place to bridge that gap (#4122).
+    """
+
+    def test_txt_maps_to_text(self) -> None:
+        # The bug case — DB-side 'txt' must round-trip to TEXT without raising.
+        # Pre-fix, ContentFormat('txt') raised ValueError silently swallowed by
+        # reingest_from_s3.py's parse_document fallback path.
+        assert ContentFormat.from_db_value("txt") is ContentFormat.TEXT
+
+    def test_html_maps_to_html(self) -> None:
+        assert ContentFormat.from_db_value("html") is ContentFormat.HTML
+
+    def test_pdf_maps_to_pdf(self) -> None:
+        assert ContentFormat.from_db_value("pdf") is ContentFormat.PDF
+
+    def test_docx_maps_to_docx(self) -> None:
+        assert ContentFormat.from_db_value("docx") is ContentFormat.DOCX
+
+    def test_unknown_value_raises_value_error(self) -> None:
+        # An unknown DB value must raise ValueError (not KeyError) so the
+        # call sites in reingest_from_s3.py — and any future consumer —
+        # see a uniform exception type aligned with the previous
+        # ``ContentFormat(<bad>)`` constructor behavior.
+        with pytest.raises(ValueError, match="not a valid"):
+            ContentFormat.from_db_value("rtf")
+
+    def test_text_is_not_a_valid_db_value(self) -> None:
+        # Reverse direction sanity check — the Python-side spelling
+        # 'text' is NOT a valid DB value.  The helper is one-way: it
+        # accepts the DB enum's value set, not the Python enum's value
+        # set.  This guards against an accidental "make it bidirectional"
+        # refactor that would silently swallow the original bug class.
+        with pytest.raises(ValueError, match="not a valid"):
+            ContentFormat.from_db_value("text")

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -462,6 +462,105 @@ class TestReparseDocumentNulBytes:
 
 
 # ---------------------------------------------------------------------------
+# _reparse_document tests — DB format='txt' regression (#4122)
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentDbFormatTxt:
+    """Regression coverage for #4122.
+
+    The DB ``derived.documents.format`` enum stores ``'txt'`` while the
+    Python ``ContentFormat`` enum spells the textual format ``'text'``.
+    Pre-fix, the bare ``ContentFormat(doc_meta["format"])`` constructor
+    at lines 927/1391/1921 of ``scripts/reingest_from_s3.py`` raised
+    ``ValueError: 'txt' is not a valid ContentFormat`` for every Federal
+    CourtListener ``.txt`` document — silently swallowed by the
+    surrounding ``except Exception:`` block.  The fix routes all three
+    sites through ``ContentFormat.from_db_value`` which maps
+    ``'txt'`` → ``ContentFormat.TEXT``.
+
+    These tests assert that ``_reparse_document`` runs ``parse_document``
+    end-to-end on a ``format='txt'`` ``doc_meta`` (no silent fallback),
+    which is the integration-level guarantee the line 927 site needs.
+    The other two call sites (1391, 1921) are mechanically identical and
+    covered by the unit-level test at ``tests/test_models.py``.
+    """
+
+    def _doc_meta(self) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "Federal",
+            "county": "Federal",
+            "court_name": "CourtListener",
+            "source_url": "https://www.courtlistener.com/opinion/9e269fb7/",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            # 'txt' is the DB enum value (matches the document_format
+            # SQL enum); pre-fix this string raised ValueError when fed
+            # straight into the ContentFormat constructor.
+            "format": "txt",
+            "case_number": "1:25-cv-00001",
+            "case_title": "State v. Evans",
+            "hearing_date": None,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "federal-courtlistener-opinions",
+            "s3_key": "federal/federal/courtlistener/raw/abc123.txt",
+            "s3_bucket": "test-bucket",
+        }
+
+    def test_format_txt_runs_scraper_parse_document_without_value_error(
+        self,
+    ) -> None:
+        """``format='txt'`` must reach ``parse_document`` — not the
+        ``except Exception`` fallback path.
+
+        Pre-fix, ``CapturedDocument(... content_format=ContentFormat('txt'))``
+        raised ``ValueError`` and the scraper's ``parse_document`` was
+        never invoked.  We assert the mock's ``parse_document`` is
+        called exactly once, and that the parsed fields propagate into
+        the returned ``extracted`` dict — proving the wiring at line 927
+        of ``scripts/reingest_from_s3.py`` works for the txt format.
+        """
+        raw = b"OPINION OF THE COURT\n\nThe judgment of conviction is AFFIRMED.\n"
+        mock_scraper_cls = MagicMock()
+        mock_parsed = MagicMock()
+        mock_parsed.ruling_text = (
+            "OPINION OF THE COURT\n\nThe judgment of conviction is AFFIRMED.\n"
+        )
+        mock_parsed.case_number = "1:25-cv-00001"
+        # Simulate the #3970 mapper — case_name_full populated, so the
+        # scraper-emitted title is the full caption rather than the
+        # surname-only short form that AC#2 of #3978 measures.
+        mock_parsed.case_title = "State v. Evans"
+        mock_parsed.judge_name = None
+        mock_parsed.outcome = None
+        mock_parsed.motion_type = None
+        mock_parsed.department = None
+        mock_parsed.parties = []
+        mock_parsed.hearing_date = None
+        mock_scraper_cls.return_value.parse_document.return_value = mock_parsed
+        reingest._SCRAPER_REGISTRY["federal-courtlistener-opinions"] = mock_scraper_cls
+
+        try:
+            result = reingest._reparse_document(
+                raw,
+                "federal-courtlistener-opinions",
+                self._doc_meta(),
+            )
+            # parse_document MUST have run — pre-fix this was zero.
+            assert mock_scraper_cls.return_value.parse_document.call_count == 1
+            # The parsed full-caption title must propagate into the result.
+            # Pre-fix the regex fallback path produced None (or the
+            # surname-only DB value), never the parser's full caption.
+            assert result["case_title"] == "State v. Evans"
+            # And the extraction-method label must reflect that the
+            # scraper actually ran.
+            assert result["extraction_methods"].get("case_title") == "scraper"
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("federal-courtlistener-opinions", None)
+
+
+# ---------------------------------------------------------------------------
 # _reparse_document tests — stored_ruling_text format awareness (#2360)
 # ---------------------------------------------------------------------------
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -924,7 +924,7 @@ def _reparse_document(
                 court=doc_meta["court_name"],
                 source_url=doc_meta["source_url"],
                 capture_timestamp=doc_meta["captured_at"],
-                content_format=ContentFormat(doc_meta["format"]),
+                content_format=ContentFormat.from_db_value(doc_meta["format"]),
                 raw_content=raw_content,
                 content_hash=doc_meta["content_hash"],
             )
@@ -1388,7 +1388,7 @@ def _full_reparse_document(
                 court=doc_meta["court_name"],
                 source_url=doc_meta["source_url"],
                 capture_timestamp=doc_meta["captured_at"],
-                content_format=ContentFormat(doc_meta["format"]),
+                content_format=ContentFormat.from_db_value(doc_meta["format"]),
                 raw_content=raw_content,
                 content_hash=content_hash,
             )
@@ -1918,7 +1918,7 @@ def _reparse_document_multimodal(
                 court=doc_meta["court_name"],
                 source_url=doc_meta["source_url"],
                 capture_timestamp=doc_meta["captured_at"],
-                content_format=ContentFormat(doc_meta["format"]),
+                content_format=ContentFormat.from_db_value(doc_meta["format"]),
                 raw_content=raw_content,
                 content_hash=doc_meta.get("content_hash", ""),
             )


### PR DESCRIPTION
## Summary

The DB `derived.documents.format` enum stores `'txt'` while the Python `ContentFormat` enum spells the textual format `'text'`. Pre-fix, `scripts/reingest_from_s3.py` constructed `CapturedDocument` objects with `content_format=ContentFormat(doc_meta["format"])` at three sites (lines 927, 1391, 1921). For every Federal CourtListener `.txt` document — 2,479 of 2,529 (98%) — that constructor raised `ValueError: 'txt' is not a valid ContentFormat`, silently swallowed by the surrounding `except Exception:` blocks; the scraper's `parse_document` was therefore never invoked and the case-title mapper fix from #3970 never fired, leaving #3978's AC#2 pinned at 209.

This PR adds a `ContentFormat.from_db_value` classmethod that maps DB enum values to enum members, and routes all three reingest call sites through it. The mapping is intentionally one-way (`'text'` raises ValueError) so a future "make it bidirectional" refactor cannot silently re-introduce the original bug class.

Closes #4122

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] CloudWatch query `filter @message like /ContentFormat/ | filter @message like /'txt' is not a valid/` over the next reingest oneshot window returns `count = 0` (issue AC#1)
- [ ] Verification evidence posted on issue (see /task A.8)
