### PR TITLE
fix(dispatcher): use gtimeout fallback when timeout absent for macOS portability (#4125)

### DIFF
--- a/scripts/dispatcher/agent_runner_run_claude_phase.sh
+++ b/scripts/dispatcher/agent_runner_run_claude_phase.sh
@@ -61,6 +61,40 @@ if ! declare -F die >/dev/null 2>&1; then
     }
 fi
 
+# ── _resolve_timeout_cmd() — portable timeout(1) lookup (#4125) ────────────
+#
+# GNU coreutils ships ``timeout(1)`` on Linux. macOS BSD does NOT ship a
+# ``timeout`` binary out of the box. Operators with ``brew install coreutils``
+# get ``gtimeout`` (the ``g``-prefixed coreutils alias). The helper's
+# ``run_claude_phase`` wraps ``claude -p`` in ``timeout "$_phase_timeout" ...``
+# so a hung claude surfaces as exit 124 — but on a fresh Mac without
+# coreutils, bash returns rc=127 ("command not found") instead of rc=124,
+# the rc==124 short-circuit branch never fires, and the
+# ``test_agent_runner_run_claude_phase.sh`` runtime-timeout regression
+# silently fails locally with empty stdout.
+#
+# Resolve once at call time (cheap — two ``command -v`` checks) and return
+# the binary name. Empty string means neither is on PATH; ``run_claude_phase``
+# treats that as "exec inner command directly with no timer", which loses
+# the rc=124 branch but is strictly better than aborting with rc=127. The
+# self-sufficient runtime-timeout regression test stubs ``timeout`` into
+# its private ``$_tbin`` directory the same way the entrypoint test does
+# (see ``scripts/tests/test_agent_runner_entrypoint.sh`` lines 599-605),
+# so the test path doesn't depend on the operator having coreutils
+# installed.
+#
+# Output: prints either ``timeout``, ``gtimeout``, or empty string on
+# stdout. Always exits 0.
+_resolve_timeout_cmd() {
+    if command -v timeout >/dev/null 2>&1; then
+        printf 'timeout'
+    elif command -v gtimeout >/dev/null 2>&1; then
+        printf 'gtimeout'
+    else
+        printf ''
+    fi
+}
+
 # ── _ms_now() — portable epoch-milliseconds helper (#4099) ──────────────────
 #
 # GNU ``date -u +%s%3N`` returns epoch-seconds + 3-digit nanoseconds (i.e.
@@ -287,6 +321,13 @@ run_claude_phase() {
     # name appears in the constants block above as a comment anchor
     # for the test_per_phase_timeout.py static lints.
     _phase_timeout=$(claude_phase_timeout_seconds_by_phase "$_phase")
+    # #4125: pick ``timeout`` (Linux) or ``gtimeout`` (macOS + coreutils);
+    # empty string when neither is on PATH (fresh Mac with no coreutils),
+    # in which case we exec claude directly without a timer. Runtime
+    # ``rc=124`` branch is unreachable in that fallback, but that's
+    # strictly better than rc=127 ("command not found") which the bare
+    # ``timeout`` invocation produced before this fix.
+    _timeout_cmd=$(_resolve_timeout_cmd)
     # #4099: route through ``_ms_now`` (python3-backed) so macOS BSD date
     # doesn't silently emit ``17780132253N`` — see helper docstring above.
     _phase_start_ms=$(_ms_now)
@@ -297,6 +338,7 @@ run_claude_phase() {
             "phase=$_phase" \
             "skill=$_skill" \
             "cwd=$(pwd)" \
+            "timeout_cmd=$_timeout_cmd" \
             "timeout_seconds=$_phase_timeout"
         # #3683: wrap ``claude -p`` in ``timeout`` so a hung or wedged
         # claude process surfaces as a distinct ``claude_phase_timeout``
@@ -304,7 +346,10 @@ run_claude_phase() {
         # up to 30 minutes until the heartbeat reaper fires.
         # #3766: per-phase timeout — look up at function-call time so a
         # post-init mutation of the table (test override) takes effect.
-        timeout "$_phase_timeout" \
+        # #4125: ``$_timeout_cmd`` resolves to ``timeout`` / ``gtimeout`` /
+        # empty (see _resolve_timeout_cmd above). When empty, the leading
+        # token expansion vanishes and bash execs ``claude -p ...`` directly.
+        $_timeout_cmd ${_timeout_cmd:+"$_phase_timeout"} \
             claude -p "/task-v2-$_skill $AGENT_ID" \
             --output-format json \
             --dangerously-skip-permissions \
@@ -337,7 +382,16 @@ run_claude_phase() {
         # terminal_reason="completed". Route through the same output-resolution
         # chain as the clean-exit branch (see lines ~2176-2267, canonical copy)
         # instead of emitting a misleading BLOCKED envelope.
-        if jq -e '.result and .is_error == false and (.terminal_reason == "completed")' \
+        # #4125: explicitly require ``_out_file`` to be non-empty (``-s``)
+        # before invoking jq. macOS jq-1.6 returns rc=0 with empty output
+        # when given an empty input file, so the bare ``jq -e ...`` filter
+        # silently fired the salvage branch on a SIGKILLed-empty file —
+        # which falls through ``read_phase_output`` (no dispatcher-output
+        # written) → ``jq -c '.result'`` (still empty) → empty stdout, no
+        # BLOCKED envelope. Linux jq-1.7+ exits rc=2 on empty input which
+        # masked the bug in CI. The ``-s`` guard makes the salvage path
+        # correct regardless of jq version.
+        if [[ -s "$_out_file" ]] && jq -e '.result and .is_error == false and (.terminal_reason == "completed")' \
                 "$_out_file" >/dev/null 2>&1; then
             _claude_duration_ms=$(jq -r '.duration_ms // "unknown"' "$_out_file" 2>/dev/null)
             log "claude_phase_timeout_salvaged" \

--- a/scripts/dispatcher/tests/test_agent_runner_push_and_pr_timeouts.py
+++ b/scripts/dispatcher/tests/test_agent_runner_push_and_pr_timeouts.py
@@ -348,19 +348,35 @@ class TestTimeoutWrappersPresent:
         is unchanged — the value is still derived from a TIMEOUT_SECONDS
         env-driven constant — but the lookup happens via the per-phase
         table at function-call time.
+
+        #4125 — also accept the macOS-portable
+        ``$_timeout_cmd ${_timeout_cmd:+"$_phase_timeout"}`` form. The
+        leading ``$_timeout_cmd`` resolves to either ``timeout`` (Linux),
+        ``gtimeout`` (macOS + coreutils), or empty (fresh Mac). The
+        semantic intent is unchanged — when the command resolves
+        non-empty, the expansion still yields ``<cmd> "$_phase_timeout"
+        claude -p ...``. We anchor on the ``${_timeout_cmd:+...}``
+        construct because it is a unique fingerprint for the resolver
+        path that won't match any other line.
         """
         for lineno, line in self._run_claude_phase_lines():
             if line.strip().startswith("#"):
                 continue
             if "claude" in line and "-p" in line and "--output-format" in line:
-                # Accept either the legacy ``timeout "$<VAR>_TIMEOUT_SECONDS"``
-                # form OR the #3766 ``timeout "$_phase_timeout"`` form.
+                # Accept legacy ``timeout "$<VAR>_TIMEOUT_SECONDS"``,
+                # ``timeout "$_phase_timeout"`` (#3766), or the #4125
+                # macOS-portable resolver-driven form
+                # ``$_timeout_cmd ${_timeout_cmd:+"$_phase_timeout"}``.
                 assert re.search(
                     r'timeout\s+"\$\w*TIMEOUT_SECONDS"', line
-                ) or re.search(r'timeout\s+"\$_phase_timeout"', line), (
+                ) or re.search(r'timeout\s+"\$_phase_timeout"', line) or re.search(
+                    r'\$_timeout_cmd\s+\$\{_timeout_cmd:\+"\$_phase_timeout"\}',
+                    line,
+                ), (
                     f"L{lineno}: ``claude -p`` in run_claude_phase is not wrapped by "
-                    f'``timeout "$<VAR>_TIMEOUT_SECONDS"`` or ``timeout "$_phase_timeout"`` '
-                    f"(#3683, #3766). Line: {line!r}"
+                    f'``timeout "$<VAR>_TIMEOUT_SECONDS"``, ``timeout "$_phase_timeout"``, '
+                    f'or ``$_timeout_cmd ${{_timeout_cmd:+"$_phase_timeout"}}`` '
+                    f"(#3683, #3766, #4125). Line: {line!r}"
                 )
 
 

--- a/scripts/dispatcher/tests/test_agent_runner_run_claude_phase.sh
+++ b/scripts/dispatcher/tests/test_agent_runner_run_claude_phase.sh
@@ -76,7 +76,16 @@ pass "helper script $HELPER exists"
 # downstream ``$((end - start))`` arithmetic with
 # ``value too great for base``. Listing ``_ms_now`` here so a future
 # refactor that drops or renames the helper trips this static lint.
-for fn in _ms_now write_phase_input read_phase_output phase_to_skill run_claude_phase \
+#
+# #4125: ``_resolve_timeout_cmd`` is the helper's portable timeout(1)
+# resolver — picks ``timeout`` (Linux) or ``gtimeout`` (macOS+coreutils)
+# at run time, falls back to empty string when neither is on PATH so a
+# fresh Mac without coreutils still exec's ``claude -p`` directly
+# instead of aborting with rc=127 ("command not found"). Listing
+# ``_resolve_timeout_cmd`` here so a future refactor that drops the
+# resolver re-introduces the macOS portability gap and trips this lint.
+for fn in _ms_now _resolve_timeout_cmd write_phase_input read_phase_output \
+          phase_to_skill run_claude_phase \
           claude_phase_timeout_seconds_by_phase; do
     if ! ( set +u; source "$HELPER"; type "$fn" >/dev/null 2>&1 ); then
         fail "helper defines $fn" \
@@ -164,6 +173,95 @@ if [[ "$broken_stub_output" == 'unknown' ]]; then
 else
     fail "_ms_now falls back to 'unknown' when python3 returns rc=0 with empty stdout (#4099)" \
         "expected 'unknown', got '$broken_stub_output'"
+fi
+
+# ── #4125 regression: _resolve_timeout_cmd — macOS portability ─────────────
+#
+# The bug being prevented: bare ``timeout`` invocation in run_claude_phase
+# returns rc=127 ("command not found") on macOS BSD without coreutils,
+# which never trips the rc==124 short-circuit and silently breaks the
+# runtime-timeout regression below. The resolver picks ``timeout`` /
+# ``gtimeout`` at runtime via ``command -v`` lookups, falling back to an
+# empty string so the call site exec's the inner command directly when
+# neither is on PATH. Verify all three branches.
+
+# Case 1: PATH has only ``timeout`` (Linux-shape).
+timeout_only_tmp=$(mktemp -d)
+TEMP_DIRS+=("$timeout_only_tmp")
+printf '#!/usr/bin/env bash\nexit 0\n' > "$timeout_only_tmp/timeout"
+chmod +x "$timeout_only_tmp/timeout"
+timeout_only_output=$(
+    set +u
+    # Empty PATH except our stub so ``command -v gtimeout`` can't find
+    # a coreutils install on the test host.
+    export PATH="$timeout_only_tmp"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _resolve_timeout_cmd
+)
+if [[ "$timeout_only_output" == 'timeout' ]]; then
+    pass "_resolve_timeout_cmd picks 'timeout' when only timeout is on PATH (#4125 — Linux shape)"
+else
+    fail "_resolve_timeout_cmd picks 'timeout' when only timeout is on PATH (#4125 — Linux shape)" \
+        "expected 'timeout', got '$timeout_only_output'"
+fi
+
+# Case 2: PATH has only ``gtimeout`` (macOS + coreutils shape).
+gtimeout_only_tmp=$(mktemp -d)
+TEMP_DIRS+=("$gtimeout_only_tmp")
+printf '#!/usr/bin/env bash\nexit 0\n' > "$gtimeout_only_tmp/gtimeout"
+chmod +x "$gtimeout_only_tmp/gtimeout"
+gtimeout_only_output=$(
+    set +u
+    export PATH="$gtimeout_only_tmp"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _resolve_timeout_cmd
+)
+if [[ "$gtimeout_only_output" == 'gtimeout' ]]; then
+    pass "_resolve_timeout_cmd picks 'gtimeout' when only gtimeout is on PATH (#4125 — macOS+coreutils shape)"
+else
+    fail "_resolve_timeout_cmd picks 'gtimeout' when only gtimeout is on PATH (#4125 — macOS+coreutils shape)" \
+        "expected 'gtimeout', got '$gtimeout_only_output'"
+fi
+
+# Case 3: PATH has neither (fresh Mac without coreutils).
+neither_tmp=$(mktemp -d)
+TEMP_DIRS+=("$neither_tmp")
+neither_output=$(
+    set +u
+    export PATH="$neither_tmp"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _resolve_timeout_cmd
+)
+if [[ -z "$neither_output" ]]; then
+    pass "_resolve_timeout_cmd returns empty string when neither is on PATH (#4125 — fresh Mac)"
+else
+    fail "_resolve_timeout_cmd returns empty string when neither is on PATH (#4125 — fresh Mac)" \
+        "expected empty string, got '$neither_output'"
+fi
+
+# Case 4: PATH has both — ``timeout`` wins (Linux precedence over Mac+coreutils;
+# avoids surprising operators who installed coreutils via brew on a Linux
+# distro that already ships its own coreutils).
+both_tmp=$(mktemp -d)
+TEMP_DIRS+=("$both_tmp")
+printf '#!/usr/bin/env bash\nexit 0\n' > "$both_tmp/timeout"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$both_tmp/gtimeout"
+chmod +x "$both_tmp/timeout" "$both_tmp/gtimeout"
+both_output=$(
+    set +u
+    export PATH="$both_tmp"
+    # shellcheck disable=SC1090
+    source "$HELPER"
+    _resolve_timeout_cmd
+)
+if [[ "$both_output" == 'timeout' ]]; then
+    pass "_resolve_timeout_cmd prefers 'timeout' over 'gtimeout' when both are on PATH (#4125)"
+else
+    fail "_resolve_timeout_cmd prefers 'timeout' over 'gtimeout' when both are on PATH (#4125)" \
+        "expected 'timeout', got '$both_output'"
 fi
 
 # ── phase_to_skill: phase name → skill suffix mapping ────────────────────────
@@ -370,6 +468,44 @@ run_timeout_regression_test() {
     local err_file="$tmp/err.log"
 
     mkdir -p "$ws" "$repo/tmp/dispatcher-output" "$stub_bin"
+
+    # #4125: stub ``timeout`` so the test runs on macOS without coreutils.
+    # macOS BSD does not ship ``timeout(1)`` — without this stub the bare
+    # ``$_timeout_cmd "$_phase_timeout" claude ...`` invocation in
+    # ``run_claude_phase`` would either resolve to nothing (bypassing the
+    # rc==124 short-circuit because no timer ever fires) or — pre-#4125,
+    # before the resolver — exit rc=127 ("command not found"). The stub
+    # mirrors GNU ``timeout(1)`` semantics for the ``timer fired`` path:
+    # SIGTERM the inner command after ``$1`` seconds and return rc=124,
+    # so the helper's rc==124 branch builds the BLOCKED envelope as
+    # expected. Mirrors the precedent set by
+    # ``scripts/tests/test_agent_runner_entrypoint.sh`` (lines 599-605),
+    # which stubs a passthrough ``timeout`` for the same portability
+    # reason.
+    cat > "$stub_bin/timeout" <<'TIMEOUTEOF'
+#!/usr/bin/env bash
+# argv: <seconds> <inner-cmd> <inner-args...>
+# Mimics GNU timeout(1) for the runtime-timeout regression test:
+# fork the inner command, sleep for $seconds, and if it's still
+# running, SIGTERM it and return 124. Bash 3.2-compatible (no
+# ``wait -n``, no ``-fr 0`` peeking).
+seconds="$1"
+shift
+"$@" &
+inner_pid=$!
+( sleep "$seconds" ; kill -TERM "$inner_pid" 2>/dev/null ) &
+sleeper_pid=$!
+wait "$inner_pid" 2>/dev/null
+inner_rc=$?
+# If the sleeper killed the inner process, $inner_rc is 143 (SIGTERM)
+# on most shells; normalize to 124 to match GNU timeout(1).
+kill -0 "$sleeper_pid" 2>/dev/null && kill "$sleeper_pid" 2>/dev/null
+if (( inner_rc == 143 )); then
+    exit 124
+fi
+exit "$inner_rc"
+TIMEOUTEOF
+    chmod +x "$stub_bin/timeout"
 
     # Stub claude: sleep 5 so the 1s timeout fires.
     printf '#!/usr/bin/env bash\nsleep 5\n' > "$stub_bin/claude"

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -81,6 +81,15 @@ cleanup() {
 trap cleanup EXIT
 
 TEST_TMP=$(mktemp -d)
+# Canonicalize via ``pwd -P`` so paths compare cleanly against shim
+# output on macOS (#4126). ``mktemp -d`` returns ``/var/folders/...``
+# but BSD's ``/var`` is a symlink to ``/private/var``; tests that
+# compare a fixture path against ``Path(...).resolve()`` output from
+# ``phase_input_shim.py`` see the ``/private/`` prefix and mismatch.
+# Resolving once at fixture root fixes every downstream comparison
+# without per-test wrapping. Linux is unaffected — ``/tmp`` is not
+# symlinked, so ``pwd -P`` is a no-op.
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
 
 # ── Build a stub-bin directory on PATH ─────────────────────────────────────
 #
@@ -3676,7 +3685,12 @@ done
 # ``run_claude_phase`` for portable epoch-ms timing. Must be extracted
 # into the fixture or the sourced ``run_claude_phase`` body fails with
 # ``_ms_now: command not found`` on every invocation.
+# #4125: ``_resolve_timeout_cmd`` is the macOS-portability resolver for
+# ``timeout`` / ``gtimeout`` — also HELPER-resident, also called from
+# ``run_claude_phase``. Same extraction requirement: omit it and the
+# sourced fixture aborts with ``_resolve_timeout_cmd: command not found``.
 for fn in _ms_now \
+          _resolve_timeout_cmd \
           claude_phase_timeout_seconds_by_phase \
           run_claude_phase \
           write_phase_input \
@@ -4204,6 +4218,7 @@ done
 # into the fixture or the sourced ``run_claude_phase`` body fails with
 # ``_ms_now: command not found`` on every invocation.
 for fn in _ms_now \
+          _resolve_timeout_cmd \
           phase_to_skill \
           read_phase_output \
           write_phase_input \
@@ -5732,6 +5747,7 @@ done
 # into the fixture or the sourced ``run_claude_phase`` body fails with
 # ``_ms_now: command not found`` on every invocation.
 for fn in _ms_now \
+          _resolve_timeout_cmd \
           phase_to_skill \
           read_phase_output \
           write_phase_input \


### PR DESCRIPTION
## Summary

Adds a `_resolve_timeout_cmd()` helper to `scripts/dispatcher/agent_runner_run_claude_phase.sh` that picks `timeout` (Linux) or `gtimeout` (macOS + coreutils) at runtime via `command -v`, falling back to an empty string when neither is on PATH. The `claude -p` invocation expands as `$_timeout_cmd ${_timeout_cmd:+"$_phase_timeout"} claude -p ...` — bit-identical to the pre-fix shape on Linux, but no longer aborts with rc=127 ("command not found") on a fresh Mac without coreutils. The `test_agent_runner_run_claude_phase.sh` runtime-timeout regression no longer silently fails on macOS.

Also surfaces and fixes a latent salvage-prelude bug exposed by adding the `timeout` stub to the regression test: macOS jq-1.6 returns rc=0 with empty output when given an empty input file, which silently fired the `rc==124` salvage branch on a SIGKILLed-empty `_out_file`. Linux jq-1.7+ exits rc=2 on empty input which masked the bug in CI. Add an `[[ -s "$_out_file" ]]` guard so the salvage path is correct regardless of jq version.

Closes #4125

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass — verified locally on macOS bash 3.2.57 with NEITHER `timeout` NOR `gtimeout` installed:
  - `test_agent_runner_run_claude_phase.sh` 39/39 PASS (4 new resolver regression tests + the headline runtime-timeout test now passing)
  - `test_agent_runner_entrypoint.sh` 474/474 PASS
  - `test_per_phase_timeout.py` 18/18 PASS
  - `test_agent_runner_push_and_pr_timeouts.py` 18/18 PASS (regex updated for #4125 form)
  - Full `scripts/dispatcher/tests/` suite 2164/2164 PASS
- [x] CI green — `ci-passed` SUCCESS, `mergeable=MERGEABLE`, all `scripts-tests` shards SUCCESS, all guard checks SUCCESS or SKIPPED

### Post-deploy verification
- [x] N/A — no deployed component (helper file is sourced at agent-runner runtime; the change is bit-identical to the pre-fix shape on Linux Fargate, which is the deploy target. Local macOS portability is the affordance and is verified in the test plan above).
