### PR TITLE
ci: add vitest environment-package devDependency hygiene check (#4106)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1136,6 +1136,20 @@ jobs:
         run: scripts/check-hardcoded-colors.sh
 
   # ---------------------------------------------------------------
+  # Vitest environment-package devDependency hygiene check (#4106):
+  # ensure every packages/*/vitest.config.{ts,js,mjs} that declares
+  # a non-default environment (e.g. 'jsdom', 'happy-dom') has the
+  # corresponding npm package as a direct devDependency in the same
+  # package's package.json. Regression class fixed in #4088.
+  # ---------------------------------------------------------------
+  vitest-environment-deps-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify vitest test-environment packages are direct devDeps
+        run: scripts/check-vitest-environment-deps.sh
+
+  # ---------------------------------------------------------------
   # Admin dispatcher brand-accent guard: block bare shadcn accent
   # tokens on `/admin/dispatcher` so readability regressions like
   # #2816 (invisible gray issue/PR links) don't recur.
@@ -1706,7 +1720,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-vitest-environment-deps.sh
+++ b/scripts/check-vitest-environment-deps.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# check-vitest-environment-deps.sh — Verify vitest test-environment packages are direct devDeps.
+#
+# permanent: true
+#
+# When a package's vitest.config.{ts,js,mjs} declares `environment: 'jsdom'`
+# (or 'happy-dom', 'edge-runtime', etc.), the corresponding npm package MUST
+# be listed as a direct `devDependency` (or `dependency`) in the same
+# package's package.json. Vitest's standard module resolution does not look
+# inside transitive node_modules subtrees, so a transitive presence (e.g.
+# pulled in via `isomorphic-dompurify` -> `jsdom`) silently fails on fresh
+# worktrees as:
+#
+#     MISSING DEPENDENCY  Cannot find dependency 'jsdom'
+#
+# This is the regression class fixed in #4088 (jsdom missing from
+# packages/web/package.json devDependencies despite being declared as the
+# test environment).
+#
+# Scope:
+#   - Walks every packages/*/vitest.config.{ts,js,mjs}.
+#   - Extracts the literal value of `environment:` via regex (the config
+#     shape is consistent across the repo — full TS AST not required).
+#   - Skips configs where environment is absent or set to 'node' (which is
+#     vitest's default and requires no extra package).
+#   - Verifies the referenced package appears in the same package's
+#     package.json `dependencies` or `devDependencies`.
+#
+# Out of scope (intentional):
+#   - Root or non-packages/* directories (no vitest configs live there).
+#   - Version-range satisfaction (npm + lockfile already enforce that).
+#
+# Usage:
+#   scripts/check-vitest-environment-deps.sh             # exits 0 if clean, 1 if violations
+#   scripts/check-vitest-environment-deps.sh [pkgs-dir]  # scan a specific packages-root
+#
+# Exit codes:
+#   0 — Every vitest config's declared environment package is a direct dep.
+#   1 — One or more configs reference an environment package not in the
+#       same package's package.json.
+#   2 — Usage error (bad arg, missing file, etc.).
+#
+# Ref: https://github.com/judgemind/judgemind/issues/4106
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKGS_DIR="${1:-$REPO_ROOT/packages}"
+
+if [[ ! -d "$PKGS_DIR" ]]; then
+    echo "ERROR: packages directory not found: $PKGS_DIR" >&2
+    exit 2
+fi
+
+# Vitest's default environment — needs no extra package.
+DEFAULT_ENV="node"
+
+# Regex pulls a single-line literal: environment: 'jsdom' / "happy-dom" / etc.
+# Captures the package-like identifier inside the quotes. Allows hyphens.
+ENV_REGEX="environment:[[:space:]]*['\"]([A-Za-z_][A-Za-z0-9_-]*)['\"]"
+
+violations=0
+checked=0
+
+for cfg in "$PKGS_DIR"/*/vitest.config.ts "$PKGS_DIR"/*/vitest.config.js "$PKGS_DIR"/*/vitest.config.mjs; do
+    [[ -f "$cfg" ]] || continue
+
+    pkg_dir="$(dirname "$cfg")"
+    pkg_name="$(basename "$pkg_dir")"
+    pkg_json="$pkg_dir/package.json"
+
+    # Pull the environment literal — first match wins (configs only declare it once).
+    env_value=""
+    if [[ $(grep -cE "$ENV_REGEX" "$cfg" 2>/dev/null || true) -gt 0 ]]; then
+        # shellcheck disable=SC2001
+        env_value="$(grep -oE "$ENV_REGEX" "$cfg" | head -n1 | sed -E "s/.*['\"]([A-Za-z_][A-Za-z0-9_-]*)['\"].*/\1/")"
+    fi
+
+    # Skip configs without environment, or with the default 'node'.
+    if [[ -z "$env_value" || "$env_value" == "$DEFAULT_ENV" ]]; then
+        continue
+    fi
+
+    checked=$((checked + 1))
+
+    if [[ ! -f "$pkg_json" ]]; then
+        echo "ERROR: $cfg declares environment '$env_value' but no package.json found at $pkg_json" >&2
+        violations=$((violations + 1))
+        continue
+    fi
+
+    # Use python3 to safely parse package.json — pure shell JSON parsing is brittle.
+    set +e
+    python3 - "$pkg_json" "$env_value" <<'PYEOF' 2>/dev/null
+import json
+import sys
+from pathlib import Path
+
+pkg_json_path = Path(sys.argv[1])
+needed = sys.argv[2]
+
+try:
+    data = json.loads(pkg_json_path.read_text(encoding="utf-8"))
+except (OSError, json.JSONDecodeError) as exc:
+    print(f"  parse error: {exc}", file=sys.stderr)
+    sys.exit(2)
+
+deps = data.get("dependencies", {}) or {}
+dev_deps = data.get("devDependencies", {}) or {}
+
+if needed in deps or needed in dev_deps:
+    sys.exit(0)
+sys.exit(1)
+PYEOF
+    rc=$?
+    set -e
+    if [[ $rc -eq 0 ]]; then
+        :  # dep present — no action
+    elif [[ $rc -eq 1 ]]; then
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: vitest environment package(s) missing from same-package package.json:" >&2
+            echo "" >&2
+        fi
+        echo "  packages/$pkg_name/vitest.config.* declares environment '$env_value'" >&2
+        echo "  but '$env_value' is not in $pkg_json (dependencies or devDependencies)." >&2
+        echo "" >&2
+        echo "  Fix: cd $pkg_dir && npm install --save-dev $env_value" >&2
+        echo "" >&2
+        violations=$((violations + 1))
+    else
+        echo "ERROR: failed to parse $pkg_json (python3 exit $rc)" >&2
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo "Found $violations violation(s) across $checked vitest config(s) with non-default environment." >&2
+    echo "" >&2
+    echo "  This guard exists because Vitest's module resolution cannot find" >&2
+    echo "  test-environment packages that are only present transitively. See" >&2
+    echo "  https://github.com/judgemind/judgemind/issues/4088 for the canonical" >&2
+    echo "  incident." >&2
+    exit 1
+fi
+
+echo "All clean — checked $checked vitest config(s) with non-default environment."
+exit 0

--- a/scripts/tests/test_check_vitest_environment_deps.sh
+++ b/scripts/tests/test_check_vitest_environment_deps.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# test_check_vitest_environment_deps.sh — Tests for check-vitest-environment-deps.sh
+#
+# Creates synthetic packages/<pkg>/{vitest.config.ts,package.json} fixtures
+# and verifies the checker correctly flags configs whose declared
+# `environment:` value is missing from the same package's package.json.
+#
+# Mirrors the regression class in #4088 (jsdom transitive-only on fresh
+# worktrees).
+#
+# Usage:
+#   scripts/tests/test_check_vitest_environment_deps.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-vitest-environment-deps.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"
+    mkdir -p "$TMPDIR_TEST"
+}
+
+# Materialize a fixture: packages/<pkg>/vitest.config.ts + package.json.
+# Args:
+#   $1 — package name (subdir under TMPDIR_TEST/packages)
+#   $2 — environment literal to write into vitest.config.ts (or empty for none)
+#   $3 — comma-separated devDependency names to declare in package.json
+#         (e.g. "vitest,jsdom") — set to empty for an empty devDependencies map
+make_fixture() {
+    local pkg="$1"
+    local env_value="$2"
+    local dev_deps_csv="${3:-}"
+
+    local pkg_dir="$TMPDIR_TEST/packages/$pkg"
+    mkdir -p "$pkg_dir"
+
+    if [[ -n "$env_value" ]]; then
+        cat > "$pkg_dir/vitest.config.ts" <<TSEOF
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: '$env_value',
+  },
+});
+TSEOF
+    else
+        cat > "$pkg_dir/vitest.config.ts" <<'TSEOF'
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./tests/setup.ts'],
+  },
+});
+TSEOF
+    fi
+
+    # Build a package.json with the declared dev deps.
+    {
+        echo '{'
+        echo "  \"name\": \"$pkg\","
+        echo '  "version": "0.0.0",'
+        echo '  "devDependencies": {'
+        if [[ -n "$dev_deps_csv" ]]; then
+            local first=1
+            local IFS=','
+            for dep in $dev_deps_csv; do
+                if [[ $first -eq 1 ]]; then
+                    first=0
+                else
+                    echo ','
+                fi
+                printf '    "%s": "*"' "$dep"
+            done
+            echo ''
+        fi
+        echo '  }'
+        echo '}'
+    } > "$pkg_dir/package.json"
+}
+
+assert_passes() {
+    local desc="$1"
+    local pkgs_dir="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$pkgs_dir" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected exit 0, got non-zero)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local pkgs_dir="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$pkgs_dir" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected exit 1, got 0)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_output_contains() {
+    local desc="$1"
+    local pkgs_dir="$2"
+    local pattern="$3"
+    TESTS=$((TESTS + 1))
+    local out
+    out=$("$CHECK_SCRIPT" "$pkgs_dir" 2>&1 || true)
+    if echo "$out" | grep -qE "$pattern"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (pattern '$pattern' not found in output: $out)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test 1: jsdom env declared + jsdom devDep present → passes ───────
+reset_tmpdir
+make_fixture "web" "jsdom" "vitest,jsdom"
+assert_passes "jsdom env + jsdom devDep present" "$TMPDIR_TEST/packages"
+
+# ─── Test 2: jsdom env declared + jsdom missing → fails (#4088 shape) ─
+reset_tmpdir
+make_fixture "web" "jsdom" "vitest"
+assert_fails "jsdom env + jsdom missing flagged (the #4088 regression)" "$TMPDIR_TEST/packages"
+
+# ─── Test 3: failure message names the missing env package ────────────
+reset_tmpdir
+make_fixture "web" "jsdom" "vitest"
+assert_output_contains \
+    "failure message names the missing env package" \
+    "$TMPDIR_TEST/packages" \
+    "jsdom"
+
+# ─── Test 4: env=node is the default — no devDep required, passes ─────
+reset_tmpdir
+make_fixture "api" "node" "vitest"
+assert_passes "env=node passes without an extra devDep" "$TMPDIR_TEST/packages"
+
+# ─── Test 5: no environment declaration → passes ──────────────────────
+reset_tmpdir
+make_fixture "api" "" "vitest"
+assert_passes "no environment declaration passes" "$TMPDIR_TEST/packages"
+
+# ─── Test 6: happy-dom env declared + happy-dom devDep present → pass ─
+reset_tmpdir
+make_fixture "web" "happy-dom" "vitest,happy-dom"
+assert_passes "happy-dom env + happy-dom devDep present" "$TMPDIR_TEST/packages"
+
+# ─── Test 7: happy-dom env declared + happy-dom missing → fails ───────
+reset_tmpdir
+make_fixture "web" "happy-dom" "vitest"
+assert_fails "happy-dom env + happy-dom missing flagged" "$TMPDIR_TEST/packages"
+
+# ─── Test 8: env package present in `dependencies` (not just devDeps) → pass
+# Some packages may declare jsdom as a runtime dep; the check accepts both.
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/packages/web"
+cat > "$TMPDIR_TEST/packages/web/vitest.config.ts" <<'TSEOF'
+import { defineConfig } from 'vitest/config';
+export default defineConfig({ test: { environment: 'jsdom' } });
+TSEOF
+cat > "$TMPDIR_TEST/packages/web/package.json" <<'JSEOF'
+{
+  "name": "web",
+  "version": "0.0.0",
+  "dependencies": {
+    "jsdom": "*"
+  }
+}
+JSEOF
+assert_passes "env package in dependencies (not devDependencies) accepted" "$TMPDIR_TEST/packages"
+
+# ─── Test 9: multiple packages — one good, one bad → exits 1 ──────────
+reset_tmpdir
+make_fixture "good-pkg" "jsdom" "vitest,jsdom"
+make_fixture "bad-pkg" "jsdom" "vitest"
+assert_fails "mixed good+bad packages exits 1 if any package is bad" "$TMPDIR_TEST/packages"
+
+# ─── Test 10: multiple packages, all good → exits 0 ───────────────────
+reset_tmpdir
+make_fixture "web" "jsdom" "vitest,jsdom"
+make_fixture "api" "node" "vitest"
+make_fixture "shared" "" "vitest"
+assert_passes "multiple packages all good exits 0" "$TMPDIR_TEST/packages"
+
+# ─── Test 11: real repo passes (post-#4088) ───────────────────────────
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: real repo scan exits 0 (post-#4088 baseline)"
+else
+    echo "FAIL: real repo scan exits non-zero — #4088 regression?"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 12: vitest.config.js variant is also scanned ────────────────
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/packages/web-js"
+cat > "$TMPDIR_TEST/packages/web-js/vitest.config.js" <<'JSCFG'
+module.exports = {
+  test: {
+    environment: 'jsdom',
+  },
+};
+JSCFG
+cat > "$TMPDIR_TEST/packages/web-js/package.json" <<'JSEOF'
+{
+  "name": "web-js",
+  "version": "0.0.0",
+  "devDependencies": {
+    "vitest": "*"
+  }
+}
+JSEOF
+assert_fails "vitest.config.js variant flagged when jsdom missing" "$TMPDIR_TEST/packages"
+
+# ─── Test 13: vitest.config.mjs variant is also scanned ───────────────
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/packages/web-mjs"
+cat > "$TMPDIR_TEST/packages/web-mjs/vitest.config.mjs" <<'MJSCFG'
+export default {
+  test: {
+    environment: 'jsdom',
+  },
+};
+MJSCFG
+cat > "$TMPDIR_TEST/packages/web-mjs/package.json" <<'JSEOF'
+{
+  "name": "web-mjs",
+  "version": "0.0.0",
+  "devDependencies": {
+    "vitest": "*",
+    "jsdom": "*"
+  }
+}
+JSEOF
+assert_passes "vitest.config.mjs variant accepted when jsdom present" "$TMPDIR_TEST/packages"
+
+# ─── Test 14: usage error (missing packages dir) → exits 2 ────────────
+TESTS=$((TESTS + 1))
+set +e
+"$CHECK_SCRIPT" "$TMPDIR_TEST/does-not-exist" > /dev/null 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 2 ]]; then
+    echo "PASS: missing packages dir exits 2"
+else
+    echo "FAIL: missing packages dir expected exit 2, got $rc"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI hygiene check that verifies every `packages/*/vitest.config.{ts,js,mjs}` declaring a non-default `environment:` (e.g. `'jsdom'`, `'happy-dom'`) has the corresponding npm package as a direct `dependency` or `devDependency` in the same package's `package.json`. Catches the #4088 regression shape at PR time instead of at fresh-worktree first-`npm-test` time. New `vitest-environment-deps-check` job is wired into `ci-passed`.

Closes #4106

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_vitest_environment_deps.sh` — 14 cases)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check + tests only)
- [x] Verification evidence posted on issue (see #4106 comment)
