### PR TITLE
dx(scraper-tests): add shared make_reingest_cap_doc helper (#4153)

### DIFF
--- a/packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py
+++ b/packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py
@@ -21,6 +21,7 @@ import httpx
 import pytest
 import respx
 import structlog.testing
+from helpers.reingest import make_reingest_cap_doc
 
 from courts.ca.cc_tentatives_portal import (
     BASE_URL,
@@ -35,7 +36,17 @@ from courts.ca.cc_tentatives_portal import (
     _parse_listing_table,
 )
 from courts.ca.cc_tentatives_portal import default_config as portal_default_config
-from framework import CapturedDocument, ContentFormat
+from framework import ContentFormat
+
+# Identifier-shape defaults shared across this module's reingest-path
+# regression tests.  Kept as module constants so each call to the shared
+# ``make_reingest_cap_doc`` helper pins the same scraper identity.
+_CC_SCRAPER_ID = "ca-cc-tentatives-portal"
+_CC_STATE = "CA"
+_CC_COUNTY = "Contra Costa"
+_CC_COURT = "Superior Court"
+_CC_SOURCE_URL = "https://contracosta.courts.ca.gov/tentative-ruling/l24-04564"
+_CC_CAPTURE_TS = datetime(2025, 1, 28, 12, 0, 0, tzinfo=UTC)
 
 pytestmark = pytest.mark.regression
 
@@ -539,29 +550,6 @@ def _build_envelope_bytes(
     return json.dumps(envelope).encode("utf-8")
 
 
-def _make_cap_doc(raw_content: bytes) -> CapturedDocument:
-    """Build a CapturedDocument the way reingest_from_s3._reparse_document does.
-
-    Mirrors the production shape: only ``raw_content`` and the
-    identifier fields are set; every parsed field is left at its
-    default (``None`` / ``[]`` / ``{}``).  The structured-field
-    population MUST come from ``parse_document`` reading
-    ``raw_content`` — exactly the contract this test suite enforces.
-    """
-    return CapturedDocument(
-        document_id="test-doc-id",
-        scraper_id="ca-cc-tentatives-portal",
-        state="CA",
-        county="Contra Costa",
-        court="Superior Court",
-        source_url="https://contracosta.courts.ca.gov/tentative-ruling/l24-04564",
-        capture_timestamp=datetime(2025, 1, 28, 12, 0, 0, tzinfo=UTC),
-        content_format=ContentFormat.TEXT,
-        raw_content=raw_content,
-        content_hash="deadbeef" * 8,
-    )
-
-
 def test_parse_document_reingest_populates_fields_from_envelope() -> None:
     """Acceptance criterion #3 (#4133) — parse_document populates structured fields
     from raw_content alone, with no live-capture state available.
@@ -577,7 +565,15 @@ def test_parse_document_reingest_populates_fields_from_envelope() -> None:
     pdf_bytes = _load_bytes("sample.pdf")
 
     raw = _build_envelope_bytes(detail_html=detail_html, pdf_bytes=pdf_bytes)
-    doc = _make_cap_doc(raw)
+    doc = make_reingest_cap_doc(
+        raw_content=raw,
+        scraper_id=_CC_SCRAPER_ID,
+        state=_CC_STATE,
+        county=_CC_COUNTY,
+        court=_CC_COURT,
+        source_url=_CC_SOURCE_URL,
+        capture_timestamp=_CC_CAPTURE_TS,
+    )
     assert doc.case_number is None
     assert doc.judge_name is None
     assert doc.department is None
@@ -627,7 +623,15 @@ def test_parse_document_reingest_pre_4133_pdf_bytes_returns_unchanged() -> None:
     (the symmetric merge in #4142 keeps the DB seeds intact).
     """
     pdf_bytes = _load_bytes("sample.pdf")
-    doc = _make_cap_doc(pdf_bytes)
+    doc = make_reingest_cap_doc(
+        raw_content=pdf_bytes,
+        scraper_id=_CC_SCRAPER_ID,
+        state=_CC_STATE,
+        county=_CC_COUNTY,
+        court=_CC_COURT,
+        source_url=_CC_SOURCE_URL,
+        capture_timestamp=_CC_CAPTURE_TS,
+    )
 
     scraper = _make_reingest_scraper()
     parsed = scraper.parse_document(doc)
@@ -646,7 +650,15 @@ def test_parse_document_reingest_pre_4133_pdf_bytes_returns_unchanged() -> None:
 def test_parse_document_reingest_invalid_envelope_shape_returns_unchanged() -> None:
     """A JSON-decodable but wrong-shaped envelope must not populate garbage fields."""
     raw = json.dumps({"unrelated": "payload"}).encode("utf-8")
-    doc = _make_cap_doc(raw)
+    doc = make_reingest_cap_doc(
+        raw_content=raw,
+        scraper_id=_CC_SCRAPER_ID,
+        state=_CC_STATE,
+        county=_CC_COUNTY,
+        court=_CC_COURT,
+        source_url=_CC_SOURCE_URL,
+        capture_timestamp=_CC_CAPTURE_TS,
+    )
 
     scraper = _make_reingest_scraper()
     parsed = scraper.parse_document(doc)
@@ -660,7 +672,15 @@ def test_parse_document_reingest_invalid_envelope_shape_returns_unchanged() -> N
 
 def test_parse_document_reingest_empty_raw_content_returns_unchanged() -> None:
     """Empty raw_content (defensive case) must not crash."""
-    doc = _make_cap_doc(b"")
+    doc = make_reingest_cap_doc(
+        raw_content=b"",
+        scraper_id=_CC_SCRAPER_ID,
+        state=_CC_STATE,
+        county=_CC_COUNTY,
+        court=_CC_COURT,
+        source_url=_CC_SOURCE_URL,
+        capture_timestamp=_CC_CAPTURE_TS,
+    )
     scraper = _make_reingest_scraper()
     parsed = scraper.parse_document(doc)
     assert parsed.case_number is None
@@ -683,7 +703,15 @@ def test_parse_document_reingest_envelope_with_unknown_pdf_filename_skips_dept()
         pdf_bytes=pdf_bytes,
         pdf_url="https://example.com/some-other-name.pdf",
     )
-    doc = _make_cap_doc(raw)
+    doc = make_reingest_cap_doc(
+        raw_content=raw,
+        scraper_id=_CC_SCRAPER_ID,
+        state=_CC_STATE,
+        county=_CC_COUNTY,
+        court=_CC_COURT,
+        source_url=_CC_SOURCE_URL,
+        capture_timestamp=_CC_CAPTURE_TS,
+    )
 
     scraper = _make_reingest_scraper()
     parsed = scraper.parse_document(doc)

--- a/packages/scraper-framework/tests/courts/test_courtlistener.py
+++ b/packages/scraper-framework/tests/courts/test_courtlistener.py
@@ -13,13 +13,14 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from datetime import UTC, datetime
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import httpx
 import pytest
 import respx
 import structlog.testing
+from helpers.reingest import make_reingest_cap_doc
 
 from courts.federal.courtlistener import (
     _CL_COURT_ID_TO_JURISDICTION,
@@ -34,6 +35,13 @@ from courts.federal.courtlistener import (
     default_config,
 )
 from framework import CapturedDocument, ContentFormat, ScraperConfig
+
+# Identifier-shape defaults shared across the reingest-path regression tests.
+_CL_SCRAPER_ID = "federal-courtlistener-opinions"
+_CL_STATE = "Federal"
+_CL_COUNTY = "Federal"
+_CL_COURT = "CourtListener"
+_CL_SOURCE_URL_BASE = "https://www.courtlistener.com/api/rest/v4/opinions"
 
 # ---------------------------------------------------------------------------
 # Fixtures — sample API responses
@@ -1634,6 +1642,10 @@ class TestParseDocumentReingestPath:
     ) -> CapturedDocument:
         """Build a fresh CapturedDocument with only raw_content set —
         mirrors the shape ``scripts/reingest_from_s3.py:890-901`` constructs.
+
+        Delegates to ``helpers.reingest.make_reingest_cap_doc`` (the
+        shared scaffold from #4153) — only the envelope-shape JSON
+        construction is CourtListener-specific.
         """
         envelope: dict = {}
         if cluster is not None:
@@ -1644,16 +1656,15 @@ class TestParseDocumentReingestPath:
             envelope["docket"] = docket
         raw_content = json.dumps(envelope, default=str).encode("utf-8")
 
-        return CapturedDocument(
-            document_id="reingest-doc-1",
-            scraper_id="federal-courtlistener-opinions",
-            state="Federal",
-            county="Federal",
-            court="CourtListener",
-            source_url="https://www.courtlistener.com/api/rest/v4/opinions/2001/",
-            capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
-            content_format=ContentFormat.TEXT,
+        return make_reingest_cap_doc(
             raw_content=raw_content,
+            scraper_id=_CL_SCRAPER_ID,
+            state=_CL_STATE,
+            county=_CL_COUNTY,
+            court=_CL_COURT,
+            source_url=f"{_CL_SOURCE_URL_BASE}/2001/",
+            content_format=ContentFormat.TEXT,
+            document_id="reingest-doc-1",
             content_hash="0" * 64,
         )
 
@@ -1715,16 +1726,14 @@ class TestParseDocumentReingestPath:
         leave the doc untouched so the reingest caller can fall back to
         its raw text decode.
         """
-        doc = CapturedDocument(
-            document_id="reingest-bad-json",
-            scraper_id="federal-courtlistener-opinions",
-            state="Federal",
-            county="Federal",
-            court="CourtListener",
-            source_url="https://www.courtlistener.com/api/rest/v4/opinions/9999/",
-            capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
-            content_format=ContentFormat.TEXT,
+        doc = make_reingest_cap_doc(
             raw_content=b"not json",
+            scraper_id=_CL_SCRAPER_ID,
+            state=_CL_STATE,
+            county=_CL_COUNTY,
+            court=_CL_COURT,
+            source_url=f"{_CL_SOURCE_URL_BASE}/9999/",
+            document_id="reingest-bad-json",
             content_hash="0" * 64,
         )
 
@@ -1744,16 +1753,14 @@ class TestParseDocumentReingestPath:
         """
         # Well-formed JSON but no cluster/opinion keys.
         raw = json.dumps({"unrelated": {"data": "shape"}}).encode("utf-8")
-        doc = CapturedDocument(
-            document_id="reingest-wrong-shape",
-            scraper_id="federal-courtlistener-opinions",
-            state="Federal",
-            county="Federal",
-            court="CourtListener",
-            source_url="https://www.courtlistener.com/api/rest/v4/opinions/9999/",
-            capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
-            content_format=ContentFormat.TEXT,
+        doc = make_reingest_cap_doc(
             raw_content=raw,
+            scraper_id=_CL_SCRAPER_ID,
+            state=_CL_STATE,
+            county=_CL_COUNTY,
+            court=_CL_COURT,
+            source_url=f"{_CL_SOURCE_URL_BASE}/9999/",
+            document_id="reingest-wrong-shape",
             content_hash="0" * 64,
         )
 
@@ -1841,16 +1848,14 @@ class TestParseDocumentReingestPath:
 
     def test_parse_document_handles_none_raw_content(self) -> None:
         """Defensive: parse_document on a doc with raw_content=b'' returns unchanged."""
-        doc = CapturedDocument(
-            document_id="reingest-empty",
-            scraper_id="federal-courtlistener-opinions",
-            state="Federal",
-            county="Federal",
-            court="CourtListener",
-            source_url="https://www.courtlistener.com/api/rest/v4/opinions/9999/",
-            capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
-            content_format=ContentFormat.TEXT,
+        doc = make_reingest_cap_doc(
             raw_content=b"",
+            scraper_id=_CL_SCRAPER_ID,
+            state=_CL_STATE,
+            county=_CL_COUNTY,
+            court=_CL_COURT,
+            source_url=f"{_CL_SOURCE_URL_BASE}/9999/",
+            document_id="reingest-empty",
             content_hash="0" * 64,
         )
 

--- a/packages/scraper-framework/tests/helpers/reingest.py
+++ b/packages/scraper-framework/tests/helpers/reingest.py
@@ -1,0 +1,134 @@
+"""Shared test helpers for parse_document reingest-path regression tests.
+
+Several scrapers (CourtListener #3986, Contra Costa portal #4133,
+SF civil #4134) have parse_document implementations that on the live
+capture path receive a ``CapturedDocument`` whose structured fields
+(``case_number``, ``judge_name``, ``ruling_text``, ...) have already been
+populated upstream — and therefore historically were free to be no-ops or
+to assume those fields were set.  Reingest from S3
+(``scripts/reingest_from_s3.py::_reparse_document``) breaks that
+assumption: it constructs a fresh ``CapturedDocument`` with only
+``raw_content`` and the identifier fields set, then calls
+``parse_document(cap_doc)``.  Any field that ``parse_document`` does not
+explicitly populate gets clobbered to the default by the merge logic
+downstream.
+
+The fix in each scraper is to make ``parse_document`` populate every
+relevant field from ``raw_content`` alone.  The regression test for that
+fix needs to construct exactly the reingest-shape ``CapturedDocument``
+and assert structured fields are recovered after parse_document runs.
+
+This module provides the shared scaffold so each scraper's regression
+test does not re-derive the cap_doc construction inline.
+
+See:
+- ``scripts/reingest_from_s3.py::_reparse_document`` (lines ~919-938)
+- Issue #4046 audit: ``docs/investigations/parse_document-reingest-safety-2026-05.md``
+- Issue #4153 (this helper)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from framework import CapturedDocument, ContentFormat
+
+
+def make_reingest_cap_doc(
+    *,
+    raw_content: bytes,
+    scraper_id: str,
+    state: str = "CA",
+    county: str = "Test",
+    court: str = "Test Superior Court",
+    source_url: str = "https://example.com/doc",
+    content_format: ContentFormat = ContentFormat.TEXT,
+    document_id: str = "test-doc-id",
+    capture_timestamp: datetime | None = None,
+    content_hash: str = "deadbeef" * 8,
+) -> CapturedDocument:
+    """Build a CapturedDocument matching ``scripts/reingest_from_s3.py`` shape.
+
+    Mirrors the production reingest shape: only ``raw_content`` and the
+    identifier fields are set; every parsed field
+    (``case_number``, ``case_title``, ``judge_name``, ``hearing_date``,
+    ``ruling_text``, ``ruling_text_html``, ``outcome``, ``motion_type``,
+    ``parties``, ``extra``, ``courthouse``, ``department``) is left at its
+    default (``None`` / ``[]`` / ``{}``).  The structured-field
+    population MUST come from ``parse_document`` reading ``raw_content``
+    — exactly the contract the regression-test suites enforce.
+
+    Parameters
+    ----------
+    raw_content
+        The bytes ``parse_document`` will read.  Test cases pass either
+        a JSON envelope (the live-capture archive shape), arbitrary
+        non-JSON bytes (the "decode-fails-gracefully" tolerance case),
+        or empty bytes (the "defensive-empty-input" case).
+    scraper_id
+        The scraper's canonical id (e.g. ``federal-courtlistener-opinions``,
+        ``ca-cc-tentatives-portal``, ``ca-sf-civil-tentatives``).  Required
+        — every scraper has its own and there is no defensible default.
+    state, county, court, source_url, content_format, document_id, content_hash
+        Identifier-shape fields.  Defaults match the reingest production
+        path's choices but each is overridable per-call.
+    capture_timestamp
+        Defaults to a fixed deterministic ``2026-01-01T00:00:00Z`` if not
+        provided — keeps regression-test goldens stable across reruns.
+    """
+    if capture_timestamp is None:
+        capture_timestamp = datetime(2026, 1, 1, tzinfo=UTC)
+
+    return CapturedDocument(
+        document_id=document_id,
+        scraper_id=scraper_id,
+        state=state,
+        county=county,
+        court=court,
+        source_url=source_url,
+        capture_timestamp=capture_timestamp,
+        content_format=content_format,
+        raw_content=raw_content,
+        content_hash=content_hash,
+    )
+
+
+# Field names populated by parse_document on the reingest path.  The
+# defensive "raw_content fails to decode → return unchanged" tolerance
+# tests assert that every one of these stays at its model-default after
+# parse_document runs against unparseable raw_content.
+_PARSE_POPULATED_SCALAR_FIELDS = (
+    "case_number",
+    "case_title",
+    "courthouse",
+    "department",
+    "judge_name",
+    "hearing_date",
+    "ruling_text",
+    "ruling_text_html",
+    "outcome",
+    "motion_type",
+)
+
+
+def assert_structured_fields_unchanged(doc: CapturedDocument) -> None:
+    """Assert every parse_document-populated field is at its default.
+
+    Useful for the "raw_content fails to decode → return unchanged"
+    tolerance regression tests: pre-parse_document the cap_doc carries
+    only raw_content + identifiers, so these defaults must hold; if
+    parse_document tolerates the bad input correctly the same defaults
+    must still hold post-parse_document.
+
+    Tests that want to assert pre-parse defaults can call this on the
+    fresh cap_doc; tests that want to assert post-parse-of-bad-input
+    can call it on the parsed result.
+
+    Raises ``AssertionError`` if any populated-on-success field has
+    drifted from its model default.
+    """
+    for field_name in _PARSE_POPULATED_SCALAR_FIELDS:
+        actual = getattr(doc, field_name)
+        assert actual is None, f"expected {field_name} to be None (default), got {actual!r}"
+    assert doc.parties == [], f"expected parties to be [] (default), got {doc.parties!r}"
+    assert doc.extra == {}, f"expected extra to be {{}} (default), got {doc.extra!r}"

--- a/packages/scraper-framework/tests/helpers/test_reingest_helpers.py
+++ b/packages/scraper-framework/tests/helpers/test_reingest_helpers.py
@@ -1,0 +1,156 @@
+"""Unit tests for ``tests/helpers/reingest.py``.
+
+These tests pin the contract that the reingest-cap_doc helper:
+
+1. Returns a ``CapturedDocument`` with ONLY ``raw_content`` and
+   identifier fields set (every parsed field at default).
+2. Lets per-call kwargs override the identifier defaults.
+3. ``assert_structured_fields_unchanged`` accepts the helper's output
+   unchanged and rejects any drift on a populated parsed field.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from framework import CapturedDocument, ContentFormat
+from helpers.reingest import (
+    assert_structured_fields_unchanged,
+    make_reingest_cap_doc,
+)
+
+
+class TestMakeReingestCapDoc:
+    def test_required_fields_only_returns_cap_doc_with_defaults(self) -> None:
+        """With only ``raw_content`` and ``scraper_id`` set, every parsed
+        field is at its model-default and identifier fields take the
+        helper's documented defaults.
+        """
+        doc = make_reingest_cap_doc(
+            raw_content=b"hello",
+            scraper_id="federal-courtlistener-opinions",
+        )
+
+        assert isinstance(doc, CapturedDocument)
+        # raw_content + identifiers populated.
+        assert doc.raw_content == b"hello"
+        assert doc.scraper_id == "federal-courtlistener-opinions"
+        assert doc.state == "CA"
+        assert doc.county == "Test"
+        assert doc.court == "Test Superior Court"
+        assert doc.source_url == "https://example.com/doc"
+        assert doc.content_format == ContentFormat.TEXT
+        assert doc.document_id == "test-doc-id"
+        assert doc.content_hash == "deadbeef" * 8
+
+        # capture_timestamp defaults to a deterministic value.
+        assert doc.capture_timestamp == datetime(2026, 1, 1, tzinfo=UTC)
+
+        # Every parse_document-populated field is at its default — this
+        # is the core invariant the reingest helper exists to enforce.
+        assert doc.case_number is None
+        assert doc.case_title is None
+        assert doc.courthouse is None
+        assert doc.department is None
+        assert doc.judge_name is None
+        assert doc.hearing_date is None
+        assert doc.ruling_text is None
+        assert doc.ruling_text_html is None
+        assert doc.outcome is None
+        assert doc.motion_type is None
+        assert doc.parties == []
+        assert doc.extra == {}
+
+    def test_overrides_propagate(self) -> None:
+        """Per-call kwargs override every identifier-shape default."""
+        ts = datetime(2025, 6, 30, 12, 0, 0, tzinfo=UTC)
+        doc = make_reingest_cap_doc(
+            raw_content=b"{}",
+            scraper_id="ca-cc-tentatives-portal",
+            state="CA",
+            county="Contra Costa",
+            court="Superior Court",
+            source_url="https://contracosta.courts.ca.gov/tentative-ruling/x",
+            content_format=ContentFormat.TEXT,
+            document_id="custom-doc-id",
+            capture_timestamp=ts,
+            content_hash="cafef00d" * 8,
+        )
+
+        assert doc.scraper_id == "ca-cc-tentatives-portal"
+        assert doc.county == "Contra Costa"
+        assert doc.court == "Superior Court"
+        assert doc.source_url == "https://contracosta.courts.ca.gov/tentative-ruling/x"
+        assert doc.document_id == "custom-doc-id"
+        assert doc.capture_timestamp == ts
+        assert doc.content_hash == "cafef00d" * 8
+
+    def test_empty_raw_content_is_allowed(self) -> None:
+        """The defensive empty-bytes case must not raise — parse_document
+        tolerance tests rely on it.
+        """
+        doc = make_reingest_cap_doc(
+            raw_content=b"",
+            scraper_id="federal-courtlistener-opinions",
+        )
+        assert doc.raw_content == b""
+
+
+class TestAssertStructuredFieldsUnchanged:
+    def test_accepts_fresh_cap_doc(self) -> None:
+        """A fresh helper-built cap_doc must satisfy the assertion."""
+        doc = make_reingest_cap_doc(
+            raw_content=b"hello",
+            scraper_id="federal-courtlistener-opinions",
+        )
+        # No exception expected.
+        assert_structured_fields_unchanged(doc)
+
+    @pytest.mark.parametrize(
+        "field_name,value",
+        [
+            ("case_number", "22-1234"),
+            ("case_title", "Smith v. Jones"),
+            ("judge_name", "Justice Roberts"),
+            ("hearing_date", datetime(2026, 3, 1, tzinfo=UTC)),
+            ("ruling_text", "MOTION GRANTED"),
+            ("ruling_text_html", "<p>MOTION GRANTED</p>"),
+            ("outcome", "GRANTED"),
+            ("motion_type", "Demurrer"),
+            ("courthouse", "Martinez Courthouse"),
+            ("department", "16"),
+        ],
+    )
+    def test_rejects_populated_scalar(self, field_name: str, value: object) -> None:
+        """Drift on any populated-on-success scalar field must raise."""
+        doc = make_reingest_cap_doc(
+            raw_content=b"hello",
+            scraper_id="federal-courtlistener-opinions",
+        )
+        # Mutate the field via model_copy so we don't fight Pydantic.
+        mutated = doc.model_copy(update={field_name: value})
+
+        with pytest.raises(AssertionError, match=field_name):
+            assert_structured_fields_unchanged(mutated)
+
+    def test_rejects_populated_parties(self) -> None:
+        """Drift on ``parties`` (list field) must raise."""
+        doc = make_reingest_cap_doc(
+            raw_content=b"hello",
+            scraper_id="federal-courtlistener-opinions",
+        )
+        mutated = doc.model_copy(update={"parties": [{"role": "plaintiff", "name": "Smith"}]})
+        with pytest.raises(AssertionError, match="parties"):
+            assert_structured_fields_unchanged(mutated)
+
+    def test_rejects_populated_extra(self) -> None:
+        """Drift on ``extra`` (dict field) must raise."""
+        doc = make_reingest_cap_doc(
+            raw_content=b"hello",
+            scraper_id="federal-courtlistener-opinions",
+        )
+        mutated = doc.model_copy(update={"extra": {"slug": "x"}})
+        with pytest.raises(AssertionError, match="extra"):
+            assert_structured_fields_unchanged(mutated)


### PR DESCRIPTION
## Summary

Extract `make_reingest_cap_doc` + `assert_structured_fields_unchanged` into a new `tests/helpers/reingest.py` so the parse_document reingest-path regression tests stop redefining their own ad-hoc `_make_cap_doc` / `_make_envelope_doc` helpers. Migrate `test_courtlistener.py` (#3986) and `test_cc_tentatives_portal.py` (#4133) to use the shared helper.

Closes #4153

## Test plan

### Automated checks
- [x] Lint passes — ruff check on changed files clean
- [x] Format check passes — ruff format --check on changed files clean
- [x] Tests pass — `pytest tests/helpers/ tests/courts/` 1926 passed
- [x] CI green — canonical merge gate reached SUCCESS at 285s

### Post-deploy verification
- [x] N/A — no deployed component (test-only refactor in tests/helpers/)
