### PR TITLE
dx(task): add fix(test) probe + verification-only-close outcome to Step 4b (#4184)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -315,21 +315,26 @@ The adoption-to-merge path should be the common case when this check fires — i
 - *"Add metric / alarm"* → `aws cloudwatch list-metrics --namespace <ns>` / `aws cloudwatch describe-alarms --alarm-name-prefix <prefix>`.
 - *"Add / document X"* → `grep -r "X" docs/ .claude/skills/ CLAUDE.md` or `mcp__github__search_code` for the concept.
 - *"Fix code bug / introduce helper"* → grep for the function name or error-message string across `packages/`.
+- *"fix(test) — failing test reproduction"* — when the issue title starts with `fix(test)` (or carries `type/dx` AND has a `Verify: ./scripts/...` / `Verify: pytest ...` / `Verify: npm ...` line in the body), run that verify line **verbatim against the worktree's freshly-rebased base** (Step A.1a already aligned the worktree to `origin/main`). If it returns clean (no FAIL output, exit 0, the failing assertion the issue cites no longer fires), pivot to the "Gap already satisfied" branch and post a comment naming the PR that landed the fix — `git log --oneline --all -- <test-or-source-path>` is the fastest way to identify the load-bearing commit. This pattern came out of the #4178 / #4173 retro: #4178 was filed on a stale baseline 7.5 hours after #4173 had merged the macOS jq-1.6 empty-file salvage-prelude fix, and the agent saved the entire ralph cycle by running the verify line as one of its first tool calls.
 
 **Decision tree:**
 
 - **Gap confirmed real** (the setting is off, the metric does not exist, the doc is absent, the bug is still present): continue to Path A / Path B as usual.
-- **Gap already satisfied** (probe output shows the state already matches the issue's goal): do NOT abandon the task. Post a comment on the issue quoting the probe output and proposing a reduced scope — typically a docs-only PR that documents the current state and cites the prior PR / Terraform attribute that already shipped it. Write the comment to `{worktree}/tmp/gap_probe_comment.txt`, post it, then continue with the reduced docs-only scope:
+- **Gap already satisfied** (probe output shows the state already matches the issue's goal): do NOT abandon the task. Post a comment on the issue quoting the probe output and proposing one of two reduced-scope outcomes:
+  - **Reduced docs-only PR** — when there is a residual docs delta worth producing (e.g. "document that Container Insights is enabled and cite the Terraform attribute that landed it"). The AC's intent usually has a residual of this shape; complete it as a minimal PR before proceeding to merge.
+  - **Verification-only close** — when there is no remaining docs delta, which is the common case for `fix(test)` issues whose acceptance criteria are exhausted by "the test passes." The probe output IS the verification evidence; post it, name the PR that landed the fix, close the issue with `--reason completed`, and run `scripts/unblock-dependents.sh <N>` if anything was blocking on it. Skip Path A entirely — there is no PR to file. The label-interlock teardown (`gh issue edit <N> --remove-label status/in-progress`) still runs at the close.
+
+  Write the comment to `{worktree}/tmp/gap_probe_comment.txt` and post it:
   ```
   gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/gap_probe_comment.txt
   ```
-  The docs delta is worth producing — the AC's intent usually has a residual: "confirm and document that this already works." Complete that as a minimal PR before proceeding to merge.
 - **Probe ambiguous** (e.g. the AWS API returns unexpected output, the grep hits unrelated files, the state is partially configured): treat as "gap real" and continue to Path A.
 
 Exit codes:
 
 - **Gap real or ambiguous** → continue to Path A / Path B.
-- **Gap already satisfied** → post comment, pivot to reduced (docs-only) scope, continue as Path A with the reduced scope.
+- **Gap already satisfied (docs delta remains)** → post comment, pivot to reduced (docs-only) scope, continue as Path A with the reduced scope.
+- **Gap already satisfied (no docs delta — typical fix(test))** → post comment with probe output as evidence, close issue with `--reason completed`, release `status/in-progress` label, run `scripts/unblock-dependents.sh <N>`. Skip Path A — there is no PR.
 
 ---
 

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -90,7 +90,17 @@ Before filing a "does X" / "enable X" / "add X" issue, run a single command that
   ```
   Already fixed if: the offending code path no longer exists, or a recent commit message references the fix.
 
-**Decision after probing:** If the gap is genuinely absent (the feature/setting/doc does not yet exist), file the issue normally. If the gap is already satisfied, either close the draft or pivot scope to a doc-only update that confirms the current state (e.g., "document that Container Insights is enabled and cite the Terraform attribute"). If the probe is ambiguous, treat as real and file normally — agents can do their own probe at pickup time per Step 4b in `.claude/skills/task/SKILL.md`.
+- **`fix(test)` — failing test reproduction** → for any "the test currently fails" issue, re-run the failing test (or grep) against current `origin/main` — **not** your worktree branch — before filing. Worktree branches lag behind `main` the moment they're cut, so a baseline measurement taken from one is stale by definition.
+  ```
+  git fetch origin main
+  git switch --detach origin/main
+  ./scripts/tests/<failing-test>.sh 2>&1 | grep "FAIL"   # whatever the verify line is
+  # …or for pytest:
+  pytest packages/<pkg>/tests/<test_path> -k <failing_test> -x
+  ```
+  Already fixed if: the verify command returns clean (exit 0, no FAIL output) — a load-bearing PR merged after your baseline was captured. The fix in #4173 (macOS jq-1.6 empty-file salvage-prelude) had merged 7.5 hours before #4178 was filed on a stale baseline; running the verify line at file time would have surfaced that immediately. Cite the merging PR in the close comment.
+
+**Decision after probing:** If the gap is genuinely absent (the feature/setting/doc does not yet exist), file the issue normally. If the gap is already satisfied, either close the draft, pivot scope to a doc-only update that confirms the current state (e.g., "document that Container Insights is enabled and cite the Terraform attribute"), or — for `fix(test)` issues whose ACs are exhausted by "the test passes" — skip filing and post the verification-only evidence elsewhere (a comment on the parent issue, or no action at all). If the probe is ambiguous, treat as real and file normally — agents can do their own probe at pickup time per Step 4b in `.claude/skills/task/SKILL.md`.
 
 ## Priority Framework
 


### PR DESCRIPTION
## Summary

Step 4b's gap-probe catalog gains a `fix(test)` pattern (re-run the failing test's verify line verbatim before claiming) and a "verification-only close" outcome alongside the existing "reduced docs-only PR" outcome — for `fix(test)` issues whose ACs are exhausted by "the test passes" with no remaining PR to file. `docs/agent/issue-authoring.md` §Verify the gap exists before filing gets a sibling probe pattern that tells issue authors to re-run against `origin/main` (not their worktree branch) before filing, since worktree baselines are stale by definition. Came out of the #4178 / #4173 retro.

Closes #4184

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/SKILL.md only)
- [x] Verification evidence posted on issue (see A.8)
