### PR TITLE
feat(ci): structured flake telemetry from wait-for-ci.sh auto-rerun events (#4163)

### DIFF
--- a/scripts/summarize-ci-flakes.sh
+++ b/scripts/summarize-ci-flakes.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# summarize-ci-flakes.sh — Aggregate the JSONL log produced by wait-for-ci.sh
+# (#4163) into a per-label leaderboard.
+#
+# # venv: none
+# # permanent: true
+#
+# ── Why ──────────────────────────────────────────────────────────────────────
+#
+# `scripts/wait-for-ci.sh` appends one JSON line per auto-rerun event to
+# `tmp/wait-for-ci-flakes.jsonl` (path overridable via WAIT_FOR_CI_FLAKE_LOG).
+# Each line carries a fixed schema — see the script header. This helper reads
+# the same file, optionally filters by a recent time window, and prints a
+# count-per-label leaderboard so we can spot which flake patterns fire most.
+#
+# A label crossing some threshold (e.g. 3+ occurrences in a week) is the
+# signal to add a new entry to `scripts/classify-ci-flake.sh` — but that
+# decision is a human PR, not part of this helper.
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#
+# Usage:
+#   scripts/summarize-ci-flakes.sh                    # default path
+#   scripts/summarize-ci-flakes.sh <jsonl-path>       # custom path
+#   scripts/summarize-ci-flakes.sh --since 7d         # last N days
+#   scripts/summarize-ci-flakes.sh --help
+#
+# Output (stdout, sorted by count desc):
+#
+#   COUNT  LABEL
+#       7  postgres-startup
+#       2  docker-daemon
+#       1  dns-resolution
+#
+# Followed by a `total: <N>` line. If the JSONL file does not exist or is
+# empty, prints `(no flake events recorded)` to stdout and exits 0.
+#
+# Exit codes:
+#   0 — Summary printed (including the empty-file case).
+#   1 — Usage error or unreadable JSONL file.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_FLAKE_LOG="$(dirname "$SCRIPT_DIR")/tmp/wait-for-ci-flakes.jsonl"
+
+JSONL_PATH=""
+SINCE=""
+
+print_help() {
+    grep '^# Usage:' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Output' "$0" | sed 's/^# //'
+    echo ""
+    grep '^# Exit codes:' "$0" | sed 's/^# //'
+    grep '^#   [012]' "$0" | sed 's/^# //'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            print_help
+            exit 0
+            ;;
+        --since)
+            SINCE="$2"
+            shift 2
+            ;;
+        --*)
+            echo "ERROR: Unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [ -z "$JSONL_PATH" ]; then
+                JSONL_PATH="$1"
+                shift
+            else
+                echo "ERROR: Unexpected argument: $1" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+JSONL_PATH="${JSONL_PATH:-${WAIT_FOR_CI_FLAKE_LOG:-$DEFAULT_FLAKE_LOG}}"
+
+if [ ! -f "$JSONL_PATH" ] || [ ! -s "$JSONL_PATH" ]; then
+    echo "(no flake events recorded at $JSONL_PATH)"
+    exit 0
+fi
+
+# Build a `--since` cutoff in seconds-since-epoch, or empty to disable filtering.
+CUTOFF_TS=""
+if [ -n "$SINCE" ]; then
+    # Accept Nd / Nh / Nm shorthand. Anything else is a hard error.
+    case "$SINCE" in
+        *d)
+            DAYS="${SINCE%d}"
+            CUTOFF_TS=$(($(date -u +%s) - DAYS * 86400))
+            ;;
+        *h)
+            HOURS="${SINCE%h}"
+            CUTOFF_TS=$(($(date -u +%s) - HOURS * 3600))
+            ;;
+        *m)
+            MINS="${SINCE%m}"
+            CUTOFF_TS=$(($(date -u +%s) - MINS * 60))
+            ;;
+        *)
+            echo "ERROR: --since expects Nd|Nh|Nm (got: $SINCE)" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# Filter and count by label. We use `jq` to extract `(ts_epoch, label)` per
+# line, drop any malformed lines, then aggregate in `awk` rather than re-
+# invoking jq for the count step (cheaper for large logs).
+#
+# `fromdateiso8601` in jq accepts the `Z`-suffixed form directly on every
+# platform (Linux + macOS) — converting to `+00:00` first breaks GNU/macOS
+# parity because BSD jq's strptime does not implement the `+HH:MM` zone form.
+LABEL_COUNTS=$(jq -r --arg cutoff "${CUTOFF_TS:-0}" '
+    select(.label != null and .ts != null)
+    | (.ts | fromdateiso8601) as $ts
+    | select(($cutoff | tonumber) == 0 or $ts >= ($cutoff | tonumber))
+    | .label
+' "$JSONL_PATH" 2>/dev/null | sort | uniq -c | sort -rn || true)
+
+if [ -z "$LABEL_COUNTS" ]; then
+    if [ -n "$SINCE" ]; then
+        echo "(no flake events in window: --since $SINCE)"
+    else
+        echo "(no flake events recorded at $JSONL_PATH)"
+    fi
+    exit 0
+fi
+
+printf '%5s  %s\n' "COUNT" "LABEL"
+echo "$LABEL_COUNTS" | awk '{printf "%5d  %s\n", $1, $2}'
+
+TOTAL=$(echo "$LABEL_COUNTS" | awk '{sum += $1} END {print sum + 0}')
+echo ""
+echo "total: $TOTAL"

--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -178,6 +178,7 @@ run_script() {
     LOG_FAILED_FILE="${LOG_FAILED_FILE:-}" \
     RERUN_LOG_FILE="${RERUN_LOG_FILE:-}" \
     WAIT_FOR_CI_RERUN_SENTINEL_FILE="${WAIT_FOR_CI_RERUN_SENTINEL_FILE:-$tmpdir/rerun-sentinel}" \
+    WAIT_FOR_CI_FLAKE_LOG="${WAIT_FOR_CI_FLAKE_LOG:-$tmpdir/flakes-default.jsonl}" \
         "$SCRIPT_UNDER_TEST" "$@"
 }
 
@@ -715,6 +716,156 @@ LOG
     fi
 }
 
+# Test 14b (#4163): When auto-rerun fires for a known flake, exactly one
+# JSONL line is appended to WAIT_FOR_CI_FLAKE_LOG with the documented schema:
+# {ts, pr, sha, run_id, label, check_name}. Aggregators downstream depend on
+# the schema being stable.
+test_flake_telemetry_emits_jsonl_line() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_with_run_id_response "$tmpdir/responses/01.json" "schema-drift-check" "25418711047"
+    write_all_success_response "$tmpdir/responses/02.json"
+
+    local log_file rerun_log flake_log
+    log_file="$tmpdir/log-failed.txt"
+    rerun_log="$tmpdir/rerun.log"
+    flake_log="$tmpdir/flakes.jsonl"
+    cat > "$log_file" << 'LOG'
+ERROR: postgres failed to start within 30 seconds
+LOG
+
+    local output exit_code
+    exit_code=0
+    output=$(LOG_FAILED_FILE="$log_file" RERUN_LOG_FILE="$rerun_log" \
+        WAIT_FOR_CI_FLAKE_LOG="$flake_log" \
+        SHA_RESPONSE="75b03030deadbeef" \
+        MERGEABLE_RESPONSE=MERGEABLE \
+        run_script "$tmpdir" 4162 --poll-interval 0 --timeout-secs 60 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "flake_telemetry: exits 0 after rerun + success poll"
+    else
+        fail "flake_telemetry: exits 0 after rerun + success poll" "exit=$exit_code output=$output"
+    fi
+
+    # AC#1: a single JSONL line with the expected fields.
+    if [ ! -f "$flake_log" ]; then
+        fail "flake_telemetry: jsonl log file exists" "expected at $flake_log"
+        return
+    fi
+
+    local line_count
+    line_count=$(wc -l < "$flake_log" | tr -d ' ')
+    if [ "$line_count" = "1" ]; then
+        pass "flake_telemetry: exactly one JSONL line written"
+    else
+        fail "flake_telemetry: exactly one JSONL line written" "line_count=$line_count contents=$(cat "$flake_log")"
+    fi
+
+    # The line must be valid JSON.
+    if jq -e . "$flake_log" >/dev/null 2>&1; then
+        pass "flake_telemetry: line is valid JSON"
+    else
+        fail "flake_telemetry: line is valid JSON" "contents=$(cat "$flake_log")"
+    fi
+
+    # Schema fields — assert each is present with the expected value.
+    local label pr_field run_id_field sha_field check_name ts_field
+    label=$(jq -r '.label' "$flake_log")
+    pr_field=$(jq -r '.pr' "$flake_log")
+    run_id_field=$(jq -r '.run_id' "$flake_log")
+    sha_field=$(jq -r '.sha' "$flake_log")
+    check_name=$(jq -r '.check_name' "$flake_log")
+    ts_field=$(jq -r '.ts' "$flake_log")
+
+    if [ "$label" = "postgres-startup" ]; then
+        pass "flake_telemetry: label=postgres-startup"
+    else
+        fail "flake_telemetry: label=postgres-startup" "got: $label"
+    fi
+
+    if [ "$pr_field" = "4162" ]; then
+        pass "flake_telemetry: pr=4162 (numeric, not quoted)"
+    else
+        fail "flake_telemetry: pr=4162" "got: $pr_field"
+    fi
+
+    if [ "$run_id_field" = "25418711047" ]; then
+        pass "flake_telemetry: run_id=25418711047 (numeric, not quoted)"
+    else
+        fail "flake_telemetry: run_id=25418711047" "got: $run_id_field"
+    fi
+
+    if [ "$sha_field" = "75b03030" ]; then
+        pass "flake_telemetry: sha=75b03030 (8-char short sha)"
+    else
+        fail "flake_telemetry: sha=75b03030" "got: $sha_field"
+    fi
+
+    if [ "$check_name" = "schema-drift-check" ]; then
+        pass "flake_telemetry: check_name=schema-drift-check"
+    else
+        fail "flake_telemetry: check_name=schema-drift-check" "got: $check_name"
+    fi
+
+    # ts must be ISO-8601 UTC with trailing Z.
+    if echo "$ts_field" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$'; then
+        pass "flake_telemetry: ts is ISO-8601 UTC (suffix Z)"
+    else
+        fail "flake_telemetry: ts is ISO-8601 UTC" "got: $ts_field"
+    fi
+}
+
+# Test 14c (#4163 AC#3): Two flake events on different runs aggregate via the
+# documented one-liner `jq -r .label | sort | uniq -c`. This guards the
+# "no free-form prose" / "same fields every time" property.
+test_flake_telemetry_aggregatable() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # Pre-seed the JSONL with two prior events, then the test produces a third.
+    local flake_log="$tmpdir/flakes.jsonl"
+    cat > "$flake_log" << 'JSONL'
+{"ts":"2026-05-04T01:02:03Z","pr":4100,"sha":"aaaaaaaa","run_id":99999,"label":"postgres-startup","check_name":"schema-drift-check"}
+{"ts":"2026-05-04T02:03:04Z","pr":4101,"sha":"bbbbbbbb","run_id":99998,"label":"postgres-startup","check_name":"schema-drift-check"}
+JSONL
+
+    write_failure_with_run_id_response "$tmpdir/responses/01.json" "unit-tests" "12345678"
+    write_all_success_response "$tmpdir/responses/02.json"
+
+    local log_file rerun_log
+    log_file="$tmpdir/log-failed.txt"
+    rerun_log="$tmpdir/rerun.log"
+    cat > "$log_file" << 'LOG'
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock
+LOG
+
+    local exit_code
+    exit_code=0
+    LOG_FAILED_FILE="$log_file" RERUN_LOG_FILE="$rerun_log" \
+        WAIT_FOR_CI_FLAKE_LOG="$flake_log" \
+        SHA_RESPONSE="cccccccc" \
+        MERGEABLE_RESPONSE=MERGEABLE \
+        run_script "$tmpdir" 4163 --poll-interval 0 --timeout-secs 60 >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -ne 0 ]; then
+        fail "flake_telemetry_aggregatable: rerun + success poll exits 0" "exit=$exit_code"
+        return
+    fi
+
+    # AC#3: aggregator one-liner.
+    local agg
+    agg=$(jq -r .label "$flake_log" | sort | uniq -c | tr -s ' ' | sed 's/^ *//')
+    local expected
+    expected="1 docker-daemon
+2 postgres-startup"
+    if [ "$agg" = "$expected" ]; then
+        pass "flake_telemetry_aggregatable: jq -r .label | sort | uniq -c yields the leaderboard"
+    else
+        fail "flake_telemetry_aggregatable: jq -r .label | sort | uniq -c yields the leaderboard" "got: $agg"
+    fi
+}
+
 # Test 14 (#4148): --no-auto-rerun must disable the classifier path entirely
 # even when a flake pattern is present in the job log.
 test_no_auto_rerun_flag_disables_classifier() {
@@ -763,6 +914,8 @@ test_auto_rerun_on_postgres_startup_flake
 test_two_consecutive_flakes_exit_1
 test_real_failure_no_rerun
 test_no_auto_rerun_flag_disables_classifier
+test_flake_telemetry_emits_jsonl_line
+test_flake_telemetry_aggregatable
 
 echo ""
 echo "────────────────────────────────────────────"

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -79,6 +79,26 @@
 #       A second flake on the same run exits 1 — see #4148.
 #   2 — Timeout: --timeout-secs elapsed without reaching a terminal state.
 #
+# ── Flake telemetry (#4163) ──────────────────────────────────────────────────
+#
+# Every time the auto-rerun classifier fires `gh run rerun` for a known flake,
+# one structured JSON line is appended to a stable file so downstream tooling
+# can aggregate flake frequencies without scraping CI logs. The default path
+# is `tmp/wait-for-ci-flakes.jsonl` resolved relative to the script's parent
+# (i.e. the repo or worktree root that contains `scripts/`). Tests override
+# the path via the `WAIT_FOR_CI_FLAKE_LOG` env var.
+#
+# Each line carries a fixed schema (no free-form prose) so a one-liner like
+# `jq -r .label tmp/wait-for-ci-flakes.jsonl | sort | uniq -c` produces the
+# leaderboard. Schema:
+#
+#   {"ts":"<ISO-8601 UTC>","pr":<int>,"sha":"<short sha>","run_id":<int>,
+#    "label":"<flake-label>","check_name":"<failed check name>"}
+#
+# A companion helper `scripts/summarize-ci-flakes.sh` reads the same file and
+# prints a per-label count. Promotion of a label to the auto-rerun table
+# remains a human PR (out of scope for this script).
+#
 # ─────────────────────────────────────────────────────────────────────────────
 
 set -euo pipefail
@@ -95,6 +115,12 @@ AUTO_RERUN=1
 # `classify-ci-flake.sh` helper without depending on PATH.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLASSIFIER="$SCRIPT_DIR/classify-ci-flake.sh"
+
+# Default flake telemetry log path — `<repo-or-worktree-root>/tmp/wait-for-ci-flakes.jsonl`.
+# `SCRIPT_DIR` is `<root>/scripts`, so the parent is the root itself. Tests
+# override via `WAIT_FOR_CI_FLAKE_LOG` to point at a per-test tmpdir.
+DEFAULT_FLAKE_LOG="$(dirname "$SCRIPT_DIR")/tmp/wait-for-ci-flakes.jsonl"
+FLAKE_LOG="${WAIT_FOR_CI_FLAKE_LOG:-$DEFAULT_FLAKE_LOG}"
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 
@@ -212,6 +238,45 @@ record_rerun_fired() {
     echo "$run_id" >> "$RERUN_SENTINEL_FILE"
 }
 
+# Emit one JSONL line of flake telemetry to $FLAKE_LOG (#4163).
+#
+# Args: <pr> <sha> <run_id> <label> <check_name>
+#
+# The line is built with `jq -cn` so embedded quotes / shell metachars in any
+# field are escaped correctly. We tolerate jq write failures silently — the
+# rerun must still happen even if the disk is full or the parent directory is
+# read-only. The whole helper returns 0 unconditionally so a logging error
+# never wedges the polling loop.
+emit_flake_telemetry() {
+    local pr="$1"
+    local sha="$2"
+    local run_id="$3"
+    local label="$4"
+    local check_name="$5"
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    mkdir -p "$(dirname "$FLAKE_LOG")" 2>/dev/null || return 0
+
+    local short_sha="${sha:0:8}"
+    # Note: `label` is a jq reserved keyword, so we pass it as `$lbl` and
+    # remap to the public field name in the object literal.
+    local line
+    line=$(jq -cn \
+        --arg ts "$ts" \
+        --argjson pr "$pr" \
+        --arg sha "$short_sha" \
+        --argjson run_id "$run_id" \
+        --arg lbl "$label" \
+        --arg check_name "$check_name" \
+        '{ts: $ts, pr: $pr, sha: $sha, run_id: $run_id, label: $lbl, check_name: $check_name}' 2>/dev/null) || return 0
+
+    if [ -n "$line" ]; then
+        printf '%s\n' "$line" >> "$FLAKE_LOG" 2>/dev/null || return 0
+    fi
+    return 0
+}
+
 # ── Poll loop ─────────────────────────────────────────────────────────────────
 
 START_TS=$(date +%s)
@@ -247,23 +312,30 @@ while true; do
             FLAKE_DETECTED=0
             FLAKE_LABEL=""
             FLAKE_RUN_ID=""
+            FLAKE_CHECK_NAME=""
 
-            # Extract one (failed-check, run-id) pair per failed check.
-            # We only need to check the first failed run-id we see —
-            # `gh run rerun --failed` already reruns every failed job on
-            # that run, and rerunning multiple distinct runs from one
-            # script invocation is out of scope (one rerun per SHA per
-            # script call). The first failed check in the rollup is
-            # representative.
+            # Extract (check_name, details_url) pairs for every failed check.
+            # We capture the check name alongside the URL so the telemetry
+            # emitter (#4163) can record which named check fired the flake —
+            # consumers want to know whether postgres-startup is hitting
+            # `schema-drift-check`, `unit-tests`, or somewhere new. We only
+            # need to act on the first failed run-id we see — `gh run rerun
+            # --failed` already reruns every failed job on that run, and
+            # rerunning multiple distinct runs from one script invocation is
+            # out of scope (one rerun per SHA per script call).
+            #
+            # Tab-separated to survive in any plausible check name; check
+            # names with embedded tabs are not a concern (GitHub's check-name
+            # validator forbids control chars).
             FAILED_DETAILS=$(echo "$CHECK_RUNS_JSON" | jq -r '
                 .[]
                 | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled"))
-                | (.details_url // "")
+                | "\(.name // "")\t\(.details_url // "")"
             ')
 
             # Walk failed checks until we find one whose run-id parses AND
             # whose log classifies as a known flake.
-            while IFS= read -r URL; do
+            while IFS=$'\t' read -r CHECK_NAME URL; do
                 [ -z "$URL" ] && continue
                 CANDIDATE_RUN_ID=$(parse_run_id_from_url "$URL")
                 if [ -z "$CANDIDATE_RUN_ID" ]; then
@@ -283,6 +355,7 @@ while true; do
                     FLAKE_DETECTED=1
                     FLAKE_LABEL="${CLASSIFICATION#flake/}"
                     FLAKE_RUN_ID="$CANDIDATE_RUN_ID"
+                    FLAKE_CHECK_NAME="$CHECK_NAME"
                     break
                 fi
             done <<EOF
@@ -300,6 +373,10 @@ EOF
                 echo "flake detected: ${FLAKE_LABEL} (run ${FLAKE_RUN_ID}) — auto-rerunning failed jobs and continuing to poll."
                 if gh run rerun "$FLAKE_RUN_ID" --repo "$REPO" --failed >/dev/null 2>&1; then
                     record_rerun_fired "$FLAKE_RUN_ID"
+                    # Append one structured JSONL line so downstream tooling
+                    # can aggregate flake frequencies (#4163). Best-effort —
+                    # never fails the polling loop.
+                    emit_flake_telemetry "$PR_NUMBER" "$SHA" "$FLAKE_RUN_ID" "$FLAKE_LABEL" "$FLAKE_CHECK_NAME"
                     # Sleep one poll interval so the new run has a moment to
                     # register before the next check-runs fetch.
                     sleep "$POLL_INTERVAL"


### PR DESCRIPTION
## Summary

`scripts/wait-for-ci.sh` now appends one structured JSONL line to `tmp/wait-for-ci-flakes.jsonl` (path overridable via `WAIT_FOR_CI_FLAKE_LOG`) every time the auto-rerun classifier fires `gh run rerun` for a known flake. Adds `scripts/summarize-ci-flakes.sh` for per-label aggregation. Two new unit tests pin the schema and the documented `jq -r .label | sort | uniq -c` aggregation.

Closes #4163

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_wait_for_ci.sh` — 44/44 PASS locally with the two new flake-telemetry tests; `scripts-tests (shell-fast, 14, not-slow)` SUCCESS in CI)
- [x] CI green (canonical merge gate green: mergeable=MERGEABLE, ci-passed=SUCCESS)

### Post-deploy verification
- [x] N/A — no deployed component (developer-tooling shell scripts only). Telemetry will accumulate in operator/agent worktrees as the auto-rerun classifier fires; `summarize-ci-flakes.sh` reads them on demand.
- [x] Verification evidence posted on issue (see A.8)
