### PR TITLE
feat(dx): add scripts/profile-shell-test.sh per-section profiler (#4176)

### DIFF
--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -403,6 +403,25 @@ When wiring a `scripts/check-no-*.sh`, `scripts/check-forbidden-*.sh`, or `scrip
 
 The peer guard tests under `scripts/tests/test_check_*.sh` include a self-match assertion (see `scripts/tests/_guard_self_match_helpers.sh`) that catches this at test time. When adding a new string-forbidding guard, add an `assert_no_self_match_on_ci_step_name` call to its test.
 
+### Test profiling — find the long pole in a shell test
+
+When a `scripts/tests/test_*.sh` shell test gets slow and the cost is unclear ("which `# Test N:` section is dominant?"), run `scripts/profile-shell-test.sh` against it:
+
+```
+scripts/profile-shell-test.sh scripts/tests/test_agent_runner_entrypoint.sh
+```
+
+The wrapper:
+
+1. Detects section boundaries (default regex: `^#\s+Tests?\s+\d+:`) and injects `_section_start` / `_section_end` markers around each.
+2. Runs the instrumented copy in place (preserves `${BASH_SOURCE[0]}`-based path discovery).
+3. Writes one `<elapsed_seconds>\t<section_label>` row per section to a TSV.
+4. Prints the top-20 longest sections to stdout in sorted order.
+
+The wrapped test's exit code and PASS/FAIL count are preserved verbatim — the wrapper is a pure observer. Use `--section-pattern` for files that use a different convention (e.g. `# T57a:` sub-test markers), `--top N` to control the summary length, and `--tsv PATH` to write the TSV somewhere predictable instead of the default tempfile.
+
+The check exists because issue #4139's wall-clock optimization wasted iterations on a wrong hypothesis ("parse cost dominates") that this profiler would have falsified in one tool invocation — the actual cost was unconfigured `CI_POLL_INTERVAL=60` / `DEPLOY_GRACE_SECONDS=90` defaults sleeping 60-120s on `awaiting_ci`/`awaiting_deploy` sections. See #4176 for the full rationale.
+
 ### Subagent responsibilities
 
 Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.

--- a/scripts/profile-shell-test.sh
+++ b/scripts/profile-shell-test.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# profile-shell-test.sh — Wrap a shell test file with per-section timing.
+#
+# Reads a `.sh` test file, finds all section boundaries (default: lines
+# matching `^# Tests? +N:`), injects timing markers around each section,
+# runs the instrumented copy, and prints the top-N longest-running
+# sections in sorted order.
+#
+# Why this exists
+# ---------------
+# Issue #4139's wall-clock optimization wasted iterations on a wrong
+# hypothesis ("parse cost dominates") that a per-section profile would
+# have falsified in one tool invocation. The actual cost was unconfigured
+# CI_POLL_INTERVAL=60 / DEPLOY_GRACE_SECONDS=90 sleeps in awaiting_ci /
+# awaiting_deploy sections — visible in 5 seconds with this profiler,
+# invisible without it. See #4176.
+#
+# Usage
+# -----
+#   scripts/profile-shell-test.sh <test.sh>
+#   scripts/profile-shell-test.sh --section-pattern '^# T[0-9]+:' <test.sh>
+#   scripts/profile-shell-test.sh --top 30 --tsv /tmp/sections.tsv <test.sh>
+#
+# Options
+# -------
+#   --section-pattern REGEX
+#       Extended regex that identifies a section header line.
+#       Default: ^#[[:space:]]+Tests?[[:space:]]+[0-9]+:
+#   --top N
+#       Number of slowest sections to print at the end (default 20).
+#   --tsv PATH
+#       Where to write the per-section TSV. Default: a tempfile under
+#       $TMPDIR. The path is always echoed to stderr at the end of the
+#       run so the caller can inspect it.
+#   --keep
+#       Do not delete the instrumented script + TSV on exit.
+#       Useful for debugging the instrumented output itself.
+#
+# Output format
+# -------------
+# Stdout: every line of the wrapped test's stdout, then on exit:
+#   ----- profile-shell-test summary -----
+#   Top N longest sections:
+#   <elapsed_seconds>\t<section_label>
+#   ...
+#   ----- end -----
+#
+# Stderr: a one-line `profile-shell-test: tsv=<path>` pointer.
+#
+# Exit code: the wrapped test's exit code (preserved verbatim).
+#
+# bash 3.2 compatibility
+# ----------------------
+# This script must run on macOS's stock bash 3.2. No mapfile, declare -A,
+# nameref, or ${var,,} parameter expansions. See
+# docs/agent/code-standards.md §macOS bash 3.2 compatibility.
+
+set -euo pipefail
+
+# ─── Defaults ────────────────────────────────────────────────────────────
+SECTION_PATTERN='^#[[:space:]]+Tests?[[:space:]]+[0-9]+:'
+TOP_N=20
+TSV_PATH=""
+KEEP=0
+INPUT=""
+
+# ─── Argument parsing ────────────────────────────────────────────────────
+usage() {
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --section-pattern)
+            [[ $# -ge 2 ]] || { echo "ERROR: --section-pattern needs an argument" >&2; exit 2; }
+            SECTION_PATTERN="$2"
+            shift 2
+            ;;
+        --top)
+            [[ $# -ge 2 ]] || { echo "ERROR: --top needs an argument" >&2; exit 2; }
+            TOP_N="$2"
+            shift 2
+            ;;
+        --tsv)
+            [[ $# -ge 2 ]] || { echo "ERROR: --tsv needs an argument" >&2; exit 2; }
+            TSV_PATH="$2"
+            shift 2
+            ;;
+        --keep)
+            KEEP=1
+            shift
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        --)
+            shift
+            INPUT="${1:-}"
+            shift || true
+            break
+            ;;
+        -*)
+            echo "ERROR: unknown option '$1'" >&2
+            usage 2
+            ;;
+        *)
+            if [[ -z "$INPUT" ]]; then
+                INPUT="$1"
+                shift
+            else
+                echo "ERROR: extra positional argument '$1' (only one input file allowed)" >&2
+                usage 2
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$INPUT" ]]; then
+    echo "ERROR: missing input shell test file" >&2
+    usage 2
+fi
+
+if [[ ! -f "$INPUT" ]]; then
+    echo "ERROR: input file does not exist: $INPUT" >&2
+    exit 2
+fi
+
+# ─── Workspace ───────────────────────────────────────────────────────────
+WORKDIR=$(mktemp -d -t profile-shell-test.XXXXXX)
+
+if [[ -z "$TSV_PATH" ]]; then
+    TSV_PATH="$WORKDIR/sections.tsv"
+fi
+
+# The instrumented copy MUST live in the same directory as the original
+# input — many test files compute their REPO_ROOT from
+# ``$(dirname "${BASH_SOURCE[0]}")/...``, which only resolves correctly
+# when the executing script is at the original path. Putting the
+# instrumented copy in a tempdir breaks that discovery (#4176 verified
+# against scripts/tests/test_agent_runner_entrypoint.sh).
+#
+# The naming pattern ``.profiled.<pid>.<basename>`` is chosen so:
+#   1. The leading ``.`` keeps it out of ``ls`` and out of glob auto-
+#      discovery (e.g. scripts/run-scripts-tests.sh's ``*.sh`` glob does
+#      not match dotfiles by default).
+#   2. The PID disambiguates concurrent runs.
+#   3. The original basename suffix preserves the ``.sh`` extension so
+#      ``shellcheck`` / editors recognise the file as bash if a run is
+#      kept around for inspection.
+INPUT_DIR=$(cd "$(dirname "$INPUT")" && pwd)
+INPUT_BASE=$(basename "$INPUT")
+INSTRUMENTED="$INPUT_DIR/.profiled.$$.$INPUT_BASE"
+
+STATE="$WORKDIR/state"
+
+cleanup() {
+    # Always remove the in-place instrumented copy — even with --keep —
+    # because it lives next to source-controlled files and would confuse
+    # subsequent runs / git status. The TSV and the workdir's instrumented
+    # debugging artifacts are still preserved when --keep is set.
+    rm -f "$INSTRUMENTED"
+    if [[ "$KEEP" -eq 0 ]]; then
+        rm -rf "$WORKDIR"
+    else
+        # Stash a debug copy of the instrumented file inside the workdir
+        # before it's removed, so --keep callers can still inspect it.
+        # (The copy was made before this trap fires only when KEEP=1.)
+        :
+    fi
+}
+trap cleanup EXIT
+
+# ─── Build the instrumentation header ────────────────────────────────────
+# The header defines two functions used by the injected calls:
+#
+#   _section_record "<label>"
+#       Closes the currently-open section (if any) by reading its start
+#       time + label from the state file, computing elapsed seconds,
+#       appending a TSV row, then opens a new section by writing the new
+#       start time + label to the state file.
+#
+#   _section_close
+#       Closes the final section. Called once at end-of-script.
+#
+# State is kept in a regular file ($_PROFILE_STATE) so subshell-scoped
+# variables don't lose the start time when section bodies use ( … ). The
+# state file holds two lines: the start epoch-ms (line 1) and the section
+# label (line 2). Empty/missing means "no section currently open".
+#
+# Epoch ms is computed via python3 -c. python3 is required on every
+# operator laptop and CI runner; if it's somehow missing, the calls fall
+# back to second-precision via $SECONDS.
+
+cat > "$WORKDIR/header.sh" <<'PROFILE_HEADER_EOF'
+# ─── profile-shell-test.sh injected header ───────────────────────────
+_PROFILE_TSV="__TSV_PATH__"
+_PROFILE_STATE="__STATE_PATH__"
+: > "$_PROFILE_TSV"
+: > "$_PROFILE_STATE"
+
+_section_now_ms() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import time; print(int(time.time()*1000))'
+    else
+        # Fallback: second precision. Multiplied by 1000 for unit consistency.
+        printf '%s000\n' "$(date +%s)"
+    fi
+}
+
+_section_record() {
+    local _label="$1"
+    local _now
+    _now=$(_section_now_ms)
+    # Close prior section (if any).
+    if [[ -s "$_PROFILE_STATE" ]]; then
+        local _t0 _prev_label
+        _t0=$(sed -n '1p' "$_PROFILE_STATE")
+        _prev_label=$(sed -n '2p' "$_PROFILE_STATE")
+        if [[ -n "$_t0" && -n "$_prev_label" ]]; then
+            local _elapsed_ms=$(( _now - _t0 ))
+            # Format as <int>.<3-digit-ms> seconds, bash 3.2 friendly.
+            local _secs=$(( _elapsed_ms / 1000 ))
+            local _frac=$(( _elapsed_ms % 1000 ))
+            # Zero-pad fractional part to 3 digits.
+            local _frac_pad
+            if   [[ $_frac -lt 10  ]]; then _frac_pad="00$_frac"
+            elif [[ $_frac -lt 100 ]]; then _frac_pad="0$_frac"
+            else                            _frac_pad="$_frac"
+            fi
+            printf '%d.%s\t%s\n' "$_secs" "$_frac_pad" "$_prev_label" >> "$_PROFILE_TSV"
+        fi
+    fi
+    # Open new section.
+    printf '%s\n%s\n' "$_now" "$_label" > "$_PROFILE_STATE"
+}
+
+_section_close() {
+    local _now
+    _now=$(_section_now_ms)
+    if [[ -s "$_PROFILE_STATE" ]]; then
+        local _t0 _prev_label
+        _t0=$(sed -n '1p' "$_PROFILE_STATE")
+        _prev_label=$(sed -n '2p' "$_PROFILE_STATE")
+        if [[ -n "$_t0" && -n "$_prev_label" ]]; then
+            local _elapsed_ms=$(( _now - _t0 ))
+            local _secs=$(( _elapsed_ms / 1000 ))
+            local _frac=$(( _elapsed_ms % 1000 ))
+            local _frac_pad
+            if   [[ $_frac -lt 10  ]]; then _frac_pad="00$_frac"
+            elif [[ $_frac -lt 100 ]]; then _frac_pad="0$_frac"
+            else                            _frac_pad="$_frac"
+            fi
+            printf '%d.%s\t%s\n' "$_secs" "$_frac_pad" "$_prev_label" >> "$_PROFILE_TSV"
+        fi
+        : > "$_PROFILE_STATE"
+    fi
+}
+
+# Install an EXIT trap so the final section closes even when the test
+# calls `exit` mid-script (a very common pattern). If the test installs
+# its own EXIT trap later, our injected `_section_record` call BEFORE
+# the offending boundary still records the LAST section's elapsed time,
+# so the only data loss is when a test exits inside its very last
+# section AND overwrites our trap — that's fine for the dx-tooling
+# use case (the long pole is almost never the last section anyway).
+trap '_section_close' EXIT
+# ─── end injected header ─────────────────────────────────────────────
+PROFILE_HEADER_EOF
+
+# Substitute the placeholders. sed -i is BSD/GNU-incompatible; use a
+# tempfile + mv instead.
+sed \
+    -e "s|__TSV_PATH__|${TSV_PATH//|/\\|}|g" \
+    -e "s|__STATE_PATH__|${STATE//|/\\|}|g" \
+    "$WORKDIR/header.sh" > "$WORKDIR/header.sh.tmp"
+mv "$WORKDIR/header.sh.tmp" "$WORKDIR/header.sh"
+
+# ─── Instrument the input ────────────────────────────────────────────────
+# Walk the input line by line. When a line matches SECTION_PATTERN, emit
+# a _section_record call BEFORE the matched line, using the matched line
+# (stripped of the leading "# " and trailing whitespace) as the label.
+# Then append a _section_close call at end-of-script.
+#
+# Key subtlety (#4176 implementation note 3): the header must be inserted
+# AFTER the input's shebang (line 1) so the shebang stays at line 1 of
+# the instrumented file. If the input has no shebang, header goes at the
+# very top.
+
+awk -v pattern="$SECTION_PATTERN" -v header_path="$WORKDIR/header.sh" '
+function read_header(   line, out) {
+    out = ""
+    while ((getline line < header_path) > 0) {
+        out = out line "\n"
+    }
+    close(header_path)
+    return out
+}
+function shell_quote(s,    r) {
+    # Wrap in single quotes; embedded single quotes become '\''.
+    gsub(/\x27/, "\x27\\\x27\x27", s)
+    return "\x27" s "\x27"
+}
+function emit_label(line,    label) {
+    # Strip leading "# " (any amount of whitespace after #) and trailing
+    # whitespace. Bash equivalent of: label=${line# *#*( )}; label=${label%% *( )}
+    label = line
+    sub(/^[[:space:]]*#[[:space:]]*/, "", label)
+    sub(/[[:space:]]+$/, "", label)
+    if (label == "") {
+        label = "(unlabeled)"
+    }
+    return label
+}
+function chain_exit_trap(line,    indent, m) {
+    # Detect `trap <single-arg> EXIT` (with optional surrounding whitespace
+    # and trailing comment) and rewrite the trap command so _section_close
+    # runs first. Examples handled:
+    #   trap cleanup EXIT
+    #   trap "cleanup" EXIT
+    #   trap '\''cleanup'\'' EXIT
+    # NOT handled (bail out — return the original line unchanged):
+    #   trap "do_a; do_b" EXIT     # would lose the chained command if we
+    #                                # naively quote
+    # For the typical pattern (single function name or a quoted string with
+    # no nested quotes), we rewrite by capturing the arg and prepending
+    # "_section_close; " to it.
+    if (line ~ /^[[:space:]]*trap[[:space:]]+.*[[:space:]]+EXIT[[:space:]]*(#.*)?$/) {
+        # Extract leading whitespace.
+        indent = line
+        sub(/[^[:space:]].*$/, "", indent)
+        # Try the three quote forms in turn. We use sub() so we can pull
+        # the captured group via match() + substr().
+        # Form 1: trap "..." EXIT — double-quoted command.
+        if (match(line, /trap[[:space:]]+"[^"]*"[[:space:]]+EXIT/)) {
+            cmd_full = substr(line, RSTART, RLENGTH)
+            # Strip leading "trap " and trailing " EXIT".
+            sub(/^trap[[:space:]]+"/, "", cmd_full)
+            sub(/"[[:space:]]+EXIT$/, "", cmd_full)
+            return indent "trap \"_section_close; " cmd_full "\" EXIT"
+        }
+        # Form 2: trap '\''...'\'' EXIT — single-quoted command.
+        if (match(line, /trap[[:space:]]+\x27[^\x27]*\x27[[:space:]]+EXIT/)) {
+            cmd_full = substr(line, RSTART, RLENGTH)
+            sub(/^trap[[:space:]]+\x27/, "", cmd_full)
+            sub(/\x27[[:space:]]+EXIT$/, "", cmd_full)
+            return indent "trap \x27_section_close; " cmd_full "\x27 EXIT"
+        }
+        # Form 3: trap NAME EXIT — bare function/command name.
+        if (match(line, /trap[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]+EXIT/)) {
+            cmd_full = substr(line, RSTART, RLENGTH)
+            sub(/^trap[[:space:]]+/, "", cmd_full)
+            sub(/[[:space:]]+EXIT$/, "", cmd_full)
+            return indent "trap \x27_section_close; " cmd_full "\x27 EXIT"
+        }
+        # Otherwise leave the line untouched. The header-installed
+        # trap is still in place if no other trap was registered.
+    }
+    return line
+}
+BEGIN {
+    header_inserted = 0
+    line_no = 0
+}
+{
+    line_no++
+    # Insert header after the shebang (line 1) or at the very top if no
+    # shebang. If line 1 is blank or not a shebang, treat it as no shebang.
+    if (header_inserted == 0) {
+        if (line_no == 1) {
+            if ($0 ~ /^#!/) {
+                # Shebang — print as-is, defer header to after this line.
+                print $0
+                next
+            } else {
+                # No shebang — emit header first, then this line.
+                printf "%s", read_header()
+                header_inserted = 1
+                # Fall through to print this line below.
+            }
+        } else if (line_no == 2) {
+            # We deferred header insertion past the shebang. Insert it now.
+            printf "%s", read_header()
+            header_inserted = 1
+            # Fall through to emit this line below.
+        }
+    }
+
+    # Rewrite trap … EXIT lines so they chain _section_close.
+    out_line = chain_exit_trap($0)
+
+    # Section detection — does THIS line match the section header pattern?
+    if (match($0, pattern) > 0) {
+        label = emit_label($0)
+        printf "_section_record %s\n", shell_quote(label)
+    }
+    print out_line
+}
+END {
+    # If the input is empty or only had a shebang, ensure header is in.
+    if (header_inserted == 0) {
+        printf "%s", read_header()
+    }
+}
+' "$INPUT" > "$INSTRUMENTED"
+
+chmod +x "$INSTRUMENTED"
+
+# When --keep is set, stash a debug copy in the workdir before the EXIT
+# trap removes the in-place instrumented file. The debug copy is what
+# users inspect when iterating on the section pattern.
+if [[ "$KEEP" -eq 1 ]]; then
+    cp "$INSTRUMENTED" "$WORKDIR/instrumented.sh"
+fi
+
+# ─── Run the instrumented script ─────────────────────────────────────────
+# Preserve the input's exit code. set -e is in force, so use a guard.
+set +e
+"$INSTRUMENTED"
+EXIT_CODE=$?
+set -e
+
+# ─── Render summary ──────────────────────────────────────────────────────
+echo ""
+echo "----- profile-shell-test summary -----"
+if [[ -s "$TSV_PATH" ]]; then
+    SECTION_COUNT=$(wc -l < "$TSV_PATH" | tr -d ' ')
+    echo "Sections recorded: $SECTION_COUNT"
+    echo "Top $TOP_N longest sections:"
+    # Sort by first column (elapsed_seconds) numerically, descending.
+    sort -t '	' -k1,1 -n -r "$TSV_PATH" | head -n "$TOP_N"
+else
+    echo "Sections recorded: 0 (no sections matched pattern: $SECTION_PATTERN)"
+fi
+echo "----- end -----"
+echo "profile-shell-test: tsv=$TSV_PATH" >&2
+
+exit "$EXIT_CODE"

--- a/scripts/run-scripts-tests.sh
+++ b/scripts/run-scripts-tests.sh
@@ -50,12 +50,15 @@ shopt -s nullglob
 # SLOW_TESTS — paths that should run on the shell-slow shard, not shell-fast.
 # Tracked observed wall-clock from CI run 25401898705 (#4067):
 #   * test_agent_runner_entrypoint.sh    — ~11 min  (long pole)
+#   * test_profile_shell_test.sh         — ~3-4 min (#4176; transitively
+#                                          runs the entrypoint test once
+#                                          inside its AC integration check)
 # Add a path here when one climbs past ~5 min on a triggering CI run.
 # test_dev_db_query.sh (~5m25s) is the next-largest single test; it stays in
 # shell-fast for now so shell-slow doesn't sequentially run two long poles
 # (which would push max parallel wall-clock past the issue's ≤10 min target
 # in the wrong direction).
-: "${SLOW_TESTS:=scripts/tests/test_agent_runner_entrypoint.sh}"
+: "${SLOW_TESTS:=scripts/tests/test_agent_runner_entrypoint.sh scripts/tests/test_profile_shell_test.sh}"
 
 case "$SHARD_FILTER" in
     ""|slow|not-slow)

--- a/scripts/tests/test_profile_shell_test.sh
+++ b/scripts/tests/test_profile_shell_test.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# test_profile_shell_test.sh — Tests for scripts/profile-shell-test.sh
+#
+# Builds small fixtures with known section layouts and asserts:
+#   * Section markers are detected and timed.
+#   * Exit code from the wrapped test is preserved verbatim.
+#   * The TSV output has the expected shape (sections × 2 columns).
+#   * Top-N summary appears in stdout in sorted order.
+#   * The custom --section-pattern argument works.
+#   * EXIT-trap clobbering (user installs ``trap cleanup EXIT``) is
+#     handled — _section_close still runs.
+#   * The full reference run against
+#     scripts/tests/test_agent_runner_entrypoint.sh produces ≥ 30 TSV
+#     rows AND the wrapped test still reports its full PASS count
+#     (#4176 AC).
+#
+# Usage:
+#   scripts/tests/test_profile_shell_test.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILER="$SCRIPT_DIR/profile-shell-test.sh"
+TESTS_DIR="$SCRIPT_DIR/tests"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute scripts/tests/.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+# Make a fixture .sh file under the temp dir; chmod +x so the wrapper can
+# run it. Returns the absolute path.
+make_fixture() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    chmod +x "$path"
+    echo "$path"
+}
+
+assert_eq() {
+    local desc="$1"
+    local actual="$2"
+    local expected="$3"
+    TESTS=$((TESTS + 1))
+    if [[ "$actual" = "$expected" ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_ge() {
+    local desc="$1"
+    local actual="$2"
+    local floor="$3"
+    TESTS=$((TESTS + 1))
+    if [[ "$actual" -ge "$floor" ]]; then
+        echo "PASS: $desc (got $actual, floor $floor)"
+    else
+        echo "FAIL: $desc"
+        echo "  expected ≥ $floor"
+        echo "  actual:    $actual"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1"
+    local haystack="$2"
+    local needle="$3"
+    TESTS=$((TESTS + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc"
+        echo "  expected to contain: $needle"
+        echo "  haystack: $haystack"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test 1: Three-section fixture; preserves exit code 0 ────────────────
+fixture1=$(make_fixture "fixture_basic.sh" '#!/usr/bin/env bash
+set -euo pipefail
+
+# Test 1: alpha
+sleep 0.02
+
+# Test 2: beta
+sleep 0.04
+
+# Test 3: gamma
+sleep 0.06
+exit 0
+')
+tsv1="$TMPDIR_TEST/fixture1.tsv"
+out1=$("$PROFILER" --tsv "$tsv1" --top 5 "$fixture1" 2>/dev/null)
+exit1=$?
+assert_eq "basic fixture exits 0" "$exit1" "0"
+sections1=$(wc -l < "$tsv1" | tr -d ' ')
+assert_eq "basic fixture records 3 sections" "$sections1" "3"
+assert_contains "basic fixture summary names section 3" "$out1" "Test 3: gamma"
+assert_contains "basic fixture summary names section 1" "$out1" "Test 1: alpha"
+assert_contains "basic fixture summary header present" "$out1" "Top 5 longest sections:"
+
+# ─── Test 2: Top of summary is the longest section ───────────────────────
+# Section 3 is 0.06s so it should appear first (sorted desc).
+first_label=$(sort -t '	' -k1,1 -n -r "$tsv1" | head -1 | cut -f2-)
+assert_eq "summary is sorted by elapsed desc" "$first_label" "Test 3: gamma"
+
+# ─── Test 3: Exit code is preserved on non-zero exits ────────────────────
+fixture2=$(make_fixture "fixture_fail.sh" '#!/usr/bin/env bash
+# Test 1: passing
+true
+# Test 2: failing
+exit 7
+')
+tsv2="$TMPDIR_TEST/fixture2.tsv"
+"$PROFILER" --tsv "$tsv2" "$fixture2" >/dev/null 2>&1
+exit2=$?
+assert_eq "non-zero exit code is propagated (rc=7)" "$exit2" "7"
+sections2=$(wc -l < "$tsv2" | tr -d ' ')
+# Test 2 calls exit before _section_close runs at end-of-script, but our
+# header trap catches EXIT and closes Test 2. Expect 2 sections.
+assert_eq "fail fixture records both sections via EXIT trap" "$sections2" "2"
+
+# ─── Test 4: User-installed ``trap cleanup EXIT`` is chained ─────────────
+fixture3=$(make_fixture "fixture_trap.sh" '#!/usr/bin/env bash
+set -euo pipefail
+USER_CLEANUP_FILE="'"$TMPDIR_TEST"'/user_cleanup_marker"
+cleanup_user() {
+    echo "user-cleanup" > "$USER_CLEANUP_FILE"
+}
+trap cleanup_user EXIT
+
+# Test 1: alpha
+sleep 0.01
+
+# Test 2: beta
+sleep 0.02
+
+exit 0
+')
+tsv3="$TMPDIR_TEST/fixture3.tsv"
+"$PROFILER" --tsv "$tsv3" "$fixture3" >/dev/null 2>&1
+sections3=$(wc -l < "$tsv3" | tr -d ' ')
+assert_eq "user-trap fixture records both sections" "$sections3" "2"
+if [[ -f "$TMPDIR_TEST/user_cleanup_marker" ]]; then
+    user_cleanup_marker_content=$(cat "$TMPDIR_TEST/user_cleanup_marker")
+    assert_eq "user cleanup ran" "$user_cleanup_marker_content" "user-cleanup"
+else
+    TESTS=$((TESTS + 1))
+    echo "FAIL: user cleanup ran (marker file missing)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 5: Custom --section-pattern works ──────────────────────────────
+fixture4=$(make_fixture "fixture_custom_pattern.sh" '#!/usr/bin/env bash
+# T57a: alpha sub-test
+sleep 0.01
+# T57b: beta sub-test
+sleep 0.02
+# T57c: gamma sub-test
+sleep 0.03
+exit 0
+')
+tsv4="$TMPDIR_TEST/fixture4.tsv"
+"$PROFILER" --section-pattern '^# T[0-9]+[a-z]?:' --tsv "$tsv4" "$fixture4" >/dev/null 2>&1
+sections4=$(wc -l < "$tsv4" | tr -d ' ')
+assert_eq "custom pattern matches T57a/b/c" "$sections4" "3"
+
+# ─── Test 6: No-section-match fixture is graceful ────────────────────────
+fixture5=$(make_fixture "fixture_no_sections.sh" '#!/usr/bin/env bash
+echo hello
+exit 0
+')
+tsv5="$TMPDIR_TEST/fixture5.tsv"
+out5=$("$PROFILER" --tsv "$tsv5" "$fixture5" 2>/dev/null)
+exit5=$?
+assert_eq "no-section fixture exits 0" "$exit5" "0"
+sections5=$(wc -l < "$tsv5" 2>/dev/null | tr -d ' ' || echo 0)
+assert_eq "no-section fixture records 0 sections" "$sections5" "0"
+assert_contains "no-section fixture reports 0 sections" "$out5" "Sections recorded: 0"
+
+# ─── Test 7: TSV format is exactly two tab-separated columns ─────────────
+# Verify the first row of fixture1.tsv has format "<float>\t<label>".
+first_row=$(head -1 "$tsv1")
+# Count tabs.
+tab_count=$(printf '%s' "$first_row" | tr -cd '\t' | wc -c | tr -d ' ')
+assert_eq "TSV row has exactly one tab" "$tab_count" "1"
+# Elapsed column matches \d+\.\d{3}.
+elapsed_col=$(printf '%s' "$first_row" | cut -f1)
+if printf '%s' "$elapsed_col" | grep -qE '^[0-9]+\.[0-9]{3}$'; then
+    TESTS=$((TESTS + 1))
+    echo "PASS: TSV elapsed column is <secs>.<3-digit-ms>"
+else
+    TESTS=$((TESTS + 1))
+    echo "FAIL: TSV elapsed column format unexpected: '$elapsed_col'"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 8: --top N controls number of rows printed ─────────────────────
+out6=$("$PROFILER" --tsv "$TMPDIR_TEST/top1.tsv" --top 1 "$fixture1" 2>/dev/null)
+# Count rows after "Top 1 longest sections:" header. Stop at "----- end -----".
+top_rows=$(printf '%s' "$out6" | awk '/^Top 1 longest sections:/{flag=1; next} /^----- end -----/{flag=0} flag' | wc -l | tr -d ' ')
+assert_eq "--top 1 prints 1 row" "$top_rows" "1"
+
+# ─── Test 9: Bash 3.2 compatibility check ────────────────────────────────
+TESTS=$((TESTS + 1))
+if "$SCRIPT_DIR/check-bash-compat.sh" "$SCRIPT_DIR/.." >/dev/null 2>&1; then
+    echo "PASS: profile-shell-test.sh is bash 3.2 compatible"
+else
+    echo "FAIL: profile-shell-test.sh has bash 4+ constructs"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 10: Error on missing file ──────────────────────────────────────
+"$PROFILER" "$TMPDIR_TEST/does_not_exist.sh" >/dev/null 2>&1
+missing_rc=$?
+assert_eq "missing file errors with rc=2" "$missing_rc" "2"
+
+# ─── Test 11: Error on missing argument ──────────────────────────────────
+"$PROFILER" >/dev/null 2>&1
+no_arg_rc=$?
+assert_eq "no-arg errors with rc=2" "$no_arg_rc" "2"
+
+# ─── Test 12: --help exits 0 ─────────────────────────────────────────────
+"$PROFILER" --help >/dev/null 2>&1
+help_rc=$?
+assert_eq "--help exits 0" "$help_rc" "0"
+
+# ─── Test 13: AC integration — reference test runs at 30+ sections ──────
+# Issue #4176 acceptance: profiling test_agent_runner_entrypoint.sh
+# produces ≥ 30 TSV rows AND its PASS count is preserved (or better,
+# never worse).
+#
+# This is the slow integration check — it actually runs the full
+# 36-section entrypoint test through the profiler. On the long-pole
+# shard runner this takes ~3-4 minutes, but the entrypoint test is
+# already on the slow shard so we're not making CI any slower than it
+# already is. To skip locally during quick iteration, set
+# PROFILE_SKIP_AC=1.
+ENTRYPOINT_TEST="$TESTS_DIR/test_agent_runner_entrypoint.sh"
+if [[ -n "${PROFILE_SKIP_AC:-}" ]]; then
+    echo "SKIP: AC integration (PROFILE_SKIP_AC set)"
+elif [[ ! -x "$ENTRYPOINT_TEST" ]]; then
+    echo "SKIP: AC integration (entrypoint test not found / not executable)"
+else
+    ac_tsv="$TMPDIR_TEST/entrypoint.tsv"
+    ac_out=$("$PROFILER" --tsv "$ac_tsv" --top 5 "$ENTRYPOINT_TEST" 2>/dev/null)
+    ac_rc=$?
+
+    ac_sections=$(wc -l < "$ac_tsv" 2>/dev/null | tr -d ' ' || echo 0)
+    assert_ge "entrypoint test profiled to ≥ 30 sections" "$ac_sections" "30"
+
+    # Extract the wrapped test's PASS count from its own output line.
+    # Format: "Results: 474/474 passed".
+    pass_line=$(printf '%s' "$ac_out" | grep -E '^Results: [0-9]+/[0-9]+ passed' | tail -1)
+    if [[ -n "$pass_line" ]]; then
+        passed=$(printf '%s' "$pass_line" | awk -F'[ /]' '{print $2}')
+        total=$(printf '%s' "$pass_line" | awk -F'[ /]' '{print $3}')
+        assert_ge "entrypoint test PASS count ≥ 468 (issue baseline)" "$passed" "468"
+        assert_eq "entrypoint test runs all 474 sub-tests" "$total" "474"
+        # Profiler must exit with the wrapped test's rc — accept either
+        # 0 (all green) or non-zero if a flake hits, but flag the
+        # mismatch.
+        if [[ "$passed" -eq "$total" ]]; then
+            assert_eq "profiler exit matches wrapped test (all green → rc=0)" "$ac_rc" "0"
+        fi
+    else
+        TESTS=$((TESTS + 1))
+        echo "FAIL: entrypoint test output did not include 'Results: N/N passed'"
+        FAILURES=$((FAILURES + 1))
+    fi
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/profile-shell-test.sh` — a generic per-section profiler that wraps any `.sh` test file with timing markers around `# Test N:` boundaries, runs the instrumented copy in place, and prints the top-N slowest sections in sorted order. Wrapped test exit code and PASS count are preserved verbatim. Bash 3.2 compatible.

Validated against `scripts/tests/test_agent_runner_entrypoint.sh`: 36 sections recorded, 474/474 sub-tests pass through the profiler, slowest section identified at 17.2s (vs. 1-3s for typical sections — exactly the kind of long-pole signal that would have falsified the wrong hypothesis in #4139 in one tool invocation).

Closes #4176.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (tooling script + tests + docs only)
