### PR TITLE
fix(test): canonicalize TEST_TMP via pwd -P for macOS /private prefix (#4126)

### DIFF
--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -81,6 +81,15 @@ cleanup() {
 trap cleanup EXIT
 
 TEST_TMP=$(mktemp -d)
+# Canonicalize via ``pwd -P`` so paths compare cleanly against shim
+# output on macOS (#4126). ``mktemp -d`` returns ``/var/folders/...``
+# but BSD's ``/var`` is a symlink to ``/private/var``; tests that
+# compare a fixture path against ``Path(...).resolve()`` output from
+# ``phase_input_shim.py`` see the ``/private/`` prefix and mismatch.
+# Resolving once at fixture root fixes every downstream comparison
+# without per-test wrapping. Linux is unaffected — ``/tmp`` is not
+# symlinked, so ``pwd -P`` is a no-op.
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
 
 # ── Build a stub-bin directory on PATH ─────────────────────────────────────
 #


### PR DESCRIPTION
## Summary

Canonicalize `TEST_TMP` once at fixture-root setup in `scripts/tests/test_agent_runner_entrypoint.sh` so every downstream fixture path inherits the realpath form. On macOS, `mktemp -d` returns `/var/folders/...` but BSD's `/var` is a symlink to `/private/var`; the shim's `Path(...).resolve()` produces the canonical `/private/var/...` form, causing the `#3547 — verify shim sets worktree_path to REPO_ROOT in ECS lane` assertion to mismatch. Resolving at the fixture root preempts the entire class of `path == "$tmpdir"` comparisons in the file. Linux is unaffected because `/tmp` is not symlinked.

Closes #4126

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test fixture only; shell-slow CI job exercises the assertion)
- [x] Verification evidence posted on issue (see A.8)
