### PR TITLE
docs(code-standards): codify ≥4x sleep-gap rule for shell-test fixtures (#4192)

### DIFF
--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -422,6 +422,10 @@ The wrapped test's exit code and PASS/FAIL count are preserved verbatim — the 
 
 The check exists because issue #4139's wall-clock optimization wasted iterations on a wrong hypothesis ("parse cost dominates") that this profiler would have falsified in one tool invocation — the actual cost was unconfigured `CI_POLL_INTERVAL=60` / `DEPLOY_GRACE_SECONDS=90` defaults sleeping 60-120s on `awaiting_ci`/`awaiting_deploy` sections. See #4176 for the full rationale.
 
+### Timing-sensitive shell-test fixtures (sleep-gap rule)
+
+Shell-test fixtures that use `sleep` to produce a deterministic ordering (e.g. asserting "sorted by elapsed desc") must use **at least a 4× gap between successive sleeps**. CI scheduling jitter routinely adds 10s-100s of milliseconds to a `sleep` call under load — gaps narrower than 4× can be reordered, flipping the assertion and producing a flake that gives no signal of being timing-related (see #4188 for the precedent: `0.02 / 0.04 / 0.06` flaked, `0.05 / 0.20 / 0.50` does not). When tempted to shrink the gap to "speed up the test," shrink the smallest sleep instead and keep the 4× ratio.
+
 ### Subagent responsibilities
 
 Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.


### PR DESCRIPTION
## Summary

Adds a 3-line subsection `### Timing-sensitive shell-test fixtures (sleep-gap rule)` to `docs/agent/code-standards.md` codifying the lesson learned in #4188: shell-test fixtures that use `sleep` to produce a deterministic ordering must use **at least a 4× gap between successive sleeps** to defeat CI scheduling jitter. Cites #4188 with the concrete `0.02/0.04/0.06` (flaked) → `0.05/0.20/0.50` (does not) precedent values from PR #4191.

The fixture-side regression note already lives in `scripts/tests/test_profile_shell_test.sh:98-107` (PR #4191). This doc note's job is discoverability — the next person writing a timing-sensitive shell-test fixture finds the rule in `code-standards.md` before shipping a flake.

Closes #4192

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — docs-only change, no deployed component
