### PR TITLE
feat(dx): widen profile-shell-test default pattern to T_issue<N> markers (#4183)

### DIFF
--- a/scripts/profile-shell-test.sh
+++ b/scripts/profile-shell-test.sh
@@ -2,9 +2,12 @@
 # profile-shell-test.sh — Wrap a shell test file with per-section timing.
 #
 # Reads a `.sh` test file, finds all section boundaries (default: lines
-# matching `^# Tests? +N:`), injects timing markers around each section,
-# runs the instrumented copy, and prints the top-N longest-running
-# sections in sorted order.
+# matching `^# Tests? +(T(_issue)?)?N(a-z)?:`, which covers both the
+# legacy `# Test 1:` and the post-#3666 `# Test T_issue3656:` /
+# `# Test T3675:` / `# Test T3656a:` conventions described in
+# `docs/agent/code-standards.md` §Test marker convention), injects
+# timing markers around each section, runs the instrumented copy, and
+# prints the top-N longest-running sections in sorted order.
 #
 # Why this exists
 # ---------------
@@ -25,7 +28,17 @@
 # -------
 #   --section-pattern REGEX
 #       Extended regex that identifies a section header line.
-#       Default: ^#[[:space:]]+Tests?[[:space:]]+[0-9]+:
+#       Default: ^#[[:space:]]+Tests?[[:space:]]+(T(_issue)?)?[0-9]+[a-z]?:
+#       This covers all four header forms used in scripts/tests/:
+#         * `# Test 1:`           (legacy sequential — T44–T59 grandfathered)
+#         * `# Test T3675:`       (new convention, bare T<N>)
+#         * `# Test T_issue3656:` (new convention, T_issue<N>)
+#         * `# Test T3656a:`      (same-issue disambiguation, T<N><a-z>)
+#       See `docs/agent/code-standards.md` §Test marker convention. The
+#       trailing `[a-z]?` covers same-issue disambiguation; sub-test
+#       markers like `# T57a:` (no leading `Test` keyword) are out of
+#       scope for the default and require an explicit
+#       `--section-pattern '^# T[0-9]+[a-z]?:'` override.
 #   --top N
 #       Number of slowest sections to print at the end (default 20).
 #   --tsv PATH
@@ -58,7 +71,7 @@
 set -euo pipefail
 
 # ─── Defaults ────────────────────────────────────────────────────────────
-SECTION_PATTERN='^#[[:space:]]+Tests?[[:space:]]+[0-9]+:'
+SECTION_PATTERN='^#[[:space:]]+Tests?[[:space:]]+(T(_issue)?)?[0-9]+[a-z]?:'
 TOP_N=20
 TSV_PATH=""
 KEEP=0
@@ -66,7 +79,7 @@ INPUT=""
 
 # ─── Argument parsing ────────────────────────────────────────────────────
 usage() {
-    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    sed -n '2,50p' "$0" | sed 's/^# \{0,1\}//'
     exit "${1:-0}"
 }
 

--- a/scripts/tests/test_profile_shell_test.sh
+++ b/scripts/tests/test_profile_shell_test.sh
@@ -289,6 +289,35 @@ else
     fi
 fi
 
+# ─── Test T_issue4183: default pattern covers Test N + T_issue<N> + T<N><a-z> ─
+# Issue #4183 acceptance: the default --section-pattern must match all three
+# header forms in `scripts/tests/`:
+#   * legacy `# Test N:`       (T44–T59 grandfathered)
+#   * new   `# Test T_issue<N>:`
+#   * new   `# Test T<N><a-z>:` (same-issue disambiguation)
+# Without this, an agent profiling a newly-authored test sees
+# "Sections recorded: 0" and has to re-run with an explicit
+# --section-pattern, defeating the "single-tool-invocation surfaces the
+# long pole" property the profiler exists for. See #4183 for the bug.
+fixture_t4183=$(make_fixture "fixture_t_issue4183.sh" '#!/usr/bin/env bash
+set -euo pipefail
+
+# Test 1: legacy sequential
+sleep 0.01
+
+# Test T_issue3656: post-#3666 issue-numbered convention
+sleep 0.02
+
+# Test T3656a: same-issue disambiguation letter suffix
+sleep 0.03
+
+exit 0
+')
+tsv_t4183="$TMPDIR_TEST/fixture_t4183.tsv"
+"$PROFILER" --tsv "$tsv_t4183" "$fixture_t4183" >/dev/null 2>&1
+sections_t4183=$(wc -l < "$tsv_t4183" | tr -d ' ')
+assert_eq "default pattern catches Test N + T_issue<N> + T<N><a-z>" "$sections_t4183" "3"
+
 # ─── Summary ─────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $((TESTS - FAILURES))/$TESTS passed"


### PR DESCRIPTION
## Summary

Widens the default `--section-pattern` in `scripts/profile-shell-test.sh` from `^#[[:space:]]+Tests?[[:space:]]+[0-9]+:` to `^#[[:space:]]+Tests?[[:space:]]+(T(_issue)?)?[0-9]+[a-z]?:` so the profiler matches all four `# Test ...:` header forms used across `scripts/tests/` — legacy `# Test 1:` plus the post-#3666 `# Test T<N>:` / `# Test T_issue<N>:` / `# Test T<N><a-z>:` conventions. Without this, profiling any newly-authored test reported "Sections recorded: 0" and required a manual `--section-pattern` override.

Live run against `scripts/tests/test_agent_runner_entrypoint.sh` now profiles 55 sections under the new default (up from 36) — the gain is the T44–T59 + T_issue<N> + T<N> + T<N><a-z> markers that were previously invisible. PASS count preserved at 474/474.

Closes #4183

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (DX tooling script + its tests only; not deployed to dev/prod)
