### PR TITLE
fix(test): widen test_profile_shell_test sleep gaps to defeat CI jitter (#4188)

### DIFF
--- a/scripts/tests/test_profile_shell_test.sh
+++ b/scripts/tests/test_profile_shell_test.sh
@@ -95,17 +95,29 @@ assert_contains() {
 }
 
 # ─── Test 1: Three-section fixture; preserves exit code 0 ────────────────
+# NOTE — timing-jitter constraint (#4188): the sort-by-elapsed-desc
+# assertion below (Test 2) requires a strict ordering Test 3 > Test 2 >
+# Test 1 by wall-clock elapsed time. On a busy CI runner, scheduling
+# jitter can add 10s-100s of milliseconds to a `sleep` call, so the gaps
+# between sleeps must be wide enough that no realistic jitter can
+# reorder them. The 0.05 / 0.20 / 0.50 schedule below leaves a 4× gap
+# between successive sleeps, which makes a flip statistically
+# infeasible. The previous 0.02 / 0.04 / 0.06 schedule had only a 1.5×
+# gap and flaked under load (see #4188 / PR #4187 CI run 25433409933).
+# If you are tempted to reduce these sleeps to "speed up the test" —
+# don't. The deterministic ordering matters more than the ~0.7s of
+# extra wall-clock time.
 fixture1=$(make_fixture "fixture_basic.sh" '#!/usr/bin/env bash
 set -euo pipefail
 
 # Test 1: alpha
-sleep 0.02
+sleep 0.05
 
 # Test 2: beta
-sleep 0.04
+sleep 0.20
 
 # Test 3: gamma
-sleep 0.06
+sleep 0.50
 exit 0
 ')
 tsv1="$TMPDIR_TEST/fixture1.tsv"


### PR DESCRIPTION
## Summary

Widens the Test 1 fixture sleeps in `scripts/tests/test_profile_shell_test.sh` from `0.02 / 0.04 / 0.06` (1.5× gap) to `0.05 / 0.20 / 0.50` (4× gap) so CI scheduling jitter can't reorder them and flip the "summary is sorted by elapsed desc" assertion. Adds a regression-style comment above the fixture explaining the timing-jitter constraint so the next person debugging a flake here doesn't have to re-derive the failure mode.

This is **Option B** from the issue's two options. Option A (refactor the profiler to accept an `--elapsed-ms` override) was declined — it would bleed test-only surface area into the production profiler script for the benefit of one fixture. Option B is a minimal-surface, zero-production-impact fix.

Closes #4188

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Stress verification (locally on this worktree)
- [x] Ran `scripts/tests/test_profile_shell_test.sh` 50 times in a row via a stress loop with `PROFILE_SKIP_AC=1`. **Result: 0 sort-assertion flakes, 0 total failures.**
- [x] `grep -A 2 "scheduling jitter\|timing.jitter" scripts/tests/test_profile_shell_test.sh` finds the new regression note (AC #2).
- [x] `scripts/check-bash-compat.sh` is clean — no bash 4+ constructs introduced.

### Post-deploy verification
- [x] N/A — test-fixture-only change, no deployed component.
