### PR TITLE
feat(ingestion): per-doc reingest_doc_timing log so perf bugs are self-diagnosing (#4116)

### DIFF
--- a/packages/scraper-framework/src/ingestion/doc_timing.py
+++ b/packages/scraper-framework/src/ingestion/doc_timing.py
@@ -1,0 +1,228 @@
+"""Per-document phase timing helper for the ingestion pipeline (#4116).
+
+Both ``packages/scraper-framework/src/ingestion/worker.py`` (live ingestion)
+and ``scripts/reingest_from_s3.py`` (offline reingest) process documents
+through the same logical phases:
+
+  1. ``parse_document_ms`` — extract text from the raw S3 content via
+     pdfplumber/HTML and run the scraper's ``parse_document()``.
+  2. ``regex_fallback_ms`` — apply deterministic regex fallbacks to fill
+     fields that scraper + LLM extraction left missing.
+  3. ``validation_ms`` — run the deterministic validator (#2424) against
+     the extracted ruling.
+  4. ``db_write_ms`` — upsert case + insert document/ruling + parties.
+
+When one of these phases regresses (e.g. #4104's quadratic regex on long
+opinion text), the bottleneck used to be invisible without external
+profiling.  This helper emits a single structured ``reingest_doc_timing``
+log line per document so the next perf bug in this pipeline is
+self-diagnosing.
+
+Usage::
+
+    from ingestion.doc_timing import DocTiming
+
+    with DocTiming(emit_fn, document_id="abc-123", county="Federal") as t:
+        with t.phase("parse_document_ms"):
+            text = parse_pdf(raw_content)
+            extracted = scraper.parse_document(...)
+
+        # ... LLM extraction ...
+
+        with t.phase("regex_fallback_ms"):
+            apply_regex_fallbacks(extracted, text)
+
+        with t.phase("validation_ms"):
+            det_result = run_deterministic_rules(...)
+
+        with t.phase("db_write_ms"):
+            upsert_case(...)
+            insert_document_and_ruling(...)
+
+On context-manager exit, ``DocTiming`` calls ``emit_fn(payload)`` once
+with a dict shaped like::
+
+    {
+      "event": "reingest_doc_timing",
+      "document_id": "abc-123",
+      "county": "Federal",
+      "parse_document_ms": 12,
+      "regex_fallback_ms": 2419,
+      "validation_ms": 8,
+      "db_write_ms": 47,
+      "total_ms": 2486,
+    }
+
+Two ready-made emitters are provided so the worker (stdlib logging) and
+the reingest script (structlog) can share the timing primitive without
+each call site having to know how to format the dict:
+
+  * :func:`emit_via_stdlib_logger` — for ``logging.Logger``.
+  * :func:`emit_via_structlog_logger` — for ``structlog.BoundLogger``.
+
+Phases that were never entered are reported as ``0``.  Calling
+``timing.phase(name)`` for an unknown phase raises ``ValueError`` so a
+typo in the call site fails loudly rather than dropping a measurement
+silently.
+
+Re-entering the same phase accumulates time (e.g. ``regex_fallback_ms``
+fires once per ruling for split documents).  This matches operator
+intuition: if a 5-ruling document spends 100ms in regex per ruling, the
+log line shows 500ms total time spent in that phase.
+
+Timer source: ``time.perf_counter()`` — high-resolution, monotonic, not
+affected by wall-clock adjustments.  Tests can mock this to assert
+specific bucket values deterministically.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import time
+from collections.abc import Callable, Iterator
+from typing import Any
+
+# Single source of truth for the bucket names.  Worker and reingest
+# import this so adding a new bucket only updates one place.
+PHASE_NAMES: tuple[str, ...] = (
+    "parse_document_ms",
+    "regex_fallback_ms",
+    "validation_ms",
+    "db_write_ms",
+)
+
+#: Stable event name used in both stdlib + structlog emitters.  Tests
+#: and CloudWatch Logs Insights queries pivot on this string, so it is
+#: defined once here.
+EVENT_NAME: str = "reingest_doc_timing"
+
+EmitFn = Callable[[dict[str, Any]], None]
+
+
+def emit_via_stdlib_logger(logger: logging.Logger) -> EmitFn:
+    """Build an emit function that writes via the stdlib ``logging`` API.
+
+    Used by ``ingestion.worker.IngestionWorker.process_event``.  The
+    framework's structlog stdlib bridge (``configure_structlog(
+    stdlib_bridge=True)``, used by the worker entrypoint) picks up the
+    ``extra=`` kwargs and renders them as JSON fields.
+    """
+
+    def _emit(payload: dict[str, Any]) -> None:
+        # Pop ``event`` so it doesn't clash with logging's positional
+        # message; pass it as the message instead so it appears under
+        # the standard "message"/"event" key in the structured output.
+        event = payload.pop("event", EVENT_NAME)
+        logger.info(event, extra={"telemetry_event": event, **payload})
+
+    return _emit
+
+
+def emit_via_structlog_logger(logger: Any) -> EmitFn:
+    """Build an emit function that writes via a ``structlog.BoundLogger``.
+
+    Used by ``scripts/reingest_from_s3.py`` which calls
+    ``structlog.get_logger()``.  structlog's API takes the event as
+    the first positional arg and **kwargs for context fields.
+    """
+
+    def _emit(payload: dict[str, Any]) -> None:
+        event = payload.pop("event", EVENT_NAME)
+        logger.info(event, **payload)
+
+    return _emit
+
+
+class DocTiming:
+    """Per-document phase timer.
+
+    The timer accumulates time across multiple calls to :meth:`phase`
+    for the same phase name (re-entry is supported and additive —
+    useful when a single document produces multiple split rulings that
+    each go through validation + db_write).
+
+    Attributes are intentionally minimal so the helper stays cheap in
+    the hot path.  Callers that don't want a log line (e.g. unit tests
+    on unrelated code paths) should not instantiate ``DocTiming`` at
+    all — this class is the explicit instrumentation hook, not a
+    background metric.
+    """
+
+    __slots__ = ("_buckets_ms", "_extra", "_emit_fn", "_emitted")
+
+    def __init__(self, emit_fn: EmitFn, **extra: Any) -> None:
+        """Create a timer.
+
+        Args:
+            emit_fn: Callable invoked once with the final payload dict
+                on context-manager exit (or on the first manual
+                :meth:`emit`).  Use :func:`emit_via_stdlib_logger` or
+                :func:`emit_via_structlog_logger` to bind it to a
+                logger.
+            **extra: Free-form fields merged into the payload (e.g.
+                ``document_id``, ``county``, ``scraper_id``).  All
+                four phase buckets initialize to ``0`` so the log
+                line is rectangular even for documents that exited
+                early (e.g. deterministic-validation FAIL with no DB
+                write).
+        """
+        self._buckets_ms: dict[str, float] = dict.fromkeys(PHASE_NAMES, 0.0)
+        self._extra = dict(extra)
+        self._emit_fn = emit_fn
+        self._emitted = False
+
+    @contextlib.contextmanager
+    def phase(self, name: str) -> Iterator[None]:
+        """Time a phase.  Re-entering the same name accumulates."""
+        self._validate_phase(name)
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            self._buckets_ms[name] += elapsed_ms
+
+    def add_ms(self, name: str, elapsed_ms: float) -> None:
+        """Add ``elapsed_ms`` to a phase bucket without using a context manager.
+
+        Useful when re-indenting a long block under ``with timing.phase(...)``
+        would create a 100+-line diff or fight an existing ``try/except`` —
+        the caller takes a ``time.perf_counter()`` reading at the boundaries
+        and hands the delta to this helper.  The bucket-name validation and
+        accumulation semantics are identical to :meth:`phase`.
+        """
+        self._validate_phase(name)
+        self._buckets_ms[name] += elapsed_ms
+
+    def _validate_phase(self, name: str) -> None:
+        if name not in self._buckets_ms:
+            raise ValueError(f"Unknown phase {name!r}. Valid phases: {PHASE_NAMES}")
+
+    def emit(self) -> None:
+        """Emit the structured log line.
+
+        Idempotent — calling more than once is a no-op so the
+        ``__exit__`` path can rely on ``emit()`` even when callers
+        also invoke it manually for early-return paths (e.g.
+        deterministic-validation FAIL skips the DB write but still
+        wants the partial timing record).
+        """
+        if self._emitted:
+            return
+        self._emitted = True
+        rounded = {name: round(self._buckets_ms[name]) for name in PHASE_NAMES}
+        total_ms = sum(rounded.values())
+        payload: dict[str, Any] = {
+            "event": EVENT_NAME,
+            **self._extra,
+            **rounded,
+            "total_ms": total_ms,
+        }
+        self._emit_fn(payload)
+
+    def __enter__(self) -> DocTiming:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.emit()

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -67,6 +67,7 @@ from .db import (
     upsert_court,
 )
 from .department_normalize import normalize_department
+from .doc_timing import DocTiming, emit_via_stdlib_logger
 from .extract import (
     clean_case_title,
     dedupe_repeated_title,
@@ -1646,6 +1647,59 @@ class IngestionWorker:
           3. Fall back to regex extraction.
 
         Exposed for testing. Raises on unrecoverable errors.
+
+        Per-doc phase timing (#4116) is emitted as a single
+        ``reingest_doc_timing`` log line on every exit path (success,
+        early-return, raise) so the next perf bug in this pipeline is
+        self-diagnosing.  Bookkeeping lives in :meth:`_process_event_timed`
+        — see ``ingestion.doc_timing`` for the helper's contract.
+        """
+        # Pipeline branch — non-ruling scrapers (#3688).
+        # The ca-governor-appointments scraper emits judge-bio press releases
+        # that share the CapturedDocument shape but are NOT rulings. Without
+        # this branch the LLM extractor produces UNKNOWN-* case_numbers,
+        # empty case_titles, and a 'Governor / Statewide' court row that
+        # pollutes derived.rulings (178 rows as of 2026-04-28). Raw HTML is
+        # preserved in S3 + staging.captures so #2144 can recover appointee
+        # data via courts.ca.governor_appointments.parse_appointees().
+        scraper_id: str = event_data.get("scraper_id", "")
+        if scraper_id == "ca-governor-appointments":
+            logger.info(
+                "Routing governor-appointment document to bio path (skipping ruling extraction)",
+                extra={
+                    "document_id": event_data["document_id"],
+                    "scraper_id": scraper_id,
+                    "telemetry_event": "governor_appointment_routed_to_bio_path",
+                },
+            )
+            return
+
+        timing = DocTiming(
+            emit_via_stdlib_logger(logger),
+            document_id=event_data["document_id"],
+            county=event_data["county"],
+            state=event_data["state"],
+            scraper_id=scraper_id,
+        )
+        try:
+            self._process_event_timed(event_data, timing)
+        finally:
+            timing.emit()
+
+    def _process_event_timed(
+        self,
+        event_data: dict[str, Any],
+        timing: DocTiming,
+    ) -> None:
+        """Inner body of :meth:`process_event` wrapped by ``DocTiming``.
+
+        Split out so :meth:`process_event` can emit one
+        ``reingest_doc_timing`` log line on every exit path (success,
+        early-return, raise) without re-indenting the entire function
+        body.  ``timing`` accumulates per-phase elapsed time as
+        ``timing.phase(name)`` blocks fire inside this body — every
+        ``return`` from this method counts as an exit and triggers the
+        outer wrapper's ``timing.emit()`` exactly once.
         """
         document_id: str = event_data["document_id"]
         state: str = event_data["state"]
@@ -1677,74 +1731,64 @@ class IngestionWorker:
 
         strategy = decide_extraction_strategy(state, county, scraper_id=scraper_id)
 
-        # Pipeline branch — non-ruling scrapers (#3688).
-        # The ca-governor-appointments scraper emits judge-bio press releases
-        # that share the CapturedDocument shape but are NOT rulings. Without
-        # this branch the LLM extractor produces UNKNOWN-* case_numbers,
-        # empty case_titles, and a 'Governor / Statewide' court row that
-        # pollutes derived.rulings (178 rows as of 2026-04-28). Raw HTML is
-        # preserved in S3 + staging.captures so #2144 can recover appointee
-        # data via courts.ca.governor_appointments.parse_appointees().
-        if scraper_id == "ca-governor-appointments":
-            logger.info(
-                "Routing governor-appointment document to bio path (skipping ruling extraction)",
-                extra={
-                    "document_id": document_id,
-                    "scraper_id": scraper_id,
-                    "telemetry_event": "governor_appointment_routed_to_bio_path",
-                },
-            )
-            return
-
-        # PDF preprocessing: if ruling_text is raw PDF binary, extract text first.
-        # This handles documents where the scraper stored raw PDF bytes instead of
-        # extracted text (e.g. Riverside, Orange county PDFs).
-        #
-        # Preserve the raw PDF bytes before text extraction so the multimodal
-        # extraction path (per-page image LLM calls) can use them (#1590).
+        # ------------------------------------------------------------------
+        # PHASE: parse_document_ms (#4116)
+        # ------------------------------------------------------------------
+        # Cover the raw-PDF text extraction (pdfplumber via
+        # extract_text_from_pdf) plus the S3 multimodal-PDF download.  Both
+        # are bounded by IO + C-extension parsing latency, distinct from the
+        # downstream LLM call and DB write.
+        # ------------------------------------------------------------------
         raw_pdf_bytes: bytes | None = None
-        if ruling_text and content_format == "pdf" and is_pdf_binary(ruling_text):
-            raw_pdf_bytes = (
-                ruling_text.encode("latin-1") if isinstance(ruling_text, str) else ruling_text
-            )
-            extracted_pdf_text = extract_text_from_pdf(ruling_text)
-            if extracted_pdf_text:
-                logger.info(
-                    "Extracted text from raw PDF binary",
-                    extra={
-                        "document_id": document_id,
-                        "original_length": len(ruling_text),
-                        "extracted_length": len(extracted_pdf_text),
-                    },
+        with timing.phase("parse_document_ms"):
+            # PDF preprocessing: if ruling_text is raw PDF binary, extract text first.
+            # This handles documents where the scraper stored raw PDF bytes instead of
+            # extracted text (e.g. Riverside, Orange county PDFs).
+            #
+            # Preserve the raw PDF bytes before text extraction so the multimodal
+            # extraction path (per-page image LLM calls) can use them (#1590).
+            if ruling_text and content_format == "pdf" and is_pdf_binary(ruling_text):
+                raw_pdf_bytes = (
+                    ruling_text.encode("latin-1") if isinstance(ruling_text, str) else ruling_text
                 )
-                ruling_text = extracted_pdf_text
-            else:
-                logger.warning(
-                    "PDF text extraction returned no text — LLM may fail",
-                    extra={"document_id": document_id},
-                )
-                # When extraction returned empty (not None), normalize to
-                # empty string so the downstream "no ruling text" warning
-                # fires correctly (#1335).  When extraction returned None
-                # (complete failure), keep the original raw binary so
-                # existing behavior is preserved.
-                if extracted_pdf_text is not None:
-                    ruling_text = ""
+                extracted_pdf_text = extract_text_from_pdf(ruling_text)
+                if extracted_pdf_text:
+                    logger.info(
+                        "Extracted text from raw PDF binary",
+                        extra={
+                            "document_id": document_id,
+                            "original_length": len(ruling_text),
+                            "extracted_length": len(extracted_pdf_text),
+                        },
+                    )
+                    ruling_text = extracted_pdf_text
+                else:
+                    logger.warning(
+                        "PDF text extraction returned no text — LLM may fail",
+                        extra={"document_id": document_id},
+                    )
+                    # When extraction returned empty (not None), normalize to
+                    # empty string so the downstream "no ruling text" warning
+                    # fires correctly (#1335).  When extraction returned None
+                    # (complete failure), keep the original raw binary so
+                    # existing behavior is preserved.
+                    if extracted_pdf_text is not None:
+                        ruling_text = ""
 
-        # ------------------------------------------------------------------
-        # S3 PDF download for multimodal extraction (#2312)
-        # ------------------------------------------------------------------
-        # When a scraper pre-extracts PDF text in parse_document() (e.g.
-        # Santa Clara), ruling_text is pdfplumber text, not raw binary.
-        # is_pdf_binary() returns False, so raw_pdf_bytes stays None.
-        # For MULTIMODAL counties, download the original PDF from S3 so
-        # the multimodal path can send page images to the LLM.
-        if raw_pdf_bytes is None and content_format == "pdf" and s3_key:
-            # ``strategy.use_multimodal`` is True for ExtractionMethod.MULTIMODAL
-            # AND for unconfigured counties (the helper preserves the worker's
-            # pre-refactor default-multimodal behavior, #4081).
-            if strategy.use_multimodal:
-                raw_pdf_bytes = self._fetch_raw_pdf_from_s3(s3_key, s3_bucket, document_id)
+            # ------------------------------------------------------------------
+            # S3 PDF download for multimodal extraction (#2312)
+            # ------------------------------------------------------------------
+            # When a scraper pre-extracts PDF text in parse_document() (e.g.
+            # Santa Clara), ruling_text is pdfplumber text, not raw binary.
+            # is_pdf_binary() returns False, so raw_pdf_bytes stays None.
+            # For MULTIMODAL counties, download the original PDF from S3 so
+            # the multimodal path can send page images to the LLM.
+            if raw_pdf_bytes is None and content_format == "pdf" and s3_key:
+                # ``strategy.use_multimodal`` is True for ExtractionMethod.MULTIMODAL
+                # AND for unconfigured counties (the helper preserves the worker's
+                # pre-refactor default-multimodal behavior, #4081).
+                if strategy.use_multimodal:
+                    raw_pdf_bytes = self._fetch_raw_pdf_from_s3(s3_key, s3_bucket, document_id)
 
         # ------------------------------------------------------------------
         # Document splitting — detect multi-case calendar pages (#1475)
@@ -2026,49 +2070,56 @@ class IngestionWorker:
                 raise LlmEnrichmentExhaustedError("LLM enrichment exhausted all retries")
 
         # ------------------------------------------------------------------
+        # PHASE: regex_fallback_ms (#4116)
+        # ------------------------------------------------------------------
         # Remaining regex fallbacks — hearing_date, judge_name, case_number,
         # and case_type are still extracted via regex when missing.  The
         # enrichment fields (outcome, motion_type, case_title, parties)
         # are handled exclusively by LLM enrichment above (#2178).
+        #
+        # ``clean_ruling_text`` is included in this bucket — it runs the
+        # same regex-heavy text normalization as the other fallbacks and
+        # was implicated in the #4104 quadratic-cost regression.
         # ------------------------------------------------------------------
-        if hearing_dt is None and ruling_text:
-            hearing_dt = extract_hearing_date(ruling_text)
-            if hearing_dt is not None:
-                extraction_methods.setdefault("hearing_date", "regex")
-                logger.info(
-                    "Extracted hearing_date from ruling text (regex fallback)",
-                    extra={"document_id": document_id, "hearing_date": str(hearing_dt)},
-                )
+        with timing.phase("regex_fallback_ms"):
+            if hearing_dt is None and ruling_text:
+                hearing_dt = extract_hearing_date(ruling_text)
+                if hearing_dt is not None:
+                    extraction_methods.setdefault("hearing_date", "regex")
+                    logger.info(
+                        "Extracted hearing_date from ruling text (regex fallback)",
+                        extra={"document_id": document_id, "hearing_date": str(hearing_dt)},
+                    )
 
-        if is_llm_extracted and ruling_text:
-            if judge_name is None:
-                judge_name = extract_judge_name(ruling_text)
-                if judge_name is not None:
-                    extraction_methods["judge_name"] = "regex_post_llm"
+            if is_llm_extracted and ruling_text:
+                if judge_name is None:
+                    judge_name = extract_judge_name(ruling_text)
+                    if judge_name is not None:
+                        extraction_methods["judge_name"] = "regex_post_llm"
 
-        # case_type from case number — does not require ruling_text.
-        if case_type is None and case_number:
-            case_type = extract_case_type_from_number(case_number)
-            if case_type:
-                extraction_methods.setdefault("case_type", "regex")
+            # case_type from case number — does not require ruling_text.
+            if case_type is None and case_number:
+                case_type = extract_case_type_from_number(case_number)
+                if case_type:
+                    extraction_methods.setdefault("case_type", "regex")
 
-        # Clean ruling text for display — the cleaned version is stored
-        # in Postgres.
-        cleaned_ruling_text = clean_ruling_text(ruling_text)
+            # Clean ruling text for display — the cleaned version is stored
+            # in Postgres.
+            cleaned_ruling_text = clean_ruling_text(ruling_text)
 
-        court_name = f"{court}, County of {county}"
+            court_name = f"{court}, County of {county}"
 
-        # Fallback case number extraction (regex)
-        if not case_number and ruling_text:
-            extracted = extract_case_number(ruling_text)
-            if extracted:
-                method = "regex_post_llm" if is_llm_extracted else "regex"
-                extraction_methods.setdefault("case_number", method)
-                logger.info(
-                    "Extracted case_number from ruling text (regex fallback)",
-                    extra={"document_id": document_id, "case_number": extracted},
-                )
-                case_number = extracted
+            # Fallback case number extraction (regex)
+            if not case_number and ruling_text:
+                extracted = extract_case_number(ruling_text)
+                if extracted:
+                    method = "regex_post_llm" if is_llm_extracted else "regex"
+                    extraction_methods.setdefault("case_number", method)
+                    logger.info(
+                        "Extracted case_number from ruling text (regex fallback)",
+                        extra={"document_id": document_id, "case_number": extracted},
+                    )
+                    case_number = extracted
 
         # ------------------------------------------------------------------
         # Deterministic case_title cleanup (#2212, #2370)
@@ -2421,19 +2472,22 @@ class IngestionWorker:
             )
 
         # ------------------------------------------------------------------
+        # PHASE: validation_ms (deterministic, #4116)
+        # ------------------------------------------------------------------
         # Deterministic validation rules — cheap, rule-based checks that
         # run on every document (#2329).  These catch obvious structural
         # failures (raw HTML, wrong dates, concatenated titles) without
         # requiring an LLM call.  Runs before the LLM validation gate.
         # ------------------------------------------------------------------
         captured_at_date: date | None = capture_ts.date() if capture_ts else None
-        det_result = run_deterministic_rules(
-            ruling_text=cleaned_ruling_text,
-            case_number=case_number or f"UNKNOWN-{document_id}",
-            case_title=case_title,
-            hearing_date=hearing_dt,
-            captured_at=captured_at_date,
-        )
+        with timing.phase("validation_ms"):
+            det_result = run_deterministic_rules(
+                ruling_text=cleaned_ruling_text,
+                case_number=case_number or f"UNKNOWN-{document_id}",
+                case_title=case_title,
+                hearing_date=hearing_dt,
+                captured_at=captured_at_date,
+            )
 
         if det_result.overall != "pass":
             logger.info(
@@ -2544,21 +2598,25 @@ class IngestionWorker:
         validation_result: ValidationResult | None = None
         if self._validation_enabled:
             hearing_date_str = str(hearing_dt) if hearing_dt else None
-            validation_result = validate_document(
-                ruling_text=cleaned_ruling_text,
-                case_number=case_number,
-                case_title=case_title,
-                judge_name=judge_name,
-                motion_type=motion_type,
-                outcome=outcome,
-                hearing_date=hearing_date_str,
-                department=department,
-                county=county,
-                client=self._validation_client,
-                # Provider intentionally omitted: validate_document falls
-                # through to LLM_PROVIDER env var (#4032).
-                timeout=self._llm_timeout,
-            )
+            # PHASE: validation_ms (LLM gate, #4116) — additive with the
+            # deterministic block above; same bucket so callers see total
+            # validation cost in one number.
+            with timing.phase("validation_ms"):
+                validation_result = validate_document(
+                    ruling_text=cleaned_ruling_text,
+                    case_number=case_number,
+                    case_title=case_title,
+                    judge_name=judge_name,
+                    motion_type=motion_type,
+                    outcome=outcome,
+                    hearing_date=hearing_date_str,
+                    department=department,
+                    county=county,
+                    client=self._validation_client,
+                    # Provider intentionally omitted: validate_document falls
+                    # through to LLM_PROVIDER env var (#4032).
+                    timeout=self._llm_timeout,
+                )
 
             logger.info(
                 "Validation gate result",
@@ -2725,6 +2783,12 @@ class IngestionWorker:
                 f"{content_hash}:ruling:{split_index}".encode()
             ).hexdigest()
 
+        # PHASE: db_write_ms (#4116) — boundary-marked rather than wrapped
+        # in a ``with timing.phase(...)`` to avoid re-indenting the ~170-
+        # line transaction body.  ``add_ms`` is called in the ``finally`` /
+        # ``except`` arms so a raised exception still records the time
+        # spent in the failed transaction.
+        _db_write_t0 = time.perf_counter()
         conn = self._get_connection()
         try:
             # 1. Ensure court exists
@@ -2899,7 +2963,9 @@ class IngestionWorker:
             conn.commit()
         except Exception:
             conn.rollback()
+            timing.add_ms("db_write_ms", (time.perf_counter() - _db_write_t0) * 1000.0)
             raise
+        timing.add_ms("db_write_ms", (time.perf_counter() - _db_write_t0) * 1000.0)
 
         # Index in OpenSearch.  For split rulings, always index (each split
         # gets its own OS entry keyed by the synthetic split document_id).

--- a/packages/scraper-framework/tests/ingestion/test_doc_timing.py
+++ b/packages/scraper-framework/tests/ingestion/test_doc_timing.py
@@ -249,10 +249,8 @@ def test_reparse_document_records_parse_and_regex_timing() -> None:
     import sys
 
     # Reuse the same path-bootstrap as test_reingest_from_s3.py.
-    _SCRIPTS_DIR = os.path.join(
-        os.path.dirname(__file__), "..", "..", "..", "..", "scripts"
-    )
-    sys.path.insert(0, _SCRIPTS_DIR)
+    scripts_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "scripts")
+    sys.path.insert(0, scripts_dir)
     reingest = importlib.import_module("reingest_from_s3")
 
     raw_html = b"<html><body><p>Some ruling text.</p></body></html>"

--- a/packages/scraper-framework/tests/ingestion/test_doc_timing.py
+++ b/packages/scraper-framework/tests/ingestion/test_doc_timing.py
@@ -1,0 +1,294 @@
+"""Tests for the per-doc ``reingest_doc_timing`` instrumentation (#4116).
+
+The ``DocTiming`` helper in ``ingestion.doc_timing`` is the shared
+primitive used by both ``ingestion.worker.IngestionWorker.process_event``
+(live ingestion) and ``scripts/reingest_from_s3.py`` (offline reingest)
+to emit one structured timing line per processed document.
+
+These tests verify:
+
+* The log line fires exactly once per document.
+* All four required phase keys are always present
+  (``parse_document_ms``, ``regex_fallback_ms``, ``validation_ms``,
+  ``db_write_ms``) — even when a phase was never entered.
+* Re-entering the same phase accumulates time additively (split-doc
+  semantics — see ``ingestion.doc_timing.DocTiming.add_ms``).
+* ``time.perf_counter`` is mocked deterministically so the bucket
+  values are exact integer ms.
+* Calling ``phase()`` with an unknown name fails loudly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from ingestion.doc_timing import (
+    EVENT_NAME,
+    PHASE_NAMES,
+    DocTiming,
+    emit_via_stdlib_logger,
+    emit_via_structlog_logger,
+)
+
+
+def _capture_emit() -> tuple[list[dict], callable]:
+    """Build a list-backed emit_fn for assertions."""
+    captured: list[dict] = []
+
+    def _emit(payload: dict) -> None:
+        captured.append(payload)
+
+    return captured, _emit
+
+
+def test_reingest_doc_timing_emits_all_required_keys() -> None:
+    """All four phase buckets + total + extras + event name must appear.
+
+    Acceptance criterion #3 (issue #4116): the log line carries all
+    expected keys with deterministic values when ``time.perf_counter``
+    is mocked.
+    """
+    captured, emit_fn = _capture_emit()
+
+    # Mock time.perf_counter to return increasing ticks (one tick per
+    # call, 0.1 seconds apart = 100 ms each).
+    ticks = iter([0.0, 0.1, 0.2, 0.32, 0.5, 0.55])
+    with patch("ingestion.doc_timing.time.perf_counter", side_effect=lambda: next(ticks)):
+        with DocTiming(
+            emit_fn,
+            document_id="abc-123",
+            county="Federal",
+        ) as t:
+            with t.phase("parse_document_ms"):  # 0.0 -> 0.1 = 100 ms
+                pass
+            with t.phase("regex_fallback_ms"):  # 0.2 -> 0.32 = 120 ms
+                pass
+            with t.phase("validation_ms"):  # 0.5 -> 0.55 = 50 ms
+                pass
+
+    assert len(captured) == 1
+    payload = captured[0]
+
+    # All four phase keys present + event + total_ms + extras.
+    for key in PHASE_NAMES:
+        assert key in payload, f"missing phase {key!r} in {payload}"
+
+    assert payload["event"] == EVENT_NAME
+    assert payload["document_id"] == "abc-123"
+    assert payload["county"] == "Federal"
+
+    # Deterministic mock values.
+    assert payload["parse_document_ms"] == 100
+    assert payload["regex_fallback_ms"] == 120
+    assert payload["validation_ms"] == 50
+    # Never entered → 0.
+    assert payload["db_write_ms"] == 0
+
+    # total_ms = sum of buckets.
+    assert payload["total_ms"] == 270
+
+
+def test_reingest_doc_timing_unentered_phases_report_zero() -> None:
+    """The log line is rectangular: every bucket has a value (default 0)."""
+    captured, emit_fn = _capture_emit()
+
+    with DocTiming(emit_fn, document_id="d1") as t:
+        # Don't enter any phase — should still emit with all four buckets.
+        del t
+
+    assert len(captured) == 1
+    payload = captured[0]
+    for key in PHASE_NAMES:
+        assert payload[key] == 0, f"{key} should default to 0, got {payload[key]}"
+    assert payload["total_ms"] == 0
+
+
+def test_reingest_doc_timing_phase_re_entry_accumulates() -> None:
+    """Re-entering the same phase (e.g. per-ruling regex on a split doc)
+    must accumulate, not overwrite.
+    """
+    captured, emit_fn = _capture_emit()
+
+    # 4 ticks: two phase blocks, each 50ms.
+    ticks = iter([0.0, 0.05, 0.1, 0.15])
+    with patch("ingestion.doc_timing.time.perf_counter", side_effect=lambda: next(ticks)):
+        with DocTiming(emit_fn, document_id="d1") as t:
+            with t.phase("regex_fallback_ms"):
+                pass
+            with t.phase("regex_fallback_ms"):
+                pass
+
+    assert captured[0]["regex_fallback_ms"] == 100  # 50 + 50, not 50
+
+
+def test_reingest_doc_timing_add_ms_accumulates() -> None:
+    """``add_ms`` writes directly to a bucket (used in worker.py + reingest
+    where re-indenting under ``with timing.phase(...)`` is impractical).
+    """
+    captured, emit_fn = _capture_emit()
+
+    with DocTiming(emit_fn, document_id="d1") as t:
+        t.add_ms("db_write_ms", 42.0)
+        t.add_ms("db_write_ms", 8.0)
+
+    assert captured[0]["db_write_ms"] == 50
+
+
+def test_reingest_doc_timing_unknown_phase_raises() -> None:
+    """Typos in phase names fail loudly rather than silently dropping."""
+    _, emit_fn = _capture_emit()
+    with DocTiming(emit_fn, document_id="d1") as t:
+        with pytest.raises(ValueError, match="Unknown phase"):
+            with t.phase("nonexistent_phase_ms"):
+                pass
+
+
+def test_reingest_doc_timing_emits_on_exception() -> None:
+    """Even when the body raises, the log line must still fire — that's
+    the whole point of the helper for #4104-style perf bugs.
+    """
+    captured, emit_fn = _capture_emit()
+
+    with pytest.raises(RuntimeError):
+        with DocTiming(emit_fn, document_id="d1") as t:
+            with t.phase("parse_document_ms"):
+                raise RuntimeError("simulated parse failure")
+
+    assert len(captured) == 1
+    assert captured[0]["document_id"] == "d1"
+
+
+def test_reingest_doc_timing_emit_is_idempotent() -> None:
+    """Manual ``emit()`` followed by ``__exit__`` only logs once."""
+    captured, emit_fn = _capture_emit()
+
+    t = DocTiming(emit_fn, document_id="d1")
+    t.emit()
+    t.emit()  # no-op
+
+    with t:
+        pass  # __exit__ also calls emit() — still no double-log
+
+    assert len(captured) == 1
+
+
+def test_emit_via_stdlib_logger_routes_to_logging_extra() -> None:
+    """``emit_via_stdlib_logger`` calls ``logger.info(event, extra=...)``."""
+    import logging
+
+    captured: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    log = logging.getLogger("test_doc_timing.stdlib")
+    log.setLevel(logging.DEBUG)
+    handler = _Capture()
+    log.addHandler(handler)
+
+    try:
+        with DocTiming(emit_via_stdlib_logger(log), document_id="d1") as t:
+            t.add_ms("parse_document_ms", 12.0)
+    finally:
+        log.removeHandler(handler)
+
+    assert len(captured) == 1
+    rec = captured[0]
+    assert rec.getMessage() == EVENT_NAME
+    # ``extra=`` kwargs land as record attributes.
+    assert rec.parse_document_ms == 12  # type: ignore[attr-defined]
+    assert rec.document_id == "d1"  # type: ignore[attr-defined]
+    assert rec.telemetry_event == EVENT_NAME  # type: ignore[attr-defined]
+
+
+def test_emit_via_structlog_logger_routes_to_kwargs() -> None:
+    """``emit_via_structlog_logger`` invokes ``logger.info(event, **payload)``.
+
+    Accepts a stand-in object with an ``info(event, **kwargs)`` shape so
+    we don't need to depend on structlog being importable in the test
+    environment.
+    """
+    captured: list[tuple[str, dict]] = []
+
+    class _StructlogStub:
+        def info(self, event: str, **kwargs: object) -> None:
+            captured.append((event, dict(kwargs)))
+
+    stub = _StructlogStub()
+
+    with DocTiming(emit_via_structlog_logger(stub), document_id="d1") as t:
+        t.add_ms("regex_fallback_ms", 25.0)
+
+    assert len(captured) == 1
+    event, kwargs = captured[0]
+    assert event == EVENT_NAME
+    assert kwargs["regex_fallback_ms"] == 25
+    assert kwargs["document_id"] == "d1"
+    # All four buckets always present.
+    for key in PHASE_NAMES:
+        assert key in kwargs
+
+
+def test_reparse_document_records_parse_and_regex_timing() -> None:
+    """End-to-end smoke: ``_reparse_document`` populates ``parse_document_ms``
+    and ``regex_fallback_ms`` on the returned dict so the per-doc loop
+    in :func:`reingest_from_s3.reingest_batch` can hand them to
+    :class:`DocTiming.add_ms`.
+
+    This guards the wiring between ``_reparse_document`` (instrumented
+    here for #4116) and the main DB-write loop that builds the
+    ``reingest_doc_timing`` log line.  The test bypasses the LLM (no
+    client), the registered scraper (unknown id), and external IO
+    (raw bytes are HTML).
+    """
+    import importlib
+    import os
+    import sys
+
+    # Reuse the same path-bootstrap as test_reingest_from_s3.py.
+    _SCRIPTS_DIR = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "..", "scripts"
+    )
+    sys.path.insert(0, _SCRIPTS_DIR)
+    reingest = importlib.import_module("reingest_from_s3")
+
+    raw_html = b"<html><body><p>Some ruling text.</p></body></html>"
+    doc_meta = {
+        "document_id": "00000000-0000-0000-0000-000000000001",
+        "case_id": "00000000-0000-0000-0000-000000000001",
+        "case_number": "C12345",
+        "case_title": "Smith v. Jones",
+        "case_type": "civil",
+        "court_id": "00000000-0000-0000-0000-000000000001",
+        "court_name": "Test Court",
+        "state": "CA",
+        "county": "TestCounty",
+        "scraper_id": "no-such-scraper-for-doc-timing-test",
+        "format": "html",
+        "captured_at": None,
+        "hearing_date": None,
+        "content_hash": "deadbeef",
+        "s3_key": "test/key.html",
+        "s3_bucket": "test-bucket",
+        "source_url": "https://example.com/x",
+        "stored_ruling_text": None,
+    }
+
+    result = reingest._reparse_document(
+        raw_html,
+        doc_meta["scraper_id"],
+        doc_meta,
+        pdf_timeout=5.0,
+        llm_client=None,
+    )
+
+    assert "parse_document_ms" in result
+    assert "regex_fallback_ms" in result
+    # Both phases run on every call path through _reparse_document — the
+    # values are real wall-clock measurements, not mocked, so we just
+    # assert >= 0.0 (perf_counter is monotonic).
+    assert result["parse_document_ms"] >= 0.0
+    assert result["regex_fallback_ms"] >= 0.0

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -206,6 +206,7 @@ from ingestion.db import (  # noqa: E402
     upsert_case,
     upsert_case_judge,
 )
+from ingestion.doc_timing import DocTiming, emit_via_structlog_logger  # noqa: E402
 from ingestion.extract import (  # noqa: E402
     dedupe_repeated_title,
     extract_case_number,
@@ -887,6 +888,13 @@ def _reparse_document(
     """
     _load_scraper_registry()
 
+    # Per-doc phase timing (#4116) — accumulated into the result dict so
+    # the main DB-write loop can pick them up via ``DocTiming.add_ms``
+    # without re-implementing parse/regex timing across the 3 reparse
+    # entry points.  ``regex_fallback_ms`` is filled in when
+    # ``_apply_regex_fallbacks`` runs (single chokepoint at line ~1196).
+    _parse_t0 = time.perf_counter()
+
     doc_format = doc_meta.get("format", "html")
     text = _extract_text_from_content(
         raw_content, doc_format, pdf_timeout=pdf_timeout
@@ -1018,6 +1026,10 @@ def _reparse_document(
                 extracted["ruling_text"] = section
         except Exception:
             pass  # Fall through to full-text extraction
+
+    # End of parse_document_ms phase (#4116) — captured before the LLM
+    # extraction call which has its own ``llm_latency_ms`` timer.
+    extracted["parse_document_ms"] = (time.perf_counter() - _parse_t0) * 1000.0
 
     # ------------------------------------------------------------------
     # LLM extraction — secondary method for missing fields
@@ -1190,7 +1202,9 @@ def _reparse_document(
     # Regex fallback — fill any fields still missing after scraper + LLM
     # ------------------------------------------------------------------
     extracted["extraction_methods"] = extraction_methods
+    _regex_t0 = time.perf_counter()
     _apply_regex_fallbacks(extracted, regex_text, scraper_id=scraper_id)
+    extracted["regex_fallback_ms"] = (time.perf_counter() - _regex_t0) * 1000.0
 
     if extraction_methods:
         logger.info(
@@ -1294,13 +1308,18 @@ def _full_reparse_document(
         result["is_split"] = False
         return [result]
 
-    # Extract text from the raw content (PDF or HTML)
+    # Extract text from the raw content (PDF or HTML).  ``parse_document_ms``
+    # in the split-doc path covers only the text extraction here — the
+    # downstream split function may invoke its own LLM call which is timed
+    # separately by the LLM extractor.
+    _split_parse_t0 = time.perf_counter()
     doc_format = doc_meta.get("format", "html")
     text = _extract_text_from_content(
         raw_content,
         doc_format,
         pdf_timeout=pdf_timeout,
     ).replace("\x00", "")
+    _split_parse_ms = (time.perf_counter() - _split_parse_t0) * 1000.0
 
     # Prefer LLM-based splitting when available — it produces higher-quality
     # ruling_text (e.g. full legal analyses instead of disposition summaries,
@@ -1507,10 +1526,19 @@ def _full_reparse_document(
         # Regex fallback — fill any fields still missing after split (#1749)
         # Uses the shared helper to stay in sync with _reparse_document().
         # ------------------------------------------------------------------
+        _regex_t0 = time.perf_counter()
         if extracted["ruling_text"]:
             _apply_regex_fallbacks(
                 extracted, extracted["ruling_text"], scraper_id=scraper_id
             )
+        extracted["regex_fallback_ms"] = (time.perf_counter() - _regex_t0) * 1000.0
+
+        # Attribute the doc-level parse_document_ms to the first ruling so
+        # the per-doc timing log captures the work-once cost; subsequent
+        # rulings within the same split see 0 for parse_document_ms but
+        # carry their own regex_fallback_ms.  The main DB-write loop
+        # accumulates across all extracted entries from the same doc.
+        extracted["parse_document_ms"] = _split_parse_ms if not results else 0.0
 
         results.append(extracted)
 
@@ -2023,6 +2051,7 @@ def _reparse_document_multimodal(
         # and case_title from page images.  Other fields (judge_name,
         # outcome, motion_type) may still be missing and can be filled
         # by regex extraction from the ruling text.
+        _regex_t0 = time.perf_counter()
         if extracted["ruling_text"]:
             _apply_regex_fallbacks(
                 extracted, extracted["ruling_text"], scraper_id=scraper_id
@@ -2038,6 +2067,11 @@ def _reparse_document_multimodal(
                 if val:
                     extracted["case_type"] = val
                     extracted["extraction_methods"].setdefault("case_type", "regex")
+        extracted["regex_fallback_ms"] = (time.perf_counter() - _regex_t0) * 1000.0
+        # Multimodal does not invoke pdfplumber; ``parse_document_ms`` is
+        # 0 for this path.  The multimodal LLM call itself is timed
+        # separately by ``LlmExtractor`` (#4116).
+        extracted["parse_document_ms"] = 0.0
 
         # LLM enrichment — fills outcome, motion_type, case_title, parties.
         # The multimodal transcription pipeline deliberately does NOT extract
@@ -2549,6 +2583,25 @@ def reingest_batch(
         doc_id_str = doc_meta["document_id"]
         court_id_str = doc_meta["court_id"]
 
+        # Per-doc phase timing (#4116).  Parse + regex_fallback ms are
+        # already accumulated on each entry of ``extracted_list`` by the
+        # parse functions; this loop adds them up and times its own
+        # validation_ms + db_write_ms boundaries.  ``timing.emit()`` runs
+        # exactly once per source document on every exit path (success,
+        # exception, deterministic-FAIL skip-this-ruling).
+        timing = DocTiming(
+            emit_via_structlog_logger(logger),
+            document_id=doc_id_str,
+            county=doc_meta.get("county"),
+            state=doc_meta.get("state"),
+            scraper_id=doc_meta.get("scraper_id"),
+        )
+        for _e in extracted_list:
+            if "parse_document_ms" in _e:
+                timing.add_ms("parse_document_ms", _e.pop("parse_document_ms"))
+            if "regex_fallback_ms" in _e:
+                timing.add_ms("regex_fallback_ms", _e.pop("regex_fallback_ms"))
+
         try:
             with conn.transaction():
                 # Check if this document was split into multiple rulings
@@ -2622,6 +2675,7 @@ def reingest_batch(
                         for num in sibling_case_numbers
                         if num and num != own_case_number
                     ]
+                    _val_t0 = time.perf_counter()
                     det_result = run_deterministic_rules(
                         ruling_text=extracted.get("ruling_text"),
                         case_number=own_case_number,
@@ -2629,6 +2683,10 @@ def reingest_batch(
                         hearing_date=det_hearing,
                         captured_at=captured_at_date,
                         other_case_numbers=other_nums or None,
+                    )
+                    timing.add_ms(
+                        "validation_ms",
+                        (time.perf_counter() - _val_t0) * 1000.0,
                     )
                     if det_result.overall != "pass":
                         logger.info(
@@ -2683,6 +2741,7 @@ def reingest_batch(
                         # Skip this ruling's DB write but continue with
                         # sibling rulings from the same document.
                         continue
+                    _db_t0 = time.perf_counter()
                     effective_case_number = (
                         extracted["case_number"]
                         or doc_meta["case_number"]
@@ -2811,6 +2870,9 @@ def reingest_batch(
                     batch_upsert_parties(
                         conn, new_case_id, extracted.get("parties", [])
                     )
+                    timing.add_ms(
+                        "db_write_ms", (time.perf_counter() - _db_t0) * 1000.0
+                    )
 
             conn.commit()
             updated += 1
@@ -2831,6 +2893,11 @@ def reingest_batch(
                 document_id=doc_id_str,
                 exc_info=True,
             )
+        finally:
+            # Emit the per-doc ``reingest_doc_timing`` log line on every
+            # exit path (commit success, exception, deterministic FAIL).
+            # Idempotent — DocTiming.emit guards against double-emission.
+            timing.emit()
 
     return {
         "processed": processed,


### PR DESCRIPTION
## Summary

Add a shared per-document phase-timing helper in `packages/scraper-framework/src/ingestion/doc_timing.py` and wire it into both the live ingestion worker (`IngestionWorker.process_event`) and the offline reingest script (`scripts/reingest_from_s3.py`).

The helper emits one structured `reingest_doc_timing` log line per processed document with four phase buckets (`parse_document_ms`, `regex_fallback_ms`, `validation_ms`, `db_write_ms`) plus `total_ms` and identifying fields. Phase recording uses `time.perf_counter` so tests can mock it deterministically.

When the next perf bug hits this hot path (#4104 for the regex fallback, #4061 for LLM-skip latency), CloudWatch Logs Insights queries on `telemetry_event = "reingest_doc_timing"` will show which bucket regressed without an external profiling round-trip.

Closes #4116.

## Note

The implementing agent ran out of usage budget before opening this PR. Branch was pushed cleanly with 2 commits (the second is a ruff N806 rename). Dispatcher (parent session) is opening the PR per `feedback_task_subagent_ci_watch_exhaustion.md`.

## Test plan

- [x] 10 new tests in `packages/scraper-framework/tests/ingestion/test_doc_timing.py` (per implementing agent's process summary on the issue)
- [x] Worker tests + full scraper-framework suite green locally per agent's report
- [ ] CI green (will be confirmed via `gh pr merge --auto`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
