### PR TITLE
fix(ca-sf-civil): make sf_civil_tentatives.parse_document reingest-safe (#4134)

### DIFF
--- a/docs/investigations/parse_document-reingest-safety-2026-05.md
+++ b/docs/investigations/parse_document-reingest-safety-2026-05.md
@@ -87,18 +87,22 @@ lives in `pdf_link_scraper.py`, which is a shared base class consumed by
 | `ca/sd_calendar.py:578` | **Reingest-aware** | HTML bytes | Yes — primary path | Docstring explicitly names "during reingest" as the main use case. `doc.raw_content.decode("utf-8")` → `parse_calendar_page(html)` matched by `doc.case_number`. Safe and explicitly documented. |
 | `ca/sd_pipeline.py:188` | **Reingest-aware** (delegating) | HTML bytes | Yes | Delegates to `SDTentativeRulingsScraper.parse_document` (sd_tentatives.py). Safe. |
 | `ca/sd_tentatives.py:843` | **Reingest-aware** | HTML bytes | Yes | `doc.raw_content.decode("utf-8")` → `parse_roa_page(html)`. LLM supplements outcome/motion_type when enabled. Safe. |
-| `ca/sf_civil_tentatives.py:1153` | **Live-only (no-op)** | HTML bytes (per-ruling AJAX response text) | Yes (via `_reparse_document`) | Returns `doc` unchanged. `raw_content` is the per-ruling HTML text from the AJAX API, so `_extract_text_from_content` UTF-8-decodes it into `extracted["ruling_text"]` (cf. CourtListener: there `raw_content` was a JSON envelope, so the decode produced a JSON string — that was the #3986 bug). **No truncation hazard like #3986** because the body is HTML text rather than a JSON envelope. **But:** `case_number`, `case_title`, `hearing_date`, `motion_type`, `judge_name`, `department`, `parties`, `ruling_text_html`, `outcome` all populated only in `_ruling_to_document` from the AJAX response's structured fields. Reingest can recover `case_number/case_title/hearing_date` from `doc_meta`; `judge_name`/`department`/`parties` are unconditionally cleared (see "How `_reparse_document` consumes" §5 above). Existing docstring is misleading — says fields are "pre-populated during fetch" but doesn't mention reingest. **Same shape as #3986 minus the JSON-envelope-as-ruling_text symptom.** |
+| `ca/sf_civil_tentatives.py:1153` | **Reingest-aware (post-#4134)** | JSON envelope bytes (ParsedRuling fields + ruling_id + department) | Yes — primary path | Post-fix: `_ruling_to_document` archives a JSON envelope to `raw_content`, and `parse_document` JSON-decodes + calls `_populate_from_envelope` (single source of truth for both code paths). Tolerates legacy bare-HTML archives — returns doc unchanged so reingest's UTF-8 decode + DB-seed fallback still applies. Safe. |
 | `ca/sf_tentatives.py:214` | **Reingest-aware** (via super) | PDF bytes | Yes | `super().parse_document(doc)` + judge / hearing-date / case-title from PDF text. Safe. |
 | `ca/ventura_tentatives.py:518` | **Reingest-aware** | PDF or HTML bytes | Yes | Branches on `doc.content_format`; both branches call `_extract_pdf_text`/`_extract_html_text` and populate fields. Safe. |
 | `federal/courtlistener.py:513` | **Reingest-aware** (post-#3986) | JSON envelope bytes | Yes — primary path | Post-fix: `parse_document` calls `_populate_from_envelope` for both live-capture and reingest. Single source of truth. Safe. |
 
 ## Summary by class
 
-- **Reingest-aware (or Mixed → Reingest-aware in the reingest branch):** 17 implementations. All safe.
-- **Live-only (no-op):** 3 implementations:
+- **Reingest-aware (or Mixed → Reingest-aware in the reingest branch):** 18 implementations (post-#4134). All safe.
+- **Live-only (no-op):** 2 implementations:
   1. `ca/cc_tentatives_portal.py:549`
   2. `ca/oc_tentatives.py:162` (intentional — LLM-handled, already documented)
-  3. `ca/sf_civil_tentatives.py:1153`
+
+  Previously `ca/sf_civil_tentatives.py:1153` was on this list; #4134 moved
+  it to Reingest-aware by switching ``raw_content`` to a JSON envelope and
+  routing both ``_ruling_to_document`` and ``parse_document`` through a
+  shared ``_populate_from_envelope`` helper.
 
 ## Live-only triage
 
@@ -114,13 +118,20 @@ lives in `pdf_link_scraper.py`, which is a shared base class consumed by
   field (modulo `doc_meta` seeds for `case_number/case_title/hearing_date`).
 - **Action:** filed follow-up issue (see below) to refactor along the #3986 shape — extract a `_populate_from_pdf_or_listing_envelope` helper so `parse_document` can populate fields from PDF text at minimum, and document that `ruling_text_html` is unrecoverable on reingest (or change the archive shape to include detail HTML).
 
-### `ca/sf_civil_tentatives.py:1153` — UNSAFE for reingest (no-op clobber)
+### `ca/sf_civil_tentatives.py:1153` — RESOLVED in #4134
 
-- `raw_content` is the per-ruling HTML text — `ruling_text` would round-trip via UTF-8 decode.
-- Structured fields (`case_number/case_title/hearing_date/motion_type/judge_name/department/parties/ruling_text_html/outcome`) come from the AJAX API's structured response, parsed in `_ruling_to_document`. None of those structured fields survive in `raw_content`.
-- The no-op `parse_document` returns `doc` unchanged, so `_reparse_document` clears `judge_name/department/parties` to `None`/`[]` (see §5 above). DB-seeded `case_number/case_title/hearing_date` survive; everything else is gone.
-- **No truncation-cap hazard** like #3986 because the body is HTML rather than a JSON envelope, but the structural-field loss is the same shape.
-- **Action:** filed follow-up issue (see below) to either (a) refactor `_ruling_to_document` so that the AJAX response is archived as a JSON envelope into `raw_content` and `parse_document` re-populates from it (mirrors CourtListener's #3986 fix), or (b) explicitly document that this scraper is not reingest-safe and add a runtime guard that refuses to reingest documents from `scraper_id="ca-sf-tentatives-civil"` until the refactor lands.
+- Resolution: chose Option A from the follow-up — `_ruling_to_document`
+  now archives a JSON envelope (ParsedRuling fields + ruling_id +
+  department) to `raw_content`, and `parse_document` JSON-decodes +
+  routes through a new shared `_populate_from_envelope` helper. Single
+  source of truth for live capture and reingest.
+- Legacy archives: `parse_document` tolerates pre-#4134 bare-HTML
+  bodies — returns doc unchanged so reingest's UTF-8 decode + DB-seed
+  fallback still applies. Backfilling legacy archives to the new
+  envelope shape is out of scope (separate p3 follow-up if needed).
+- See the table row above for the post-fix classification and PR #4134
+  for the regression test in
+  `tests/courts/test_sf_civil_tentatives.py::TestParseDocumentReingestSafety`.
 
 ### `ca/oc_tentatives.py:162` — Documented as LLM-handled
 

--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -526,6 +526,42 @@ def normalize_case_title(raw_title: str | None) -> str | None:
     return title
 
 
+def _build_ruling_envelope(
+    ruling: ParsedRuling,
+    ruling_id: int,
+    department: str,
+) -> dict[str, Any]:
+    """Build the JSON envelope archived in ``raw_content`` (#4134).
+
+    The envelope captures everything ``_populate_from_envelope`` needs to
+    reconstruct the document on the reingest path. Live capture writes
+    this envelope to ``raw_content`` and immediately calls
+    ``_populate_from_envelope`` with the same dict; reingest JSON-decodes
+    ``raw_content`` and calls ``_populate_from_envelope`` with the
+    decoded dict. Single shape, two callers.
+
+    Args:
+        ruling: The parsed ruling data from the AJAX response.
+        ruling_id: The RulingID used to fetch this ruling.
+        department: The department number resolved from RulingID.
+
+    Returns:
+        A dict suitable for ``json.dumps`` — keys are str, values are
+        primitive (str/int/None/list).
+    """
+    return {
+        "case_number": ruling.case_number,
+        "case_title": ruling.case_title,
+        "court_date": ruling.court_date,
+        "calendar_matter": ruling.calendar_matter,
+        "ruling_text": ruling.ruling_text,
+        "ruling_html": ruling.ruling_html,
+        "case_info_url": ruling.case_info_url,
+        "ruling_id": ruling_id,
+        "department": department,
+    }
+
+
 def extract_session_id(html: str) -> str | None:
     """Extract the seshID from tr.dll page HTML.
 
@@ -1102,11 +1138,15 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
     ) -> CapturedDocument:
         """Convert a ParsedRuling into a CapturedDocument.
 
-        The raw_content is the per-ruling HTML text. Each ruling gets
-        unique raw_content so that content-addressed archival (SHA-256 hash
-        → document_id) produces a unique document per ruling. Archiving the
-        full JSON response would cause all rulings from the same API call
-        to share the same content_hash and collapse into one document.
+        The raw_content is a JSON envelope of the ParsedRuling fields plus
+        the ``ruling_id`` and ``department`` (#4134). The envelope shape
+        lets ``parse_document`` reconstruct every field on the reingest
+        path — without it, only ``ruling_text``/``ruling_text_html`` would
+        survive (the legacy bare-HTML shape this method used to write).
+
+        Each ruling's envelope is unique (different case number + ruling
+        text + ruling_id), so content-addressed archival (SHA-256 hash →
+        document_id) still produces one document per ruling.
 
         Args:
             ruling: The parsed ruling data.
@@ -1116,9 +1156,12 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
         Returns:
             A populated CapturedDocument.
         """
-        # Use the ruling HTML as raw content for archival
-        content = ruling.ruling_html or ruling.ruling_text or ""
-        raw_content = content.encode("utf-8")
+        envelope = _build_ruling_envelope(
+            ruling=ruling,
+            ruling_id=ruling_id,
+            department=department,
+        )
+        raw_content = json.dumps(envelope, default=str).encode("utf-8")
 
         source_url = f"{CIVIL_API_URL}?RulingID={ruling_id}"
 
@@ -1128,59 +1171,124 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
             content_format=ContentFormat.HTML,
         )
 
-        doc.department = department
-        doc.courthouse = "San Francisco Courthouse"
-        doc.case_number = ruling.case_number
-        doc.case_title = normalize_case_title(ruling.case_title)
-        doc.hearing_date = parse_hearing_date(ruling.court_date)
-        doc.ruling_text = ruling.ruling_text
-        doc.ruling_text_html = ruling.ruling_html
-        doc.motion_type = ruling.calendar_matter
-        doc.outcome = extract_outcome(ruling.ruling_text)
-        doc.parties = extract_parties_from_title(ruling.case_title)
-
-        # Resolve judge name from department via court roster
-        doc.judge_name = self._dept_judge_map.get(department)
-
-        # Store metadata for downstream processing
-        doc.extra["ruling_id"] = ruling_id
-        doc.extra["dept_type"] = RULING_ID_MAP[ruling_id]["type"]
-        if ruling.case_info_url:
-            doc.extra["case_info_url"] = ruling.case_info_url
-
+        self._populate_from_envelope(doc, envelope)
         return doc
 
     def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
-        """No-op on the live-capture path — all fields are populated during
-        ``fetch_documents`` via ``_ruling_to_document`` from the AJAX
-        response's structured data.
+        """Populate structured fields from ``doc.raw_content`` (#4134).
 
-        **Reingest hazard (audit #4046, follow-up #4134):** this method is
-        also called from ``scripts/reingest_from_s3.py::_reparse_document``
-        with a fresh ``CapturedDocument`` carrying only ``raw_content``
-        (per-ruling HTML bytes). ``raw_content`` does NOT contain the AJAX
-        response's structured fields — those existed only in the live
-        ``ParsedRuling``. Returning the doc unchanged means ``judge_name``,
-        ``department``, ``parties``, ``outcome``, ``motion_type``, and
-        ``ruling_text_html`` get cleared by the reingest merge logic,
-        and only ``ruling_text`` (via UTF-8 decode of the HTML body) plus
-        the DB-seeded ``case_number/case_title/hearing_date`` survive.
-        **Reingest of SF-civil-tentatives documents is NOT fully
-        supported** — the surviving fields are a subset of the original
-        capture. Unlike #3986 there is no truncation-cap symptom because
-        the body is HTML rather than a JSON envelope, but the structural
-        loss is the same shape. #4134 tracks the refactor along the
-        #3986 ``_populate_from_envelope`` shape.
+        Single source of truth for both the live capture path
+        (``_ruling_to_document`` calls ``_populate_from_envelope`` after
+        building ``raw_content``) and the reingest path
+        (``scripts/reingest_from_s3.py::_reparse_document`` constructs a
+        fresh ``CapturedDocument`` carrying only ``raw_content`` and calls
+        this method).
 
-        Args:
-            doc: The document to parse.
+        After #4134, ``raw_content`` is a JSON envelope of the
+        ``ParsedRuling`` fields plus ``ruling_id``/``department``. Decoded
+        and routed through ``_populate_from_envelope``, every structured
+        field — ``case_number``, ``case_title``, ``hearing_date``,
+        ``ruling_text``, ``ruling_text_html``, ``motion_type``,
+        ``outcome``, ``parties``, ``judge_name``, ``department``,
+        ``courthouse``, plus ``extra.ruling_id`` and
+        ``extra.case_info_url`` — is repopulated identically to the live
+        path. The previous bare-``return doc`` no-op silently cleared
+        ``judge_name``/``department``/``parties``/``outcome``/``motion_type``
+        on the reingest merge (audit #4046).
 
-        Returns:
-            The document unchanged.
+        Tolerates legacy archives whose ``raw_content`` is the pre-#4134
+        bare HTML body (not valid JSON, or JSON without the expected
+        envelope keys): in that case the doc is returned unchanged so the
+        reingest caller falls back to its existing UTF-8 decode + DB-
+        seeded fields. Out of scope is backfilling those legacy archives
+        to the new envelope shape — that's a follow-up p3 task.
         """
-        # Fields are pre-populated during fetch — no additional parsing needed
-        # since the AJAX API returns structured data.
+        if not doc.raw_content:
+            return doc
+
+        try:
+            payload = json.loads(doc.raw_content)
+        except (ValueError, TypeError):
+            # Legacy archive — bare HTML body bytes. Return unchanged so
+            # reingest's existing fallback (UTF-8 decode + DB-seeded
+            # metadata) keeps working.
+            return doc
+
+        if not isinstance(payload, dict):
+            return doc
+
+        # Envelope sanity check — every #4134 envelope carries the
+        # ``ruling_html``/``ruling_text``/``ruling_id`` triad.  If any of
+        # those is missing the payload was written by some other shape
+        # (e.g. an externally-tampered archive); don't risk populating
+        # with garbage.
+        required_keys = {"ruling_id", "department"}
+        if not required_keys.issubset(payload.keys()):
+            return doc
+
+        self._populate_from_envelope(doc, payload)
         return doc
+
+    def _populate_from_envelope(
+        self,
+        doc: CapturedDocument,
+        envelope: dict[str, Any],
+    ) -> None:
+        """Populate structured fields on ``doc`` from a ParsedRuling envelope.
+
+        Single source of truth for the field-mapping logic shared by the
+        live capture path (``_ruling_to_document``) and the reingest path
+        (``parse_document``). Mutates ``doc`` in place.
+
+        Envelope keys (all optional except ``ruling_id``/``department``):
+            case_number, case_title, court_date, calendar_matter,
+            ruling_text, ruling_html, case_info_url, ruling_id, department.
+        """
+        ruling_id = envelope.get("ruling_id")
+        department = envelope.get("department") or ""
+
+        case_title_raw = envelope.get("case_title")
+        ruling_text = envelope.get("ruling_text")
+        ruling_html = envelope.get("ruling_html")
+        court_date = envelope.get("court_date")
+        calendar_matter = envelope.get("calendar_matter")
+        case_info_url = envelope.get("case_info_url")
+
+        doc.department = department or None
+        doc.courthouse = "San Francisco Courthouse"
+        doc.case_number = envelope.get("case_number")
+        doc.case_title = normalize_case_title(case_title_raw)
+        doc.hearing_date = parse_hearing_date(court_date)
+        doc.ruling_text = ruling_text
+        doc.ruling_text_html = ruling_html
+        doc.motion_type = calendar_matter
+        doc.outcome = extract_outcome(ruling_text)
+        doc.parties = extract_parties_from_title(case_title_raw)
+
+        # Resolve judge name from department via court roster.  Empty
+        # string department (defensive) maps to None lookup.
+        doc.judge_name = self._dept_judge_map.get(department) if department else None
+
+        # Store metadata for downstream processing.  Coerce ruling_id
+        # back to int when possible — JSON round-tripping preserves int
+        # but a tampered envelope might ship a string.
+        if isinstance(ruling_id, int):
+            doc.extra["ruling_id"] = ruling_id
+            dept_type = RULING_ID_MAP.get(ruling_id, {}).get("type")
+            if dept_type:
+                doc.extra["dept_type"] = dept_type
+        else:
+            try:
+                rid_int = int(ruling_id) if ruling_id is not None else None
+            except (TypeError, ValueError):
+                rid_int = None
+            if rid_int is not None:
+                doc.extra["ruling_id"] = rid_int
+                dept_type = RULING_ID_MAP.get(rid_int, {}).get("type")
+                if dept_type:
+                    doc.extra["dept_type"] = dept_type
+        if case_info_url:
+            doc.extra["case_info_url"] = case_info_url
 
 
 def default_config(s3_bucket: str = "") -> ScraperConfig:

--- a/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
@@ -1797,3 +1797,347 @@ class TestFixtureRegression:
             rulings = parse_api_response(_load_fixture(name))
             total += len(rulings)
         assert total == 33  # 12 + 11 + 10
+
+
+# ---------------------------------------------------------------------------
+# parse_document — reingest safety (#4134)
+# ---------------------------------------------------------------------------
+
+
+class TestParseDocumentReingestSafety:
+    """parse_document must populate every structured field from raw_content
+    on the reingest path (#4134).
+
+    On the reingest path, ``scripts/reingest_from_s3.py::_reparse_document``
+    constructs a fresh ``CapturedDocument`` carrying only ``raw_content`` and
+    calls ``scraper.parse_document(cap_doc)``.  Before #4134, ``raw_content``
+    was the bare per-ruling HTML and ``parse_document`` was a no-op, so the
+    reingest merge silently cleared ``judge_name``/``department``/``parties``/
+    ``outcome``/``motion_type``.  After #4134, ``raw_content`` is a JSON
+    envelope and ``parse_document`` repopulates every field.
+    """
+
+    @staticmethod
+    def _build_envelope_raw_content(**overrides: object) -> bytes:
+        """Build the JSON envelope ``_ruling_to_document`` writes today."""
+        import json as _json
+
+        envelope: dict[str, object] = {
+            "case_number": "CPF23518377",
+            "case_title": "MAIBACH VS. ABC CORP",
+            "court_date": "2026-03-23 09:00 AM",
+            "calendar_matter": "MOTION FOR SUMMARY JUDGMENT",
+            "ruling_text": "The motion is GRANTED. Plaintiff to prepare order.",
+            "ruling_html": ("<p>The motion is <b>GRANTED</b>. Plaintiff to prepare order.</p>"),
+            "case_info_url": "/CaseInfo.dll?ID=CPF23518377",
+            "ruling_id": 10,
+            "department": "301",
+        }
+        envelope.update(overrides)
+        return _json.dumps(envelope).encode("utf-8")
+
+    @staticmethod
+    def _make_reingest_cap_doc(raw_content: bytes) -> Any:
+        """Construct the shape of CapturedDocument the reingest path passes."""
+        from datetime import UTC, datetime
+
+        from framework import CapturedDocument, ContentFormat
+
+        return CapturedDocument(
+            document_id="00000000-0000-0000-0000-000000000001",
+            scraper_id="ca-sf-tentatives-civil",
+            state="CA",
+            county="San Francisco",
+            court="Superior Court",
+            source_url="https://webapps.sftc.org/tr/tr.dll?RulingID=10",
+            capture_timestamp=datetime(2026, 3, 23, tzinfo=UTC),
+            content_format=ContentFormat.HTML,
+            raw_content=raw_content,
+            content_hash="0" * 64,
+        )
+
+    def _make_scraper(
+        self, dept_judge_map: dict[str, str] | None = None
+    ) -> SFCivilTentativeRulingsScraper:
+        config = sf_civil_default_config()
+        config.request_delay_seconds = 0
+        return SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+            dept_judge_map=dept_judge_map,
+        )
+
+    def test_reingest_populates_case_number(self) -> None:
+        """parse_document populates case_number from the envelope."""
+        raw = self._build_envelope_raw_content(case_number="CGC22602981")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.case_number == "CGC22602981"
+
+    def test_reingest_populates_case_title_normalized(self) -> None:
+        """parse_document populates case_title via normalize_case_title."""
+        raw = self._build_envelope_raw_content(case_title="MAIBACH VS. ABC CORP")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        # ALL CAPS gets title-cased
+        assert parsed.case_title == "Maibach Vs. Abc Corp"
+
+    def test_reingest_populates_hearing_date(self) -> None:
+        """parse_document parses hearing_date from court_date."""
+        from datetime import datetime
+
+        raw = self._build_envelope_raw_content(court_date="2026-03-23 09:00 AM")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.hearing_date == datetime(2026, 3, 23, 9, 0)
+
+    def test_reingest_populates_ruling_text_and_html(self) -> None:
+        """parse_document populates ruling_text + ruling_text_html."""
+        raw = self._build_envelope_raw_content(
+            ruling_text="The motion is DENIED.",
+            ruling_html="<p>The motion is <b>DENIED</b>.</p>",
+        )
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.ruling_text == "The motion is DENIED."
+        assert parsed.ruling_text_html == "<p>The motion is <b>DENIED</b>.</p>"
+
+    def test_reingest_populates_motion_type(self) -> None:
+        """parse_document populates motion_type from calendar_matter."""
+        raw = self._build_envelope_raw_content(calendar_matter="DEMURRER")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.motion_type == "DEMURRER"
+
+    def test_reingest_populates_outcome(self) -> None:
+        """parse_document extracts outcome from ruling_text via regex."""
+        raw = self._build_envelope_raw_content(
+            ruling_text="The motion is GRANTED. The court rules as follows.",
+        )
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.outcome == "granted"
+
+    def test_reingest_populates_parties(self) -> None:
+        """parse_document extracts parties from case_title via VS. split."""
+        raw = self._build_envelope_raw_content(case_title="JOHN DOE VS. ACME INC")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        roles = {p["role"]: p["name"] for p in parsed.parties}
+        assert roles == {"plaintiff": "John Doe", "defendant": "Acme Inc"}
+
+    def test_reingest_populates_department_and_courthouse(self) -> None:
+        """parse_document populates department + courthouse from envelope."""
+        raw = self._build_envelope_raw_content(department="302")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.department == "302"
+        assert parsed.courthouse == "San Francisco Courthouse"
+
+    def test_reingest_populates_judge_name_from_dept_map(self) -> None:
+        """parse_document looks up judge_name via dept_judge_map (#4134)."""
+        raw = self._build_envelope_raw_content(department="301")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper(
+            dept_judge_map={"301": "Curtis E.A. Karnow"},
+        )
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.judge_name == "Curtis E.A. Karnow"
+
+    def test_reingest_judge_name_none_when_no_dept_map(self) -> None:
+        """parse_document leaves judge_name None when dept_judge_map empty."""
+        raw = self._build_envelope_raw_content(department="301")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.judge_name is None
+
+    def test_reingest_populates_extra_metadata(self) -> None:
+        """parse_document populates extra.ruling_id, dept_type, case_info_url."""
+        raw = self._build_envelope_raw_content(
+            ruling_id=10,
+            case_info_url="/CaseInfo.dll?ID=CPF23518377",
+        )
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.extra["ruling_id"] == 10
+        assert parsed.extra["dept_type"] == "Law & Motion/Discovery (odd)"
+        assert parsed.extra["case_info_url"] == "/CaseInfo.dll?ID=CPF23518377"
+
+    def test_reingest_legacy_html_body_returns_unchanged(self) -> None:
+        """Legacy archives (bare HTML body bytes, not JSON) return unchanged.
+
+        Pre-#4134 archives wrote the per-ruling HTML body to raw_content.
+        parse_document must tolerate those without raising — returning the
+        doc unchanged so reingest's existing UTF-8 decode + DB-seeded
+        metadata fallback keeps working.
+        """
+        raw = b"<p>The motion is GRANTED.</p>"
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        # No exception, no envelope-derived fields populated.
+        assert parsed.case_number is None
+        assert parsed.ruling_text is None
+        assert parsed.case_title is None
+
+    def test_reingest_invalid_json_returns_unchanged(self) -> None:
+        """Garbage raw_content (not JSON, not HTML) returns unchanged."""
+        raw = b"\x00\x01\x02not-json-not-html"
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.case_number is None
+        assert parsed.ruling_text is None
+
+    def test_reingest_json_without_envelope_keys_returns_unchanged(self) -> None:
+        """Valid JSON without ruling_id/department keys returns unchanged.
+
+        Defensive — an externally tampered archive that decodes to a dict
+        but lacks the envelope's required keys should not crash and
+        should not populate fields with garbage.
+        """
+        import json as _json
+
+        raw = _json.dumps({"unrelated": "shape", "foo": 42}).encode("utf-8")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.case_number is None
+        assert parsed.ruling_text is None
+
+    def test_reingest_empty_raw_content_returns_unchanged(self) -> None:
+        """Empty raw_content returns unchanged without raising."""
+        cap_doc = self._make_reingest_cap_doc(b"")
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.case_number is None
+        assert parsed.ruling_text is None
+
+    def test_reingest_envelope_with_string_ruling_id_coerces_to_int(self) -> None:
+        """JSON-stringified ruling_id (defensive) gets coerced back to int.
+
+        json.dumps preserves int round-trip, but a tampered archive could
+        ship a string. _populate_from_envelope must coerce so dept_type
+        lookup still works.
+        """
+        import json as _json
+
+        envelope = {
+            "case_number": "CPF23518377",
+            "case_title": "TEST CASE",
+            "court_date": None,
+            "calendar_matter": None,
+            "ruling_text": None,
+            "ruling_html": None,
+            "case_info_url": None,
+            "ruling_id": "10",  # string instead of int
+            "department": "301",
+        }
+        raw = _json.dumps(envelope).encode("utf-8")
+        cap_doc = self._make_reingest_cap_doc(raw)
+        scraper = self._make_scraper()
+
+        parsed = scraper.parse_document(cap_doc)
+
+        assert parsed.extra["ruling_id"] == 10
+        assert parsed.extra["dept_type"] == "Law & Motion/Discovery (odd)"
+
+    def test_live_capture_envelope_round_trips_through_parse_document(self) -> None:
+        """End-to-end: docs from fetch_documents survive a parse_document round-trip.
+
+        Construct a fresh CapturedDocument from the live doc's raw_content
+        (mimicking what reingest does) and assert parse_document recovers
+        the same field values as the live capture.
+        """
+        from datetime import UTC, datetime
+
+        from framework import CapturedDocument, ContentFormat
+
+        json_text = _load_fixture("sf-civil-api-response-rid10-2026-03-23.json")
+        _mock_rest_api(json_text)
+
+        config = sf_civil_default_config()
+        config.request_delay_seconds = 0
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            session_id=TEST_SESSION_ID,
+            dept_judge_map={"301": "Curtis E.A. Karnow"},
+        )
+
+        with respx.mock:
+            _mock_rest_api(json_text)
+            docs = scraper.fetch_documents()
+
+        live_doc = next(d for d in docs if d.department == "301")
+
+        # Mimic reingest's CapturedDocument construction — only raw_content
+        # carries content into parse_document, every other field is the
+        # DB-seeded shape.
+        reingest_doc = CapturedDocument(
+            document_id=live_doc.document_id,
+            scraper_id=live_doc.scraper_id,
+            state=live_doc.state,
+            county=live_doc.county,
+            court=live_doc.court,
+            source_url=live_doc.source_url,
+            capture_timestamp=datetime(2026, 3, 23, tzinfo=UTC),
+            content_format=ContentFormat.HTML,
+            raw_content=live_doc.raw_content,
+            content_hash="0" * 64,
+        )
+
+        parsed = scraper.parse_document(reingest_doc)
+
+        assert parsed.case_number == live_doc.case_number
+        assert parsed.case_title == live_doc.case_title
+        assert parsed.hearing_date == live_doc.hearing_date
+        assert parsed.ruling_text == live_doc.ruling_text
+        assert parsed.ruling_text_html == live_doc.ruling_text_html
+        assert parsed.motion_type == live_doc.motion_type
+        assert parsed.outcome == live_doc.outcome
+        assert parsed.parties == live_doc.parties
+        assert parsed.department == live_doc.department
+        assert parsed.courthouse == live_doc.courthouse
+        assert parsed.judge_name == live_doc.judge_name
+        assert parsed.extra.get("ruling_id") == live_doc.extra.get("ruling_id")
+        assert parsed.extra.get("dept_type") == live_doc.extra.get("dept_type")


### PR DESCRIPTION
## Summary

Refactor `sf_civil_tentatives.py::parse_document` along the #3986 shape — single source of truth for live capture and reingest.

`_ruling_to_document` now archives a JSON envelope (ParsedRuling fields plus `ruling_id` + `department`) into `raw_content`, and `parse_document` decodes it and routes through a new shared `_populate_from_envelope` helper. The previous bare-`return doc` no-op silently cleared `judge_name`/`department`/`parties`/`outcome`/`motion_type` on the reingest merge in `_reparse_document` (audit #4046).

Closes #4134

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (17 new tests under `TestParseDocumentReingestSafety`)
- [x] CI green

### Post-deploy verification
- [x] N/A — pure code refactor of an extraction code path. The scraper continues to write per-ruling envelopes for archival; existing-archive shape is tolerated by the `parse_document` legacy fallback so no reingest disruption. Verification reduces to the regression test suite. Backfill of pre-#4134 archives to the new envelope shape is explicitly out of scope per the issue (separate p3 follow-up if needed).
- [x] Verification evidence posted on issue (see A.8)
