### PR TITLE
infra(dx): add check-bash-set-u-empty-array.sh guard (#4143)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,6 +788,17 @@ jobs:
       - name: Verify scripts stay within the bash 3.2 feature subset
         if: matrix.shard == 'python'
         run: scripts/check-bash-compat.sh
+      # Issue #4143: bash 5.x footgun where 'declare -a <name>'
+      # (without an inline =()) is later expanded as ${#<name>[@]}
+      # under set -u — works on macOS bash 3.2 but trips
+      # 'unbound variable' on Linux CI bash 5.x. Surfaced in #4119 /
+      # PR #4140 (the cloudwatch-alarm-docs check). Sibling guard to
+      # check-bash-compat.sh — that one covers bash-4+ syntax that
+      # doesn't exist on 3.2; this one covers a construct that exists
+      # on both but has different observable behavior under set -u.
+      - name: Verify scripts initialise indexed arrays before reading under nounset
+        if: matrix.shard == 'python'
+        run: scripts/check-bash-set-u-empty-array.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
       # that adding a new shell test is just `touch + chmod +x` — no

--- a/scripts/check-bash-set-u-empty-array.sh
+++ b/scripts/check-bash-set-u-empty-array.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# check-bash-set-u-empty-array.sh — Forbid the bash 5.x footgun where
+# ``declare -a <name>`` (without ``=()``) is later expanded as
+# ``${#<name>[@]}`` or ``"${<name>[@]}"`` under ``set -u``.
+#
+# Why this check exists
+# ---------------------
+# ``declare -a <name>`` declares an indexed array but does NOT assign
+# it. On bash 3.2 (macOS operator laptops), reading
+# ``${#empty_declared_array[@]}`` returns 0 cleanly. On bash 5.x (Linux
+# CI runners) under ``set -u``, the same read trips ``unbound
+# variable``:
+#
+#     scripts/check-cloudwatch-alarm-docs.sh: line 231: unresolved: unbound variable
+#
+# This is a textbook platform-skew bug — passes locally, fails CI —
+# exactly the gap that ``scripts/check-bash-compat.sh`` covers for the
+# bash 4+ feature set. Surfaced in #4119 / PR #4140; tracked here as
+# #4143.
+#
+# The canonical fix is one character: ``declare -a <name>`` →
+# ``<name>=()``. The latter both declares the variable AND assigns an
+# empty array, so the subsequent ``${#<name>[@]}`` read sees a
+# bound-but-empty array and returns 0 on every bash version.
+#
+# Detection strategy
+# ------------------
+# This check is line-text-based (not AST-based) so it runs in a few
+# hundred milliseconds on a cold macOS laptop. For each shell script:
+#
+#   1. Detect whether ``set -u`` (or ``set -o nounset``, or any ``set
+#      -[a-z]*u`` flags combo like ``-eu`` / ``-euo pipefail``) appears
+#      anywhere in the file. If not, skip the file — no nounset, no
+#      bug.
+#
+#   2. Find every ``declare -a <name>`` (or ``typeset -a <name>``)
+#      that is NOT immediately followed by ``=`` — i.e. a bare declare
+#      without an inline assignment. Record the line number and the
+#      array name.
+#
+#   3. For each (name, declare_line) pair: scan the file from
+#      ``declare_line + 1`` to EOF looking for either:
+#        - an assignment ``<name>=(`` or ``<name>+=(`` (clears the bug
+#          — array is bound before any read), OR
+#        - a read ``${#<name>[@]}`` or ``"${<name>[@]}"`` or
+#          ``"${<name>[*]}"`` (triggers the bug).
+#      Whichever comes first determines the verdict: read-first → flag,
+#      assign-first → safe.
+#
+# What it does NOT flag
+# ---------------------
+#   - ``declare -a <name>=()`` — the inline form is fine.
+#   - ``<name>=()`` — the no-declare form is fine.
+#   - ``declare -a <name>`` followed by ``<name>+=(...)`` BEFORE any
+#     ``${#<name>[@]}`` read — append-then-read is bash 3.2 / 5.x
+#     compatible because ``+=`` on an undeclared array binds it.
+#   - Files without any ``set -u`` / ``set -o nounset`` directive — no
+#     nounset, no bug.
+#   - Comment lines (first non-whitespace is ``#``).
+#
+# Sibling check: ``scripts/check-bash-compat.sh`` covers the bash-4+
+# constructs that simply don't exist on bash 3.2 (mapfile, declare
+# -A, namerefs, case-conversion expansions, ;;&, |&). This check
+# covers a different class of failure: a construct that exists on
+# both bash 3.2 and 5.x but has *different observable behavior*
+# under ``set -u``. The two checks are complementary, not
+# overlapping.
+#
+# Usage
+# -----
+#   scripts/check-bash-set-u-empty-array.sh          # scan repo's scripts/
+#   scripts/check-bash-set-u-empty-array.sh [dir]    # scan a specific directory
+#
+# Exit codes
+# ----------
+#   0 — No violations found.
+#   1 — One or more shell scripts have ``declare -a <name>`` followed
+#       by ``${#<name>[@]}`` (or ``"${<name>[@]}"``) under ``set -u``
+#       without an intervening assignment. The offending lines are
+#       printed with file:line:content plus the suggested fix.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Files that legitimately mention the forbidden pattern ───────────────
+# The check script and its test must spell the pattern literally.
+EXCLUDE_FILES=(
+    "scripts/check-bash-set-u-empty-array.sh"
+    "scripts/tests/test_check_bash_set_u_empty_array.sh"
+)
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    "__pycache__"
+    "tmp"
+)
+
+# ─── Locate the shell scripts to scan ────────────────────────────────────
+SCRIPTS_DIR="$SCAN_DIR/scripts"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+    # When invoked against a test TMPDIR that doesn't have a scripts/
+    # subdir, treat SCAN_DIR itself as the target.
+    SCRIPTS_DIR="$SCAN_DIR"
+fi
+
+prune_args=()
+for d in "${EXCLUDE_DIRS[@]}"; do
+    prune_args+=(-name "$d" -type d -prune -o)
+done
+
+sh_files=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && sh_files+=("$f")
+done < <(find "$SCRIPTS_DIR" "${prune_args[@]+"${prune_args[@]}"}" \
+    -type f -name '*.sh' -print 2>/dev/null | sort || true)
+
+if [[ ${#sh_files[@]} -eq 0 ]]; then
+    echo "check-bash-set-u-empty-array: no *.sh files found under $SCRIPTS_DIR — nothing to check."
+    exit 0
+fi
+
+# ─── Per-file scan ───────────────────────────────────────────────────────
+violations=0
+report_lines=()
+
+# Match any ``set`` invocation that turns on nounset:
+#   set -u
+#   set -eu
+#   set -euo pipefail
+#   set -o nounset
+# Comment-leading whitespace is stripped before this regex is applied.
+NOUNSET_REGEX='^[[:space:]]*set[[:space:]]+(-[a-zA-Z]*u[a-zA-Z]*([[:space:]]|$)|-o[[:space:]]+nounset)'
+
+# Match ``declare -a <name>`` or ``typeset -a <name>`` where <name> is
+# NOT followed by ``=`` (i.e. bare declare). Captures <name> in
+# BASH_REMATCH[2].
+DECLARE_BARE_REGEX='^[[:space:]]*(declare|typeset)[[:space:]]+-[a-zA-Z]*a[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)([[:space:]]|$)'
+
+for file in "${sh_files[@]}"; do
+    # Skip allow-listed files.
+    skip=false
+    for excl in "${EXCLUDE_FILES[@]}"; do
+        if [[ "$file" == *"$excl" ]]; then
+            skip=true
+            break
+        fi
+    done
+    if "$skip"; then
+        continue
+    fi
+
+    # Read file into an array of lines. Use the ``while read`` idiom —
+    # not ``mapfile`` — because this very script must run on bash 3.2.
+    lines=()
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        lines+=("$line")
+    done < "$file"
+
+    nlines=${#lines[@]}
+    [[ $nlines -eq 0 ]] && continue
+
+    # Pass 1: does this file enable ``set -u``?
+    has_nounset=false
+    i=0
+    while (( i < nlines )); do
+        l="${lines[$i]}"
+        # Skip comment lines.
+        if [[ "$l" =~ ^[[:space:]]*# ]]; then
+            i=$((i + 1))
+            continue
+        fi
+        if [[ "$l" =~ $NOUNSET_REGEX ]]; then
+            has_nounset=true
+            break
+        fi
+        i=$((i + 1))
+    done
+
+    if ! "$has_nounset"; then
+        continue
+    fi
+
+    # Pass 2: find bare ``declare -a <name>`` lines and check for
+    # read-before-assign. We re-walk the file linearly, recording each
+    # bare declare and then checking forward.
+    decl_idx=0
+    while (( decl_idx < nlines )); do
+        dline="${lines[$decl_idx]}"
+
+        # Skip comments.
+        if [[ "$dline" =~ ^[[:space:]]*# ]]; then
+            decl_idx=$((decl_idx + 1))
+            continue
+        fi
+
+        if [[ "$dline" =~ $DECLARE_BARE_REGEX ]]; then
+            name="${BASH_REMATCH[2]}"
+
+            # Build name-specific patterns. ``<name>=`` and
+            # ``<name>+=`` are bash assignment forms; the read forms
+            # are ``${#<name>[@]}`` / ``${#<name>[*]}`` /
+            # ``${<name>[@]...}`` / ``${<name>[*]...}``.
+            #
+            # Regex notes:
+            #   - Anchor reads at ``\$\{`` (literal ``${``) so we don't
+            #     match ``$<name>`` (scalar read, not array).
+            #   - Anchor assigns at ``<name>=(`` or ``<name>+=(`` so
+            #     a substring like ``foo_bar=...`` does not falsely
+            #     match when the array name is ``foo``.
+            assign_regex="(^|[^A-Za-z0-9_])${name}\\+?=\\("
+            read_regex="\\\$\\{#?${name}\\["
+
+            scan_idx=$((decl_idx + 1))
+            verdict=""
+            verdict_line=0
+            verdict_content=""
+            while (( scan_idx < nlines )); do
+                sline="${lines[$scan_idx]}"
+
+                # Skip comments inside the scan.
+                if [[ "$sline" =~ ^[[:space:]]*# ]]; then
+                    scan_idx=$((scan_idx + 1))
+                    continue
+                fi
+
+                # Check assignment first — it is the safe outcome and
+                # we want to short-circuit cleanly.
+                if [[ "$sline" =~ $assign_regex ]]; then
+                    verdict="assigned"
+                    break
+                fi
+
+                if [[ "$sline" =~ $read_regex ]]; then
+                    verdict="read"
+                    verdict_line=$((scan_idx + 1))
+                    verdict_content="$sline"
+                    break
+                fi
+
+                scan_idx=$((scan_idx + 1))
+            done
+
+            if [[ "$verdict" == "read" ]]; then
+                report_lines+=("  [declare -a $name read before assign under set -u]")
+                report_lines+=("    $file:$((decl_idx + 1)): $dline")
+                report_lines+=("    $file:$verdict_line: $verdict_content")
+                report_lines+=("    fix: replace 'declare -a $name' with '$name=()'")
+                violations=$((violations + 1))
+            fi
+        fi
+
+        decl_idx=$((decl_idx + 1))
+    done
+done
+
+if (( violations > 0 )); then
+    echo "ERROR: bash 5.x set -u + declare -a empty-array footgun(s) detected in scripts/**/*.sh."
+    echo ""
+    echo "  'declare -a <name>' declares an indexed array but does NOT"
+    echo "  assign it. On bash 3.2 (macOS) reading \${#<name>[@]} returns"
+    echo "  0 cleanly; on bash 5.x (Linux CI) under 'set -u' the same"
+    echo "  read trips '<name>: unbound variable'. Fix: replace"
+    echo "  'declare -a <name>' with '<name>=()' so the variable is"
+    echo "  bound to an empty array at declaration time."
+    echo ""
+    for line in "${report_lines[@]}"; do
+        echo "$line"
+    done
+    echo ""
+    echo "  Total violations: $violations"
+    echo ""
+    echo "  See: scripts/check-bash-set-u-empty-array.sh header for the"
+    echo "  full rationale and #4143 / PR #4140 for the originating"
+    echo "  incident."
+    exit 1
+fi
+
+echo "check-bash-set-u-empty-array: ${#sh_files[@]} shell script(s) scanned — all clean."
+exit 0

--- a/scripts/tests/test_check_bash_set_u_empty_array.sh
+++ b/scripts/tests/test_check_bash_set_u_empty_array.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# test_check_bash_set_u_empty_array.sh — Tests for
+# scripts/check-bash-set-u-empty-array.sh.
+#
+# Verifies that the checker correctly flags the bash 5.x footgun where
+# ``declare -a <name>`` (without ``=()``) is later expanded as
+# ``${#<name>[@]}`` under ``set -u``, while NOT flagging the safe
+# variants (``=()`` initializer, append-then-read, no nounset).
+#
+# Each test writes a synthetic shell file under ``$TMPDIR_TEST/scripts/``
+# and invokes the check against ``$TMPDIR_TEST``.
+#
+# Usage:
+#   scripts/tests/test_check_bash_set_u_empty_array.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-bash-set-u-empty-array.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMPDIR_TEST/scripts"
+
+write_file() {
+    # $1: file path (relative to $TMPDIR_TEST/scripts/)
+    # contents via stdin
+    local path="$TMPDIR_TEST/scripts/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+    chmod +x "$path"
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST/scripts"
+    mkdir -p "$TMPDIR_TEST/scripts"
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: Bare declare -a + set -u + ${#name[@]} read → fails ────────
+write_file "bad_declare_a_size_read.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a missing
+echo "${#missing[@]}"
+EOF
+assert_fails "declare -a + set -u + \${#name[@]} read triggers the check"
+reset_tmpdir
+
+# ─── Test 2: Bare declare -a + set -euo pipefail + read → fails ─────────
+write_file "bad_set_euo_pipefail.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+declare -a unresolved
+if (( ${#unresolved[@]} > 0 )); then
+    echo "found"
+fi
+EOF
+assert_fails "declare -a + set -euo pipefail + size read triggers the check"
+reset_tmpdir
+
+# ─── Test 3: Bare declare -a + set -o nounset + read → fails ────────────
+write_file "bad_set_o_nounset.sh" <<'EOF'
+#!/usr/bin/env bash
+set -o nounset
+declare -a items
+echo "${items[@]}"
+EOF
+assert_fails "declare -a + set -o nounset + array read triggers the check"
+reset_tmpdir
+
+# ─── Test 4: Bare typeset -a (synonym) + set -u + read → fails ──────────
+write_file "bad_typeset_a.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+typeset -a items
+echo "${#items[@]}"
+EOF
+assert_fails "typeset -a + set -u + size read triggers the check"
+reset_tmpdir
+
+# ─── Test 5: Safe — name=() initializer + set -u + read → passes ────────
+# This is the canonical fix the check suggests.
+write_file "good_empty_initializer.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+missing=()
+echo "${#missing[@]}"
+EOF
+assert_passes "name=() initializer with set -u and size read passes"
+reset_tmpdir
+
+# ─── Test 6: Safe — declare -a name=() inline assignment → passes ───────
+write_file "good_declare_inline.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a missing=()
+echo "${#missing[@]}"
+EOF
+assert_passes "declare -a name=() inline assignment passes"
+reset_tmpdir
+
+# ─── Test 7: Safe — declare -a + append-before-read → passes ────────────
+# ``+=`` on an undeclared array still binds it, so a subsequent
+# ``${#name[@]}`` read is safe even on bash 5.x with set -u.
+write_file "good_declare_then_append.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a items
+items+=("first")
+items+=("second")
+echo "${#items[@]}"
+EOF
+assert_passes "declare -a + append-before-read (correct existing pattern) passes"
+reset_tmpdir
+
+# ─── Test 8: Safe — declare -a + plain assign + read → passes ──────────
+write_file "good_declare_then_assign.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a items
+items=("a" "b")
+echo "${#items[@]}"
+EOF
+assert_passes "declare -a + plain assign-before-read passes"
+reset_tmpdir
+
+# ─── Test 9: Safe — no set -u + declare -a + read → passes ─────────────
+# Without nounset the read is harmless on every bash version.
+write_file "good_no_nounset.sh" <<'EOF'
+#!/usr/bin/env bash
+declare -a items
+echo "${#items[@]}"
+EOF
+assert_passes "declare -a + read without set -u (no nounset, no bug) passes"
+reset_tmpdir
+
+# ─── Test 10: Safe — set -u + declare -a + only @ expansion (no read) ───
+# Just declaring without ever reading is safe; the check should not
+# flag a bare declare that is never expanded.
+write_file "good_declare_no_read.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a items
+echo "ok"
+EOF
+assert_passes "declare -a never expanded passes"
+reset_tmpdir
+
+# ─── Test 11: Safe — comments referencing the pattern → passes ─────────
+write_file "good_comments.sh" <<'EOF'
+#!/usr/bin/env bash
+# Historical: 'declare -a missing' under 'set -u' would trip
+# 'unbound variable' on bash 5.x when ${#missing[@]} was read.
+# Fix: missing=() instead of declare -a missing.
+set -u
+missing=()
+echo "${#missing[@]}"
+EOF
+assert_passes "Comments referencing the bad pattern are exempted"
+reset_tmpdir
+
+# ─── Test 12: Safe — substring/lookalike name → passes ─────────────────
+# ``foo_bar=(...)`` should NOT count as an assignment to ``foo``, and
+# ``${#foo_bar[@]}`` should NOT count as a read of ``foo``. The
+# check uses word-boundary anchoring on the name.
+write_file "good_lookalike_names.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a foo
+foo_bar=("x" "y")
+echo "${#foo_bar[@]}"
+foo=()
+echo "${#foo[@]}"
+EOF
+assert_passes "Lookalike names (foo_bar) are not confused with the declared name (foo)"
+reset_tmpdir
+
+# ─── Test 13: Mixed — one bad, one good in same file → fails ───────────
+write_file "mixed_bad_and_good.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a bad_one
+declare -a good_one
+good_one=("x")
+echo "${#bad_one[@]}"
+echo "${#good_one[@]}"
+EOF
+assert_fails "Mixed file flags only the bad declare and not the good one"
+reset_tmpdir
+
+# ─── Test 14: Multiple violations across files → fails ─────────────────
+write_file "bad_a.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+declare -a x
+echo "${#x[@]}"
+EOF
+write_file "bad_b.sh" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+declare -a y
+echo "${y[@]}"
+EOF
+assert_fails "Violations across multiple files are detected"
+reset_tmpdir
+
+# ─── Test 15: Self-scan — real repo scripts/ tree → passes ─────────────
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" "$REPO_ROOT" > /dev/null 2>&1; then
+    echo "PASS: Real repo scripts/ tree passes (no violations)"
+else
+    echo "FAIL: Real repo scripts/ tree contains a violation"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 16: No self-match on ci.yml step name ────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain a forbidden token (e.g. literal "declare -a" in
+# the step's name: field). See #2541/#2542.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-bash-set-u-empty-array.sh" "sh"
+
+# ─── Summary ───────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a sibling guard to `scripts/check-bash-compat.sh` that catches the bash 5.x footgun where `declare -a <name>` (without an inline `=()`) is later expanded as `${#<name>[@]}` or `"${<name>[@]}"` under `set -u`. The pattern is a no-op on macOS bash 3.2 but trips `<name>: unbound variable` on Linux CI bash 5.x — the exact failure that surfaced in #4119 / PR #4140 (`scripts/check-cloudwatch-alarm-docs.sh`).

The implementation is line-text-based with regex anchoring (no AST, no bash 4+ features), runs in a few hundred milliseconds, and is wired into the existing `scripts-tests` `python` shard alongside `check-bash-compat.sh`. The 16-test suite under `scripts/tests/test_check_bash_set_u_empty_array.sh` covers positive (bad pattern caught), negative (`=()` initializer / inline / append-then-read / no-nounset / lookalike names), real-repo self-scan, and the standard ci.yml step-name self-match assertion.

Closes #4143

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check / shell guard only). Verification evidence comment will state the skip reason on issue #4143.
