### PR TITLE
ci(terraform): assert ALL expected postconditions, not first-match-wins (#4037)

### DIFF
--- a/infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/check.sh
+++ b/infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/check.sh
@@ -48,29 +48,46 @@ set -e
 
 echo "$plan_output"
 
-# Any one of the missing-secret / digest-pin / stopTimeout
-# postconditions firing at plan time is sufficient proof the fixture
-# is well-formed. The fixture intentionally trips the missing-secret +
-# digest-pin checks via `aws_ecs_task_definition.broken` and the
-# stopTimeout check via `aws_ecs_task_definition.broken_stop_timeout`
-# (#3940).
-if echo "$plan_output" | grep -q "missing ANTHROPIC_API_KEY"; then
-  echo "PASS: missing-secret postcondition fired at plan time (preferred)."
-  exit 0
-fi
-if echo "$plan_output" | grep -q "is not digest-pinned"; then
-  echo "PASS: digest-pin postcondition fired at plan time (preferred)."
-  exit 0
-fi
-if echo "$plan_output" | grep -q 'stopTimeout != 120'; then
-  echo "PASS: stopTimeout-cap postcondition fired at plan time (preferred)."
+# #4037: assert ALL expected postcondition messages are present, not
+# first-match-wins. The previous shape ("any one PASS = exit 0") would
+# silently mask a regression that disabled, e.g., the stopTimeout
+# postcondition -- the missing-secret PASS would still be observed
+# first and the script would exit 0.
+#
+# The fixture intentionally trips the missing-secret + digest-pin
+# checks via `aws_ecs_task_definition.broken` and the stopTimeout
+# check via `aws_ecs_task_definition.broken_stop_timeout` (#3940).
+# All three error messages should appear concurrently in the same
+# `terraform plan` output.
+expected_passes=(
+  "missing ANTHROPIC_API_KEY"
+  "is not digest-pinned"
+  'stopTimeout != 120'
+)
+missing=()
+for needle in "${expected_passes[@]}"; do
+  if ! echo "$plan_output" | grep -q "$needle"; then
+    missing+=("$needle")
+  fi
+done
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo "PASS: all expected postconditions fired at plan time."
   exit 0
 fi
 
-if [ "$plan_exit" -eq 0 ]; then
+# Deferred-to-apply fallback: if plan succeeded AND no needles fired,
+# the postconditions are deferred to apply (expected when self.*
+# references are not knowable until apply). Only a *complete* miss is
+# acceptable here -- a partial miss (some needles present, others not)
+# means at least one postcondition was definitely evaluated at plan
+# time but a sibling did not fire, which is the regression class this
+# script must catch.
+if [ "$plan_exit" -eq 0 ] && [ ${#missing[@]} -eq ${#expected_passes[@]} ]; then
   echo "PASS: plan succeeded -- postconditions deferred to apply (expected when self.* references are not knowable until apply)."
   exit 0
 fi
 
-echo "FAIL: terraform plan exited $plan_exit but no expected postcondition error message was visible in the output." >&2
+echo "FAIL: expected postcondition messages not seen in plan output (plan_exit=$plan_exit):" >&2
+printf '  - %s\n' "${missing[@]}" >&2
 exit 1


### PR DESCRIPTION
## Summary

Promotes `infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/check.sh` from "any PASS = exit 0" (first-match-wins) to "every expected PASS must appear, else exit 1." A regression that silently disables one of the three sibling postconditions (e.g. a typo in the `error_message` of the `stopTimeout`-cap or `digest-pin` postcondition) would previously have been masked by the more-prominent missing-secret PASS — the runner now catches it.

Closes #4037

## Changes

- `check.sh` rewritten to iterate over an `expected_passes=("missing ANTHROPIC_API_KEY" "is not digest-pinned" 'stopTimeout != 120')` list, accumulate `missing[]`, and exit 0 only when `missing[]` is empty.
- Deferred-to-apply fallback preserved but tightened: only fires when **none** of the needles appear (a partial miss is now treated as a regression rather than a silent PASS).
- No production `main.tf` changes.

## Audit of sibling module check.sh files (AC #2)

| Module | Pattern | Action |
|---|---|---|
| `dispatcher-v3-task-defs` | First-match-wins, 3 expected PASSes | Fixed |
| `dispatcher-v3-scheduled-skills` | Already asserts ALL (`saw_family_check && saw_topic_check`) | None — already correct |
| `dispatcher-daemon` | Single check (`missing ANTHROPIC_API_KEY`) | None — N=1, no masking possible |
| `api-service` | Single check (`missing DATABASE_URL`) | None — N=1 |
| `compute` | Single check (`missing DATABASE_URL`) | None — N=1 |
| `scraper-zero-record-check` | Single check (`missing DATABASE_URL`) | None — N=1 |
| `dispatcher-agent-runner` | Single check (`missing ANTHROPIC_API_KEY`) | None — N=1 |

The bug class only exists when 2+ expected PASSes can mask each other. Single-needle modules are equivalent under both shapes; rewriting them would be stylistic only.

## Verification transcript (AC #3 regression test)

**Step 1 — happy path on clean fixture:**

```
$ bash infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/check.sh
... terraform init / validate / plan with all 3 postconditions firing ...
PASS: all expected postconditions fired at plan time.
exit=0
```

**Step 2 — stub `main.tf`'s `stopTimeout` error_message:**

```
-      error_message = "rendered stopTimeout != 120. Fargate rejects task-defs with stopTimeout > 120s; the wall-clock cap must be enforced launcher-side. See #3940."
+      error_message = "rendered stopTimeout is not 120 (regression-test stub). See #3940."
```

**Step 3 — re-run check.sh, expect FAIL:**

```
$ bash infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/check.sh
...
rendered stopTimeout is not 120 (regression-test stub). See #3940.
FAIL: expected postcondition messages not seen in plan output (plan_exit=1):
  - stopTimeout != 120
exit=1
```

**Step 4 — revert stub, re-run, confirm clean PASS:**

```
$ git diff --stat -- infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/main.tf
# (empty -- main.tf reverted)

$ bash infra/terraform/modules/dispatcher-v3-task-defs/tests/postconditions/check.sh
...
PASS: all expected postconditions fired at plan time.
exit=0
```

The stub was reverted before commit. `git status` and the final commit diff confirm only `check.sh` changed.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green (specifically `dispatcher-v3-task-defs postcondition check` step in `.github/workflows/terraform.yml`)

### Post-deploy verification
- [x] N/A — no deployed component (test-runner script wired only into CI; no runtime impact on dev/prod)
