### PR TITLE
fix(ca-cc-portal): make cc_tentatives_portal.parse_document reingest-safe (#4133)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives_portal.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives_portal.py
@@ -52,9 +52,12 @@ Phase 1 implementation: #2609
 
 from __future__ import annotations
 
+import base64
+import json
 import re
 import time
 from datetime import UTC, datetime
+from typing import Any
 from urllib.parse import urljoin
 
 import httpx
@@ -475,6 +478,15 @@ class CCTentativesPortalScraper(BaseScraper):
     ) -> CapturedDocument | None:
         """Fetch the detail page and PDF for a single listing row.
 
+        Builds a JSON envelope as ``raw_content`` so that
+        ``parse_document`` can populate every structured field from
+        ``raw_content`` alone — the reingest path
+        (``scripts/reingest_from_s3.py::_reparse_document``) constructs a
+        fresh ``CapturedDocument`` carrying only ``raw_content`` and DB
+        identifiers, so anything not in the envelope is unrecoverable on
+        reingest. See ``_populate_from_envelope`` for the field mapping
+        and #4133 / #3986 for the refactor history.
+
         Args:
             client: The shared httpx client.
             row: Parsed row dict from _parse_listing_table.
@@ -491,8 +503,9 @@ class CCTentativesPortalScraper(BaseScraper):
         detail_response = client.get(detail_url)
         detail_response.raise_for_status()
         detail_html_bytes = detail_response.content
+        detail_html_text = detail_response.text
 
-        detail = _parse_detail_page(detail_response.text)
+        detail = _parse_detail_page(detail_html_text)
 
         pdf_url = detail.get("pdf_url")
         if not pdf_url:
@@ -505,27 +518,102 @@ class CCTentativesPortalScraper(BaseScraper):
         pdf_response.raise_for_status()
         pdf_bytes = pdf_response.content
 
-        # Build document (PDF as primary raw content, per CC pipeline pattern)
+        # Build the JSON envelope (#4133 — Option A from the issue).  This
+        # is the single source of truth for every structured field,
+        # archived to S3 verbatim and round-tripped on reingest.  PDF and
+        # detail HTML bytes are base64-encoded so the envelope is valid
+        # UTF-8 / valid JSON; ``json.dumps(default=str)`` handles the
+        # ``hearing_date`` datetime in the row dict.
+        envelope = {
+            "row": row,
+            "detail_html_b64": base64.b64encode(detail_html_bytes).decode("ascii"),
+            "pdf_url": pdf_url,
+            "pdf_bytes_b64": base64.b64encode(pdf_bytes).decode("ascii"),
+            "judge_id": judge_id,
+            "judge_name_dropdown": judge_name_dropdown,
+        }
+        envelope_bytes = json.dumps(envelope, default=str).encode("utf-8")
+
+        # ``ContentFormat.TEXT`` so the reingest text-extractor decodes
+        # the envelope as UTF-8 (rather than handing it to pdfplumber as
+        # if it were PDF bytes).  ``parse_document`` overwrites the
+        # JSON-as-text ``ruling_text`` with the structured ruling text.
         doc = self._make_base_doc(
             source_url=detail_url,
-            raw_content=pdf_bytes,
-            content_format=ContentFormat.PDF,
+            raw_content=envelope_bytes,
+            content_format=ContentFormat.TEXT,
         )
 
-        # Populate scraper-provided fields
+        self._populate_from_envelope(doc, envelope=envelope)
+        return doc
+
+    def _populate_from_envelope(
+        self,
+        doc: CapturedDocument,
+        *,
+        envelope: dict[str, Any],
+    ) -> None:
+        """Populate structured fields on ``doc`` from a CC-portal JSON envelope.
+
+        Single source of truth for the field-mapping logic shared by the
+        live capture path (``_fetch_single_ruling``) and the reingest
+        path (``parse_document``).  Mutates ``doc`` in place.  Mirrors
+        the #3986 ``_populate_from_envelope`` shape used by the
+        ``CourtListenerScraper``.
+
+        The envelope shape is:
+
+        ``{"row": <listing-row dict>, "detail_html_b64": <base64-HTML>,``
+        ``"pdf_url": <str>, "pdf_bytes_b64": <base64-PDF>,``
+        ``"judge_id": <str>, "judge_name_dropdown": <str>}``
+
+        Args:
+            doc: The document to populate.
+            envelope: The decoded JSON envelope dict.
+        """
+        row = envelope.get("row") or {}
+        if not isinstance(row, dict):
+            row = {}
+
+        pdf_url = envelope.get("pdf_url")
+        judge_name_dropdown = envelope.get("judge_name_dropdown") or ""
+
+        # Decode the detail HTML so we can re-derive ruling_text /
+        # ruling_text_html / aside-judge_name without a network call.
+        detail_html_b64 = envelope.get("detail_html_b64") or ""
+        detail_html_bytes = b""
+        detail_html_text = ""
+        if detail_html_b64:
+            try:
+                detail_html_bytes = base64.b64decode(detail_html_b64)
+                detail_html_text = detail_html_bytes.decode("utf-8", errors="replace")
+            except (ValueError, TypeError):
+                detail_html_bytes = b""
+                detail_html_text = ""
+        detail = _parse_detail_page(detail_html_text) if detail_html_text else {}
+
+        # --- Listing-row-derived fields ---
         doc.case_number = row.get("case_number")
         doc.case_title = row.get("case_title")
-        doc.hearing_date = row.get("hearing_date")
         doc.motion_type = row.get("motion_type")
+
+        # ``hearing_date`` may be a datetime (live path) or an ISO-8601
+        # string (reingest path — json.dumps(default=str) wrote it that
+        # way).  Coerce to datetime so the schema gets a consistent type.
+        hearing_date_raw = row.get("hearing_date")
+        doc.hearing_date = _coerce_hearing_date(hearing_date_raw)
+
+        # --- Detail-page-derived fields ---
         doc.ruling_text = detail.get("ruling_text")
         doc.ruling_text_html = detail.get("ruling_text_html")
 
-        # Judge name: prefer the aside (more specific), fall back to dropdown name
+        # Judge name: prefer aside (most specific), fall back to dropdown name.
         judge_name_aside = detail.get("judge_name")
-        doc.judge_name = judge_name_aside or judge_name_dropdown
+        doc.judge_name = judge_name_aside or judge_name_dropdown or None
 
-        # Department from PDF filename (derivable, not from a structured field)
-        pdf_filename = pdf_url.rsplit("/", 1)[-1] if "/" in pdf_url else pdf_url
+        # --- PDF-URL-derived fields ---
+        # Department from PDF filename (16_012925.pdf -> "16").  Courthouse
+        # from CC's per-department mapping (cc_tentatives._cc_courthouse).
         dept = _cc_dept_from_filename(pdf_url)
         if dept:
             doc.department = dept
@@ -535,47 +623,116 @@ class CCTentativesPortalScraper(BaseScraper):
             if courthouse:
                 doc.courthouse = courthouse
 
-        # Store secondary artifacts and metadata in extra
+        # --- Secondary artifacts in extra ---
+        # Keep the same shape as the pre-#4133 version so downstream
+        # consumers (S3 archival, the worker, tests) see no change.
+        # ``detail_html`` stays in ``extra`` as bytes for backwards
+        # compatibility with code that reads it (currently only tests).
+        pdf_filename: str | None = None
+        if pdf_url and "/" in pdf_url:
+            pdf_filename = pdf_url.rsplit("/", 1)[-1]
+        elif pdf_url:
+            pdf_filename = pdf_url
+
         doc.extra["detail_html"] = detail_html_bytes
-        doc.extra["detail_url"] = detail_url
+        doc.extra["detail_url"] = row.get("detail_url") or doc.source_url
         doc.extra["pdf_url"] = pdf_url
         doc.extra["pdf_filename"] = pdf_filename
-        doc.extra["slug"] = slug
+        doc.extra["slug"] = row.get("slug")
         doc.extra["case_type"] = row.get("case_type")
-        doc.extra["judge_id"] = judge_id
-
-        return doc
+        doc.extra["judge_id"] = envelope.get("judge_id")
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """No-op on the live-capture path — all fields are populated during
-        ``fetch_documents`` via ``_fetch_single_ruling``.
+        """Parse structured fields from ``doc.raw_content``.
 
-        The portal detail page provides structured HTML ruling text directly,
-        so no PDF text extraction or LLM parsing is needed during live
-        capture. This mirrors the SF civil tentatives pattern where
-        extraction happens during fetch.
+        Single source of truth for both the live capture path
+        (``_fetch_single_ruling`` calls ``_populate_from_envelope`` after
+        building the JSON envelope) and the reingest path
+        (``scripts/reingest_from_s3.py::_reparse_document`` constructs a
+        fresh ``CapturedDocument`` carrying only ``raw_content`` and
+        calls this method).  Mirrors the #3986 fix shape on
+        ``CourtListenerScraper.parse_document``.
 
-        **Reingest hazard (audit #4046, follow-up #4133):** this method is
-        also called from ``scripts/reingest_from_s3.py::_reparse_document``
-        with a fresh ``CapturedDocument`` carrying only ``raw_content``
-        (PDF bytes). Returning the doc unchanged means ``judge_name``,
-        ``department``, ``parties``, ``outcome``, and ``motion_type`` get
-        cleared by the reingest merge logic, ``ruling_text_html`` is
-        permanently lost (it lives in ``extra["detail_html"]`` at capture
-        time, not in ``raw_content``), and only ``ruling_text`` is
-        recovered (via pdfplumber on the PDF bytes) plus the DB-seeded
-        ``case_number/case_title/hearing_date``. **Reingest of CC-portal
-        documents is NOT fully supported** — the surviving fields are a
-        subset of the original capture. #4133 tracks the refactor along
-        the #3986 ``_populate_from_envelope`` shape.
+        The raw_content is the JSON envelope built by
+        ``_fetch_single_ruling`` (since #4133):
+
+        ``{"row": <listing-row dict>, "detail_html_b64": <base64-HTML>,``
+        ``"pdf_url": <str>, "pdf_bytes_b64": <base64-PDF>,``
+        ``"judge_id": <str>, "judge_name_dropdown": <str>}``
+
+        Tolerates ``raw_content`` that is not valid JSON or is missing
+        the expected ``row`` key — pre-#4133 captures archived raw PDF
+        bytes, so the envelope decode will fail.  In those cases the doc
+        is returned unchanged so the reingest caller falls back to
+        pdfplumber on the PDF bytes (via ``_extract_text_from_content``)
+        and the DB-seeded ``case_number`` / ``case_title`` /
+        ``hearing_date`` / ``judge_name`` / ``department`` from the
+        rulings row (via the symmetric merge in #4142).
 
         Args:
             doc: The document to parse.
 
         Returns:
-            The document unchanged.
+            The document with structured fields populated (envelope
+            decode succeeded) or unchanged (envelope decode failed).
         """
+        if not doc.raw_content:
+            return doc
+
+        try:
+            payload = json.loads(doc.raw_content)
+        except (ValueError, TypeError):
+            # Not valid JSON — likely a pre-#4133 capture (raw PDF bytes).
+            # Return unchanged so the reingest caller falls back to its
+            # PDF-text-extract path plus DB-seeded fields.
+            return doc
+
+        if not isinstance(payload, dict):
+            return doc
+
+        if not isinstance(payload.get("row"), dict):
+            # Envelope shape doesn't match what we wrote — leave the doc
+            # untouched rather than risk populating with garbage.
+            return doc
+
+        self._populate_from_envelope(doc, envelope=payload)
         return doc
+
+
+def _coerce_hearing_date(value: Any) -> datetime | None:
+    """Coerce a hearing_date value (datetime, ISO string, or None) to datetime.
+
+    The listing-row dict carries a real ``datetime`` on the live path,
+    but ``json.dumps(default=str)`` serializes it to an ISO-8601 string
+    that round-trips through reingest.  Accept either shape.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        # ``str(datetime)`` produces "2025-01-29 16:31:00+00:00".
+        # ``datetime.isoformat()`` produces "2025-01-29T16:31:00+00:00".
+        # ``fromisoformat`` accepts both forms in Python 3.11+.
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            pass
+        # Fallback: try the older forms used by the live-path parser.
+        for fmt in (
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S%z",
+            "%Y-%m-%d %H:%M:%S",
+        ):
+            try:
+                parsed = datetime.strptime(value, fmt)
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=UTC)
+                return parsed
+            except ValueError:
+                continue
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py
+++ b/packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py
@@ -12,7 +12,9 @@ Fixtures in tests/fixtures/cc_portal/:
 
 from __future__ import annotations
 
-from datetime import datetime
+import base64
+import json
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
@@ -26,12 +28,14 @@ from courts.ca.cc_tentatives_portal import (
     LISTING_URL,
     CCTentativesPortalScraper,
     _cc_dept_from_filename,
+    _coerce_hearing_date,
     _is_test_entry,
     _parse_detail_page,
     _parse_judge_dropdown,
     _parse_listing_table,
 )
 from courts.ca.cc_tentatives_portal import default_config as portal_default_config
+from framework import CapturedDocument, ContentFormat
 
 pytestmark = pytest.mark.regression
 
@@ -285,8 +289,20 @@ def test_fetch_documents_filters_test_entries_and_emits_skip_log() -> None:
 
 
 @respx.mock
-def test_fetch_documents_downloads_pdf_and_keeps_detail_html() -> None:
-    """PDF should be raw_content; detail HTML should be in doc.extra['detail_html']."""
+def test_fetch_documents_archives_envelope_with_pdf_and_detail_html() -> None:
+    """raw_content is a JSON envelope (#4133); PDF and detail HTML round-trip through it.
+
+    Pre-#4133 ``raw_content`` was the raw PDF bytes and the detail HTML
+    lived only in ``doc.extra["detail_html"]`` — neither shape survived
+    reingest because reingest builds a fresh ``CapturedDocument``
+    carrying only ``raw_content``.  Post-#4133 the envelope holds both
+    artifacts plus the listing-row dict, so ``parse_document`` can
+    re-derive every field on the reingest path.
+
+    ``doc.extra["detail_html"]`` is preserved on the live path for
+    backwards compatibility with consumers that read it (currently only
+    these tests).
+    """
     # Use a form with only Reyes (id=245)
     reyes_only_form = (
         '<html><body><form><select name="field_judge_target_id">'
@@ -318,12 +334,21 @@ def test_fetch_documents_downloads_pdf_and_keeps_detail_html() -> None:
     assert len(docs) == 1
     doc = docs[0]
 
-    # PDF is the primary raw content
-    assert doc.raw_content == pdf_bytes
+    # raw_content is now the JSON envelope (TEXT format), not raw PDF bytes
+    assert doc.content_format == ContentFormat.TEXT
+    payload = json.loads(doc.raw_content)
+    assert isinstance(payload, dict)
+    assert "row" in payload and isinstance(payload["row"], dict)
+    assert payload["row"]["case_number"] == "L24-04564"
 
-    # Detail HTML is in extra
-    assert "detail_html" in doc.extra
+    # Both byte-streams round-trip through the envelope as base64.
+    assert base64.b64decode(payload["pdf_bytes_b64"]) == pdf_bytes
+    assert base64.b64decode(payload["detail_html_b64"]) == detail_html_bytes
+
+    # Backwards-compatible extras still populated on the live path.
     assert doc.extra["detail_html"] == detail_html_bytes
+    assert doc.extra["pdf_url"].endswith("/system/files/general/16_012925.pdf")
+    assert doc.extra["slug"] == "l24-04564"
 
     # Both requests were made
     assert respx.calls.call_count >= 4  # form + listing + detail + pdf
@@ -459,3 +484,246 @@ def test_default_config_registered() -> None:
 
     ids = get_scraper_ids()
     assert "ca-cc-tentatives-portal" in ids
+
+
+# ---------------------------------------------------------------------------
+# 14. parse_document reingest-safety regression tests (#4133)
+# ---------------------------------------------------------------------------
+
+
+def _make_reingest_scraper() -> CCTentativesPortalScraper:
+    """Build a scraper instance suitable for parse_document-only tests."""
+    config = portal_default_config()
+    config = config.model_copy(update={"request_delay_seconds": 0.0})
+    return CCTentativesPortalScraper(config=config)
+
+
+def _build_envelope_bytes(
+    *,
+    detail_html: bytes,
+    pdf_bytes: bytes,
+    pdf_url: str = "https://contracosta.courts.ca.gov/system/files/general/16_012925.pdf",
+    case_number: str = "L24-04564",
+    case_title: str = "SCOTT FUGERE VS. THE COUNTY OF CONTRA COSTA",
+    motion_type: str = "CASE MANAGEMENT CONFERENCE",
+    case_type: str = "Civil",
+    slug: str = "l24-04564",
+    judge_id: str = "245",
+    judge_name_dropdown: str = "BENJAMIN REYES",
+    hearing_date_iso: str = "2025-01-29T16:31:00+00:00",
+) -> bytes:
+    """Build a JSON envelope mirroring what _fetch_single_ruling writes.
+
+    Used by the reingest regression tests below to exercise
+    ``parse_document`` without going through the live HTTP path.  The
+    ``hearing_date`` field is intentionally an ISO-8601 string (not a
+    ``datetime``) — that's what reingest sees after the envelope
+    round-trips through ``json.dumps(default=str)`` and S3.
+    """
+    envelope = {
+        "row": {
+            "slug": slug,
+            "detail_url": f"{BASE_URL}/tentative-ruling/{slug}",
+            "case_number": case_number,
+            "case_title": case_title,
+            "case_type": case_type,
+            "motion_type": motion_type,
+            "hearing_date": hearing_date_iso,
+        },
+        "detail_html_b64": base64.b64encode(detail_html).decode("ascii"),
+        "pdf_url": pdf_url,
+        "pdf_bytes_b64": base64.b64encode(pdf_bytes).decode("ascii"),
+        "judge_id": judge_id,
+        "judge_name_dropdown": judge_name_dropdown,
+    }
+    return json.dumps(envelope).encode("utf-8")
+
+
+def _make_cap_doc(raw_content: bytes) -> CapturedDocument:
+    """Build a CapturedDocument the way reingest_from_s3._reparse_document does.
+
+    Mirrors the production shape: only ``raw_content`` and the
+    identifier fields are set; every parsed field is left at its
+    default (``None`` / ``[]`` / ``{}``).  The structured-field
+    population MUST come from ``parse_document`` reading
+    ``raw_content`` — exactly the contract this test suite enforces.
+    """
+    return CapturedDocument(
+        document_id="test-doc-id",
+        scraper_id="ca-cc-tentatives-portal",
+        state="CA",
+        county="Contra Costa",
+        court="Superior Court",
+        source_url="https://contracosta.courts.ca.gov/tentative-ruling/l24-04564",
+        capture_timestamp=datetime(2025, 1, 28, 12, 0, 0, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=raw_content,
+        content_hash="deadbeef" * 8,
+    )
+
+
+def test_parse_document_reingest_populates_fields_from_envelope() -> None:
+    """Acceptance criterion #3 (#4133) — parse_document populates structured fields
+    from raw_content alone, with no live-capture state available.
+
+    Constructs a fresh ``CapturedDocument`` carrying only the JSON
+    envelope as ``raw_content`` (the exact shape reingest hands to
+    ``parse_document``) and asserts that every field that
+    ``_fetch_single_ruling`` populates on the live path is recovered.
+    This is the test that would have caught #3986 and would have
+    flagged this scraper in the audit if it had existed.
+    """
+    detail_html = _load_bytes("detail_l24-04564.html")
+    pdf_bytes = _load_bytes("sample.pdf")
+
+    raw = _build_envelope_bytes(detail_html=detail_html, pdf_bytes=pdf_bytes)
+    doc = _make_cap_doc(raw)
+    assert doc.case_number is None
+    assert doc.judge_name is None
+    assert doc.department is None
+    assert doc.ruling_text is None
+    assert doc.ruling_text_html is None
+
+    scraper = _make_reingest_scraper()
+    parsed = scraper.parse_document(doc)
+
+    # Listing-row-derived fields recovered from the envelope.
+    assert parsed.case_number == "L24-04564"
+    assert parsed.case_title is not None
+    assert "FUGERE" in parsed.case_title or "CONTRA COSTA" in parsed.case_title
+    assert parsed.motion_type == "CASE MANAGEMENT CONFERENCE"
+
+    # hearing_date round-trips through ISO-8601 and lands as a datetime.
+    assert isinstance(parsed.hearing_date, datetime)
+    assert parsed.hearing_date.year == 2025
+    assert parsed.hearing_date.month == 1
+    assert parsed.hearing_date.day == 29
+
+    # Detail-page-derived fields re-derived from the embedded HTML —
+    # ruling_text_html is the field that was permanently lost pre-#4133.
+    assert parsed.ruling_text is not None
+    assert "Before the Court are a demurrer" in parsed.ruling_text
+    assert parsed.ruling_text_html is not None
+    assert parsed.judge_name == "BENJAMIN REYES"
+
+    # PDF-URL-derived fields.
+    assert parsed.department == "16"
+    assert parsed.courthouse == "Martinez Courthouse"
+
+    # Extras keep the same shape as the live path.
+    assert parsed.extra["pdf_url"].endswith("/system/files/general/16_012925.pdf")
+    assert parsed.extra["pdf_filename"] == "16_012925.pdf"
+    assert parsed.extra["slug"] == "l24-04564"
+    assert parsed.extra["judge_id"] == "245"
+
+
+def test_parse_document_reingest_pre_4133_pdf_bytes_returns_unchanged() -> None:
+    """Pre-#4133 captures archived raw PDF bytes (not a JSON envelope).
+
+    On the reingest path those archived docs hand ``parse_document`` raw
+    PDF bytes that fail JSON decode.  The method MUST tolerate this and
+    return the doc unchanged — reingest's ``_extract_text_from_content``
+    + DB-seeded fields handle the recovery for those legacy captures
+    (the symmetric merge in #4142 keeps the DB seeds intact).
+    """
+    pdf_bytes = _load_bytes("sample.pdf")
+    doc = _make_cap_doc(pdf_bytes)
+
+    scraper = _make_reingest_scraper()
+    parsed = scraper.parse_document(doc)
+
+    # All structured fields stay at their defaults — the merge in
+    # _reparse_document then falls back to DB seeds (#4142).
+    assert parsed.case_number is None
+    assert parsed.judge_name is None
+    assert parsed.department is None
+    assert parsed.ruling_text is None
+    assert parsed.ruling_text_html is None
+    # raw_content is preserved unchanged for downstream pdfplumber.
+    assert parsed.raw_content == pdf_bytes
+
+
+def test_parse_document_reingest_invalid_envelope_shape_returns_unchanged() -> None:
+    """A JSON-decodable but wrong-shaped envelope must not populate garbage fields."""
+    raw = json.dumps({"unrelated": "payload"}).encode("utf-8")
+    doc = _make_cap_doc(raw)
+
+    scraper = _make_reingest_scraper()
+    parsed = scraper.parse_document(doc)
+
+    assert parsed.case_number is None
+    assert parsed.judge_name is None
+    assert parsed.ruling_text is None
+    # raw_content is preserved.
+    assert parsed.raw_content == raw
+
+
+def test_parse_document_reingest_empty_raw_content_returns_unchanged() -> None:
+    """Empty raw_content (defensive case) must not crash."""
+    doc = _make_cap_doc(b"")
+    scraper = _make_reingest_scraper()
+    parsed = scraper.parse_document(doc)
+    assert parsed.case_number is None
+    assert parsed.ruling_text is None
+
+
+def test_parse_document_reingest_envelope_with_unknown_pdf_filename_skips_dept() -> None:
+    """An envelope whose pdf_url does not match the dept regex must not crash.
+
+    Reproduces the case where a non-standard PDF filename appears
+    (e.g. a one-off uploaded with a different naming convention).
+    The dept/courthouse fields stay None; everything else still
+    populates.
+    """
+    detail_html = _load_bytes("detail_l24-04564.html")
+    pdf_bytes = _load_bytes("sample.pdf")
+
+    raw = _build_envelope_bytes(
+        detail_html=detail_html,
+        pdf_bytes=pdf_bytes,
+        pdf_url="https://example.com/some-other-name.pdf",
+    )
+    doc = _make_cap_doc(raw)
+
+    scraper = _make_reingest_scraper()
+    parsed = scraper.parse_document(doc)
+
+    assert parsed.case_number == "L24-04564"
+    assert parsed.judge_name == "BENJAMIN REYES"
+    assert parsed.department is None
+    assert parsed.courthouse is None
+
+
+# ---------------------------------------------------------------------------
+# 15. _coerce_hearing_date — accepts datetime, ISO string, or None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_year", "expected_month", "expected_day"),
+    [
+        (datetime(2025, 1, 29, tzinfo=UTC), 2025, 1, 29),
+        ("2025-01-29T16:31:00+00:00", 2025, 1, 29),
+        ("2025-01-29 16:31:00+00:00", 2025, 1, 29),
+        ("2025-01-29T16:31:00", 2025, 1, 29),
+    ],
+)
+def test_coerce_hearing_date_round_trips(
+    value: datetime | str,
+    expected_year: int,
+    expected_month: int,
+    expected_day: int,
+) -> None:
+    coerced = _coerce_hearing_date(value)
+    assert coerced is not None
+    assert coerced.year == expected_year
+    assert coerced.month == expected_month
+    assert coerced.day == expected_day
+
+
+def test_coerce_hearing_date_none_returns_none() -> None:
+    assert _coerce_hearing_date(None) is None
+
+
+def test_coerce_hearing_date_garbage_string_returns_none() -> None:
+    assert _coerce_hearing_date("not a date") is None


### PR DESCRIPTION
## Summary

Refactor `cc_tentatives_portal.parse_document` along the #3986 shape — switch `raw_content` to a JSON envelope (`{row, detail_html_b64, pdf_url, pdf_bytes_b64, judge_id, judge_name_dropdown}`) and extract a `_populate_from_envelope` helper called from both `_fetch_single_ruling` (live) and `parse_document` (reingest). Reingest now recovers every field including `ruling_text_html`, which was permanently lost pre-fix.

Closes #4133

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (44/44 in `test_cc_tentatives_portal.py`, 7340 in full scraper-framework suite)
- [x] Reingest-safety hygiene check passes (`scripts/check-parse-document-reingest-safety.sh`)
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeded (`deploy-scraper.yml` run 25420101225 — all 4 jobs green; ingestion-worker task-def revision 620 with image tag matching merge SHA `993d372`).
- [x] Verification evidence posted on issue.

## Notes

- **Option A chosen** (envelope) over Option B (PDF + extra). Option A makes `ruling_text_html` recoverable on reingest, which Option B explicitly cannot.
- **Backwards compatible.** Pre-#4133 archived captures (raw PDF bytes) still reingest via `parse_document` returning unchanged → pdfplumber + DB-seed merge (#4142).
- **`content_format` flipped from PDF to TEXT** for new captures, matching the CourtListener envelope pattern (#3986).
- No backfill of already-archived documents — explicitly out of scope per the issue (separate p3 follow-up if needed).
