### PR TITLE
feat(ci): auto-rerun known-flake CI failures in wait-for-ci.sh (#4148)

### DIFF
--- a/scripts/classify-ci-flake.sh
+++ b/scripts/classify-ci-flake.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# classify-ci-flake.sh — Classify a CI failure as a known flake or a real failure.
+#
+# # venv: none
+# # permanent: true
+#
+# ── Why ──────────────────────────────────────────────────────────────────────
+#
+# CI hits transient infra flakes that look identical to real failures from the
+# outside (`gh pr view` reports `failure`, `wait-for-ci.sh` exits 1, the agent
+# is forced into the manual rerun loop). The most common offender is the
+# `schema-drift-check` job aborting on `ERROR: postgres failed to start within
+# 30 seconds` because the postgres service container failed to bind in time on
+# a slow runner. Each occurrence costs ~5-10 min of wall-clock per agent task.
+#
+# This helper classifies a failed-job log tail by tail-pattern match. It does
+# NOT decide whether to rerun — that is the caller's job (see
+# `scripts/wait-for-ci.sh`). Keeping the classifier as a separate single-input
+# / single-output script makes it trivially unit-testable and allows other
+# callers (post-mortem scripts, the dispatcher's diagnoser, etc.) to reuse the
+# same rule table.
+#
+# Adding a new flake pattern is a one-line edit to the `FLAKE_PATTERNS` table
+# below: append `<label>=<grep -E regex>`. The label is the human-readable
+# string emitted on stdout when a match is found and is what the caller logs
+# in the transcript (`flake detected: postgres-startup`).
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#
+# Usage:
+#   scripts/classify-ci-flake.sh           # reads job log on stdin
+#   scripts/classify-ci-flake.sh <file>    # reads from file
+#
+# Output (stdout, single line):
+#   flake/<label>     — the log matched a known flake pattern
+#   real              — no known flake pattern matched
+#
+# Exit codes:
+#   0 — Classification emitted to stdout (success regardless of flake/real).
+#   1 — Usage error (no stdin and missing file argument).
+#
+# ── Pattern table ────────────────────────────────────────────────────────────
+#
+# Each entry is `<label>|<grep -E regex>`. The script applies them in order;
+# the first matching pattern wins. Labels MUST NOT contain a `|` character.
+# Patterns are extended-regex (`grep -E`).
+#
+# Today's known-flake catalogue:
+#
+# - postgres-startup: `schema-drift-check` and other jobs that boot a postgres
+#   service container print this exact line on a slow-runner timeout. Source:
+#   `scripts/check_schema_drift.sh:39`.
+# - docker-daemon: GitHub-hosted runners occasionally lose the Docker socket
+#   for the first ~10s of a job. Manifests as `Cannot connect to the Docker
+#   daemon`.
+# - dns-resolution: transient DNS hiccups inside the runner; `apt-get`,
+#   `npm install`, `git clone` all surface this with substring `Could not
+#   resolve host`.
+# - github-network: GitHub Actions runner occasionally loses connectivity to
+#   `api.github.com` mid-job; surfaces as `unable to access` or `Failed to
+#   connect to github.com`.
+#
+# To add a new pattern: append a line to FLAKE_PATTERNS below. Keep the regex
+# specific enough that real test failures will not match — broad patterns mask
+# real outages.
+
+set -euo pipefail
+
+# Pattern table — order matters (first match wins). Format: label|regex
+# shellcheck disable=SC2034  # FLAKE_PATTERNS values consumed via `${row#*|}` below
+FLAKE_PATTERNS=(
+    "postgres-startup|ERROR: postgres failed to start within [0-9]+ seconds"
+    "docker-daemon|Cannot connect to the Docker daemon"
+    "dns-resolution|Could not resolve host"
+    "github-network|Failed to connect to github\.com"
+)
+
+print_help() {
+    grep '^# Usage:' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Output' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Exit codes:' "$0" | sed 's/^# //'
+    grep '^#   [012]' "$0" | sed 's/^# //'
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+    print_help
+    exit 0
+fi
+
+# Read input from file or stdin.
+if [ $# -ge 1 ]; then
+    INPUT_FILE="$1"
+    if [ ! -f "$INPUT_FILE" ]; then
+        echo "ERROR: input file does not exist: $INPUT_FILE" >&2
+        exit 1
+    fi
+    LOG_CONTENT=$(cat "$INPUT_FILE")
+else
+    # No file arg — read stdin.
+    if [ -t 0 ]; then
+        echo "ERROR: no input — pipe a job log on stdin or pass a file path." >&2
+        echo "Run with --help for usage." >&2
+        exit 1
+    fi
+    LOG_CONTENT=$(cat)
+fi
+
+# Walk the pattern table in order. First match wins.
+for ROW in "${FLAKE_PATTERNS[@]}"; do
+    LABEL="${ROW%%|*}"
+    REGEX="${ROW#*|}"
+    if printf '%s' "$LOG_CONTENT" | grep -E -q -- "$REGEX"; then
+        echo "flake/${LABEL}"
+        exit 0
+    fi
+done
+
+echo "real"
+exit 0

--- a/scripts/tests/test_classify_ci_flake.sh
+++ b/scripts/tests/test_classify_ci_flake.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# test_classify_ci_flake.sh — Unit tests for scripts/classify-ci-flake.sh.
+#
+# Exercises every entry in the FLAKE_PATTERNS table plus a real-failure
+# control case, the file-input path, and the no-input usage error.
+#
+# Usage:
+#   scripts/tests/test_classify_ci_flake.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/classify-ci-flake.sh"
+
+if [ ! -x "$SCRIPT_UNDER_TEST" ]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+}
+
+# Run the classifier with a stdin string, assert exact stdout.
+# Usage: assert_stdin_yields <name> <stdin> <expected>
+assert_stdin_yields() {
+    local name="$1" stdin="$2" expected="$3" actual
+    actual=$(printf '%s' "$stdin" | "$SCRIPT_UNDER_TEST" 2>/dev/null || true)
+    if [ "$actual" = "$expected" ]; then
+        pass "$name"
+    else
+        fail "$name" "expected='$expected' got='$actual'"
+    fi
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# postgres-startup: the canonical schema-drift-check flake (#4148 motivation).
+test_postgres_startup_match() {
+    assert_stdin_yields "postgres_startup_match" \
+        "some setup output
+ERROR: postgres failed to start within 30 seconds
+more output" \
+        "flake/postgres-startup"
+}
+
+# postgres-startup: regex tolerates a different timeout value.
+test_postgres_startup_arbitrary_seconds() {
+    assert_stdin_yields "postgres_startup_arbitrary_seconds" \
+        "ERROR: postgres failed to start within 60 seconds" \
+        "flake/postgres-startup"
+}
+
+# docker-daemon: Docker socket race on GitHub-hosted runners.
+test_docker_daemon_match() {
+    assert_stdin_yields "docker_daemon_match" \
+        "Cannot connect to the Docker daemon at unix:///var/run/docker.sock" \
+        "flake/docker-daemon"
+}
+
+# dns-resolution: transient DNS hiccup (apt-get / npm / git clone).
+test_dns_resolution_match() {
+    assert_stdin_yields "dns_resolution_match" \
+        "fatal: unable to access 'https://github.com/judgemind/judgemind/': Could not resolve host: github.com" \
+        "flake/dns-resolution"
+}
+
+# github-network: connectivity loss to github.com mid-job.
+test_github_network_match() {
+    assert_stdin_yields "github_network_match" \
+        "curl: (7) Failed to connect to github.com port 443: Connection refused" \
+        "flake/github-network"
+}
+
+# Real failure: AssertionError from a unit test must classify as real.
+# This is the regression test for AC#1 — the classifier must NOT mask real
+# failures, even ones that mention `error` or `failed`.
+test_real_unit_test_failure() {
+    assert_stdin_yields "real_unit_test_failure" \
+        "test_foo (TestBar) ... FAIL
+AssertionError: expected 1 got 2
+ran 17 tests in 0.234s
+FAILED (failures=1)" \
+        "real"
+}
+
+# Real failure: a generic `error` line that is not in the flake table.
+test_real_generic_error() {
+    assert_stdin_yields "real_generic_error" \
+        "ERROR: ruff found 3 violations" \
+        "real"
+}
+
+# First-match-wins: when multiple flake patterns appear, the first listed in
+# the table wins. The script processes the table in order and exits on the
+# first match. We confirm postgres-startup wins over docker-daemon.
+test_first_match_wins() {
+    assert_stdin_yields "first_match_wins" \
+        "ERROR: postgres failed to start within 30 seconds
+Cannot connect to the Docker daemon" \
+        "flake/postgres-startup"
+}
+
+# File-input path: the classifier accepts a file path as positional arg.
+test_file_input() {
+    local tmp
+    tmp=$(mktemp)
+    # shellcheck disable=SC2064  # we want $tmp expanded now
+    trap "rm -f $tmp" RETURN
+    printf 'ERROR: postgres failed to start within 30 seconds\n' > "$tmp"
+
+    local actual
+    actual=$("$SCRIPT_UNDER_TEST" "$tmp" 2>/dev/null || true)
+    if [ "$actual" = "flake/postgres-startup" ]; then
+        pass "file_input: classifies file content"
+    else
+        fail "file_input: classifies file content" "got='$actual'"
+    fi
+}
+
+# Missing-file error: nonexistent file must exit non-zero.
+test_missing_file_errors() {
+    local exit_code
+    exit_code=0
+    "$SCRIPT_UNDER_TEST" /nonexistent/path/zzz 2>/dev/null || exit_code=$?
+    if [ "$exit_code" -ne 0 ]; then
+        pass "missing_file_errors: exits non-zero on missing input file"
+    else
+        fail "missing_file_errors: exits non-zero on missing input file" "exit=$exit_code"
+    fi
+}
+
+# Help flag.
+test_help_flag() {
+    local output exit_code
+    exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" --help 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qi "usage"; then
+        pass "help_flag: --help exits 0 and mentions Usage"
+    else
+        fail "help_flag: --help exits 0 and mentions Usage" "exit=$exit_code output=$output"
+    fi
+}
+
+# Empty input: blank stdin must classify as real.
+test_empty_input_is_real() {
+    assert_stdin_yields "empty_input_is_real" "" "real"
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_postgres_startup_match
+test_postgres_startup_arbitrary_seconds
+test_docker_daemon_match
+test_dns_resolution_match
+test_github_network_match
+test_real_unit_test_failure
+test_real_generic_error
+test_first_match_wins
+test_file_input
+test_missing_file_errors
+test_help_flag
+test_empty_input_is_real
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -86,6 +86,8 @@ CALL_COUNTER_FILE="${CALL_COUNTER_FILE:?CALL_COUNTER_FILE required}"
 SHA_RESPONSE="${SHA_RESPONSE:-deadbeefdeadbeef}"
 MERGE_STATE_RESPONSE="${MERGE_STATE_RESPONSE:-CLEAN}"
 MERGEABLE_RESPONSE="${MERGEABLE_RESPONSE:-MERGEABLE}"
+LOG_FAILED_FILE="${LOG_FAILED_FILE:-}"
+RERUN_LOG_FILE="${RERUN_LOG_FILE:-}"
 
 ARGS="$*"
 
@@ -104,6 +106,23 @@ case "$ARGS" in
         ;;
     *"mergeable"*)
         printf '%s\n' "$MERGEABLE_RESPONSE"
+        exit 0
+        ;;
+    *"run rerun"*)
+        # Record the rerun invocation so tests can assert it fired exactly N
+        # times. Each call appends a single line: `<run-id> <args>`.
+        if [ -n "$RERUN_LOG_FILE" ]; then
+            echo "$ARGS" >> "$RERUN_LOG_FILE"
+        fi
+        exit 0
+        ;;
+    *"run view"*"--log-failed"*)
+        # Emit the canned failed-job log. If LOG_FAILED_FILE is unset or
+        # missing, return empty output (which the classifier will label
+        # as `real` — i.e. the auto-rerun path is suppressed).
+        if [ -n "$LOG_FAILED_FILE" ] && [ -f "$LOG_FAILED_FILE" ]; then
+            cat "$LOG_FAILED_FILE"
+        fi
         exit 0
         ;;
     *"check-runs"*)
@@ -156,6 +175,9 @@ run_script() {
     SHA_RESPONSE="${SHA_RESPONSE:-deadbeefdeadbeef}" \
     MERGE_STATE_RESPONSE="${MERGE_STATE_RESPONSE:-CLEAN}" \
     MERGEABLE_RESPONSE="${MERGEABLE_RESPONSE:-MERGEABLE}" \
+    LOG_FAILED_FILE="${LOG_FAILED_FILE:-}" \
+    RERUN_LOG_FILE="${RERUN_LOG_FILE:-}" \
+    WAIT_FOR_CI_RERUN_SENTINEL_FILE="${WAIT_FOR_CI_RERUN_SENTINEL_FILE:-$tmpdir/rerun-sentinel}" \
         "$SCRIPT_UNDER_TEST" "$@"
 }
 
@@ -195,6 +217,27 @@ write_failure_response() {
   "check_runs": [
     {"name": "lint",        "status": "completed", "conclusion": "success",  "details_url": "https://example.com/lint"},
     {"name": "$check_name", "status": "completed", "conclusion": "failure",  "details_url": "https://example.com/web-tests"}
+  ]
+}
+JSON
+}
+
+# Write a check-runs response with one failed check whose details_url uses
+# the canonical GitHub Actions URL format. This is what production check-runs
+# actually emit and is required for the auto-rerun classifier path (#4148)
+# to extract a workflow run-id from the URL.
+#
+# Args: <file> <check_name> <run_id> [conclusion]
+write_failure_with_run_id_response() {
+    local file="$1"
+    local check_name="${2:-schema-drift-check}"
+    local run_id="${3:-25418711047}"
+    local conclusion="${4:-failure}"
+    cat > "$file" << JSON
+{
+  "check_runs": [
+    {"name": "lint",        "status": "completed", "conclusion": "success",  "details_url": "https://example.com/lint"},
+    {"name": "$check_name", "status": "completed", "conclusion": "$conclusion", "details_url": "https://github.com/judgemind/judgemind/actions/runs/$run_id/job/72104555100"}
   ]
 }
 JSON
@@ -518,6 +561,192 @@ test_double_ci_passed_entries_resolves_success() {
     fi
 }
 
+# Test 11 (#4148): Auto-rerun on known flake. The mock returns a failed
+# `schema-drift-check` job on the first poll (with a parseable run-id in
+# `details_url`). The mocked `gh run view --log-failed` returns the canonical
+# postgres-startup error string, so the classifier emits `flake/postgres-startup`.
+# The script must:
+#   - log `flake detected: postgres-startup` on stdout (AC#3),
+#   - call `gh run rerun <run-id> --failed` exactly once,
+#   - continue polling (the second response is all-success → exit 0).
+test_auto_rerun_on_postgres_startup_flake() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_with_run_id_response "$tmpdir/responses/01.json" "schema-drift-check" "25418711047"
+    write_all_success_response "$tmpdir/responses/02.json"
+
+    # Canned failed-job log that classifies as flake/postgres-startup.
+    local log_file rerun_log
+    log_file="$tmpdir/log-failed.txt"
+    rerun_log="$tmpdir/rerun.log"
+    cat > "$log_file" << 'LOG'
+schema-drift-check / check-schema (pull_request) ...
++ docker run -d --name judgemind-schema-check ...
++ docker exec judgemind-schema-check pg_isready
+ERROR: postgres failed to start within 30 seconds
+##[error]Process completed with exit code 1.
+LOG
+
+    local output exit_code
+    exit_code=0
+    output=$(LOG_FAILED_FILE="$log_file" RERUN_LOG_FILE="$rerun_log" \
+        MERGEABLE_RESPONSE=MERGEABLE \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "auto_rerun_postgres: exits 0 after rerun + success poll"
+    else
+        fail "auto_rerun_postgres: exits 0 after rerun + success poll" "exit=$exit_code output=$output"
+    fi
+
+    # AC#3: stdout must name the matched pattern.
+    if echo "$output" | grep -q "flake detected: postgres-startup"; then
+        pass "auto_rerun_postgres: stdout names matched pattern"
+    else
+        fail "auto_rerun_postgres: stdout names matched pattern" "output=$output"
+    fi
+
+    # AC#2 first half: rerun fired exactly once.
+    local rerun_count=0
+    if [ -f "$rerun_log" ]; then
+        rerun_count=$(wc -l < "$rerun_log" | tr -d ' ')
+    fi
+    if [ "$rerun_count" = "1" ]; then
+        pass "auto_rerun_postgres: gh run rerun fired exactly once"
+    else
+        fail "auto_rerun_postgres: gh run rerun fired exactly once" "rerun_count=$rerun_count log=$(cat "$rerun_log" 2>/dev/null || echo none)"
+    fi
+
+    # The rerun call must include the parsed run-id.
+    if [ -f "$rerun_log" ] && grep -q "25418711047" "$rerun_log"; then
+        pass "auto_rerun_postgres: rerun call carries the parsed run-id"
+    else
+        fail "auto_rerun_postgres: rerun call carries the parsed run-id" "log=$(cat "$rerun_log" 2>/dev/null || echo none)"
+    fi
+}
+
+# Test 12 (#4148 AC#2 second half): Two consecutive flakes on the same run
+# must exit 1 — auto-rerun fires once, then a second flake response on the
+# next poll falls through to exit 1.
+test_two_consecutive_flakes_exit_1() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    # Both polls return the same flake failure on the same run-id.
+    write_failure_with_run_id_response "$tmpdir/responses/01.json" "schema-drift-check" "25418711047"
+    write_failure_with_run_id_response "$tmpdir/responses/02.json" "schema-drift-check" "25418711047"
+
+    local log_file rerun_log
+    log_file="$tmpdir/log-failed.txt"
+    rerun_log="$tmpdir/rerun.log"
+    cat > "$log_file" << 'LOG'
+ERROR: postgres failed to start within 30 seconds
+LOG
+
+    local output exit_code
+    exit_code=0
+    output=$(LOG_FAILED_FILE="$log_file" RERUN_LOG_FILE="$rerun_log" \
+        MERGEABLE_RESPONSE=MERGEABLE \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "two_consecutive_flakes: exits 1 on second flake"
+    else
+        fail "two_consecutive_flakes: exits 1 on second flake" "exit=$exit_code output=$output"
+    fi
+
+    # AC#2: rerun fired exactly once total — never twice.
+    local rerun_count=0
+    if [ -f "$rerun_log" ]; then
+        rerun_count=$(wc -l < "$rerun_log" | tr -d ' ')
+    fi
+    if [ "$rerun_count" = "1" ]; then
+        pass "two_consecutive_flakes: rerun fired exactly once total"
+    else
+        fail "two_consecutive_flakes: rerun fired exactly once total" "rerun_count=$rerun_count"
+    fi
+
+    # The "rerun already fired" message should appear in output.
+    if echo "$output" | grep -q "rerun already fired"; then
+        pass "two_consecutive_flakes: stderr explains the rerun-already-fired condition"
+    else
+        fail "two_consecutive_flakes: stderr explains the rerun-already-fired condition" "output=$output"
+    fi
+}
+
+# Test 13 (#4148): Real (non-flake) failure must NOT trigger auto-rerun.
+# The failed job log here has no flake-pattern string, so the classifier
+# emits `real` and the script falls through to exit 1 with no rerun.
+test_real_failure_no_rerun() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_with_run_id_response "$tmpdir/responses/01.json" "unit-tests" "12345678"
+
+    local log_file rerun_log
+    log_file="$tmpdir/log-failed.txt"
+    rerun_log="$tmpdir/rerun.log"
+    cat > "$log_file" << 'LOG'
+test_foo (TestBar) ... FAIL
+AssertionError: expected 1 got 2
+ran 17 tests in 0.234s
+FAILED (failures=1)
+LOG
+
+    local output exit_code
+    exit_code=0
+    output=$(LOG_FAILED_FILE="$log_file" RERUN_LOG_FILE="$rerun_log" \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "real_failure_no_rerun: exits 1 on real failure"
+    else
+        fail "real_failure_no_rerun: exits 1 on real failure" "exit=$exit_code output=$output"
+    fi
+
+    if [ ! -f "$rerun_log" ] || [ ! -s "$rerun_log" ]; then
+        pass "real_failure_no_rerun: gh run rerun was NOT called"
+    else
+        fail "real_failure_no_rerun: gh run rerun was NOT called" "rerun_log=$(cat "$rerun_log")"
+    fi
+
+    if echo "$output" | grep -q "flake detected"; then
+        fail "real_failure_no_rerun: must NOT log 'flake detected' on real failure" "output=$output"
+    else
+        pass "real_failure_no_rerun: does not falsely claim flake"
+    fi
+}
+
+# Test 14 (#4148): --no-auto-rerun must disable the classifier path entirely
+# even when a flake pattern is present in the job log.
+test_no_auto_rerun_flag_disables_classifier() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_with_run_id_response "$tmpdir/responses/01.json" "schema-drift-check" "25418711047"
+
+    local log_file rerun_log
+    log_file="$tmpdir/log-failed.txt"
+    rerun_log="$tmpdir/rerun.log"
+    cat > "$log_file" << 'LOG'
+ERROR: postgres failed to start within 30 seconds
+LOG
+
+    local output exit_code
+    exit_code=0
+    output=$(LOG_FAILED_FILE="$log_file" RERUN_LOG_FILE="$rerun_log" \
+        run_script "$tmpdir" 42 --no-auto-rerun --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "no_auto_rerun_flag: exits 1 with --no-auto-rerun"
+    else
+        fail "no_auto_rerun_flag: exits 1 with --no-auto-rerun" "exit=$exit_code output=$output"
+    fi
+
+    if [ ! -f "$rerun_log" ] || [ ! -s "$rerun_log" ]; then
+        pass "no_auto_rerun_flag: gh run rerun was NOT called"
+    else
+        fail "no_auto_rerun_flag: gh run rerun was NOT called" "rerun_log=$(cat "$rerun_log")"
+    fi
+}
+
 # ── Run all tests ──────────────────────────────────────────────────────────
 
 test_happy_path
@@ -530,6 +759,10 @@ test_all_checks_complete_path
 test_no_regression_in_progress_ci_passed
 test_no_regression_failure_short_circuits_fastpath
 test_double_ci_passed_entries_resolves_success
+test_auto_rerun_on_postgres_startup_flake
+test_two_consecutive_flakes_exit_1
+test_real_failure_no_rerun
+test_no_auto_rerun_flag_disables_classifier
 
 echo ""
 echo "────────────────────────────────────────────"

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -52,6 +52,8 @@
 #   --timeout-secs N    Overall timeout in seconds (default: 1800)
 #   --poll-interval N   Polling interval in seconds (default: 30)
 #   --repo OWNER/REPO   GitHub repository (default: judgemind/judgemind)
+#   --no-auto-rerun     Disable the known-flake auto-rerun classifier (#4148).
+#                       When set, any failed check exits 1 immediately.
 #   --help              Print this help and exit 0
 #
 # Exit codes:
@@ -69,7 +71,12 @@
 #           ci-passed=success, no failures, and mergeStateStatus is CLEAN or
 #           UNSTABLE. Stdout names this path with `all checks complete`.
 #   1 — Early failure: one or more checks have a failed conclusion. Prints the
-#       failed check names and their details_url.
+#       failed check names and their details_url. Before exiting, the failed
+#       jobs' logs are passed to `scripts/classify-ci-flake.sh`. If any
+#       classifies as a known flake AND no rerun has fired on this run yet,
+#       `gh run rerun <run-id> --failed` is invoked once and polling continues
+#       (path stdout names the matched pattern with `flake detected: <label>`).
+#       A second flake on the same run exits 1 — see #4148.
 #   2 — Timeout: --timeout-secs elapsed without reaching a terminal state.
 #
 # ─────────────────────────────────────────────────────────────────────────────
@@ -82,6 +89,12 @@ TIMEOUT_SECS=1800
 POLL_INTERVAL=30
 REPO="judgemind/judgemind"
 PR_NUMBER=""
+AUTO_RERUN=1
+
+# Path to this script's directory — used to locate the sibling
+# `classify-ci-flake.sh` helper without depending on PATH.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLASSIFIER="$SCRIPT_DIR/classify-ci-flake.sh"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -115,6 +128,10 @@ while [ $# -gt 0 ]; do
         --repo)
             REPO="$2"
             shift 2
+            ;;
+        --no-auto-rerun)
+            AUTO_RERUN=0
+            shift
             ;;
         --*)
             echo "ERROR: Unknown option: $1" >&2
@@ -153,6 +170,48 @@ echo "PR #${PR_NUMBER} head SHA: ${SHA}"
 echo "Polling check-runs (timeout: ${TIMEOUT_SECS}s, interval: ${POLL_INTERVAL}s)..."
 echo ""
 
+# ── Auto-rerun sentinel (#4148) ──────────────────────────────────────────────
+#
+# When --auto-rerun is enabled (the default), the script will fire
+# `gh run rerun <run-id> --failed` exactly once per CI run on this SHA when a
+# failed job's log matches a known-flake pattern. The sentinel file remembers
+# which run-ids have already been rerun so a second flake on the same run
+# falls through to exit 1 — this prevents chasing a real outage forever.
+#
+# Tests override the sentinel path via WAIT_FOR_CI_RERUN_SENTINEL_FILE.
+RERUN_SENTINEL_FILE="${WAIT_FOR_CI_RERUN_SENTINEL_FILE:-${TMPDIR:-/tmp}/wait-for-ci-rerun.${SHA}}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+# Extract the workflow run-id from a check-run's details_url. GitHub formats
+# the URL as `https://<host>/<owner>/<repo>/actions/runs/<run-id>/job/<job-id>`
+# (or sometimes without the `/job/<job-id>` suffix). We tolerate either form.
+# Echoes the run-id, or empty string if no match.
+parse_run_id_from_url() {
+    local url="$1"
+    # Strip everything up to and including `/actions/runs/`, then keep digits
+    # before the next `/` boundary.
+    echo "$url" | sed -n 's|.*/actions/runs/\([0-9][0-9]*\).*|\1|p'
+}
+
+# Check whether `gh run rerun` has already been invoked for the given run-id
+# during this script's lifetime (across poll iterations). Returns 0 if the
+# sentinel records this run, 1 otherwise.
+rerun_already_fired() {
+    local run_id="$1"
+    if [ -f "$RERUN_SENTINEL_FILE" ] && grep -Fxq "$run_id" "$RERUN_SENTINEL_FILE"; then
+        return 0
+    fi
+    return 1
+}
+
+# Record that `gh run rerun` was fired for this run-id.
+record_rerun_fired() {
+    local run_id="$1"
+    mkdir -p "$(dirname "$RERUN_SENTINEL_FILE")"
+    echo "$run_id" >> "$RERUN_SENTINEL_FILE"
+}
+
 # ── Poll loop ─────────────────────────────────────────────────────────────────
 
 START_TS=$(date +%s)
@@ -178,6 +237,80 @@ while true; do
         echo ""
         echo "ERROR: ${FAILED_COUNT} check(s) failed:" >&2
         echo "$CHECK_RUNS_JSON" | jq -r '.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled")) | "  - \(.name): conclusion=\(.conclusion)  \(.details_url // "(no details url)")"' >&2
+
+        # ── Known-flake auto-rerun (#4148) ────────────────────────────────
+        # Before exiting 1, classify each failed job's log tail. If any
+        # classifies as a known flake AND no rerun has fired yet on the
+        # owning workflow run, fire `gh run rerun --failed` once and continue
+        # polling. A second flake on the same run falls through to exit 1.
+        if [ "$AUTO_RERUN" -eq 1 ] && [ -x "$CLASSIFIER" ]; then
+            FLAKE_DETECTED=0
+            FLAKE_LABEL=""
+            FLAKE_RUN_ID=""
+
+            # Extract one (failed-check, run-id) pair per failed check.
+            # We only need to check the first failed run-id we see —
+            # `gh run rerun --failed` already reruns every failed job on
+            # that run, and rerunning multiple distinct runs from one
+            # script invocation is out of scope (one rerun per SHA per
+            # script call). The first failed check in the rollup is
+            # representative.
+            FAILED_DETAILS=$(echo "$CHECK_RUNS_JSON" | jq -r '
+                .[]
+                | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled"))
+                | (.details_url // "")
+            ')
+
+            # Walk failed checks until we find one whose run-id parses AND
+            # whose log classifies as a known flake.
+            while IFS= read -r URL; do
+                [ -z "$URL" ] && continue
+                CANDIDATE_RUN_ID=$(parse_run_id_from_url "$URL")
+                if [ -z "$CANDIDATE_RUN_ID" ]; then
+                    continue
+                fi
+
+                # Fetch the failed-job log tail for this run. `gh run view
+                # --log-failed` concatenates every failed job's full log;
+                # we pass the whole thing to the classifier (the classifier
+                # is grep-based so size is fine for typical CI logs <10MB).
+                # Suppress stderr — `gh` may print a non-fatal warning about
+                # log truncation that we don't want polluting stdout.
+                JOB_LOG=$(gh run view "$CANDIDATE_RUN_ID" --repo "$REPO" --log-failed 2>/dev/null || echo "")
+
+                CLASSIFICATION=$(printf '%s' "$JOB_LOG" | "$CLASSIFIER" 2>/dev/null || echo "real")
+                if [ "${CLASSIFICATION#flake/}" != "$CLASSIFICATION" ]; then
+                    FLAKE_DETECTED=1
+                    FLAKE_LABEL="${CLASSIFICATION#flake/}"
+                    FLAKE_RUN_ID="$CANDIDATE_RUN_ID"
+                    break
+                fi
+            done <<EOF
+$FAILED_DETAILS
+EOF
+
+            if [ "$FLAKE_DETECTED" -eq 1 ]; then
+                if rerun_already_fired "$FLAKE_RUN_ID"; then
+                    echo "" >&2
+                    echo "flake detected: ${FLAKE_LABEL} (run ${FLAKE_RUN_ID}) — but rerun already fired once for this run; not retrying." >&2
+                    exit 1
+                fi
+
+                echo ""
+                echo "flake detected: ${FLAKE_LABEL} (run ${FLAKE_RUN_ID}) — auto-rerunning failed jobs and continuing to poll."
+                if gh run rerun "$FLAKE_RUN_ID" --repo "$REPO" --failed >/dev/null 2>&1; then
+                    record_rerun_fired "$FLAKE_RUN_ID"
+                    # Sleep one poll interval so the new run has a moment to
+                    # register before the next check-runs fetch.
+                    sleep "$POLL_INTERVAL"
+                    continue
+                else
+                    echo "ERROR: gh run rerun failed for run ${FLAKE_RUN_ID}; exiting 1." >&2
+                    exit 1
+                fi
+            fi
+        fi
+
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Add a `scripts/classify-ci-flake.sh` helper and wire it into `scripts/wait-for-ci.sh`'s failure path so that CI failures matching a known-flake pattern (postgres-startup, docker-daemon, dns-resolution, github-network) trigger one automatic `gh run rerun --failed` and resume polling instead of forcing the agent into a manual rerun loop. A second flake on the same run-id falls through to `exit 1` so real outages are not masked. New `--no-auto-rerun` flag opts out for callers that want the previous behavior.

Closes #4148

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only). The change ships in the next agent worktree to use `wait-for-ci.sh`; verification happens implicitly the next time CI hits a `schema-drift-check` postgres-startup flake.
- [x] Verification evidence posted on issue (see A.8)
