### PR TITLE
perf(ci): convert test_agent_runner_entrypoint.sh to direct fn calls (#4139)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,15 +619,21 @@ jobs:
             shard-filter: not-slow
           # Shard shell-slow (#4067): runs only paths in SLOW_TESTS so
           # the other tests in shell-fast no longer queue behind them.
-          # Today's slow set: test_agent_runner_entrypoint.sh (~11 min).
-          # The hard timeout-minutes:14 is the regression gate from
-          # issue #4067's cross-cutting AC — it fails the shard if the
-          # long pole drifts past ~1.3× its current observed budget.
-          # Estimated wall-clock ~11 min today; structural trim is a
-          # #4067 follow-up.
-          # See issue #4067.
+          # Today's slow set: test_agent_runner_entrypoint.sh.
+          # #4139 converted the bulk of test_agent_runner_entrypoint.sh
+          # from per-case `bash $ENTRYPOINT` invocations (~11 min wall
+          # clock baseline) to direct ``run_entrypoint_main`` calls
+          # against a once-sourced entrypoint, bringing the shard to
+          # ~2-3 min wall clock. The hard timeout-minutes:6 is the new
+          # regression gate from issue #4139 — it fails the shard if a
+          # future change reintroduces per-case re-parse cost or adds a
+          # comparable long pole. Don't bump back to 14 without a
+          # follow-up issue documenting why the structural trim is no
+          # longer holding.
+          # See issues #4067 (sharding + 14-min gate) and #4139
+          # (structural trim + 6-min gate).
           - shard: shell-slow
-            timeout-minutes: 14
+            timeout-minutes: 6
             shard-filter: slow
     env:
       PYTHONPATH: scripts

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -624,6 +624,108 @@ setup_fixtures() {
     : > "$INVOCATIONS_DIR/gh.log"
 }
 
+# ── Source-once entrypoint, then call main() per-test (#4139) ──────────────
+#
+# Pre-#4139 every full-pipeline test invoked the entrypoint as a fresh
+# bash process, spawning a new interpreter + parsing 5300+ lines per
+# case (~30 cases × ~10s each = ~5 min just on parse). #4137 made the
+# entrypoint sourceable without side effects (``set -euo pipefail`` and
+# ``exec 3>&1`` moved inside ``main()``); #4138 extracted the per-phase
+# case-arm bodies into ``agent_runner_handlers.sh``; this helper
+# exploits both: source the entrypoint ONCE at file scope (next block)
+# so every later ``run_entrypoint_main`` call inherits the parent's
+# parsed function table from the ``$( … )`` subshell with zero re-parse
+# cost.
+#
+# Rebinding AGENT_WORKSPACE-derived globals
+# ------------------------------------------
+# A handful of top-level constants in the entrypoint (REPO_ROOT,
+# TRANSITION_SHIM, PHASE_INPUT_SHIM, TERMINAL_SHIM, STATUS_TERMINAL_SHIM)
+# capture ``$AGENT_WORKSPACE`` at SOURCE time, not ``main()`` time. The
+# parent shell's source happened with no AGENT_WORKSPACE in env, so
+# those constants point at ``/var/lib/agent-runner/...`` which doesn't
+# exist on the test host. Each test passes its own AGENT_WORKSPACE
+# via env-prefix on the function call (``AGENT_WORKSPACE=… run_entrypoint_main``);
+# the helper re-evaluates the dependent constants from the now-correct
+# AGENT_WORKSPACE before calling ``main``. Same shape as
+# ``${VAR:-…}`` defaults in the entrypoint, just hoisted into the
+# wrapper because we can't re-source the file per call.
+#
+# T1 + T2 retain the original ``bash $ENTRYPOINT`` form so the
+# executable-mode path stays exercised end-to-end (AC: ≤ 4 retained
+# smoke invocations).
+# Most of the variables below appear "unused" to shellcheck because their
+# only readers are inside ``main()`` / the per-phase handlers, which
+# shellcheck doesn't trace from a function definition. They ARE read —
+# silence the warnings rather than littering each line.
+# shellcheck disable=SC2034,SC2120
+run_entrypoint_main() {
+    # AGENT_WORKSPACE-anchored paths.
+    REPO_ROOT="$AGENT_WORKSPACE/repo"
+    TRANSITION_SHIM="${AGENT_RUNNER_TRANSITION_SHIM:-$AGENT_WORKSPACE/phase_transitions_shim.py}"
+    PHASE_INPUT_SHIM="${AGENT_RUNNER_PHASE_INPUT_SHIM:-$AGENT_WORKSPACE/phase_input_shim.py}"
+    TERMINAL_SHIM="${AGENT_RUNNER_TERMINAL_SHIM:-$AGENT_WORKSPACE/phase_terminal_shim.py}"
+    STATUS_TERMINAL_SHIM="${AGENT_RUNNER_STATUS_TERMINAL_SHIM:-$AGENT_WORKSPACE/phase_status_terminal_shim.py}"
+    # AGENT_RUNNER_*-derived constants. The entrypoint binds each at
+    # source time (line numbers below match
+    # ``scripts/dispatcher/agent-runner-entrypoint.sh``); since we
+    # source once at file scope, the parent shell's binding sticks
+    # through every later subshell — env-prefixed overrides on the
+    # ``run_entrypoint_main`` call site never take effect without this
+    # re-bind. Each line below mirrors the entrypoint's ``${VAR:-…}``
+    # default so the override semantics match exactly.
+    AGENT_RUNNER_DRY_RUN="${AGENT_RUNNER_DRY_RUN:-0}"                                      # entrypoint:138
+    RALPH_HEAD_POLL_INTERVAL="${AGENT_RUNNER_RALPH_HEAD_POLL_INTERVAL:-30}"                # entrypoint:3490
+    AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL="${AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL:-5}"  # entrypoint:3776
+    # Test-friendly defaults (#4139): the entrypoint's runtime defaults
+    # (60-second polls, 90-second deploy grace, 30-minute CI timeout,
+    # 30-minute deploy timeout) make the test's full-pipeline traversal
+    # take 2-3 minutes per call (T6 + similar). The previous test wrapper
+    # (``bash $ENTRYPOINT``) inherited those long defaults too — that's
+    # the bulk of the pre-#4139 11-minute baseline. Tests that need to
+    # exercise specific timeout / grace behavior (T33, T60a, T60b)
+    # still set the env-prefix vars explicitly; they continue to work
+    # because the env-prefix takes precedence over the wrapper's default.
+    # Tests that DON'T care about polling timing inherit the fast
+    # defaults below — happy-path traversal becomes ~1s instead of ~120s.
+    CI_POLL_INTERVAL="${AGENT_RUNNER_CI_POLL_INTERVAL:-0}"                                 # entrypoint:4181 (test default 0; entrypoint runtime 60)
+    DEPLOY_POLL_INTERVAL="${AGENT_RUNNER_DEPLOY_POLL_INTERVAL:-0}"                         # entrypoint:4182 (test default 0; entrypoint runtime 60)
+    AWAITING_CI_TIMEOUT_SECONDS="${AGENT_RUNNER_AWAITING_CI_TIMEOUT_SECONDS:-3600}"        # entrypoint:4187
+    AWAITING_DEPLOY_TIMEOUT_SECONDS="${AGENT_RUNNER_AWAITING_DEPLOY_TIMEOUT_SECONDS:-1800}" # entrypoint:4188
+    DEPLOY_GRACE_SECONDS="${AGENT_RUNNER_DEPLOY_GRACE_SECONDS:-0}"                         # entrypoint:4195 (test default 0; entrypoint runtime 90)
+    MERGE_UNSTICK_MAX_ATTEMPTS="${AGENT_RUNNER_MERGE_UNSTICK_MAX_ATTEMPTS:-1}"             # entrypoint:4199
+    FIX_CONFLICT_MAX_ATTEMPTS="${AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS:-2}"               # entrypoint:4208
+    NETWORK_TIMEOUT_SECONDS="${AGENT_RUNNER_NETWORK_TIMEOUT_SECONDS:-300}"                 # entrypoint:4228
+    CLAUDE_PHASE_TIMEOUT_SECONDS="${AGENT_RUNNER_CLAUDE_PHASE_TIMEOUT_SECONDS:-1800}"      # entrypoint:4244
+    LOCAL_GIT_TIMEOUT_SECONDS="${AGENT_RUNNER_LOCAL_GIT_TIMEOUT_SECONDS:-120}"             # entrypoint:4268
+    PUSH_AND_PR_PHASE_DEADLINE_SECONDS="${AGENT_RUNNER_PUSH_AND_PR_DEADLINE_SECONDS:-600}" # entrypoint:4279
+    DEPLOY_WORKFLOW_NAMES_BASH="${AGENT_RUNNER_DEPLOY_WORKFLOW_NAMES:-Deploy API|Deploy Dispatcher|Deploy Scraper|Deploy Production|Deploy Production (Web)|Terraform|Deploy Agent Runner}" # entrypoint:4292
+    MAX_PHASE_ITERATIONS="${AGENT_RUNNER_MAX_PHASE_ITERATIONS:-40}"                        # entrypoint:5184
+    main "$@"
+}
+
+# Source the entrypoint once. After #4137 + #4138 this exposes
+# ``main``, ``phase_loop``, every ``handle_*`` function, and every helper
+# (``log``, ``persist_phase_output``, ``run_claude_phase``, etc.) in
+# the parent shell's function table. ``$( … )`` subshells inherit the
+# parent's function table for free — no re-parse, no re-source.
+#
+# REPO_ROOT collision (#4139): the entrypoint sets ``REPO_ROOT=
+# "$AGENT_WORKSPACE/repo"`` at top-level (line ~209) — its semantic is
+# the per-agent clone path. The test file's REPO_ROOT (line 34) is the
+# WORKTREE root used to locate $ENTRYPOINT, the stubs, and to interpolate
+# into ``PHASE_TRANSITIONS_DIR=$REPO_ROOT/scripts/dispatcher`` env-prefix
+# lines on every test call. Sourcing without protection clobbers the
+# test's value. Save it before the source, restore immediately after —
+# the entrypoint's per-call REPO_ROOT semantic is re-established inside
+# ``run_entrypoint_main`` from each subshell's AGENT_WORKSPACE, so the
+# parent's value can stay anchored to the worktree root.
+_test_REPO_ROOT_save="$REPO_ROOT"
+# shellcheck source=../dispatcher/agent-runner-entrypoint.sh
+source "$ENTRYPOINT"
+REPO_ROOT="$_test_REPO_ROOT_save"
+unset _test_REPO_ROOT_save
+
 # ══════════════════════════════════════════════════════════════════════════
 # Test 1: Immediate terminal — agent row already at `done`
 # ══════════════════════════════════════════════════════════════════════════
@@ -639,6 +741,11 @@ t1_workspace="$TEST_TMP/t1-workspace"
 mkdir -p "$t1_workspace"
 
 set +e
+# T1 retains the bash $ENTRYPOINT invocation (vs. run_entrypoint_main)
+# so the executable-mode path stays exercised end-to-end on every test
+# run. Pairs with T2 (happy path); the other ~28 cases use
+# run_entrypoint_main to skip the per-case 5300-line
+# bash-startup-and-parse cost. See #4139.
 out=$(AGENT_ID="00000000-1111-2222-3333-444444444444" \
       ISSUE_NUMBER="9999" \
       DATABASE_URL="postgres://test" \
@@ -706,6 +813,9 @@ t2_workspace="$TEST_TMP/t2-workspace"
 mkdir -p "$t2_workspace"
 
 set +e
+# T2 (happy-path) retains the bash $ENTRYPOINT invocation for the same
+# reason as T1 — full executable-mode coverage of the entrypoint as a
+# script. See #4139.
 out=$(AGENT_ID="11111111-2222-3333-4444-555555555555" \
       ISSUE_NUMBER="3090" \
       DATABASE_URL="postgres://test" \
@@ -942,7 +1052,7 @@ out=$(AGENT_ID="22222222-3333-4444-5555-666666666666" \
       CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -971,13 +1081,19 @@ fi
 setup_fixtures
 
 set +e
-out=$(DATABASE_URL="postgres://test" \
+# Explicit AGENT_ID="" overrides the parent shell's empty default that
+# was bound at file-scope source time. Without it, subshells silently
+# inherit the parent's AGENT_ID (set to "" by line 131 of the entrypoint
+# at source), which is identical to the missing-env behavior anyway,
+# but the explicit empty-string env-prefix makes the test self-documenting.
+out=$(AGENT_ID="" \
+      DATABASE_URL="postgres://test" \
       AGENT_WORKSPACE="$TEST_TMP/t4-workspace" \
       PATH="$STUB_BIN:$PATH" \
       INVOCATIONS_DIR="$INVOCATIONS_DIR" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1000,13 +1116,15 @@ fi
 setup_fixtures
 
 set +e
+# Explicit DATABASE_URL="" — same rationale as T4's explicit AGENT_ID="".
 out=$(AGENT_ID="33333333-4444-5555-6666-777777777777" \
+      DATABASE_URL="" \
       AGENT_WORKSPACE="$TEST_TMP/t5-workspace" \
       PATH="$STUB_BIN:$PATH" \
       INVOCATIONS_DIR="$INVOCATIONS_DIR" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1059,7 +1177,7 @@ out=$(AGENT_ID="66666666-7777-8888-9999-aaaaaaaaaaaa" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1126,7 +1244,7 @@ out=$(AGENT_ID="77777777-8888-9999-aaaa-bbbbbbbbbbbb" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1180,7 +1298,7 @@ out=$(AGENT_ID="88888888-9999-aaaa-bbbb-cccccccccccc" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1247,7 +1365,7 @@ out=$(AGENT_ID="99999999-aaaa-bbbb-cccc-dddddddddddd" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
       GIT_REV_LIST_COUNT=0 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1312,7 +1430,7 @@ out=$(AGENT_ID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1366,7 +1484,7 @@ out=$(AGENT_ID="bbbbbbbb-cccc-dddd-eeee-ffffffffffff" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1420,7 +1538,7 @@ out=$(AGENT_ID="cccccccc-dddd-eeee-ffff-000000000000" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1504,7 +1622,7 @@ out=$(AGENT_ID="dddddddd-eeee-ffff-0000-111111111111" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1560,7 +1678,7 @@ out=$(AGENT_ID="eeeeeeee-ffff-0000-1111-222222222222" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1631,7 +1749,7 @@ out=$(AGENT_ID="15151515-1515-1515-1515-151515151515" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=2 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1737,7 +1855,7 @@ out=$(AGENT_ID="16161616-1616-1616-1616-161616161616" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=2 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -1777,24 +1895,34 @@ mkdir -p "$shim_workspace"
 
 # Run the entrypoint with AGENT_RUNNER_DRY_RUN=1 so it stamps the shim
 # file under $AGENT_WORKSPACE and then short-circuits the phase loop.
+# #4139: ``run_entrypoint_main`` runs in the calling shell context and
+# its inner ``main()`` may ``exit`` (e.g. via ``die`` on validation
+# failure or by reaching a terminal phase via ``mark_ended``); wrap in
+# a subshell ``( … )`` so any inner ``exit`` only terminates the
+# subshell, not the test script. ``$( … )`` command substitutions are
+# already implicit subshells; this case wants the side effect (file
+# stamped on disk) but not the captured output, so the explicit
+# ``( … )`` is needed.
 PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-shim-extract.txt"
 printf 'done\n' > "$PHASE_FIXTURE_FILE"
 set +e
-AGENT_ID="00000000-0000-0000-0000-000000000000" \
-    ISSUE_NUMBER="3135" \
-    DATABASE_URL="postgres://test" \
-    GITHUB_TOKEN="" \
-    AGENT_WORKSPACE="$shim_workspace" \
-    REPO_URL="https://example.invalid/repo.git" \
-    PATH="$STUB_BIN:$PATH" \
-    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
-    PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
-    PRIOR_PATCH_FIXTURE="" \
-    CLAUDE_VERDICT_FIXTURE="" \
-    PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
-    PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
-    AGENT_RUNNER_DRY_RUN=1 \
-    bash "$ENTRYPOINT" >/dev/null 2>&1
+(
+    AGENT_ID="00000000-0000-0000-0000-000000000000" \
+        ISSUE_NUMBER="3135" \
+        DATABASE_URL="postgres://test" \
+        GITHUB_TOKEN="" \
+        AGENT_WORKSPACE="$shim_workspace" \
+        REPO_URL="https://example.invalid/repo.git" \
+        PATH="$STUB_BIN:$PATH" \
+        INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+        PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+        PRIOR_PATCH_FIXTURE="" \
+        CLAUDE_VERDICT_FIXTURE="" \
+        PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+        PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+        AGENT_RUNNER_DRY_RUN=1 \
+        run_entrypoint_main >/dev/null 2>&1
+)
 set -e
 
 SHIM_PY="$shim_workspace/phase_input_shim.py"
@@ -2460,7 +2588,9 @@ run_watcher_test() {
                 export "$_tok"
             done
         fi
-        bash "$ENTRYPOINT" 2>&1
+        # #4139: run_entrypoint_main reuses the parent's already-sourced
+        # entrypoint function table (via $( … ) subshell inheritance).
+        run_entrypoint_main 2>&1
     )
     _wtest_rc=$?
     set -e
@@ -2803,7 +2933,9 @@ run_post_pr_phase() {
         for _tok in "$@"; do
             export "$_tok"
         done
-        bash "$ENTRYPOINT" 2>&1
+        # #4139: run_entrypoint_main reuses the parent's already-sourced
+        # entrypoint function table (via $( … ) subshell inheritance).
+        run_entrypoint_main 2>&1
     )
     _rpp_rc=$?
     set -e
@@ -5120,7 +5252,7 @@ out=$(AGENT_ID="50000000-1111-2222-3333-444444444444" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -5187,7 +5319,7 @@ out=$(AGENT_ID="51000000-1111-2222-3333-444444444444" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -5257,7 +5389,7 @@ out=$(AGENT_ID="52000000-1111-2222-3333-444444444444" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 rc=$?
 set -e
 
@@ -5598,7 +5730,7 @@ _t57a_test_terminal_phase() {
         PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
         PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
         AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-        bash "$ENTRYPOINT" 2>&1
+        run_entrypoint_main 2>&1
     )
     _t57a_rc=$?
     set -e
@@ -5658,7 +5790,7 @@ _t57b_out=$(
     PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
     PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
     AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-    bash "$ENTRYPOINT" 2>&1
+    run_entrypoint_main 2>&1
 )
 _t57b_rc=$?
 set -e
@@ -9582,7 +9714,7 @@ T3694_TEST_OUT=$(AGENT_ID="36943694-3694-3694-3694-369436943694" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1 \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 T3694_TEST_RC=$?
 set -e
 
@@ -9701,7 +9833,7 @@ T3694B_TEST_OUT=$(AGENT_ID="36943694-3694-3694-3694-369436943695" \
       AGENT_RUNNER_DEPLOY_GRACE_SECONDS=0 \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 T3694B_TEST_RC=$?
 set -e
 
@@ -9840,7 +9972,7 @@ T3777_TEST_OUT=$(AGENT_ID="37773777-3777-3777-3777-377737773777" \
       AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1 \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
       AGENT_RUNNER_RALPH_TIMEOUT_OVERRIDE_SECONDS=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 T3777_TEST_RC=$?
 set -e
 
@@ -9939,7 +10071,7 @@ T3777B_TEST_OUT=$(AGENT_ID="37773777-3777-3777-3777-377737773778" \
       AGENT_RUNNER_DEPLOY_GRACE_SECONDS=0 \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
       GIT_REV_LIST_COUNT=1 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 T3777B_TEST_RC=$?
 set -e
 
@@ -10008,7 +10140,7 @@ T3778_TEST_OUT=$(AGENT_ID="37783778-3778-3778-3778-377837783778" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1 \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 T3778_TEST_RC=$?
 set -e
 
@@ -10102,7 +10234,7 @@ T3778B_TEST_OUT=$(AGENT_ID="37783778-3778-3778-3778-377837783779" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1 \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
-      bash "$ENTRYPOINT" 2>&1)
+      run_entrypoint_main 2>&1)
 T3778B_TEST_RC=$?
 set -e
 


### PR DESCRIPTION
## Summary

Replaces 28 of 30 ``bash $ENTRYPOINT`` per-case invocations in `scripts/tests/test_agent_runner_entrypoint.sh` with a `run_entrypoint_main` wrapper that calls the entrypoint's `main()` directly inside a `$( … )` subshell after a single file-scope `source`. T1 (immediate-terminal) and T2 (happy-path) retain `bash $ENTRYPOINT` for executable-mode end-to-end coverage. The wrapper bakes test-friendly defaults (`CI_POLL_INTERVAL=0`, `DEPLOY_POLL_INTERVAL=0`, `DEPLOY_GRACE_SECONDS=0`) — that's what actually delivers the wall-clock win, since the per-invocation `bash` startup cost was small (~50ms) but the entrypoint's runtime defaults made each happy-path traversal sleep 60-120s on `awaiting_ci`/`awaiting_deploy`. Drops the CI `scripts-tests (shell-slow)` shard `timeout-minutes` from 14 → 6 to lock in the new floor as the regression gate.

Local wall-clock: **11m17s → 1m17s (~8.8× speedup)** on macOS bash 3.2, same 468/474 PASS count.

CI run on this PR: shell-slow shard wall-clock = **1m14s** (10:31:25Z → 10:32:39Z), well under the new 6-min hard timeout and the 3-min AC.

Closes #4139

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts-tests (shell-slow)` shard wall-clock ≤ 6 min on this PR's CI run (new `timeout-minutes` gate) — observed 1m14s

### Post-deploy verification
- [x] AC #4: `scripts-tests (shell-slow)` shard wall-clock ≤ 3 min on a triggering CI run — pre-merge run 25430050570: **1m14s**; post-merge main-branch run 25430550864: **1m19s** on the merge SHA 8eb09d32
- [x] Verification evidence posted on issue #4139 — see https://github.com/judgemind/judgemind/issues/4139#issuecomment-4387287504
