### PR TITLE
feat(ci): add hygiene check for parse_document reingest-safety markers (#4141)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1068,6 +1068,22 @@ jobs:
         run: scripts/check-no-redos-pattern.sh
 
   # ---------------------------------------------------------------
+  # parse_document reingest-safety marker guard: every Live-only
+  # parse_document under packages/scraper-framework/src/courts/ must
+  # carry a docstring marker that names the reingest hazard.  Closes
+  # the recurrence shape behind audit #4046 / production incident
+  # #3986 (CourtListener returned doc unchanged on the reingest path,
+  # producing rulings whose JSON envelope was decoded as ruling_text
+  # and hit the 50000-char truncation cap).  See #4141.
+  # ---------------------------------------------------------------
+  parse-document-reingest-safety-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify Live-only parse_document docstrings name the reingest hazard
+        run: scripts/check-parse-document-reingest-safety.sh
+
+  # ---------------------------------------------------------------
   # Hardcoded model guard: enforce model ID centralization
   # ---------------------------------------------------------------
   hardcoded-models-check:
@@ -1679,7 +1695,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-parse-document-reingest-safety.sh
+++ b/scripts/check-parse-document-reingest-safety.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# check-parse-document-reingest-safety.sh — Hygiene check enforcing the
+# reingest-hazard docstring marker on Live-only ``parse_document``
+# implementations under ``packages/scraper-framework/src/courts/``.
+#
+# Why this check exists
+# ---------------------
+# Audit #4046 (``docs/investigations/parse_document-reingest-safety-2026-05.md``)
+# classified all 20 ``parse_document`` implementations against the
+# reingest path.  Live-only implementations (``parse_document`` returns
+# ``doc`` unchanged with no read of ``raw_content`` and no
+# ``super().parse_document(...)`` delegation) are the structural shape
+# that produced the #3986 production incident — CourtListener returned
+# ``doc`` unchanged on the reingest path, and its JSON envelope was
+# decoded as text and stored as ``ruling_text``, hitting the 50000-char
+# truncation cap.
+#
+# This check is the structural complement to the runtime
+# ``_TRUNCATION_SENTINEL_LENGTH`` validator: every Live-only
+# ``parse_document`` MUST carry a docstring marker that explicitly names
+# the reingest hazard.  Without this guard, a new scraper could land as
+# Live-only with a misleading docstring (the same shape #3986 fixed)
+# and the failure would only surface on the next reingest.
+#
+# Marker contract
+# ---------------
+# The Python scanner (``scripts/check_parse_document_reingest_safety.py``)
+# accepts any of these substrings (case-insensitive) in the docstring
+# of a Live-only ``parse_document``:
+#
+#   * "Reingest hazard"
+#   * "no-op on the reingest path"
+#   * "not reingest-safe"
+#
+# These match the three current Live-only sites
+# (``cc_tentatives_portal.py``, ``sf_civil_tentatives.py``,
+# ``oc_tentatives.py``).  See the audit doc for the full per-scraper
+# classification.
+#
+# Issue
+# -----
+# #4141 (this check).  Audit: #4046.  Failure-shape origin: #3986.
+#
+# Usage
+# -----
+#   scripts/check-parse-document-reingest-safety.sh        # scan default courts/
+#   scripts/check-parse-document-reingest-safety.sh PATH   # scan a specific dir
+#                                                          # (used by tests)
+#
+# Exit codes
+# ----------
+#   0 — All Live-only parse_document implementations carry the marker.
+#   1 — At least one Live-only parse_document is missing the marker.
+#   2 — Internal error (Python scanner failed to run).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCANNER="$REPO_ROOT/scripts/check_parse_document_reingest_safety.py"
+
+# ─── Resolve scan root ────────────────────────────────────────────────────
+# With no argument: scan the production courts/ tree (the default).
+# With an argument: scan that path (used by tests for fixture isolation).
+if [[ $# -eq 0 ]]; then
+    SCAN_ARGS=()
+else
+    SCAN_ARGS=(--root "$1")
+fi
+
+# ─── Run the scanner ──────────────────────────────────────────────────────
+# The scanner emits one line per violation in the form:
+#   <path>:<lineno>:<class.parse_document>
+#
+# It always exits 0; an empty stdout means "no violations".  We capture
+# stdout and decide the wrapper's exit code from there — same split as
+# check-no-redos-pattern.sh / check_no_redos_pattern.py.
+if ! python_output="$(python3 "$SCANNER" ${SCAN_ARGS[@]+"${SCAN_ARGS[@]}"})"; then
+    echo "ERROR: scanner failed to run (see stderr above)." >&2
+    exit 2
+fi
+
+# ─── Report violations ────────────────────────────────────────────────────
+if [[ -z "${python_output// /}" ]]; then
+    exit 0
+fi
+
+violations=0
+echo "ERROR: Live-only parse_document method(s) missing reingest-hazard marker."
+echo ""
+echo "  A Live-only parse_document is one that does not read"
+echo "  doc.raw_content and does not delegate to another parse_document"
+echo "  (super().parse_document(...) or parser.parse_document(...))."
+echo "  On the reingest path (scripts/reingest_from_s3.py::_reparse_document)"
+echo "  this clears judge_name/department/parties unconditionally — see"
+echo "  audit #4046 for the full failure analysis (originally surfaced by"
+echo "  #3986 in CourtListener)."
+echo ""
+echo "  Required: each Live-only parse_document docstring MUST contain at"
+echo "  least one of these substrings (case-insensitive):"
+echo ""
+echo "    - Reingest hazard"
+echo "    - no-op on the reingest path"
+echo "    - not reingest-safe"
+echo ""
+echo "  Existing examples:"
+echo "    packages/scraper-framework/src/courts/ca/cc_tentatives_portal.py"
+echo "    packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py"
+echo "    packages/scraper-framework/src/courts/ca/oc_tentatives.py"
+echo ""
+echo "  Violating methods:"
+echo ""
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    echo "    $entry"
+    violations=$((violations + 1))
+done <<< "$python_output"
+
+if (( violations > 0 )); then
+    echo ""
+    echo "  Found $violations Live-only parse_document method(s) missing the marker."
+    exit 1
+fi
+
+exit 0

--- a/scripts/check_parse_document_reingest_safety.py
+++ b/scripts/check_parse_document_reingest_safety.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check_parse_document_reingest_safety.py — AST scanner enforcing the
+reingest-hazard docstring marker on Live-only ``parse_document``
+implementations under ``packages/scraper-framework/src/courts/``.
+
+Driven by ``scripts/check-parse-document-reingest-safety.sh``.  See that
+wrapper for the full motivation, CI integration, and exit codes.
+
+Background
+----------
+Audit #4046 (``docs/investigations/parse_document-reingest-safety-2026-05.md``)
+classified all 20 ``parse_document`` implementations under
+``packages/scraper-framework/src/courts/`` against the reingest path
+that ``scripts/reingest_from_s3.py::_reparse_document`` exercises.  The
+classification rule is mechanical:
+
+* **Reingest-aware** — function body reads ``doc.raw_content`` directly
+  OR delegates to ``super().parse_document(...)`` (which itself reads
+  raw_content).  The reingest path's fresh ``CapturedDocument``
+  (carrying only ``raw_content`` + DB-seeded identifiers) round-trips
+  through the parse, so structured fields are re-derived.
+* **Mixed** — branches on a discriminant such as
+  ``doc.extra.get("pre_split")`` or ``doc.extra.get("_llm_extracted")``.
+  The reingest ``cap_doc.extra`` is empty, so the *else* branch (which
+  must itself be Reingest-aware) is what runs on reingest.  Mixed
+  methods are safe iff their non-discriminant branch reads
+  ``raw_content`` or delegates via super.
+* **Live-only** — function body is ``return doc`` (or returns ``doc``
+  unchanged) with no ``raw_content`` read and no super delegation.
+  Live-only ``parse_document`` is a no-op on reingest, which clears
+  ``judge_name``/``department``/``parties`` to ``None``/``[]`` via
+  ``_reparse_document``'s unconditional-overwrite merge logic (see the
+  audit's "How _reparse_document actually consumes parse_document"
+  section).
+
+Issue #3986 was the production-shipped example of the Live-only failure
+mode (CourtListener returned ``doc`` unchanged on the reingest path,
+producing rulings with the JSON envelope decoded as ``ruling_text``).
+The runtime ``_TRUNCATION_SENTINEL_LENGTH`` validator caught it after
+ship, by chance.  This check is the structural complement: every
+Live-only ``parse_document`` MUST carry a docstring marker that
+explicitly names the reingest hazard, ensuring no future scraper
+silently lands as Live-only with a misleading docstring like the one
+#3986 fixed.
+
+Marker contract
+---------------
+Live-only ``parse_document`` methods MUST contain at least one of these
+substrings (case-insensitive) in their docstring:
+
+* ``Reingest hazard``
+* ``no-op on the reingest path``
+* ``not reingest-safe``
+
+These are the three patterns the audit landed across the three current
+Live-only sites (``cc_tentatives_portal.py``, ``sf_civil_tentatives.py``,
+``oc_tentatives.py``).  Adding a new marker phrase is fine; adding a
+new Live-only ``parse_document`` without one of these markers is a
+build break.
+
+What this script does
+---------------------
+1. AST-parses every ``.py`` file under
+   ``packages/scraper-framework/src/courts/`` (recursively).
+2. For each ``parse_document`` method (function defined inside a class
+   body), classifies it as Live-only or Not-Live-only:
+   * Not-Live-only: contains a read of ``X.raw_content`` (where ``X``
+     is any ``Name`` or ``Attribute`` chain — typically ``doc``) OR
+     contains a call to ``super().parse_document(...)``.
+   * Live-only: everything else.
+3. For each Live-only method, asserts the docstring contains at least
+   one of the marker phrases above.
+4. Prints one line per violation in the form
+   ``<path>:<lineno>:<class.parse_document>``.
+
+Usage
+-----
+
+    python3 scripts/check_parse_document_reingest_safety.py
+
+    # Override scan root (used by the wrapper's --root flag and tests):
+    python3 scripts/check_parse_document_reingest_safety.py --root <DIR>
+
+    # Override the marker phrases (one per --marker, used by tests):
+    python3 scripts/check_parse_document_reingest_safety.py --marker "Reingest hazard"
+
+Exit codes
+----------
+
+  0 — Always.  The wrapper turns the printed-violations stream into a
+       non-zero exit, mirroring the convention used by
+       ``check_no_redos_pattern.py`` (#4117).  Splitting the
+       responsibility keeps this script's stdout the single source of
+       truth for tests and the wrapper alike.
+
+Issue
+-----
+* Audit:    #4046 (``docs/investigations/parse_document-reingest-safety-2026-05.md``)
+* Marker enforcement: #4141
+* The structural failure shape: #3986 (CourtListener)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+# ─── Default marker phrases ───────────────────────────────────────────────
+# Matched case-insensitively against the docstring of every Live-only
+# ``parse_document`` method.  At least one must be present.
+_DEFAULT_MARKERS: tuple[str, ...] = (
+    "reingest hazard",
+    "no-op on the reingest path",
+    "not reingest-safe",
+)
+
+
+# ─── Live-only classification ─────────────────────────────────────────────
+def _reads_raw_content(node: ast.AST) -> bool:
+    """Return True if the AST subtree contains an attribute access of
+    the form ``X.raw_content`` (where ``X`` is any expression — Name,
+    Attribute chain, Call, etc.)."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Attribute) and child.attr == "raw_content":
+            return True
+    return False
+
+
+def _delegates_to_other_parse_document(node: ast.AST) -> bool:
+    """Return True if the AST subtree contains a call of the form
+    ``X.parse_document(...)`` where ``X`` is anything other than the
+    bare name ``self``.
+
+    This covers both audit-recognized delegation patterns:
+
+    * ``super().parse_document(doc)`` — e.g. sb_tentatives.py,
+      riverside_tentatives.py.  The function attribute is on a
+      ``Call(func=Name("super"))`` value, which is not ``Name("self")``.
+    * ``parser.parse_document(doc)`` — e.g. sd_pipeline.py, where
+      ``parser`` is an instance of another scraper class.  The function
+      attribute is on ``Name("parser")``, which is not ``Name("self")``.
+
+    Calls of the form ``self.parse_document(...)`` (recursion) are
+    excluded — they don't delegate to a different parser, so they do
+    not count toward Reingest-aware classification on their own.
+    """
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "parse_document"
+        ):
+            value = child.func.value
+            # Skip self.parse_document(...) — recursion is not delegation.
+            if isinstance(value, ast.Name) and value.id == "self":
+                continue
+            return True
+    return False
+
+
+def _is_live_only(func: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """A ``parse_document`` is Live-only if its body neither reads
+    ``raw_content`` nor delegates to another ``parse_document``
+    implementation (via ``super()`` or via a stored instance)."""
+    if _reads_raw_content(func):
+        return False
+    if _delegates_to_other_parse_document(func):
+        return False
+    return True
+
+
+# ─── Marker check ─────────────────────────────────────────────────────────
+def _has_marker(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    markers: tuple[str, ...],
+) -> bool:
+    """Return True if ``func``'s docstring contains at least one marker
+    (case-insensitive substring match)."""
+    docstring = ast.get_docstring(func) or ""
+    haystack = docstring.lower()
+    return any(marker.lower() in haystack for marker in markers)
+
+
+# ─── File scanning ────────────────────────────────────────────────────────
+def _iter_parse_document_methods(
+    tree: ast.AST,
+) -> list[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]]:
+    """Yield ``(class_name, func_node)`` for every ``parse_document``
+    method defined inside a class body.  Module-level functions named
+    ``parse_document`` are NOT included — the audit scope is class
+    methods on scraper subclasses."""
+    results: list[tuple[str, ast.FunctionDef | ast.AsyncFunctionDef]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if (
+                    isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and item.name == "parse_document"
+                ):
+                    results.append((node.name, item))
+    return results
+
+
+def scan_file(path: Path, markers: tuple[str, ...]) -> list[tuple[Path, int, str]]:
+    """Scan one Python file for Live-only ``parse_document`` methods
+    missing the marker.  Returns a list of ``(path, lineno, label)``
+    violations.  Syntactically broken files are skipped silently
+    (mirrors the ``check_no_redos_pattern.py`` convention)."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    violations: list[tuple[Path, int, str]] = []
+    for class_name, func in _iter_parse_document_methods(tree):
+        if not _is_live_only(func):
+            continue
+        if _has_marker(func, markers):
+            continue
+        label = f"{class_name}.parse_document"
+        violations.append((path, func.lineno, label))
+    return violations
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    """Walk ``root`` and return every ``.py`` file, excluding common
+    vendored / generated directories."""
+    excluded_dirs = {".venv", "__pycache__", "node_modules", ".git"}
+    files: list[Path] = []
+    for child in root.rglob("*.py"):
+        # Skip if any path part is in the excluded set.
+        if any(part in excluded_dirs for part in child.parts):
+            continue
+        files.append(child)
+    return sorted(files)
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan parse_document methods under "
+            "packages/scraper-framework/src/courts/ for missing "
+            "reingest-hazard docstring markers (issue #4141)."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help=(
+            "Override the scan root.  Defaults to "
+            "<repo>/packages/scraper-framework/src/courts/."
+        ),
+    )
+    parser.add_argument(
+        "--marker",
+        action="append",
+        default=None,
+        help=(
+            "Override the marker phrases.  Can be repeated.  "
+            "Defaults to the three audit-landed markers."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_default_root() -> Path:
+    """The default scan root is the courts/ tree.  Resolve relative to
+    this script's location so the script works regardless of cwd."""
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    return repo_root / "packages" / "scraper-framework" / "src" / "courts"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    root: Path = args.root or _resolve_default_root()
+    markers: tuple[str, ...] = tuple(args.marker) if args.marker else _DEFAULT_MARKERS
+
+    if not root.exists():
+        # Silent skip: an empty / missing root produces no violations.
+        # This mirrors the behavior of check_no_redos_pattern.py when
+        # given a non-existent path.
+        return 0
+
+    violations: list[tuple[Path, int, str]] = []
+    for py in _iter_python_files(root):
+        violations.extend(scan_file(py, markers))
+
+    for path, lineno, label in violations:
+        print(f"{path}:{lineno}:{label}")
+
+    # Always exit 0 — the wrapper interprets non-empty stdout as
+    # a failure.  See module docstring "Exit codes".
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_parse_document_reingest_safety.sh
+++ b/scripts/tests/test_check_parse_document_reingest_safety.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# test_check_parse_document_reingest_safety.sh — Tests for
+# check-parse-document-reingest-safety.sh (issue #4141).
+#
+# Creates temporary Python files that exercise the classifier's
+# pass-and-fail cases — Live-only with marker (passes), Live-only
+# without marker (fails), Reingest-aware (passes), Mixed (passes).
+#
+# Usage:
+#   scripts/tests/test_check_parse_document_reingest_safety.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-parse-document-reingest-safety.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Live-only with "Reingest hazard" marker passes ──────────────
+create_test_file "live_only_marker_hazard.py" 'class S:
+    def parse_document(self, doc):
+        """No-op — fields populated during fetch.
+
+        Reingest hazard (audit #4046): on reingest, judge_name and
+        department are cleared by the merge logic.  See follow-up #4133.
+        """
+        return doc
+' > /dev/null
+assert_passes "Live-only with 'Reingest hazard' marker passes"
+reset_tmpdir
+
+# ─── Test 2: Live-only with "no-op on the reingest path" marker passes ───
+create_test_file "live_only_marker_oc.py" 'class S:
+    def parse_document(self, doc):
+        """No-op: field extraction is handled by the multimodal LLM pipeline.
+
+        This is also a no-op on the reingest path
+        (scripts/reingest_from_s3.py).  See audit #4046.
+        """
+        return doc
+' > /dev/null
+assert_passes "Live-only with 'no-op on the reingest path' marker passes"
+reset_tmpdir
+
+# ─── Test 3: Live-only with "not reingest-safe" marker passes ────────────
+create_test_file "live_only_marker_unsafe.py" 'class S:
+    def parse_document(self, doc):
+        """No-op — this scraper is not reingest-safe (see #4141)."""
+        return doc
+' > /dev/null
+assert_passes "Live-only with 'not reingest-safe' marker passes"
+reset_tmpdir
+
+# ─── Test 4: Live-only with NO marker fails ──────────────────────────────
+create_test_file "live_only_no_marker.py" 'class S:
+    def parse_document(self, doc):
+        """No-op — fields populated during fetch."""
+        return doc
+' > /dev/null
+assert_fails "Live-only without marker fails"
+reset_tmpdir
+
+# ─── Test 5: Live-only with NO docstring at all fails ────────────────────
+create_test_file "live_only_no_docstring.py" 'class S:
+    def parse_document(self, doc):
+        return doc
+' > /dev/null
+assert_fails "Live-only without a docstring fails"
+reset_tmpdir
+
+# ─── Test 6: Reingest-aware (reads doc.raw_content) passes ───────────────
+# No marker required — only Live-only methods need the marker.
+create_test_file "reingest_aware_raw_content.py" 'class S:
+    def parse_document(self, doc):
+        """Parse PDF text from raw_content."""
+        text = _extract_pdf_text(doc.raw_content)
+        doc.ruling_text = text
+        return doc
+' > /dev/null
+assert_passes "Reingest-aware (reads doc.raw_content) passes without marker"
+reset_tmpdir
+
+# ─── Test 7: Reingest-aware via super().parse_document(doc) passes ───────
+create_test_file "reingest_aware_super.py" 'class S(Base):
+    def parse_document(self, doc):
+        """Extend base parse with court-specific fallbacks."""
+        doc = super().parse_document(doc)
+        if doc.ruling_text and not doc.judge_name:
+            doc.judge_name = _extract_judge(doc.ruling_text)
+        return doc
+' > /dev/null
+assert_passes "Reingest-aware via super().parse_document(doc) passes without marker"
+reset_tmpdir
+
+# ─── Test 8: Reingest-aware via parser.parse_document(doc) passes ────────
+# Mirrors sd_pipeline.py — delegate to a stored instance of another scraper.
+create_test_file "reingest_aware_delegate_instance.py" 'class S:
+    def parse_document(self, doc):
+        """Delegate to Phase 2 parser."""
+        parser = self._get_phase2_parser()
+        return parser.parse_document(doc)
+' > /dev/null
+assert_passes "Reingest-aware via instance.parse_document(doc) passes"
+reset_tmpdir
+
+# ─── Test 9: Mixed (branches on pre_split, else reads raw_content) ───────
+create_test_file "mixed_pre_split.py" 'class S:
+    def parse_document(self, doc):
+        """Mixed — short-circuit on pre_split, else parse PDF text."""
+        if doc.extra.get("pre_split") or doc.extra.get("_llm_extracted"):
+            return doc
+        text = _extract_pdf_text(doc.raw_content)
+        doc.ruling_text = text
+        return doc
+' > /dev/null
+assert_passes "Mixed (pre_split short-circuit + raw_content read) passes"
+reset_tmpdir
+
+# ─── Test 10: self.parse_document recursion is NOT delegation ────────────
+# A method that only calls self.parse_document(...) is recursing, not
+# delegating to a different parser — so it should still be Live-only
+# and the marker is required.
+create_test_file "self_recursion.py" 'class S:
+    def parse_document(self, doc):
+        """Self-recursion only — should still require marker."""
+        if doc.extra.get("retry"):
+            return self.parse_document(doc)
+        return doc
+' > /dev/null
+assert_fails "self.parse_document recursion does not count as delegation"
+reset_tmpdir
+
+# ─── Test 11: Module-level parse_document function is ignored ────────────
+# The audit scope is class methods on scraper subclasses.  A
+# module-level function named parse_document is not a scraper method
+# and should not be classified.
+create_test_file "module_level.py" 'def parse_document(doc):
+    """Module-level helper, not a scraper method."""
+    return doc
+' > /dev/null
+assert_passes "Module-level parse_document function is ignored (not a class method)"
+reset_tmpdir
+
+# ─── Test 12: Method named something else is ignored ─────────────────────
+create_test_file "other_method.py" 'class S:
+    def parse_doc(self, doc):
+        """Different method name — not in scope."""
+        return doc
+' > /dev/null
+assert_passes "Method with a different name is ignored"
+reset_tmpdir
+
+# ─── Test 13: Marker matching is case-insensitive ────────────────────────
+create_test_file "case_insensitive.py" 'class S:
+    def parse_document(self, doc):
+        """REINGEST HAZARD — uppercase variant of the marker."""
+        return doc
+' > /dev/null
+assert_passes "Marker matching is case-insensitive (uppercase)"
+reset_tmpdir
+
+# ─── Test 14: Empty file passes ──────────────────────────────────────────
+create_test_file "empty.py" '"""Empty module."""
+' > /dev/null
+assert_passes "Empty module passes"
+reset_tmpdir
+
+# ─── Test 15: Syntactically broken Python is skipped silently ────────────
+create_test_file "broken.py" 'class S(:  # syntax error
+    pass
+' > /dev/null
+assert_passes "Syntactically broken Python is skipped silently"
+reset_tmpdir
+
+# ─── Test 16: Direct production-tree run reports zero violations ─────────
+# Defense-in-depth — the production tree (the default scan root) is
+# clean today (after #4046 landed all three Live-only docstring
+# updates).  Removing the marker from any of the three known Live-only
+# scrapers should fail the check, but we don't test that here because
+# it would require mutating the production tree in CI.  The fixture
+# tests (1-15) cover the equivalent behavior on synthetic files.
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: Production courts/ tree passes the check"
+else
+    echo "FAIL: Production courts/ tree fails the check (expected pass)"
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
+
+# ─── Test 17: AST scan ignores .venv/ subdir ─────────────────────────────
+mkdir -p "$TMPDIR_TEST/.venv/lib/python3.12/site-packages"
+printf 'class V:\n    def parse_document(self, doc):\n        """No marker — but vendored, should be ignored."""\n        return doc\n' \
+    > "$TMPDIR_TEST/.venv/lib/python3.12/site-packages/vendored.py"
+assert_passes ".venv/ subdir is excluded from the scan"
+reset_tmpdir
+
+# ─── Test 18: Multiple Live-only methods in one file are all reported ────
+create_test_file "two_violations.py" 'class A:
+    def parse_document(self, doc):
+        """No marker."""
+        return doc
+
+class B:
+    def parse_document(self, doc):
+        """Also no marker."""
+        return doc
+' > /dev/null
+assert_fails "Multiple Live-only violations in one file are caught"
+reset_tmpdir
+
+# ─── Test 19: Live-only with marker + Live-only without — fails ──────────
+# Mixed-state test: one good, one bad in the same scan tree.  The
+# scanner must still fail because at least one violator exists.
+create_test_file "good_and_bad/good.py" 'class Good:
+    def parse_document(self, doc):
+        """Reingest hazard — see audit #4046."""
+        return doc
+' > /dev/null
+create_test_file "good_and_bad/bad.py" 'class Bad:
+    def parse_document(self, doc):
+        """No marker."""
+        return doc
+' > /dev/null
+assert_fails "Mixed pass+fail tree fails because of the bad file"
+reset_tmpdir
+
+# ─── Test 20: No self-match on ci.yml step name ──────────────────────────
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-parse-document-reingest-safety.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-parse-document-reingest-safety.sh` (+ Python AST scanner) that enforces a docstring-marker contract on every Live-only `parse_document` under `packages/scraper-framework/src/courts/`. Wires it into `.github/workflows/ci.yml` as `parse-document-reingest-safety-check` so the next Live-only `parse_document` cannot land with a misleading docstring like the one #3986 fixed.

Closes #4141

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_parse_document_reingest_safety.sh` — 20 cases)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check only). The new job runs on this very PR; passing CI is the verification.
