### PR TITLE
refactor(dispatcher): extract per-phase handlers into agent_runner_handlers.sh (#4138)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1977,6 +1977,20 @@ fi
 # shellcheck source=./agent_runner_run_claude_phase.sh
 source "$(dirname "${BASH_SOURCE[0]}")/agent_runner_run_claude_phase.sh"
 
+# #4138 — per-phase case-arm handler bodies extracted from
+# ``phase_loop()`` for the same reasons as ``run_claude_phase`` above:
+# keep the loop a thin dispatcher, let tests source the handlers
+# directly, and mirror the precedent set by #3775. Sourced here so the
+# inner side-effect handlers (``handle_push_and_pr``,
+# ``handle_fix_conflict``, ``handle_fix_ci``, ``handle_awaiting_ci``,
+# ``handle_merge``, ``handle_awaiting_deploy``) defined below are
+# visible to the ``handle_*_arm`` callers when they execute. (Bash
+# defers function-body resolution until invocation, so the load order
+# matters for the *runtime* lookup, not the parse — but keeping the
+# source line near the existing one makes the dependency obvious to
+# readers.)
+source "$(dirname "${BASH_SOURCE[0]}")/agent_runner_handlers.sh"
+
 
 handle_scheduled_skill() {
     # Issue #3374. Dispatch a synthetic scheduled-skill phase (audit,
@@ -5227,368 +5241,51 @@ phase_loop() {
     # mechanical — they were incorrectly included in the original
     # Stage 1b dispatch, which called `/task-v2-claiming` /
     # `/task-v2-push_and_pr` and got "Unknown command" back.
+    # #4138 — per-phase case-arm bodies extracted to the sourced
+    # handler file (see the source line earlier in this script). Each
+    # ``handle_*`` (or ``handle_*_arm``) function owns its own pre/post
+    # bookkeeping —
+    # ``persist_phase_output``, ``transition_for``,
+    # ``dispatch_transition_action``, ``advance_phase``, and
+    # ``agent_runner_reaped_failure`` — so this case is now a thin
+    # dispatcher: one function call per phase. The original ralph
+    # baseline-rebase short-circuit converts its inner ``continue``
+    # to a function ``return 0`` (after ``dispatch_transition_action``
+    # has already advanced the phase row, the next loop tick observes
+    # the new phase — exact same control flow as ``continue``).
     case "$_current" in
-        planning|ralph|summary|verify)
-            # #3225 secondary mitigation — run a baseline
-            # ``git fetch origin main && git rebase origin/main`` at
-            # the START of ralph (before any claude iterations). This
-            # cuts the conflict surface by the duration of ralph
-            # (~20-25 min) so the agent works against the latest main
-            # from the beginning. On conflict, short-circuit the
-            # claude invocation and emit the same rebase_failed
-            # envelope that push_and_pr emits — transition_from_ralph
-            # routes to fix_conflict.
-            if [[ "$_current" == "ralph" ]] && \
-               [[ "${AGENT_RUNNER_RALPH_BASELINE_REBASE:-1}" == "1" ]] && \
-               [[ "$AGENT_RUNNER_DRY_RUN" != "1" ]]; then
-                log "ralph_baseline_rebase_begin"
-                set +e
-                git -C "$REPO_ROOT" fetch origin main \
-                    > "$AGENT_WORKSPACE/ralph-baseline-fetch.stdout.log" \
-                    2> "$AGENT_WORKSPACE/ralph-baseline-fetch.stderr.log"
-                _baseline_fetch_rc=$?
-                set -e
-                log "ralph_baseline_fetch_done" "exit_code=$_baseline_fetch_rc"
-                if [[ "$_baseline_fetch_rc" -eq 0 ]]; then
-                    set +e
-                    git -C "$REPO_ROOT" rebase origin/main \
-                        > "$AGENT_WORKSPACE/ralph-baseline-rebase.stdout.log" \
-                        2> "$AGENT_WORKSPACE/ralph-baseline-rebase.stderr.log"
-                    _baseline_rebase_rc=$?
-                    set -e
-                    log "ralph_baseline_rebase_done" "exit_code=$_baseline_rebase_rc"
-                    if [[ "$_baseline_rebase_rc" -ne 0 ]]; then
-                        # Capture conflict files, stash markers, abort,
-                        # emit rebase_failed envelope. Same shape as
-                        # push_and_pr's conflict path so the
-                        # fix_conflict phase can consume either.
-                        _fix_conflict_stage="$AGENT_WORKSPACE/fix-conflict"
-                        mkdir -p "$_fix_conflict_stage/conflict-markers"
-                        set +e
-                        git -C "$REPO_ROOT" diff --name-only --diff-filter=U \
-                            > "$_fix_conflict_stage/conflict-files.txt" \
-                            2> "$AGENT_WORKSPACE/git-diff-conflict-files.stderr.log"
-                        set -e
-                        while IFS= read -r _cfile; do
-                            if [[ -z "$_cfile" ]]; then
-                                continue
-                            fi
-                            _safe=$(printf '%s' "$_cfile" | tr '/' '__')
-                            if [[ -f "$REPO_ROOT/$_cfile" ]]; then
-                                cp "$REPO_ROOT/$_cfile" \
-                                    "$_fix_conflict_stage/conflict-markers/$_safe" \
-                                    2>/dev/null || true
-                            fi
-                        done < "$_fix_conflict_stage/conflict-files.txt"
-                        set +e
-                        git -C "$REPO_ROOT" rev-parse ORIG_HEAD \
-                            > "$_fix_conflict_stage/orig-head.txt" 2>/dev/null || true
-                        git -C "$REPO_ROOT" merge-base ORIG_HEAD origin/main \
-                            > "$_fix_conflict_stage/merge-base.txt" 2>/dev/null || true
-                        git -C "$REPO_ROOT" rebase --abort \
-                            > "$AGENT_WORKSPACE/ralph-baseline-rebase-abort.stdout.log" \
-                            2> "$AGENT_WORKSPACE/ralph-baseline-rebase-abort.stderr.log"
-                        set -e
-                        _baseline_conflict_files_json="[]"
-                        if [[ -s "$_fix_conflict_stage/conflict-files.txt" ]]; then
-                            _baseline_conflict_files_json=$(jq -R -s -c \
-                                'split("\n") | map(select(length > 0))' \
-                                "$_fix_conflict_stage/conflict-files.txt" 2>/dev/null \
-                                || printf '[]')
-                        fi
-                        # #3465: capture the last ~50 lines of
-                        # ralph-baseline-rebase.stderr.log (size-capped at
-                        # ~5 KB) so the diagnoser can inspect the rebase
-                        # failure reason when no unmerged files are present.
-                        _baseline_rebase_stderr_tail=$(tail -n 50 \
-                            "$AGENT_WORKSPACE/ralph-baseline-rebase.stderr.log" \
-                            2>/dev/null \
-                            | head -c 5120 \
-                            | jq -Rs '.' 2>/dev/null \
-                            || printf '""')
-                        log "ralph_baseline_rebase_conflict" \
-                            "exit_code=$_baseline_rebase_rc" \
-                            "conflict_files_json=$_baseline_conflict_files_json"
-                        # #3651: post-rebase empty-diff guard — direct
-                        # sibling of #3614/PR #3645's fix in
-                        # ``handle_push_and_pr``. When the start-of-ralph
-                        # baseline rebase fails AND the conflict-files
-                        # list is empty AND the post-abort ahead-count
-                        # collapses to 0, the agent's commits were
-                        # already in main (typically because a sibling
-                        # PR landed the same fix first, or the daemon
-                        # is retrying an already-fixed issue). Pre-#3651
-                        # this fell through to the no_unmerged_files
-                        # envelope, which transition_from_ralph routed
-                        # to the diagnoser as
-                        # ``push_and_pr_no_unmerged_files`` — terminal-
-                        # failing the agent on what is actually a benign
-                        # success (the cluster of stuck issues #2777,
-                        # #2832, #2854, #3297, #3407, #3574, #3581,
-                        # tripping the circuit breaker repeatedly).
-                        #
-                        # The fix: if the conflict-files list is empty
-                        # AND the rebase --abort returned HEAD to a
-                        # commit already in origin/main (ahead-count 0),
-                        # emit the existing ``{"no_op": true}`` envelope.
-                        # ``transition_from_ralph`` (#3651) routes that
-                        # to PHASE_NO_OP terminal succeeded — exactly
-                        # the right outcome for "fix is already in
-                        # main." The new log event
-                        # ``ralph_baseline_no_unmerged_files_already_applied``
-                        # distinguishes this advance event from the
-                        # pre-existing
-                        # ``ralph_baseline_route_to_diagnoser`` (which
-                        # still fires when the rebase actually failed
-                        # for a non-already-applied reason — same code
-                        # path as #3465). Mirrors PR #3645's
-                        # ``push_and_pr_no_unmerged_files_already_applied``.
-                        _ralph_baseline_output=""
-                        if [[ "$_baseline_conflict_files_json" == "[]" ]]; then
-                            # #3675: stronger semantic check than the
-                            # pre-#3675 ``rev-list --count`` check (see
-                            # the matching commentary in
-                            # ``handle_push_and_pr``). ``rev-list``
-                            # counts commit objects, not the diff that
-                            # would actually ship — ORIG_HEAD's
-                            # commits are still distinct objects even
-                            # when they became semantically redundant
-                            # with main during the rebase (which is
-                            # why rebase produced empty commits and
-                            # exited 128). ``git diff --quiet``
-                            # answers the actual question: "is there
-                            # any change to ship?" Exit 0 = no diff =
-                            # already in main = emit no_op.
-                            if _post_rebase_no_diff_to_main; then
-                                log "ralph_baseline_no_unmerged_files_already_applied" \
-                                    "reason=rebase_failed_but_diff_to_main_is_empty"
-                                _ralph_baseline_output=$(printf '{"no_op": true, "rebase_dropped_all_commits": true, "diff_to_main_empty": true, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
-                                    "$_baseline_rebase_stderr_tail")
-                            else
-                                # #3465 path: rebase actually failed for
-                                # a non-already-applied reason (corrupt
-                                # state, fetch issue, etc.) — route to
-                                # the diagnoser as before.
-                                _ralph_baseline_output=$(printf '{"rebase_failed": true, "no_unmerged_files": true, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
-                                    "$_baseline_rebase_stderr_tail")
-                            fi
-                        else
-                            # #3225 path: real rebase conflict — route
-                            # to fix_conflict with the file bundle.
-                            _ralph_baseline_output=$(printf '{"rebase_failed": true, "conflict_files": %s, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
-                                "$_baseline_conflict_files_json" "$_baseline_rebase_stderr_tail")
-                        fi
-                        persist_phase_output "ralph" "$_ralph_baseline_output"
-                        _bt=$(transition_for "ralph" "$_ralph_baseline_output")
-                        _ba=$(printf '%s' "$_bt" | cut -f1)
-                        _bn=$(printf '%s' "$_bt" | cut -f2)
-                        _bs=$(printf '%s' "$_bt" | cut -f3)
-                        _bh=$(printf '%s' "$_bt" | cut -f4)
-                        # #3581 — single-source-of-truth dispatch via
-                        # the helper. See dispatch_transition_action
-                        # above advance_phase. Replaces the per-phase
-                        # case-statement that landed in #3573 (ralph
-                        # baseline route_to_diagnoser arm).
-                        dispatch_transition_action "ralph_baseline" "$_ba" "$_bn" "$_bs" "$_bh" "$_ralph_baseline_output"
-                        continue
-                    fi
-                else
-                    log "ralph_baseline_fetch_failed_skipping" \
-                        "exit_code=$_baseline_fetch_rc"
-                fi
-            fi
-            if [[ "$_current" == "ralph" ]]; then
-                # #3144: start the HEAD-watcher subshell so the long
-                # ralph phase emits per-iteration observability to
-                # CloudWatch + dispatcher.ralph_patches. The watcher is
-                # stopped unconditionally after run_claude_phase returns
-                # (success or failure) so the subshell never outlives
-                # the phase it instruments.
-                start_ralph_head_watcher
-            fi
-            _output=$(run_claude_phase "$_current")
-            if [[ "$_current" == "ralph" ]]; then
-                stop_ralph_head_watcher
-            fi
-            # #3694 — ralph silent-exit instrumentation. The original
-            # symptom: three consecutive ECS agents on three different
-            # issues exited with ``output_json={}`` and ``stderr_tail=""``,
-            # producing zero diagnostic data. The worker subprocess
-            # terminated cleanly without writing a verdict marker, so the
-            # daemon classified the failure as ``ralph_not_ship`` with no
-            # block_reason.
-            #
-            # Layer 1 (this commit) makes the failure self-diagnosing —
-            # capture the worker's stdout/stderr tails into
-            # ``phase_outputs.log_text``, emit a structured
-            # ``ralph_done_marker_missing`` event, and replace the empty
-            # ``output_json`` with a payload carrying the tails as
-            # ``block_reason``. The daemon's ``_collect_failure_details``
-            # already forwards ``block_reason`` → ``failures.details
-            # .stderr_tail`` (see daemon.py ~12420), so the next
-            # occurrence will surface a populated stderr_tail in the
-            # diagnoser's verbatim-quote pull instead of the current
-            # empty string. Layer 2 (the actual fix to whatever is
-            # making the worker exit silently) lands once the new logs
-            # capture self-diagnosing data.
-            _ralph_log_tail_file=""
-            if [[ "$_current" == "ralph" ]]; then
-                _ralph_stdout_file="$AGENT_WORKSPACE/claude-p-ralph.stdout.json"
-                _ralph_stderr_file="$AGENT_WORKSPACE/claude-p-ralph.stderr.log"
-                # Build a merged tail file (last 2000 bytes of stdout +
-                # last 2000 bytes of stderr) for log_text persistence.
-                # Unconditional capture — even SHIP-path runs benefit
-                # from having the worker narrative in the DB for
-                # post-mortem when CI / verify later reveals a problem.
-                _ralph_log_tail_file="$AGENT_WORKSPACE/claude-p-ralph.log_text.txt"
-                {
-                    printf '=== claude-p-ralph.stdout.json (last 2000 bytes) ===\n'
-                    if [[ -s "$_ralph_stdout_file" ]]; then
-                        tail -c 2000 "$_ralph_stdout_file" 2>/dev/null
-                    fi
-                    printf '\n=== claude-p-ralph.stderr.log (last 2000 bytes) ===\n'
-                    if [[ -s "$_ralph_stderr_file" ]]; then
-                        tail -c 2000 "$_ralph_stderr_file" 2>/dev/null
-                    fi
-                    printf '\n'
-                } > "$_ralph_log_tail_file" 2>/dev/null || true
-                # Detect the silent-exit shape — ralph returned ``{}`` (a
-                # string-equal check is sufficient because run_claude_phase
-                # only emits ``{}`` for the non-object .result fallback;
-                # any legitimate ralph output, even an empty BLOCKED, is at
-                # least ``{"verdict": "..."}``).
-                if [[ "$_output" == "{}" ]]; then
-                    # Layer 4 silent-ralph fallback (#3782). Before
-                    # falling through to the ``ralph_done_marker_missing``
-                    # path, check whether the inner ``/task-v2-ralph``
-                    # skill DID write its inner ``ralph-done.txt`` (Step
-                    # 3b of the inner SKILL.md is marked CRITICAL — and
-                    # is reliably written) but the outer wrapper's Step
-                    # 4 Write of ``dispatcher-output/ralph.json`` was
-                    # skipped (the model finished its conversation
-                    # without doing the final tool call). Synthesize the
-                    # dispatcher-output JSON from the inner state files.
-                    # On success, ``_output`` carries a structured verdict
-                    # matching what ralph actually achieved; on failure
-                    # (ralph-done.txt missing — the genuinely-silent
-                    # case), the helper returns non-zero and we fall
-                    # through to the original Layer 1 instrumentation.
-                    _layer4_synth=""
-                    if _layer4_synth=$(synthesize_ralph_output_from_done_marker "$REPO_ROOT" 2>>"$AGENT_WORKSPACE/claude-p-ralph.stderr.log"); then
-                        if [[ -n "$_layer4_synth" ]]; then
-                            _output="$_layer4_synth"
-                        fi
-                    fi
-                fi
-                # If the Layer 4 synthesis didn't produce a verdict, fall
-                # through to Layer 1 instrumentation. Re-check
-                # ``_output == "{}"`` so a successful synthesis above
-                # short-circuits this block entirely.
-                if [[ "$_output" == "{}" ]]; then
-                    _ralph_stdout_tail=""
-                    _ralph_stderr_tail=""
-                    if [[ -s "$_ralph_stdout_file" ]]; then
-                        _ralph_stdout_tail=$(tail -c 500 "$_ralph_stdout_file" 2>/dev/null \
-                            | tr '\n\r\t' '   ' | sed -e 's/\\/\\\\/g')
-                    fi
-                    if [[ -s "$_ralph_stderr_file" ]]; then
-                        _ralph_stderr_tail=$(tail -c 500 "$_ralph_stderr_file" 2>/dev/null \
-                            | tr '\n\r\t' '   ' | sed -e 's/\\/\\\\/g')
-                    fi
-                    # ``run_claude_phase`` already captured the worker's
-                    # exit code into the ``claude_phase_done`` log line;
-                    # we don't have it in scope here directly, so emit a
-                    # placeholder. The stdout/stderr tails are the
-                    # high-value signal (they contain the actual error
-                    # lines if the worker printed any), and a future
-                    # iteration can plumb the rc through if needed.
-                    log "ralph_done_marker_missing" \
-                        "phase=ralph" \
-                        "worker_exit_code=unknown" \
-                        "worker_stdout_tail=$_ralph_stdout_tail" \
-                        "worker_stderr_tail=$_ralph_stderr_tail"
-                    # Replace the empty ``{}`` with a structured payload
-                    # so the daemon's failures.details.stderr_tail (which
-                    # mirrors block_reason for the ralph_not_ship terminal,
-                    # see daemon.py ~12420) carries the diagnostic tails
-                    # rather than "". jq -n -c builds the JSON safely with
-                    # the tails as typed string variables — no shell
-                    # interpolation into the SQL.
-                    _output=$(jq -n -c \
-                        --arg stdout_tail "$_ralph_stdout_tail" \
-                        --arg stderr_tail "$_ralph_stderr_tail" \
-                        '{verdict: "BLOCKED",
-                          category: "ralph_not_ship",
-                          block_reason: ("ralph_done_marker_missing: worker exited 0 with no done-marker. " +
-                                         "stdout_tail=" + $stdout_tail + " stderr_tail=" + $stderr_tail),
-                          worker_stdout_tail: $stdout_tail,
-                          worker_stderr_tail: $stderr_tail,
-                          ralph_done_marker_missing: true}' 2>/dev/null \
-                        || printf '{"category":"ralph_not_ship","block_reason":"ralph_done_marker_missing: jq build failed","ralph_done_marker_missing":true}')
-                fi
-            fi
-            persist_phase_output "$_current" "$_output" "$_ralph_log_tail_file"
-            if [[ "$_current" == "ralph" ]]; then
-                # Mirror the daemon's post-SHIP ralph_patches persist.
-                _verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""')
-                if [[ "$_verdict" == "SHIP" ]]; then
-                    persist_ralph_patch
-                fi
-            fi
-            _transition=$(transition_for "$_current" "$_output")
-            _action=$(printf '%s' "$_transition" | cut -f1)
-            _next=$(printf '%s' "$_transition" | cut -f2)
-            _status=$(printf '%s' "$_transition" | cut -f3)
-            _hint=$(printf '%s' "$_transition" | cut -f4)
-            # #3581 — single-source-of-truth dispatch. The helper
-            # (defined alongside advance_phase) handles every
-            # TransitionAction enum value AND every FAILURE_HINT_*
-            # constant emitted by phase_transitions.py uniformly across
-            # all phases. CI guard scripts/check-transition-dispatch-vocabulary.sh
-            # asserts the helper's vocabulary stays in sync with the
-            # Python module.
-            dispatch_transition_action "$_current" "$_action" "$_next" "$_status" "$_hint" "$_output"
+        planning)
+            handle_planning
+            ;;
+        ralph)
+            handle_ralph
+            ;;
+        summary)
+            handle_summary
+            ;;
+        verify)
+            handle_verify
             ;;
         claiming)
-            # Mechanical pseudo-phase (#3117): the daemon writes
-            # phase='claiming' only briefly while it inserts the
-            # dispatcher.agents row; the claim itself is a pure DB
-            # write, not an LLM pass. Any ECS task whose phase column
-            # reads `claiming` at boot is a post-claim lifecycle
-            # artifact — the claim already happened before the task
-            # was launched. Advance immediately to `planning` so the
-            # phase loop starts the real work without shelling out to
-            # a nonexistent `/task-v2-claiming` skill.
-            log "claiming_no_op_advance_to_planning"
-            persist_phase_output "claiming" '{"no_op": true}'
-            advance_phase "planning"
+            handle_claiming
             ;;
         push_and_pr)
-            # Mechanical phase (#3117). See handle_push_and_pr for the
-            # git push + gh pr create implementation. On success the
-            # transition shim advances to awaiting_ci (or to no_op
-            # terminal if the worktree was clean at ralph SHIP time).
-            _output=$(handle_push_and_pr)
-            persist_phase_output "push_and_pr" "$_output"
-            _transition=$(transition_for "push_and_pr" "$_output")
-            _action=$(printf '%s' "$_transition" | cut -f1)
-            _next=$(printf '%s' "$_transition" | cut -f2)
-            _status=$(printf '%s' "$_transition" | cut -f3)
-            _hint=$(printf '%s' "$_transition" | cut -f4)
-            # #3581 — single-source-of-truth dispatch via the helper.
-            # See dispatch_transition_action above advance_phase for
-            # the action-vocabulary handling. Replaces the per-phase
-            # case-statement that landed in #3543 (route_to_diagnoser
-            # arm) and #3558 (push_and_pr_no_unmerged_files hint).
-            dispatch_transition_action "push_and_pr" "$_action" "$_next" "$_status" "$_hint" "$_output"
+            handle_push_and_pr_arm
             ;;
         fix_conflict)
-            # #3225: fix_conflict phase. Budget-gated claude-resolution
-            # of rebase conflicts. handle_fix_conflict enforces the
-            # per-agent FIX_CONFLICT_MAX_ATTEMPTS budget, invokes the
-            # claude skill, applies resolved_files as a new commit on
-            # verdict=resolved, and emits the output envelope the
-            # transition shim uses to advance.
+            # #4138 transitional shape: ``T51`` in
+            # ``scripts/tests/test_agent_runner_entrypoint.sh`` extracts
+            # this arm body verbatim via awk and sources it into a stubbed
+            # subshell that does NOT define ``handle_fix_conflict_arm``.
+            # Rather than edit the test (#4138 AC #5 forbids test-file
+            # edits), the body is kept inline here so T51 keeps passing on
+            # bash 3.2. ``handle_fix_conflict_arm`` is still defined in
+            # the sourced handlers file and IS the canonical
+            # implementation — it receives the same call sequence (same
+            # events, same outputs) as this inline copy. Sub-task C will
+            # convert T51 to call ``handle_fix_conflict_arm`` directly,
+            # at which point this inline arm body collapses to the
+            # one-line dispatcher form used by every other arm.
             _output=$(handle_fix_conflict)
             _fc_verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""' 2>/dev/null || printf '')
             log "fix_conflict_handler_done" "verdict=$_fc_verdict"
@@ -5605,164 +5302,28 @@ phase_loop() {
                 "status=$_status" \
                 "hint=$_hint"
             log "fix_conflict_dispatched_action" "action=$_action"
-            # #3581 — single-source-of-truth dispatch via the helper.
-            # See dispatch_transition_action above advance_phase.
             dispatch_transition_action "fix_conflict" "$_action" "$_next" "$_status" "$_hint" "$_output"
             ;;
         fix_ci)
-            # #3245: fix_ci phase. Split out of the generic Claude-phase
-            # case because — unlike planning/ralph/summary/verify — the
-            # /task-v2-fix-ci skill explicitly defers git ops to "the
-            # daemon" (SKILL.md lines 64 + 160). Before #3245 the ECS
-            # entrypoint ran fix_ci through the generic arm and never
-            # staged / committed / pushed the skill's patch; every agent
-            # with initially-red CI looped 40 iterations without adding
-            # a single commit. handle_fix_ci mirrors the subprocess
-            # daemon's ``_run_fix_ci`` + ``_apply_fix_ci_patch`` (daemon.py
-            # ~line 12697 / 12979): PATCHED → stage + commit + push +
-            # back to awaiting_ci; FLAKY → back to awaiting_ci without
-            # commit; BLOCKED / unrecognized → fix_ci_failed terminal.
-            # handle_fix_ci owns its own advance_phase /
-            # agent_runner_reaped_failure calls so the dispatch case
-            # just invokes the handler and lets the next loop tick
-            # observe the new phase row.
-            handle_fix_ci >/dev/null
+            handle_fix_ci_arm
             ;;
         operational)
-            # #3507: operational phase. Runs the /task-v2-operational
-            # skill for tasks that need only a script run / DB query / gh
-            # action — no code change, no PR. Modeled on the verify)
-            # arm: run_claude_phase + persist_phase_output +
-            # transition_for dispatch.
-            #
-            # Verdicts from /task-v2-operational:
-            #   succeeded → advance_with_status → operational_done/succeeded
-            #   blocked   → advance_with_status → operational_failed/needs_review
-            #   failed / missing / unrecognized → route_to_diagnoser
-            #     → agent_runner_reaped_failure "operational_failed"
-            _output=$(run_claude_phase "operational")
-            persist_phase_output "operational" "$_output"
-            _transition=$(transition_for "operational" "$_output")
-            _action=$(printf '%s' "$_transition" | cut -f1)
-            _next=$(printf '%s' "$_transition" | cut -f2)
-            _status=$(printf '%s' "$_transition" | cut -f3)
-            _hint=$(printf '%s' "$_transition" | cut -f4)
-            log "operational_transition_shim_done" \
-                "action=$_action" \
-                "next=$_next" \
-                "status=$_status" \
-                "hint=$_hint"
-            # #3581 — single-source-of-truth dispatch via the helper.
-            # See dispatch_transition_action above advance_phase.
-            dispatch_transition_action "operational" "$_action" "$_next" "$_status" "$_hint" "$_output"
+            handle_operational
             ;;
         awaiting_ci)
-            # #3176: real implementation — poll ``gh pr view`` rollup,
-            # advance to ``merge`` on green, ``fix_ci`` on red, exit
-            # with terminal failure on timeout.
-            _output=$(handle_awaiting_ci)
-            persist_phase_output "awaiting_ci" "$_output"
-            _rollup_state=$(printf '%s' "$_output" | jq -r '.rollup_state // ""' 2>/dev/null)
-            _timeout=$(printf '%s' "$_output" | jq -r '.timeout // false' 2>/dev/null)
-            if [[ "$_timeout" == "true" ]]; then
-                # agent_runner_reaped_failure already set the terminal
-                # phase + status in the DB; next tick will observe it
-                # as terminal and exit.
-                :
-            elif [[ "$_rollup_state" == "green" ]]; then
-                advance_phase "merge"
-            elif [[ "$_rollup_state" == "red" ]]; then
-                advance_phase "fix_ci"
-            else
-                # No recognizable state — shouldn't happen, but don't
-                # spin. Treat as failure to surface the bug.
-                log "awaiting_ci_unrecognized_output" "output=$_output"
-                agent_runner_reaped_failure \
-                    "awaiting_ci_failed" \
-                    "unrecognized_output" \
-                    "$_output"
-            fi
+            handle_awaiting_ci_arm
             ;;
         merge)
-            # #3176: real implementation — squash-merge with
-            # branch-delete, auto-unstick on stale-rollup (one-shot),
-            # terminal failure on other non-zero exits.
-            _output=$(handle_merge)
-            persist_phase_output "merge" "$_output"
-            _merged=$(printf '%s' "$_output" | jq -r '.merged // false' 2>/dev/null)
-            _auto_unstick=$(printf '%s' "$_output" | jq -r '.auto_unstick_retry // false' 2>/dev/null)
-            _merge_failed=$(printf '%s' "$_output" | jq -r '.merge_failed // false' 2>/dev/null)
-            if [[ "$_merged" == "true" ]]; then
-                # Mirror daemon's ``_merge_pr_and_advance``: flip
-                # status=succeeded the moment the squash-merge lands,
-                # advance phase to awaiting_deploy. A crash mid-write
-                # still leaves a ``status='succeeded' phase=merge``
-                # row recoverable by the next tick.
-                advance_phase "awaiting_deploy" "succeeded"
-            elif [[ "$_auto_unstick" == "true" ]]; then
-                # Go back to awaiting_ci so the next poll sees the
-                # post-empty-commit rollup.
-                advance_phase "awaiting_ci"
-            elif [[ "$_merge_failed" == "true" ]]; then
-                # agent_runner_reaped_failure already set terminal state.
-                :
-            else
-                log "merge_unrecognized_output" "output=$_output"
-                agent_runner_reaped_failure \
-                    "merge_failed" \
-                    "unrecognized_output" \
-                    "$_output"
-            fi
+            handle_merge_arm
             ;;
         awaiting_deploy)
-            # #3176: real implementation — poll deploy workflows on
-            # the merge SHA, advance to verify on success / no-run
-            # grace, terminal failure on timeout / any deploy
-            # workflow failure.
-            _output=$(handle_awaiting_deploy)
-            persist_phase_output "awaiting_deploy" "$_output"
-            _deploy_state=$(printf '%s' "$_output" | jq -r '.deploy_state // ""' 2>/dev/null)
-            _timeout=$(printf '%s' "$_output" | jq -r '.timeout // false' 2>/dev/null)
-            if [[ "$_timeout" == "true" ]]; then
-                :
-            elif [[ "$_deploy_state" == "success" || "$_deploy_state" == "none" ]]; then
-                advance_phase "verify"
-            elif [[ "$_deploy_state" == "failure" ]]; then
-                :
-            else
-                log "awaiting_deploy_unrecognized_output" "output=$_output"
-                agent_runner_reaped_failure \
-                    "awaiting_deploy_failed" \
-                    "unrecognized_output" \
-                    "$_output"
-            fi
+            handle_awaiting_deploy_arm
             ;;
         retro|setup)
-            # Remaining mechanical stubs — Stage 3+ will wire these to
-            # real implementations (retro posts the issue comment +
-            # closes the loop; setup is currently unreachable under the
-            # Stage 1b happy path).
-            case "$_current" in
-                setup)            _next="ralph" ;;
-                retro)            _next="retro_done" ;;
-            esac
-            log "mechanical_phase_stub" "phase=$_current" "next=$_next"
-            persist_phase_output "$_current" '{"stub": true}'
-            advance_phase "$_next"
+            handle_retro_or_setup "$_current"
             ;;
         *)
-            # Issue #3455 — descriptive terminal instead of
-            # ``agent_runner_route_stub``. The catch-all fires when
-            # the phase column reads a value the dispatch loop
-            # doesn't recognize — that's a code-drift bug (a new
-            # phase landed in dispatcher.agents without being
-            # wired here), not a semantic failure, so no diagnoser
-            # routing.
-            log "phase_unknown" "phase=$_current"
-            agent_runner_reaped_failure \
-                "phase_unknown" \
-                "phase_unknown" \
-                "dispatch loop saw unknown phase=$_current (not wired in agent-runner-entrypoint.sh)"
+            handle_unknown_phase "$_current"
             ;;
     esac
     done

--- a/scripts/dispatcher/agent_runner_handlers.sh
+++ b/scripts/dispatcher/agent_runner_handlers.sh
@@ -1,0 +1,680 @@
+#!/usr/bin/env bash
+# agent_runner_handlers.sh — Sourceable per-phase case-arm handlers
+# extracted from `agent-runner-entrypoint.sh`'s `phase_loop()` (#4138).
+#
+# Defines, in roughly the order the case-statement arms appeared inline:
+#
+#   handle_planning
+#   handle_ralph
+#   handle_summary
+#   handle_verify
+#   handle_claiming
+#   handle_push_and_pr_arm
+#   handle_fix_conflict_arm
+#   handle_fix_ci_arm
+#   handle_operational
+#   handle_awaiting_ci_arm
+#   handle_merge_arm
+#   handle_awaiting_deploy_arm
+#   handle_retro_or_setup
+#   handle_unknown_phase
+#
+# Each handler owns the case-arm's pre/post bookkeeping
+# (``persist_phase_output``, ``transition_for``,
+# ``dispatch_transition_action``, ``advance_phase``,
+# ``agent_runner_reaped_failure``) for a single phase. The existing
+# inner side-effect handlers (``handle_push_and_pr``,
+# ``handle_fix_conflict``, ``handle_fix_ci``, ``handle_awaiting_ci``,
+# ``handle_merge``, ``handle_awaiting_deploy``, ``handle_scheduled_skill``)
+# keep their names and contracts; only the *case-statement-arm* bodies
+# move here.
+#
+# All handlers are bash 3.2 compatible (no associative arrays, no
+# ``mapfile``).
+#
+# # ralph baseline-rebase ``continue`` → handler return
+#
+# The original case body used ``continue`` after the baseline-rebase
+# block to skip the rest of the ralph arm and let the loop re-tick. Inside
+# a function, ``continue`` does not propagate to the calling loop.
+# ``handle_ralph`` instead returns 0 after dispatching the baseline
+# transition: the dispatched action has already advanced the agent's
+# phase row, so when ``phase_loop`` ticks again it observes the new
+# phase and routes accordingly — exact same control flow as the prior
+# ``continue``.
+#
+# Why a separate file vs. inline in the entrypoint:
+#
+#   * Mirrors the precedent set by ``agent_runner_run_claude_phase.sh``
+#     (#3775).
+#   * Keeps ``phase_loop`` a thin dispatcher (one function call per
+#     phase) so reviewers can read the loop control logic without
+#     scrolling through 600 lines of per-phase bookkeeping.
+#   * Sub-task C (#4136 / planned) will convert the test from
+#     ``bash $ENTRYPOINT`` invocations to direct function calls against
+#     the sourced handlers — extraction is the prerequisite.
+
+# ── log() / die() shims ────────────────────────────────────────────────────
+#
+# When sourced from ``agent-runner-entrypoint.sh``, ``log`` and ``die``
+# are already defined and behave correctly. When sourced directly (from
+# a test or for ad-hoc inspection), provide minimal substitutes so
+# callers don't crash. Same pattern as
+# ``agent_runner_run_claude_phase.sh``.
+
+if ! declare -F log >/dev/null 2>&1; then
+    log() {
+        _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        _event="$1"
+        shift
+        _extra=""
+        for kv in "$@"; do
+            _k=${kv%%=*}
+            _v=${kv#*=}
+            _v=$(printf '%s' "$_v" | sed 's/"/\\"/g')
+            _extra="$_extra, \"$_k\": \"$_v\""
+        done
+        printf '{"ts": "%s", "event": "agent_runner.%s", "agent_id": "%s"%s}\n' \
+            "$_ts" "$_event" "${AGENT_ID:-unknown}" "$_extra" >&2
+    }
+fi
+
+if ! declare -F die >/dev/null 2>&1; then
+    die() {
+        printf '%s\n' "$*" >&2
+        exit 1
+    }
+fi
+
+# ── Shared helper — claude-driven skill phase (planning/summary/verify) ────
+#
+# planning, summary, and verify share the exact arm body inherited from
+# the original ``planning|ralph|summary|verify)`` case: invoke
+# ``run_claude_phase``, persist the output, compute the transition, and
+# dispatch via ``dispatch_transition_action``. ``handle_ralph`` does NOT
+# call this helper because ralph layers a baseline-rebase prelude, a
+# HEAD-watcher subshell, a Layer 4 silent-exit fallback, and a
+# ``ralph_patches`` persist on top of the same skeleton.
+_handle_claude_skill_phase_arm() {
+    _phase="$1"
+    _output=$(run_claude_phase "$_phase")
+    persist_phase_output "$_phase" "$_output"
+    _transition=$(transition_for "$_phase" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    # #3581 — single-source-of-truth dispatch. The helper handles every
+    # TransitionAction enum value AND every FAILURE_HINT_* constant
+    # uniformly across all phases. CI guard
+    # scripts/check-transition-dispatch-vocabulary.sh asserts the
+    # helper's vocabulary stays in sync with the Python module.
+    dispatch_transition_action "$_phase" "$_action" "$_next" "$_status" "$_hint" "$_output"
+}
+
+# ── Claude-driven skill phases ─────────────────────────────────────────────
+
+handle_planning() {
+    _handle_claude_skill_phase_arm "planning"
+}
+
+handle_summary() {
+    _handle_claude_skill_phase_arm "summary"
+}
+
+handle_verify() {
+    _handle_claude_skill_phase_arm "verify"
+}
+
+# ── ralph (claude-driven, plus baseline-rebase + watcher + layer-4) ────────
+
+handle_ralph() {
+    # #3225 secondary mitigation — run a baseline
+    # ``git fetch origin main && git rebase origin/main`` at
+    # the START of ralph (before any claude iterations). This
+    # cuts the conflict surface by the duration of ralph
+    # (~20-25 min) so the agent works against the latest main
+    # from the beginning. On conflict, short-circuit the
+    # claude invocation and emit the same rebase_failed
+    # envelope that push_and_pr emits — transition_from_ralph
+    # routes to fix_conflict.
+    if [[ "${AGENT_RUNNER_RALPH_BASELINE_REBASE:-1}" == "1" ]] && \
+       [[ "$AGENT_RUNNER_DRY_RUN" != "1" ]]; then
+        log "ralph_baseline_rebase_begin"
+        set +e
+        git -C "$REPO_ROOT" fetch origin main \
+            > "$AGENT_WORKSPACE/ralph-baseline-fetch.stdout.log" \
+            2> "$AGENT_WORKSPACE/ralph-baseline-fetch.stderr.log"
+        _baseline_fetch_rc=$?
+        set -e
+        log "ralph_baseline_fetch_done" "exit_code=$_baseline_fetch_rc"
+        if [[ "$_baseline_fetch_rc" -eq 0 ]]; then
+            set +e
+            git -C "$REPO_ROOT" rebase origin/main \
+                > "$AGENT_WORKSPACE/ralph-baseline-rebase.stdout.log" \
+                2> "$AGENT_WORKSPACE/ralph-baseline-rebase.stderr.log"
+            _baseline_rebase_rc=$?
+            set -e
+            log "ralph_baseline_rebase_done" "exit_code=$_baseline_rebase_rc"
+            if [[ "$_baseline_rebase_rc" -ne 0 ]]; then
+                # Capture conflict files, stash markers, abort,
+                # emit rebase_failed envelope. Same shape as
+                # push_and_pr's conflict path so the
+                # fix_conflict phase can consume either.
+                _fix_conflict_stage="$AGENT_WORKSPACE/fix-conflict"
+                mkdir -p "$_fix_conflict_stage/conflict-markers"
+                set +e
+                git -C "$REPO_ROOT" diff --name-only --diff-filter=U \
+                    > "$_fix_conflict_stage/conflict-files.txt" \
+                    2> "$AGENT_WORKSPACE/git-diff-conflict-files.stderr.log"
+                set -e
+                while IFS= read -r _cfile; do
+                    if [[ -z "$_cfile" ]]; then
+                        continue
+                    fi
+                    _safe=$(printf '%s' "$_cfile" | tr '/' '__')
+                    if [[ -f "$REPO_ROOT/$_cfile" ]]; then
+                        cp "$REPO_ROOT/$_cfile" \
+                            "$_fix_conflict_stage/conflict-markers/$_safe" \
+                            2>/dev/null || true
+                    fi
+                done < "$_fix_conflict_stage/conflict-files.txt"
+                set +e
+                git -C "$REPO_ROOT" rev-parse ORIG_HEAD \
+                    > "$_fix_conflict_stage/orig-head.txt" 2>/dev/null || true
+                git -C "$REPO_ROOT" merge-base ORIG_HEAD origin/main \
+                    > "$_fix_conflict_stage/merge-base.txt" 2>/dev/null || true
+                git -C "$REPO_ROOT" rebase --abort \
+                    > "$AGENT_WORKSPACE/ralph-baseline-rebase-abort.stdout.log" \
+                    2> "$AGENT_WORKSPACE/ralph-baseline-rebase-abort.stderr.log"
+                set -e
+                _baseline_conflict_files_json="[]"
+                if [[ -s "$_fix_conflict_stage/conflict-files.txt" ]]; then
+                    _baseline_conflict_files_json=$(jq -R -s -c \
+                        'split("\n") | map(select(length > 0))' \
+                        "$_fix_conflict_stage/conflict-files.txt" 2>/dev/null \
+                        || printf '[]')
+                fi
+                # #3465: capture the last ~50 lines of
+                # ralph-baseline-rebase.stderr.log (size-capped at
+                # ~5 KB) so the diagnoser can inspect the rebase
+                # failure reason when no unmerged files are present.
+                _baseline_rebase_stderr_tail=$(tail -n 50 \
+                    "$AGENT_WORKSPACE/ralph-baseline-rebase.stderr.log" \
+                    2>/dev/null \
+                    | head -c 5120 \
+                    | jq -Rs '.' 2>/dev/null \
+                    || printf '""')
+                log "ralph_baseline_rebase_conflict" \
+                    "exit_code=$_baseline_rebase_rc" \
+                    "conflict_files_json=$_baseline_conflict_files_json"
+                # #3651: post-rebase empty-diff guard — direct
+                # sibling of #3614/PR #3645's fix in
+                # ``handle_push_and_pr``. When the start-of-ralph
+                # baseline rebase fails AND the conflict-files
+                # list is empty AND the post-abort ahead-count
+                # collapses to 0, the agent's commits were
+                # already in main (typically because a sibling
+                # PR landed the same fix first, or the daemon
+                # is retrying an already-fixed issue). Pre-#3651
+                # this fell through to the no_unmerged_files
+                # envelope, which transition_from_ralph routed
+                # to the diagnoser as
+                # ``push_and_pr_no_unmerged_files`` — terminal-
+                # failing the agent on what is actually a benign
+                # success (the cluster of stuck issues #2777,
+                # #2832, #2854, #3297, #3407, #3574, #3581,
+                # tripping the circuit breaker repeatedly).
+                #
+                # The fix: if the conflict-files list is empty
+                # AND the rebase --abort returned HEAD to a
+                # commit already in origin/main (ahead-count 0),
+                # emit the existing ``{"no_op": true}`` envelope.
+                # ``transition_from_ralph`` (#3651) routes that
+                # to PHASE_NO_OP terminal succeeded — exactly
+                # the right outcome for "fix is already in
+                # main." The new log event
+                # ``ralph_baseline_no_unmerged_files_already_applied``
+                # distinguishes this advance event from the
+                # pre-existing
+                # ``ralph_baseline_route_to_diagnoser`` (which
+                # still fires when the rebase actually failed
+                # for a non-already-applied reason — same code
+                # path as #3465). Mirrors PR #3645's
+                # ``push_and_pr_no_unmerged_files_already_applied``.
+                _ralph_baseline_output=""
+                if [[ "$_baseline_conflict_files_json" == "[]" ]]; then
+                    # #3675: stronger semantic check than the
+                    # pre-#3675 ``rev-list --count`` check (see
+                    # the matching commentary in
+                    # ``handle_push_and_pr``). ``rev-list``
+                    # counts commit objects, not the diff that
+                    # would actually ship — ORIG_HEAD's
+                    # commits are still distinct objects even
+                    # when they became semantically redundant
+                    # with main during the rebase (which is
+                    # why rebase produced empty commits and
+                    # exited 128). ``git diff --quiet``
+                    # answers the actual question: "is there
+                    # any change to ship?" Exit 0 = no diff =
+                    # already in main = emit no_op.
+                    if _post_rebase_no_diff_to_main; then
+                        log "ralph_baseline_no_unmerged_files_already_applied" \
+                            "reason=rebase_failed_but_diff_to_main_is_empty"
+                        _ralph_baseline_output=$(printf '{"no_op": true, "rebase_dropped_all_commits": true, "diff_to_main_empty": true, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
+                            "$_baseline_rebase_stderr_tail")
+                    else
+                        # #3465 path: rebase actually failed for
+                        # a non-already-applied reason (corrupt
+                        # state, fetch issue, etc.) — route to
+                        # the diagnoser as before.
+                        _ralph_baseline_output=$(printf '{"rebase_failed": true, "no_unmerged_files": true, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
+                            "$_baseline_rebase_stderr_tail")
+                    fi
+                else
+                    # #3225 path: real rebase conflict — route
+                    # to fix_conflict with the file bundle.
+                    _ralph_baseline_output=$(printf '{"rebase_failed": true, "conflict_files": %s, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
+                        "$_baseline_conflict_files_json" "$_baseline_rebase_stderr_tail")
+                fi
+                persist_phase_output "ralph" "$_ralph_baseline_output"
+                _bt=$(transition_for "ralph" "$_ralph_baseline_output")
+                _ba=$(printf '%s' "$_bt" | cut -f1)
+                _bn=$(printf '%s' "$_bt" | cut -f2)
+                _bs=$(printf '%s' "$_bt" | cut -f3)
+                _bh=$(printf '%s' "$_bt" | cut -f4)
+                # #3581 — single-source-of-truth dispatch via
+                # the helper. See dispatch_transition_action
+                # above advance_phase. Replaces the per-phase
+                # case-statement that landed in #3573 (ralph
+                # baseline route_to_diagnoser arm).
+                dispatch_transition_action "ralph_baseline" "$_ba" "$_bn" "$_bs" "$_bh" "$_ralph_baseline_output"
+                # #4138: original pre-extraction code used
+                # ``continue`` here to skip the rest of the
+                # arm and re-tick the loop. Returning from this
+                # function has the same effect — the agent's
+                # phase has been advanced (or terminal-failed)
+                # by ``dispatch_transition_action`` and the
+                # next ``phase_loop`` tick reads the new phase
+                # row and routes accordingly.
+                return 0
+            fi
+        else
+            log "ralph_baseline_fetch_failed_skipping" \
+                "exit_code=$_baseline_fetch_rc"
+        fi
+    fi
+    # #3144: start the HEAD-watcher subshell so the long
+    # ralph phase emits per-iteration observability to
+    # CloudWatch + dispatcher.ralph_patches. The watcher is
+    # stopped unconditionally after run_claude_phase returns
+    # (success or failure) so the subshell never outlives
+    # the phase it instruments.
+    start_ralph_head_watcher
+    _output=$(run_claude_phase "ralph")
+    stop_ralph_head_watcher
+    # #3694 — ralph silent-exit instrumentation. The original
+    # symptom: three consecutive ECS agents on three different
+    # issues exited with ``output_json={}`` and ``stderr_tail=""``,
+    # producing zero diagnostic data. The worker subprocess
+    # terminated cleanly without writing a verdict marker, so the
+    # daemon classified the failure as ``ralph_not_ship`` with no
+    # block_reason.
+    #
+    # Layer 1 (this commit) makes the failure self-diagnosing —
+    # capture the worker's stdout/stderr tails into
+    # ``phase_outputs.log_text``, emit a structured
+    # ``ralph_done_marker_missing`` event, and replace the empty
+    # ``output_json`` with a payload carrying the tails as
+    # ``block_reason``. The daemon's ``_collect_failure_details``
+    # already forwards ``block_reason`` → ``failures.details
+    # .stderr_tail`` (see daemon.py ~12420), so the next
+    # occurrence will surface a populated stderr_tail in the
+    # diagnoser's verbatim-quote pull instead of the current
+    # empty string. Layer 2 (the actual fix to whatever is
+    # making the worker exit silently) lands once the new logs
+    # capture self-diagnosing data.
+    _ralph_log_tail_file=""
+    _ralph_stdout_file="$AGENT_WORKSPACE/claude-p-ralph.stdout.json"
+    _ralph_stderr_file="$AGENT_WORKSPACE/claude-p-ralph.stderr.log"
+    # Build a merged tail file (last 2000 bytes of stdout +
+    # last 2000 bytes of stderr) for log_text persistence.
+    # Unconditional capture — even SHIP-path runs benefit
+    # from having the worker narrative in the DB for
+    # post-mortem when CI / verify later reveals a problem.
+    _ralph_log_tail_file="$AGENT_WORKSPACE/claude-p-ralph.log_text.txt"
+    {
+        printf '=== claude-p-ralph.stdout.json (last 2000 bytes) ===\n'
+        if [[ -s "$_ralph_stdout_file" ]]; then
+            tail -c 2000 "$_ralph_stdout_file" 2>/dev/null
+        fi
+        printf '\n=== claude-p-ralph.stderr.log (last 2000 bytes) ===\n'
+        if [[ -s "$_ralph_stderr_file" ]]; then
+            tail -c 2000 "$_ralph_stderr_file" 2>/dev/null
+        fi
+        printf '\n'
+    } > "$_ralph_log_tail_file" 2>/dev/null || true
+    # Detect the silent-exit shape — ralph returned ``{}`` (a
+    # string-equal check is sufficient because run_claude_phase
+    # only emits ``{}`` for the non-object .result fallback;
+    # any legitimate ralph output, even an empty BLOCKED, is at
+    # least ``{"verdict": "..."}``).
+    if [[ "$_output" == "{}" ]]; then
+        # Layer 4 silent-ralph fallback (#3782). Before
+        # falling through to the ``ralph_done_marker_missing``
+        # path, check whether the inner ``/task-v2-ralph``
+        # skill DID write its inner ``ralph-done.txt`` (Step
+        # 3b of the inner SKILL.md is marked CRITICAL — and
+        # is reliably written) but the outer wrapper's Step
+        # 4 Write of ``dispatcher-output/ralph.json`` was
+        # skipped (the model finished its conversation
+        # without doing the final tool call). Synthesize the
+        # dispatcher-output JSON from the inner state files.
+        # On success, ``_output`` carries a structured verdict
+        # matching what ralph actually achieved; on failure
+        # (ralph-done.txt missing — the genuinely-silent
+        # case), the helper returns non-zero and we fall
+        # through to the original Layer 1 instrumentation.
+        _layer4_synth=""
+        if _layer4_synth=$(synthesize_ralph_output_from_done_marker "$REPO_ROOT" 2>>"$AGENT_WORKSPACE/claude-p-ralph.stderr.log"); then
+            if [[ -n "$_layer4_synth" ]]; then
+                _output="$_layer4_synth"
+            fi
+        fi
+    fi
+    # If the Layer 4 synthesis didn't produce a verdict, fall
+    # through to Layer 1 instrumentation. Re-check
+    # ``_output == "{}"`` so a successful synthesis above
+    # short-circuits this block entirely.
+    if [[ "$_output" == "{}" ]]; then
+        _ralph_stdout_tail=""
+        _ralph_stderr_tail=""
+        if [[ -s "$_ralph_stdout_file" ]]; then
+            _ralph_stdout_tail=$(tail -c 500 "$_ralph_stdout_file" 2>/dev/null \
+                | tr '\n\r\t' '   ' | sed -e 's/\\/\\\\/g')
+        fi
+        if [[ -s "$_ralph_stderr_file" ]]; then
+            _ralph_stderr_tail=$(tail -c 500 "$_ralph_stderr_file" 2>/dev/null \
+                | tr '\n\r\t' '   ' | sed -e 's/\\/\\\\/g')
+        fi
+        # ``run_claude_phase`` already captured the worker's
+        # exit code into the ``claude_phase_done`` log line;
+        # we don't have it in scope here directly, so emit a
+        # placeholder. The stdout/stderr tails are the
+        # high-value signal (they contain the actual error
+        # lines if the worker printed any), and a future
+        # iteration can plumb the rc through if needed.
+        log "ralph_done_marker_missing" \
+            "phase=ralph" \
+            "worker_exit_code=unknown" \
+            "worker_stdout_tail=$_ralph_stdout_tail" \
+            "worker_stderr_tail=$_ralph_stderr_tail"
+        # Replace the empty ``{}`` with a structured payload
+        # so the daemon's failures.details.stderr_tail (which
+        # mirrors block_reason for the ralph_not_ship terminal,
+        # see daemon.py ~12420) carries the diagnostic tails
+        # rather than "". jq -n -c builds the JSON safely with
+        # the tails as typed string variables — no shell
+        # interpolation into the SQL.
+        _output=$(jq -n -c \
+            --arg stdout_tail "$_ralph_stdout_tail" \
+            --arg stderr_tail "$_ralph_stderr_tail" \
+            '{verdict: "BLOCKED",
+              category: "ralph_not_ship",
+              block_reason: ("ralph_done_marker_missing: worker exited 0 with no done-marker. " +
+                             "stdout_tail=" + $stdout_tail + " stderr_tail=" + $stderr_tail),
+              worker_stdout_tail: $stdout_tail,
+              worker_stderr_tail: $stderr_tail,
+              ralph_done_marker_missing: true}' 2>/dev/null \
+            || printf '{"category":"ralph_not_ship","block_reason":"ralph_done_marker_missing: jq build failed","ralph_done_marker_missing":true}')
+    fi
+    persist_phase_output "ralph" "$_output" "$_ralph_log_tail_file"
+    # Mirror the daemon's post-SHIP ralph_patches persist.
+    _verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""')
+    if [[ "$_verdict" == "SHIP" ]]; then
+        persist_ralph_patch
+    fi
+    _transition=$(transition_for "ralph" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    # #3581 — single-source-of-truth dispatch. The helper
+    # (defined alongside advance_phase) handles every
+    # TransitionAction enum value AND every FAILURE_HINT_*
+    # constant emitted by phase_transitions.py uniformly across
+    # all phases. CI guard scripts/check-transition-dispatch-vocabulary.sh
+    # asserts the helper's vocabulary stays in sync with the
+    # Python module.
+    dispatch_transition_action "ralph" "$_action" "$_next" "$_status" "$_hint" "$_output"
+}
+
+# ── Mechanical phases ──────────────────────────────────────────────────────
+
+handle_claiming() {
+    # Mechanical pseudo-phase (#3117): the daemon writes
+    # phase='claiming' only briefly while it inserts the
+    # dispatcher.agents row; the claim itself is a pure DB
+    # write, not an LLM pass. Any ECS task whose phase column
+    # reads `claiming` at boot is a post-claim lifecycle
+    # artifact — the claim already happened before the task
+    # was launched. Advance immediately to `planning` so the
+    # phase loop starts the real work without shelling out to
+    # a nonexistent `/task-v2-claiming` skill.
+    log "claiming_no_op_advance_to_planning"
+    persist_phase_output "claiming" '{"no_op": true}'
+    advance_phase "planning"
+}
+
+handle_push_and_pr_arm() {
+    # Mechanical phase (#3117). See handle_push_and_pr for the
+    # git push + gh pr create implementation. On success the
+    # transition shim advances to awaiting_ci (or to no_op
+    # terminal if the worktree was clean at ralph SHIP time).
+    _output=$(handle_push_and_pr)
+    persist_phase_output "push_and_pr" "$_output"
+    _transition=$(transition_for "push_and_pr" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    # #3581 — single-source-of-truth dispatch via the helper.
+    # See dispatch_transition_action above advance_phase for
+    # the action-vocabulary handling. Replaces the per-phase
+    # case-statement that landed in #3543 (route_to_diagnoser
+    # arm) and #3558 (push_and_pr_no_unmerged_files hint).
+    dispatch_transition_action "push_and_pr" "$_action" "$_next" "$_status" "$_hint" "$_output"
+}
+
+handle_fix_conflict_arm() {
+    # #3225: fix_conflict phase. Budget-gated claude-resolution
+    # of rebase conflicts. handle_fix_conflict enforces the
+    # per-agent FIX_CONFLICT_MAX_ATTEMPTS budget, invokes the
+    # claude skill, applies resolved_files as a new commit on
+    # verdict=resolved, and emits the output envelope the
+    # transition shim uses to advance.
+    _output=$(handle_fix_conflict)
+    _fc_verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""' 2>/dev/null || printf '')
+    log "fix_conflict_handler_done" "verdict=$_fc_verdict"
+    persist_phase_output "fix_conflict" "$_output"
+    log "fix_conflict_persist_done"
+    _transition=$(transition_for "fix_conflict" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    log "fix_conflict_transition_shim_done" \
+        "action=$_action" \
+        "next=$_next" \
+        "status=$_status" \
+        "hint=$_hint"
+    log "fix_conflict_dispatched_action" "action=$_action"
+    # #3581 — single-source-of-truth dispatch via the helper.
+    # See dispatch_transition_action above advance_phase.
+    dispatch_transition_action "fix_conflict" "$_action" "$_next" "$_status" "$_hint" "$_output"
+}
+
+handle_fix_ci_arm() {
+    # #3245: fix_ci phase. Split out of the generic Claude-phase
+    # case because — unlike planning/ralph/summary/verify — the
+    # /task-v2-fix-ci skill explicitly defers git ops to "the
+    # daemon" (SKILL.md lines 64 + 160). Before #3245 the ECS
+    # entrypoint ran fix_ci through the generic arm and never
+    # staged / committed / pushed the skill's patch; every agent
+    # with initially-red CI looped 40 iterations without adding
+    # a single commit. handle_fix_ci mirrors the subprocess
+    # daemon's ``_run_fix_ci`` + ``_apply_fix_ci_patch`` (daemon.py
+    # ~line 12697 / 12979): PATCHED → stage + commit + push +
+    # back to awaiting_ci; FLAKY → back to awaiting_ci without
+    # commit; BLOCKED / unrecognized → fix_ci_failed terminal.
+    # handle_fix_ci owns its own advance_phase /
+    # agent_runner_reaped_failure calls so the dispatch case
+    # just invokes the handler and lets the next loop tick
+    # observe the new phase row.
+    handle_fix_ci >/dev/null
+}
+
+handle_operational() {
+    # #3507: operational phase. Runs the /task-v2-operational
+    # skill for tasks that need only a script run / DB query / gh
+    # action — no code change, no PR. Modeled on the verify)
+    # arm: run_claude_phase + persist_phase_output +
+    # transition_for dispatch.
+    #
+    # Verdicts from /task-v2-operational:
+    #   succeeded → advance_with_status → operational_done/succeeded
+    #   blocked   → advance_with_status → operational_failed/needs_review
+    #   failed / missing / unrecognized → route_to_diagnoser
+    #     → agent_runner_reaped_failure "operational_failed"
+    _output=$(run_claude_phase "operational")
+    persist_phase_output "operational" "$_output"
+    _transition=$(transition_for "operational" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    log "operational_transition_shim_done" \
+        "action=$_action" \
+        "next=$_next" \
+        "status=$_status" \
+        "hint=$_hint"
+    # #3581 — single-source-of-truth dispatch via the helper.
+    # See dispatch_transition_action above advance_phase.
+    dispatch_transition_action "operational" "$_action" "$_next" "$_status" "$_hint" "$_output"
+}
+
+handle_awaiting_ci_arm() {
+    # #3176: real implementation — poll ``gh pr view`` rollup,
+    # advance to ``merge`` on green, ``fix_ci`` on red, exit
+    # with terminal failure on timeout.
+    _output=$(handle_awaiting_ci)
+    persist_phase_output "awaiting_ci" "$_output"
+    _rollup_state=$(printf '%s' "$_output" | jq -r '.rollup_state // ""' 2>/dev/null)
+    _timeout=$(printf '%s' "$_output" | jq -r '.timeout // false' 2>/dev/null)
+    if [[ "$_timeout" == "true" ]]; then
+        # agent_runner_reaped_failure already set the terminal
+        # phase + status in the DB; next tick will observe it
+        # as terminal and exit.
+        :
+    elif [[ "$_rollup_state" == "green" ]]; then
+        advance_phase "merge"
+    elif [[ "$_rollup_state" == "red" ]]; then
+        advance_phase "fix_ci"
+    else
+        # No recognizable state — shouldn't happen, but don't
+        # spin. Treat as failure to surface the bug.
+        log "awaiting_ci_unrecognized_output" "output=$_output"
+        agent_runner_reaped_failure \
+            "awaiting_ci_failed" \
+            "unrecognized_output" \
+            "$_output"
+    fi
+}
+
+handle_merge_arm() {
+    # #3176: real implementation — squash-merge with
+    # branch-delete, auto-unstick on stale-rollup (one-shot),
+    # terminal failure on other non-zero exits.
+    _output=$(handle_merge)
+    persist_phase_output "merge" "$_output"
+    _merged=$(printf '%s' "$_output" | jq -r '.merged // false' 2>/dev/null)
+    _auto_unstick=$(printf '%s' "$_output" | jq -r '.auto_unstick_retry // false' 2>/dev/null)
+    _merge_failed=$(printf '%s' "$_output" | jq -r '.merge_failed // false' 2>/dev/null)
+    if [[ "$_merged" == "true" ]]; then
+        # Mirror daemon's ``_merge_pr_and_advance``: flip
+        # status=succeeded the moment the squash-merge lands,
+        # advance phase to awaiting_deploy. A crash mid-write
+        # still leaves a ``status='succeeded' phase=merge``
+        # row recoverable by the next tick.
+        advance_phase "awaiting_deploy" "succeeded"
+    elif [[ "$_auto_unstick" == "true" ]]; then
+        # Go back to awaiting_ci so the next poll sees the
+        # post-empty-commit rollup.
+        advance_phase "awaiting_ci"
+    elif [[ "$_merge_failed" == "true" ]]; then
+        # agent_runner_reaped_failure already set terminal state.
+        :
+    else
+        log "merge_unrecognized_output" "output=$_output"
+        agent_runner_reaped_failure \
+            "merge_failed" \
+            "unrecognized_output" \
+            "$_output"
+    fi
+}
+
+handle_awaiting_deploy_arm() {
+    # #3176: real implementation — poll deploy workflows on
+    # the merge SHA, advance to verify on success / no-run
+    # grace, terminal failure on timeout / any deploy
+    # workflow failure.
+    _output=$(handle_awaiting_deploy)
+    persist_phase_output "awaiting_deploy" "$_output"
+    _deploy_state=$(printf '%s' "$_output" | jq -r '.deploy_state // ""' 2>/dev/null)
+    _timeout=$(printf '%s' "$_output" | jq -r '.timeout // false' 2>/dev/null)
+    if [[ "$_timeout" == "true" ]]; then
+        :
+    elif [[ "$_deploy_state" == "success" || "$_deploy_state" == "none" ]]; then
+        advance_phase "verify"
+    elif [[ "$_deploy_state" == "failure" ]]; then
+        :
+    else
+        log "awaiting_deploy_unrecognized_output" "output=$_output"
+        agent_runner_reaped_failure \
+            "awaiting_deploy_failed" \
+            "unrecognized_output" \
+            "$_output"
+    fi
+}
+
+handle_retro_or_setup() {
+    # Remaining mechanical stubs — Stage 3+ will wire these to
+    # real implementations (retro posts the issue comment +
+    # closes the loop; setup is currently unreachable under the
+    # Stage 1b happy path).
+    _current="$1"
+    _next=""
+    case "$_current" in
+        setup)            _next="ralph" ;;
+        retro)            _next="retro_done" ;;
+    esac
+    log "mechanical_phase_stub" "phase=$_current" "next=$_next"
+    persist_phase_output "$_current" '{"stub": true}'
+    advance_phase "$_next"
+}
+
+handle_unknown_phase() {
+    # Issue #3455 — descriptive terminal instead of
+    # ``agent_runner_route_stub``. The catch-all fires when
+    # the phase column reads a value the dispatch loop
+    # doesn't recognize — that's a code-drift bug (a new
+    # phase landed in dispatcher.agents without being
+    # wired here), not a semantic failure, so no diagnoser
+    # routing.
+    _current="$1"
+    log "phase_unknown" "phase=$_current"
+    agent_runner_reaped_failure \
+        "phase_unknown" \
+        "phase_unknown" \
+        "dispatch loop saw unknown phase=$_current (not wired in agent-runner-entrypoint.sh)"
+}

--- a/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
@@ -15,9 +15,29 @@ import re
 from pathlib import Path
 
 _ENTRYPOINT_PATH = Path(__file__).resolve().parents[1] / "agent-runner-entrypoint.sh"
+# #4138 — per-phase case-arm bodies were extracted from the entrypoint
+# into ``agent_runner_handlers.sh`` (mirroring the precedent set by
+# #3775's ``agent_runner_run_claude_phase.sh``). The two files together
+# now constitute "the agent runner script" for content-pattern lint
+# purposes, so this test reads their concatenation. Tests that
+# specifically need to assert *where* a pattern lives still narrow the
+# search via dedicated block-extraction helpers below.
+_HANDLERS_PATH = Path(__file__).resolve().parents[1] / "agent_runner_handlers.sh"
 
 
 def _script_text() -> str:
+    return (
+        _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        + "\n"
+        + _HANDLERS_PATH.read_text(encoding="utf-8")
+    )
+
+
+def _entrypoint_text() -> str:
+    """Pre-#4138 ``_script_text`` — entrypoint-only. Used by tests that
+    must distinguish the entrypoint's case-statement from the handlers
+    file's function bodies (e.g. ``test_push_and_pr_arm_calls_dispatch_helper``
+    finds the ``push_and_pr)`` arm inside ``phase_loop()``)."""
     return _ENTRYPOINT_PATH.read_text(encoding="utf-8")
 
 
@@ -123,17 +143,38 @@ class TestPushAndPrCaseArmRoutesViaCentralizedHelper:
     into ``dispatch_transition_action`` — but the bug-class invariant
     is preserved: the action vocabulary AND the hint are handled
     SOMEWHERE the push_and_pr) arm reaches at runtime.
+
+    #4138: the case-arm body for push_and_pr was moved out of
+    ``phase_loop()`` into ``handle_push_and_pr_arm`` in
+    ``agent_runner_handlers.sh`` (mirroring #3775). The arm in the
+    entrypoint is now ``push_and_pr) handle_push_and_pr_arm ;;``, and
+    the dispatch-helper invocation lives inside the handler body. The
+    assertions below now lint the handler function body, since that is
+    where the dispatch site actually lives at runtime.
     """
 
     @staticmethod
-    def _push_and_pr_block(text: str) -> str:
-        """Return the substring between ``push_and_pr)`` and the next
-        top-level ``fix_conflict)`` arm."""
-        start = text.find("        push_and_pr)\n")
-        end = text.find("        fix_conflict)\n", start)
-        assert start != -1, "push_and_pr) arm not found in entrypoint"
-        assert end != -1, "fix_conflict) arm not found after push_and_pr) arm"
-        return text[start:end]
+    def _push_and_pr_block(_text: str) -> str:  # noqa: ARG004
+        """Return the body of ``handle_push_and_pr_arm`` from
+        ``agent_runner_handlers.sh``. Pre-#4138 this returned the
+        substring between ``push_and_pr)`` and ``fix_conflict)`` in the
+        entrypoint's ``phase_loop`` case-statement; #4138 moved that
+        body into a named function in the handlers file. The assertions
+        downstream (``dispatch_transition_action`` is called, with the
+        phase name as the first arg) hold equivalently against the
+        handler body."""
+        handlers = _HANDLERS_PATH.read_text(encoding="utf-8")
+        start = handlers.find("handle_push_and_pr_arm() {")
+        assert start != -1, (
+            "handle_push_and_pr_arm() not found in agent_runner_handlers.sh (#4138)"
+        )
+        # The function ends at the first ``\n}\n`` line at column 0 after
+        # ``start``.
+        end = handlers.find("\n}\n", start)
+        assert end != -1, (
+            "Could not locate end of handle_push_and_pr_arm() function (#4138)"
+        )
+        return handlers[start:end]
 
     @staticmethod
     def _dispatch_helper_body(text: str) -> str:

--- a/scripts/dispatcher/tests/test_ralph_output_synthesis.sh
+++ b/scripts/dispatcher/tests/test_ralph_output_synthesis.sh
@@ -419,19 +419,36 @@ run_ac_infeasible_synthesis_test() {
     pass "AC_INFEASIBLE synthesis: verdict passes through"
 }
 
-# ── Test 5: entrypoint sources the synthesis helper ───────────────────────
+# ── Test 5: entrypoint wires the synthesis helper ─────────────────────────
 #
 # The agent-runner-entrypoint.sh script must source
 # `agent_runner_synthesize_ralph_output.sh` near the top (alongside the
-# fargate-hook helper) AND must call
-# `synthesize_ralph_output_from_done_marker` inside the
-# `_output == "{}"` && `_current == "ralph"` block of the phase loop,
-# BEFORE the `ralph_done_marker_missing` log fires. Without this wiring,
-# the synthesis function exists but is dead code.
+# fargate-hook helper) AND the silent-exit ralph branch must call
+# `synthesize_ralph_output_from_done_marker` BEFORE
+# `log "ralph_done_marker_missing"` so a successful synthesis short-
+# circuits the missing-marker path.
+#
+# #4138: the silent-exit ralph branch was extracted from
+# ``phase_loop()``'s inline ``planning|ralph|summary|verify)`` arm into
+# ``handle_ralph`` in ``scripts/dispatcher/agent_runner_handlers.sh``,
+# mirroring the precedent set by #3775. The synthesis-call/missing-
+# marker-log landmarks now live in the handlers file. The ``source``
+# of the synthesis helper still lives in the entrypoint (handlers file
+# inherits ``synthesize_ralph_output_from_done_marker`` from the same
+# scope when the entrypoint sources both files).
 
 run_entrypoint_wires_helper_test() {
     if [[ ! -f "$ENTRYPOINT" ]]; then
         fail "agent-runner-entrypoint.sh exists" "expected at $ENTRYPOINT"
+        return
+    fi
+
+    # The handlers-file path is the sibling of $ENTRYPOINT and contains
+    # ``handle_ralph`` (#4138). Some landmarks moved there.
+    local HANDLERS
+    HANDLERS="$(dirname "$ENTRYPOINT")/agent_runner_handlers.sh"
+    if [[ ! -f "$HANDLERS" ]]; then
+        fail "agent_runner_handlers.sh exists" "expected at $HANDLERS"
         return
     fi
 
@@ -442,26 +459,27 @@ run_entrypoint_wires_helper_test() {
     fi
     pass "entrypoint sources agent_runner_synthesize_ralph_output.sh"
 
-    if ! grep -q "synthesize_ralph_output_from_done_marker" "$ENTRYPOINT"; then
-        fail "entrypoint calls synthesize_ralph_output_from_done_marker" \
-            "the entrypoint must invoke the synthesis function in the silent-exit branch"
+    # The call to ``synthesize_ralph_output_from_done_marker`` lives in
+    # ``handle_ralph`` post-#4138.
+    if ! grep -q "synthesize_ralph_output_from_done_marker" "$HANDLERS"; then
+        fail "handle_ralph calls synthesize_ralph_output_from_done_marker" \
+            "handle_ralph in agent_runner_handlers.sh must invoke the synthesis function in the silent-exit branch"
         return
     fi
     pass "entrypoint calls synthesize_ralph_output_from_done_marker"
 
     # The synthesis call must come BEFORE the
-    # `ralph_done_marker_missing` log line so a successful synthesis
-    # short-circuits the missing-marker path. We pin the comparison to
-    # the actual `log "ralph_done_marker_missing"` invocation rather
-    # than any string mention of the event name (the file has comments
-    # referencing the event name elsewhere, including inside
-    # `run_claude_phase` ~2119 and the synthesis comment block above the
-    # call).
+    # `ralph_done_marker_missing` log line in the same handler body so
+    # a successful synthesis short-circuits the missing-marker path. We
+    # pin the comparison to the actual `log "ralph_done_marker_missing"`
+    # invocation rather than any string mention of the event name (the
+    # handlers file has comments referencing the event name elsewhere,
+    # including inside the inner-fallback comment block).
     local synth_line
     local missing_line
-    synth_line=$(grep -n 'synthesize_ralph_output_from_done_marker "\$REPO_ROOT"' "$ENTRYPOINT" \
+    synth_line=$(grep -n 'synthesize_ralph_output_from_done_marker "\$REPO_ROOT"' "$HANDLERS" \
         | head -1 | cut -d: -f1 || true)
-    missing_line=$(grep -n '^[[:space:]]*log "ralph_done_marker_missing"' "$ENTRYPOINT" \
+    missing_line=$(grep -n '^[[:space:]]*log "ralph_done_marker_missing"' "$HANDLERS" \
         | head -1 | cut -d: -f1 || true)
 
     if [[ -z "$synth_line" || -z "$missing_line" ]]; then

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -37,6 +37,15 @@ ENTRYPOINT="$REPO_ROOT/scripts/dispatcher/agent-runner-entrypoint.sh"
 # and claude_phase_timeout_seconds_by_phase were extracted to a sourceable helper.
 # Tests that awk-extract those functions must read from HELPER, not ENTRYPOINT.
 HELPER="$(dirname "$ENTRYPOINT")/agent_runner_run_claude_phase.sh"
+# #4138: per-phase case-arm bodies (planning, ralph, summary, verify, claiming,
+# push_and_pr, fix_conflict, fix_ci, operational, awaiting_ci, merge,
+# awaiting_deploy, retro/setup, *) were extracted from ``phase_loop()`` into
+# named handler functions in this sourceable file. Tests that awk-extract those
+# arm bodies (T3651, T3675 for the ralph baseline-rebase block) must read from
+# HANDLERS, not ENTRYPOINT. The 30 ``bash $ENTRYPOINT`` invocation tests are
+# unchanged — they still drive the entrypoint top-to-bottom and observe the
+# same external-API behavior (psql.log / claude.log / git.log / gh.log).
+HANDLERS="$(dirname "$ENTRYPOINT")/agent_runner_handlers.sh"
 FAILURES=0
 TESTS=0
 
@@ -7386,13 +7395,19 @@ fi
 # advance_with_status branch.
 # ══════════════════════════════════════════════════════════════════════════
 
-# Extract the #3651 envelope-construction block from the entrypoint via
-# awk. Boundary: from ``_ralph_baseline_output=""`` (a marker line added
-# in #3651) to the matching outer ``fi``. Walks ``if [[`` openings and
-# ``fi`` closings to get the nesting right. This matches T3614's "extract
-# the actual production code path" approach, adapted for an inline block
-# (not a function — handle_ralph_baseline_rebase doesn't exist as a
-# function in the entrypoint, see issue body).
+# Extract the #3651 envelope-construction block via awk. Boundary: from
+# ``_ralph_baseline_output=""`` (a marker line added in #3651) to the
+# matching outer ``fi``. Walks ``if [[`` openings and ``fi`` closings to
+# get the nesting right. This matches T3614's "extract the actual
+# production code path" approach, adapted for an inline block.
+#
+# #4138: the ralph baseline-rebase block was moved from an inline
+# ``planning|ralph|summary|verify)`` arm in ``phase_loop()`` into the
+# ``handle_ralph`` function in ``agent_runner_handlers.sh``. Read the
+# block from HANDLERS instead of ENTRYPOINT — the production code path
+# is unchanged (the handler is sourced into the entrypoint at startup
+# and called from the new thin dispatcher arm), only the file location
+# changed.
 t3651_block="$TEST_TMP/t3651-envelope-block.sh"
 awk '
   /_ralph_baseline_output=""/ { in_block=1; depth=0 }
@@ -7405,7 +7420,7 @@ awk '
       if (depth == 0) exit
     }
   }
-' "$ENTRYPOINT" > "$t3651_block"
+' "$HANDLERS" > "$t3651_block"
 
 if grep -q "ralph_baseline_no_unmerged_files_already_applied" "$t3651_block"; then
     pass "#3651 T3651 setup — extracted envelope block contains the new log event marker"
@@ -9264,6 +9279,10 @@ fi
 # ``fi`` block and source it standalone with the inputs the entrypoint
 # would have computed (``_baseline_conflict_files_json``,
 # ``_baseline_rebase_stderr_tail``).
+#
+# #4138: the inline block now lives inside ``handle_ralph`` in
+# ``agent_runner_handlers.sh``. Extract from HANDLERS — see T3651 setup
+# above for the same retarget rationale.
 
 t3675_block="$TEST_TMP/t3675-envelope-block.sh"
 awk '
@@ -9277,7 +9296,7 @@ awk '
       if (depth == 0) exit
     }
   }
-' "$ENTRYPOINT" > "$t3675_block"
+' "$HANDLERS" > "$t3675_block"
 
 if grep -q "ralph_baseline_no_unmerged_files_already_applied" "$t3675_block"; then
     pass "#3675 T3675 setup — extracted ralph_baseline envelope block contains the log event marker"


### PR DESCRIPTION
## Summary

Sub-task B of #4097: extract the per-phase case-statement arm bodies from `phase_loop()` in `scripts/dispatcher/agent-runner-entrypoint.sh` into named handler functions in a new sourceable file `scripts/dispatcher/agent_runner_handlers.sh`. Mirrors the precedent set by #3775 (`agent_runner_run_claude_phase.sh`). Pure structural extraction — no behavior change.

Net effect: entrypoint shrinks 5825 → 5386 lines (-439). New handlers file is 680 lines. `phase_loop()` becomes a thin dispatcher — every case arm is a single function call (with one transitional exception for `fix_conflict` to keep `T51` extraction passing without bash-test-file edits to the inline arm).

Two narrow test-file edits ride along:
- `scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py` — content-pattern lints retargeted at the handlers file (the `"no_unmerged_files": true` ralph-baseline copy + `_baseline_rebase_stderr_tail` capture moved with the block; the `dispatch_transition_action "push_and_pr"` invocation moved into `handle_push_and_pr_arm`). Same bug-class invariants preserved.
- `scripts/dispatcher/tests/test_ralph_output_synthesis.sh` — the `synthesize_ralph_output_from_done_marker` call + `ralph_done_marker_missing` log landmarks moved with `handle_ralph` into the handlers file; the test reads the call/log landmarks from there now. Same ordering invariant preserved.
- `scripts/tests/test_agent_runner_entrypoint.sh` — added `HANDLERS=...` next to the existing `HELPER=...` (#3775 precedent), retargeted T3651/T3675 awk extraction at `$HANDLERS`. The 30 `bash $ENTRYPOINT` invocations are unchanged. The 446 source-level `pass` calls are unchanged.

Closes #4138.

## Test plan

### Automated checks
- [x] Lint passes (`scripts/check-bash-compat.sh` — 218 scripts clean)
- [x] Format check passes (`scripts/check-transition-dispatch-vocabulary.sh` — 4 actions, 11 hints in sync)
- [x] Tests pass — `scripts/tests/test_agent_runner_entrypoint.sh` runtime parity vs baseline (288 PASS / 2 FAIL — same 2 pre-existing baseline failures, no regressions). 446 source-level `pass` count unchanged. 30 `bash $ENTRYPOINT` invocations preserved.
- [x] `scripts/tests/test_launch_agent_runner_smoke.sh` — 26/26 passed
- [x] `scripts/tests/test_agent_runner_start_phase.sh` — 16/16 passed
- [x] `scripts/tests/test_agent_runner_synthetic_skill_phase.sh` — 13/13 passed
- [x] `scripts/dispatcher/tests/test_ralph_output_synthesis.sh` — 22/22 passed
- [x] Full Python `scripts/dispatcher/tests/` suite — 2168 passed, 1 skipped
- [x] CI green (100 checks passed, 0 failed, mergeable=MERGEABLE, ci-passed=SUCCESS)

### Post-deploy verification
- [x] Spot-check verifies `phase_loop_tick` (52), `claude_phase_done` (34), `ralph_baseline_rebase_begin` (17) all fire post-deploy on `/ecs/judgemind-dispatcher-agent-runner-dev` — same emission inventory as pre-refactor. `verify-pr-in-deployed-sha.sh 4160` confirms merge SHA 5ed039f landed in deployed dispatcher.
- [x] Verification evidence posted on issue (see A.8)
