### PR TITLE
ci(scraper-tests): guard against inline reingest-shape CapturedDocument(...) in tests/courts/ (#4190)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1101,6 +1101,24 @@ jobs:
         run: scripts/check-parse-document-reingest-safety.sh
 
   # ---------------------------------------------------------------
+  # Tests-use-reingest-helper guard: every reingest-shape regression
+  # test under packages/scraper-framework/tests/courts/ must use the
+  # shared make_reingest_cap_doc helper instead of constructing the
+  # cap_doc inline.  Test-side analog of parse-document-reingest-safety
+  # (#4141 production-side guard).  Closes the migration loop where
+  # #4134 had to be re-migrated in #4165 because it landed before the
+  # helper.  See #4190.  Note: do not quote the forbidden string in
+  # the step name (per docs/agent/code-standards.md §Hygiene-check
+  # CI steps).
+  # ---------------------------------------------------------------
+  tests-use-reingest-helper-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify reingest-shape regression tests use the shared helper
+        run: scripts/check-tests-use-reingest-helper.sh
+
+  # ---------------------------------------------------------------
   # Hardcoded model guard: enforce model ID centralization
   # ---------------------------------------------------------------
   hardcoded-models-check:
@@ -1726,7 +1744,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/scraper-framework/tests/test_check_tests_use_reingest_helper.py
+++ b/packages/scraper-framework/tests/test_check_tests_use_reingest_helper.py
@@ -1,0 +1,483 @@
+"""Tests for ``scripts/check_tests_use_reingest_helper.py`` (issue #4190).
+
+Validates the AST scanner that flags inline reingest-shape
+``CapturedDocument(...)`` constructions under
+``packages/scraper-framework/tests/courts/`` — the test-side analog of
+``check_parse_document_reingest_safety.py`` (#4141).
+
+Coverage:
+
+* No-violation case — the current ``tests/courts/`` tree is clean (the
+  three known consumers all use ``make_reingest_cap_doc``).
+* One-violation case — a fixture file containing the inline reingest
+  shape is correctly flagged.
+* False-positive avoidance — fully-populated ``CapturedDocument(...)``
+  calls (with ``case_number=`` or ``judge_name=``) are NOT flagged.
+* Edge cases — module-level helpers, ``**kwargs``, attribute access on
+  framework, syntactically broken files, vendored ``.venv``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Locate the script under test
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_PY_SCANNER = _SCRIPTS_DIR / "check_tests_use_reingest_helper.py"
+_BASH_WRAPPER = _SCRIPTS_DIR / "check-tests-use-reingest-helper.sh"
+
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+# ruff: noqa: E402
+check_tests_use_reingest_helper = importlib.import_module(
+    "check_tests_use_reingest_helper",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# Reingest-shape construction (only identifier fields; no parsed fields).
+# This is the shape that scripts/reingest_from_s3.py::_reparse_document
+# produces and that helpers/reingest.py::make_reingest_cap_doc encodes.
+_REINGEST_SHAPE_CALL = """\
+from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+    )
+"""
+
+# Fully-populated cap_doc — passes parsed fields like case_number,
+# judge_name, hearing_date.  Must NOT be flagged.
+_FULLY_POPULATED_CALL = """\
+from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+        case_number="ABC-123",
+        judge_name="Hon. Test Judge",
+        hearing_date=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+"""
+
+# Reingest-shape construction routed through the helper — this is the
+# desired pattern, must NOT be flagged because the call is now to
+# ``make_reingest_cap_doc``, not ``CapturedDocument`` directly.
+_HELPER_CALL = """\
+from helpers.reingest import make_reingest_cap_doc
+
+def make():
+    return make_reingest_cap_doc(
+        raw_content=b"hello",
+        scraper_id="ca-test",
+    )
+"""
+
+
+def _write_fixture(root: Path, relpath: str, content: str) -> Path:
+    path = root / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Tests for the AST classification helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFieldSets:
+    """The identifier and parsed field-sets are the test-side mirror of
+    helpers/reingest.py — drift between them would make the check
+    unsound.  These tests pin them explicitly."""
+
+    def test_identifier_fields_match_helper_constructor(self) -> None:
+        """The scanner's identifier set is the keyword set the helper
+        passes to CapturedDocument.  See helpers/reingest.py."""
+        expected = frozenset(
+            {
+                "document_id",
+                "scraper_id",
+                "state",
+                "county",
+                "court",
+                "source_url",
+                "capture_timestamp",
+                "content_format",
+                "raw_content",
+                "content_hash",
+            }
+        )
+        assert check_tests_use_reingest_helper._IDENTIFIER_FIELDS == expected
+
+    def test_parsed_fields_match_helper_default_set(self) -> None:
+        """The scanner's parsed set covers every field the helper leaves
+        at default — i.e. every field a reingest-shape cap_doc must NOT
+        populate."""
+        expected = frozenset(
+            {
+                "case_number",
+                "case_title",
+                "judge_name",
+                "hearing_date",
+                "ruling_text",
+                "ruling_text_html",
+                "outcome",
+                "motion_type",
+                "parties",
+                "extra",
+                "courthouse",
+                "department",
+            }
+        )
+        assert check_tests_use_reingest_helper._PARSED_FIELDS == expected
+
+    def test_no_overlap_between_identifier_and_parsed_sets(self) -> None:
+        """A field cannot be both an identifier and a parsed field."""
+        overlap = (
+            check_tests_use_reingest_helper._IDENTIFIER_FIELDS
+            & check_tests_use_reingest_helper._PARSED_FIELDS
+        )
+        assert overlap == frozenset(), f"Unexpected overlap: {overlap}"
+
+
+# ---------------------------------------------------------------------------
+# Tests for scan_file
+# ---------------------------------------------------------------------------
+
+
+class TestScanFile:
+    """The core ``scan_file`` function: takes a Path, returns a list of
+    ``(path, lineno)`` violations."""
+
+    def test_no_violation_clean_file(self, tmp_path: Path) -> None:
+        """A file with no CapturedDocument calls produces no violations."""
+        path = _write_fixture(
+            tmp_path,
+            "clean.py",
+            "def foo() -> int:\n    return 1\n",
+        )
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_flags_inline_reingest_shape(self, tmp_path: Path) -> None:
+        """A reingest-shape inline construction is flagged."""
+        path = _write_fixture(tmp_path, "violation.py", _REINGEST_SHAPE_CALL)
+        violations = check_tests_use_reingest_helper.scan_file(path)
+        assert len(violations) == 1
+        assert violations[0][0] == path
+        # The cap_doc construction starts at line 5 of the fixture
+        # (lines 1-3 are imports, line 4 is the def, line 5 is `return`).
+        # We only verify it lies inside the function body — exact lineno
+        # is implementation detail of how ast records ast.Call.lineno.
+        assert violations[0][1] >= 5
+
+    def test_does_not_flag_fully_populated(self, tmp_path: Path) -> None:
+        """A cap_doc with parsed fields (case_number, judge_name, ...) is NOT
+        flagged — it is exercising a non-reingest path."""
+        path = _write_fixture(tmp_path, "fully_populated.py", _FULLY_POPULATED_CALL)
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_does_not_flag_helper_call(self, tmp_path: Path) -> None:
+        """A call routed through ``make_reingest_cap_doc`` is NOT flagged
+        — the call's func is no longer ``CapturedDocument``."""
+        path = _write_fixture(tmp_path, "helper.py", _HELPER_CALL)
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_does_not_flag_partial_identifier_set(self, tmp_path: Path) -> None:
+        """A CapturedDocument call missing one of the identifier fields
+        (e.g. ``content_hash``) is NOT flagged — it is a partial /
+        custom construction the test author owns intentionally."""
+        path = _write_fixture(
+            tmp_path,
+            "partial.py",
+            textwrap.dedent("""\
+                from framework import CapturedDocument, ContentFormat
+                from datetime import datetime, UTC
+
+                def make():
+                    return CapturedDocument(
+                        document_id="d1",
+                        scraper_id="ca-test",
+                        state="CA",
+                        county="Test",
+                        court="Superior Court",
+                        source_url="https://example.com/x",
+                        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+                        content_format=ContentFormat.TEXT,
+                        raw_content=b"hello",
+                        # content_hash intentionally omitted
+                    )
+            """),
+        )
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_skips_starred_kwargs(self, tmp_path: Path) -> None:
+        """A call passing **kwargs is skipped — we cannot statically
+        determine its keyword set."""
+        path = _write_fixture(
+            tmp_path,
+            "starred.py",
+            textwrap.dedent("""\
+                from framework import CapturedDocument
+
+                def make(**kwargs):
+                    return CapturedDocument(**kwargs)
+            """),
+        )
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_handles_attribute_call(self, tmp_path: Path) -> None:
+        """``framework.CapturedDocument(...)`` (attribute access) is
+        treated identically to ``CapturedDocument(...)``."""
+        path = _write_fixture(
+            tmp_path,
+            "attr.py",
+            textwrap.dedent("""\
+                import framework
+                from framework import ContentFormat
+                from datetime import datetime, UTC
+
+                def make():
+                    return framework.CapturedDocument(
+                        document_id="d1",
+                        scraper_id="ca-test",
+                        state="CA",
+                        county="Test",
+                        court="Superior Court",
+                        source_url="https://example.com/x",
+                        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+                        content_format=ContentFormat.TEXT,
+                        raw_content=b"hello",
+                        content_hash="deadbeef" * 8,
+                    )
+            """),
+        )
+        violations = check_tests_use_reingest_helper.scan_file(path)
+        assert len(violations) == 1
+
+    def test_skips_syntax_error(self, tmp_path: Path) -> None:
+        """A syntactically broken file is skipped silently."""
+        path = _write_fixture(tmp_path, "broken.py", "class S(:  # syntax error\n    pass\n")
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_skips_unreadable_file(self, tmp_path: Path) -> None:
+        """A non-existent path returns no violations (does not raise)."""
+        path = tmp_path / "does_not_exist.py"
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+    def test_does_not_flag_unrelated_class_call(self, tmp_path: Path) -> None:
+        """A call to a class named something else (e.g. ``Document``) is
+        NOT flagged — we only look at calls whose func is
+        ``CapturedDocument``."""
+        path = _write_fixture(
+            tmp_path,
+            "other.py",
+            textwrap.dedent("""\
+                class Document:
+                    def __init__(self, **kw): ...
+
+                def make():
+                    return Document(
+                        document_id="d1",
+                        scraper_id="x",
+                        state="CA",
+                        county="T",
+                        court="C",
+                        source_url="u",
+                        capture_timestamp=None,
+                        content_format=None,
+                        raw_content=b"",
+                        content_hash="",
+                    )
+            """),
+        )
+        assert check_tests_use_reingest_helper.scan_file(path) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for the file walker
+# ---------------------------------------------------------------------------
+
+
+class TestIterPythonFiles:
+    """The file-walk helper that feeds scan_file."""
+
+    def test_finds_py_files_recursively(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "a.py", "")
+        _write_fixture(tmp_path, "sub/b.py", "")
+        _write_fixture(tmp_path, "sub/sub2/c.py", "")
+        files = check_tests_use_reingest_helper._iter_python_files(tmp_path)
+        names = sorted(p.name for p in files)
+        assert names == ["a.py", "b.py", "c.py"]
+
+    def test_excludes_venv(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "a.py", "")
+        _write_fixture(tmp_path, ".venv/lib/python3.12/site-packages/vendored.py", "")
+        files = check_tests_use_reingest_helper._iter_python_files(tmp_path)
+        names = sorted(p.name for p in files)
+        assert names == ["a.py"]
+
+    def test_excludes_pycache_and_node_modules(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "a.py", "")
+        _write_fixture(tmp_path, "__pycache__/x.py", "")
+        _write_fixture(tmp_path, "node_modules/pkg/y.py", "")
+        files = check_tests_use_reingest_helper._iter_python_files(tmp_path)
+        names = sorted(p.name for p in files)
+        assert names == ["a.py"]
+
+    def test_returns_sorted(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "z.py", "")
+        _write_fixture(tmp_path, "a.py", "")
+        _write_fixture(tmp_path, "m.py", "")
+        files = check_tests_use_reingest_helper._iter_python_files(tmp_path)
+        assert files == sorted(files)
+
+
+# ---------------------------------------------------------------------------
+# Tests for main()
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """End-to-end CLI shape via main()."""
+
+    def test_no_violation_returns_0_and_prints_nothing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_fixture(tmp_path, "clean.py", _HELPER_CALL)
+        rc = check_tests_use_reingest_helper.main(["--root", str(tmp_path)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_violation_returns_0_and_prints_violation_line(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        path = _write_fixture(tmp_path, "violation.py", _REINGEST_SHAPE_CALL)
+        rc = check_tests_use_reingest_helper.main(["--root", str(tmp_path)])
+        # main() always returns 0; the wrapper turns non-empty stdout
+        # into a non-zero exit.
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert str(path) in captured.out
+        assert "CapturedDocument(...)" in captured.out
+
+    def test_missing_root_returns_0(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Pointing --root at a non-existent directory returns 0 silently."""
+        nonexistent = tmp_path / "does-not-exist"
+        rc = check_tests_use_reingest_helper.main(["--root", str(nonexistent)])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_default_root_resolves_to_tests_courts(self) -> None:
+        """The default root resolves to the production tests/courts/ path."""
+        default_root = check_tests_use_reingest_helper._resolve_default_root()
+        assert default_root.name == "courts"
+        assert default_root.parent.name == "tests"
+        assert default_root.parent.parent.name == "scraper-framework"
+
+
+# ---------------------------------------------------------------------------
+# AC #3 — Production tree is clean (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+class TestProductionTreeIsClean:
+    """The current tests/courts/ tree must scan clean — the three known
+    consumers (#3986, #4133, #4134) all migrated to the helper."""
+
+    def test_default_root_has_zero_violations(self) -> None:
+        rc = check_tests_use_reingest_helper.main([])
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Bash wrapper integration test
+# ---------------------------------------------------------------------------
+
+
+class TestBashWrapper:
+    """The bash wrapper turns scanner stdout into an exit code (0/1)."""
+
+    def test_wrapper_exits_0_on_clean_tree(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "clean.py", _HELPER_CALL)
+        result = subprocess.run(
+            [str(_BASH_WRAPPER), str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_wrapper_exits_1_on_violation(self, tmp_path: Path) -> None:
+        _write_fixture(tmp_path, "violation.py", _REINGEST_SHAPE_CALL)
+        result = subprocess.run(
+            [str(_BASH_WRAPPER), str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "violation.py" in result.stdout
+
+    def test_wrapper_exits_0_on_default_production_tree(self) -> None:
+        """AC #1 — the wrapper passes against the real tests/courts/."""
+        result = subprocess.run(
+            [str(_BASH_WRAPPER)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_wrapper_fixture_dir_violation_format(self, tmp_path: Path) -> None:
+        """AC #2 — the issue specifies a fixture dir at
+        ``packages/scraper-framework/tests/_fixtures_for_check/``.  The
+        wrapper accepts a custom path argument and exits 1 with the
+        violation listed.  We exercise the same behavior with tmp_path."""
+        violation = _write_fixture(tmp_path, "violation.py", _REINGEST_SHAPE_CALL)
+        result = subprocess.run(
+            [str(_BASH_WRAPPER), str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert str(violation) in result.stdout

--- a/scripts/check-tests-use-reingest-helper.sh
+++ b/scripts/check-tests-use-reingest-helper.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# check-tests-use-reingest-helper.sh — Hygiene check enforcing the use of
+# the shared ``make_reingest_cap_doc`` helper for reingest-shape
+# regression tests under ``packages/scraper-framework/tests/courts/``.
+#
+# Why this check exists
+# ---------------------
+# Issue #4153 introduced
+# ``packages/scraper-framework/tests/helpers/reingest.py`` exporting the
+# shared ``make_reingest_cap_doc(...)`` helper.  Three regression tests
+# now use it:
+#
+#   * tests/courts/test_courtlistener.py            (#3986, migrated in #4153)
+#   * tests/courts/ca/test_cc_tentatives_portal.py  (#4133, migrated in #4153)
+#   * tests/courts/test_sf_civil_tentatives.py      (#4134, migrated in #4165)
+#
+# #4134 had to be re-migrated in #4165 because it landed *before* #4153
+# and built its own inline ``CapturedDocument(...)`` constructions.
+# Without this CI guard, the next scraper that needs a reingest-path
+# regression test could repeat the pattern — a fresh inline cap_doc
+# construction that drifts from the helper's contract.  This guard is
+# the test-side analog of #4141's production-side guard.
+#
+# What is a reingest-shape CapturedDocument call?
+# -----------------------------------------------
+# A ``CapturedDocument(...)`` call is reingest-shape when it passes a
+# superset of the identifier-fields set:
+#
+#   {document_id, scraper_id, state, county, court, source_url,
+#    capture_timestamp, content_format, raw_content, content_hash}
+#
+# AND does NOT pass any of:
+#
+#   {case_number, case_title, judge_name, hearing_date, ruling_text,
+#    ruling_text_html, outcome, motion_type, parties, extra,
+#    courthouse, department}
+#
+# These two conditions together define exactly the shape that
+# ``scripts/reingest_from_s3.py::_reparse_document`` produces.  Every
+# such cap_doc construction in tests/courts/ MUST go through
+# ``make_reingest_cap_doc(...)`` so the helper's contract is the
+# single source of truth.
+#
+# Issue
+# -----
+# #4190 (this check).  Helper: #4153.  Production analog: #4141.
+# Audit: #4046.  Failure-shape origin: #3986.
+#
+# Usage
+# -----
+#   scripts/check-tests-use-reingest-helper.sh        # scan default tests/courts/
+#   scripts/check-tests-use-reingest-helper.sh PATH   # scan a specific dir
+#                                                     # (used by tests)
+#
+# Exit codes
+# ----------
+#   0 — No inline reingest-shape CapturedDocument(...) constructions found.
+#   1 — At least one violation found.
+#   2 — Internal error (Python scanner failed to run).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCANNER="$REPO_ROOT/scripts/check_tests_use_reingest_helper.py"
+
+# ─── Resolve scan root ────────────────────────────────────────────────────
+# With no argument: scan the production tests/courts/ tree (the default).
+# With an argument: scan that path (used by tests for fixture isolation).
+if [[ $# -eq 0 ]]; then
+    SCAN_ARGS=()
+else
+    SCAN_ARGS=(--root "$1")
+fi
+
+# ─── Run the scanner ──────────────────────────────────────────────────────
+# The scanner emits one line per violation in the form:
+#   <path>:<lineno>:CapturedDocument(...)
+#
+# It always exits 0; an empty stdout means "no violations".  We capture
+# stdout and decide the wrapper's exit code from there — same split as
+# check-parse-document-reingest-safety.sh / check_parse_document_reingest_safety.py.
+if ! python_output="$(python3 "$SCANNER" ${SCAN_ARGS[@]+"${SCAN_ARGS[@]}"})"; then
+    echo "ERROR: scanner failed to run (see stderr above)." >&2
+    exit 2
+fi
+
+# ─── Report violations ────────────────────────────────────────────────────
+if [[ -z "${python_output// /}" ]]; then
+    exit 0
+fi
+
+violations=0
+echo "ERROR: Inline reingest-shape CapturedDocument(...) construction(s) in tests/courts/."
+echo ""
+echo "  A reingest-shape CapturedDocument call passes only the identifier"
+echo "  fields (document_id, scraper_id, state, county, court, source_url,"
+echo "  capture_timestamp, content_format, raw_content, content_hash) and"
+echo "  none of the parsed fields (case_number, case_title, judge_name,"
+echo "  hearing_date, ruling_text, ruling_text_html, outcome, motion_type,"
+echo "  parties, extra, courthouse, department).  Reingest regression"
+echo "  tests MUST use the shared helper instead:"
+echo ""
+echo "    from helpers.reingest import make_reingest_cap_doc"
+echo ""
+echo "    cap_doc = make_reingest_cap_doc("
+echo "        raw_content=raw,"
+echo "        scraper_id=\"<scraper-id>\","
+echo "        ...,"
+echo "    )"
+echo ""
+echo "  The helper centralizes the contract — the same cap_doc shape that"
+echo "  scripts/reingest_from_s3.py::_reparse_document produces — so every"
+echo "  test exercising the reingest path stays aligned.  See #4153 for"
+echo "  the helper, #4141 for the production-side guard, and #4046 for"
+echo "  the audit."
+echo ""
+echo "  Existing reingest-aware tests:"
+echo "    packages/scraper-framework/tests/courts/test_courtlistener.py"
+echo "    packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py"
+echo "    packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py"
+echo ""
+echo "  Violating call sites:"
+echo ""
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    echo "    $entry"
+    violations=$((violations + 1))
+done <<< "$python_output"
+
+if (( violations > 0 )); then
+    echo ""
+    echo "  Found $violations inline reingest-shape CapturedDocument(...) construction(s)."
+    exit 1
+fi
+
+exit 0

--- a/scripts/check_tests_use_reingest_helper.py
+++ b/scripts/check_tests_use_reingest_helper.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check_tests_use_reingest_helper.py — AST scanner enforcing the use of
+the shared ``make_reingest_cap_doc`` helper for reingest-shape regression
+tests under ``packages/scraper-framework/tests/courts/``.
+
+Driven by ``scripts/check-tests-use-reingest-helper.sh``.  See that
+wrapper for the full motivation, CI integration, and exit codes.
+
+Background
+----------
+Audit #4046 (``docs/investigations/parse_document-reingest-safety-2026-05.md``)
+established that production scrapers' ``parse_document`` methods MUST
+populate every relevant field from ``raw_content`` alone, because
+``scripts/reingest_from_s3.py::_reparse_document`` constructs a fresh
+``CapturedDocument`` carrying only ``raw_content`` + identifier fields
+and clears all parsed fields it does not re-derive.
+
+Issue #4153 introduced ``packages/scraper-framework/tests/helpers/reingest.py``
+exporting ``make_reingest_cap_doc(...)`` — a shared helper that
+constructs exactly that reingest-shape ``CapturedDocument``.  The
+production-side guard (``scripts/check-parse-document-reingest-safety.sh``
+from #4141) enforces that Live-only ``parse_document`` implementations
+carry a docstring marker about the reingest hazard.  This check is the
+test-side analog: it enforces that any new reingest-path regression
+test under ``tests/courts/`` uses the shared helper instead of
+constructing the cap_doc inline.
+
+Three migrations took place because of structural drift:
+
+* #4153 (the helper) + ``test_courtlistener.py`` migrated in #4153
+* ``test_cc_tentatives_portal.py`` (#4133) migrated in #4153
+* ``test_sf_civil_tentatives.py`` (#4134) migrated in #4165
+
+#4134 had to be re-migrated in #4165 because it landed *before* #4153
+and built its own inline ``CapturedDocument(...)`` constructions.  The
+audit in #4046 anticipated this loop, but there was no CI guard
+preventing the next scraper from doing the same thing.  This check
+closes that loop.
+
+What "reingest-shape" means
+---------------------------
+A ``CapturedDocument(...)`` call is **reingest-shape** when its
+keyword-argument set is a *superset* of the identifier-fields set:
+
+    {document_id, scraper_id, state, county, court, source_url,
+     capture_timestamp, content_format, raw_content, content_hash}
+
+AND it does NOT pass any of the parsed-field set (mirroring
+``_PARSE_POPULATED_SCALAR_FIELDS`` from ``helpers/reingest.py``):
+
+    {case_number, case_title, judge_name, hearing_date, ruling_text,
+     ruling_text_html, outcome, motion_type, parties, extra,
+     courthouse, department}
+
+The "superset" rule lets test cases override identifier-default values
+(e.g. ``content_format=ContentFormat.PDF``) without tripping the check.
+The "no parsed fields" rule is what distinguishes a reingest-shape
+construction from a fully-populated cap_doc — once a test passes
+``case_number=`` or ``hearing_date=``, it is exercising a different
+path than the reingest one and the helper does not apply.
+
+If the call passes ``**kwargs`` (a starred-keyword-arg) we cannot
+classify it — we conservatively skip such calls (no violation).
+
+What this script does
+---------------------
+1. AST-parses every ``.py`` file under
+   ``packages/scraper-framework/tests/courts/`` (recursively).
+2. For each ``ast.Call`` whose ``func`` is a ``Name`` or ``Attribute``
+   ending in ``CapturedDocument``, classifies the call shape.
+3. For each reingest-shape inline call, prints one line in the form
+   ``<path>:<lineno>:CapturedDocument(...)``.
+
+Usage
+-----
+
+    python3 scripts/check_tests_use_reingest_helper.py
+
+    # Override scan root (used by the wrapper's --root flag and tests):
+    python3 scripts/check_tests_use_reingest_helper.py --root <DIR>
+
+Exit codes
+----------
+
+  0 — Always.  The wrapper turns the printed-violations stream into a
+       non-zero exit, mirroring the convention used by
+       ``check_parse_document_reingest_safety.py`` (#4141) and
+       ``check_no_redos_pattern.py`` (#4117).
+
+Issue
+-----
+* This guard:           #4190
+* Helper:               #4153
+* Migrated tests:       #4153, #4133, #4165
+* Production analog:    #4141 (audit #4046)
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+# ─── Field-set contract ───────────────────────────────────────────────────
+# Identifier fields the reingest helper (helpers/reingest.py) sets.  A
+# reingest-shape call must pass at least these — i.e. its keywords are
+# a superset of this set.  Mirrors the constructor argument list of
+# ``make_reingest_cap_doc`` (the helper) and ``_reparse_document`` (the
+# production reingest path in ``scripts/reingest_from_s3.py``).
+_IDENTIFIER_FIELDS: frozenset[str] = frozenset(
+    {
+        "document_id",
+        "scraper_id",
+        "state",
+        "county",
+        "court",
+        "source_url",
+        "capture_timestamp",
+        "content_format",
+        "raw_content",
+        "content_hash",
+    }
+)
+
+# Parsed fields the reingest helper leaves at default.  A reingest-shape
+# call MUST NOT pass any of these — once any parsed field is set, the
+# call is exercising a non-reingest code path.  Mirrors
+# ``_PARSE_POPULATED_SCALAR_FIELDS`` plus the list/dict fields
+# (``parties``, ``extra``) and the courthouse/department geographic
+# fields, per the issue #4190 spec.
+_PARSED_FIELDS: frozenset[str] = frozenset(
+    {
+        "case_number",
+        "case_title",
+        "judge_name",
+        "hearing_date",
+        "ruling_text",
+        "ruling_text_html",
+        "outcome",
+        "motion_type",
+        "parties",
+        "extra",
+        "courthouse",
+        "department",
+    }
+)
+
+
+# ─── AST helpers ──────────────────────────────────────────────────────────
+def _is_captured_document_call(call: ast.Call) -> bool:
+    """Return True if the call's ``func`` resolves to ``CapturedDocument``.
+
+    Matches both bare-name calls (``CapturedDocument(...)`` after a
+    ``from framework import CapturedDocument``) and attribute calls
+    (``framework.CapturedDocument(...)``)."""
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id == "CapturedDocument"
+    if isinstance(func, ast.Attribute):
+        return func.attr == "CapturedDocument"
+    return False
+
+
+def _has_starred_kwargs(call: ast.Call) -> bool:
+    """Return True if the call passes a ``**kwargs``.
+
+    AST encodes ``f(**d)`` as a ``keyword`` whose ``arg`` is ``None``.
+    When this is present we cannot statically determine the keyword
+    set, so we skip the call (no violation)."""
+    return any(kw.arg is None for kw in call.keywords)
+
+
+def _is_reingest_shape(call: ast.Call) -> bool:
+    """Return True if the call's keyword set matches the reingest shape.
+
+    Rules (see module docstring):
+
+    * keyword set is a superset of ``_IDENTIFIER_FIELDS``
+    * no keyword in ``_PARSED_FIELDS`` is present
+    * no ``**kwargs`` (handled separately by the caller)
+    """
+    keyword_names = {kw.arg for kw in call.keywords if kw.arg is not None}
+    if not _IDENTIFIER_FIELDS.issubset(keyword_names):
+        return False
+    if keyword_names & _PARSED_FIELDS:
+        return False
+    return True
+
+
+# ─── File scanning ────────────────────────────────────────────────────────
+def scan_file(path: Path) -> list[tuple[Path, int]]:
+    """Scan one Python file for inline reingest-shape ``CapturedDocument(...)``
+    calls.  Returns a list of ``(path, lineno)`` violations.
+    Syntactically broken files are skipped silently (mirrors the
+    ``check_no_redos_pattern.py`` / ``check_parse_document_reingest_safety.py``
+    convention)."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    violations: list[tuple[Path, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_captured_document_call(node):
+            continue
+        if _has_starred_kwargs(node):
+            continue
+        if _is_reingest_shape(node):
+            violations.append((path, node.lineno))
+    return violations
+
+
+def _iter_python_files(root: Path) -> list[Path]:
+    """Walk ``root`` and return every ``.py`` file, excluding common
+    vendored / generated directories."""
+    excluded_dirs = {".venv", "__pycache__", "node_modules", ".git"}
+    files: list[Path] = []
+    for child in root.rglob("*.py"):
+        if any(part in excluded_dirs for part in child.parts):
+            continue
+        files.append(child)
+    return sorted(files)
+
+
+# ─── CLI ──────────────────────────────────────────────────────────────────
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scan tests under packages/scraper-framework/tests/courts/ "
+            "for inline reingest-shape CapturedDocument(...) constructions "
+            "(issue #4190)."
+        )
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help=(
+            "Override the scan root.  Defaults to "
+            "<repo>/packages/scraper-framework/tests/courts/."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_default_root() -> Path:
+    """The default scan root is the tests/courts/ tree.  Resolve relative
+    to this script's location so the script works regardless of cwd."""
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    return repo_root / "packages" / "scraper-framework" / "tests" / "courts"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    root: Path = args.root or _resolve_default_root()
+
+    if not root.exists():
+        # Silent skip: an empty / missing root produces no violations.
+        # Mirrors check_parse_document_reingest_safety.py.
+        return 0
+
+    violations: list[tuple[Path, int]] = []
+    for py in _iter_python_files(root):
+        violations.extend(scan_file(py))
+
+    for path, lineno in violations:
+        print(f"{path}:{lineno}:CapturedDocument(...)")
+
+    # Always exit 0 — the wrapper interprets non-empty stdout as
+    # a failure.  See module docstring "Exit codes".
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_tests_use_reingest_helper.sh
+++ b/scripts/tests/test_check_tests_use_reingest_helper.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# test_check_tests_use_reingest_helper.sh — Tests for
+# check-tests-use-reingest-helper.sh (issue #4190).
+#
+# Mirrors the structure of test_check_parse_document_reingest_safety.sh
+# (#4141): synthesizes Python files exercising the scanner's
+# pass-and-fail cases — reingest-shape inline construction (fails),
+# fully-populated cap_doc (passes), helper-routed call (passes), etc.
+#
+# Usage:
+#   scripts/tests/test_check_tests_use_reingest_helper.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-tests-use-reingest-helper.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Reingest-shape inline call FAILS ────────────────────────────
+create_test_file "reingest_shape.py" 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+    )
+' > /dev/null
+assert_fails "Reingest-shape inline CapturedDocument fails"
+reset_tmpdir
+
+# ─── Test 2: Fully-populated cap_doc PASSES ──────────────────────────────
+create_test_file "fully_populated.py" 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+        case_number="ABC-123",
+        judge_name="Hon. Test Judge",
+        hearing_date=datetime(2026, 2, 1, tzinfo=UTC),
+    )
+' > /dev/null
+assert_passes "Fully-populated CapturedDocument (case_number, judge_name) passes"
+reset_tmpdir
+
+# ─── Test 3: Helper-routed call PASSES ───────────────────────────────────
+create_test_file "helper_call.py" 'from helpers.reingest import make_reingest_cap_doc
+
+def make():
+    return make_reingest_cap_doc(
+        raw_content=b"hello",
+        scraper_id="ca-test",
+    )
+' > /dev/null
+assert_passes "make_reingest_cap_doc(...) passes (not a CapturedDocument call)"
+reset_tmpdir
+
+# ─── Test 4: Call passing extra (parsed-set) field FAILS as PASSES ───────
+# A call passing only ``extra={...}`` plus identifiers is NOT reingest
+# shape — ``extra`` is in the parsed-fields set, so its presence
+# excludes the call from the violation set.
+create_test_file "with_extra.py" 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+        extra={"flag": True},
+    )
+' > /dev/null
+assert_passes "CapturedDocument(..., extra={...}) is not reingest-shape"
+reset_tmpdir
+
+# ─── Test 5: Partial identifier set PASSES ───────────────────────────────
+# Missing one of the identifier fields means the call is not a complete
+# reingest-shape — it's a custom partial construction.
+create_test_file "partial.py" 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+    )
+' > /dev/null
+assert_passes "Partial identifier set (missing content_hash) passes"
+reset_tmpdir
+
+# ─── Test 6: ``**kwargs`` skipped silently ───────────────────────────────
+create_test_file "starred.py" 'from framework import CapturedDocument
+
+def make(**kwargs):
+    return CapturedDocument(**kwargs)
+' > /dev/null
+assert_passes "**kwargs CapturedDocument call skipped"
+reset_tmpdir
+
+# ─── Test 7: Multiple violations in one file FAIL ────────────────────────
+create_test_file "multi.py" 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make_a():
+    return CapturedDocument(
+        document_id="a",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/a",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"a",
+        content_hash="aa",
+    )
+
+def make_b():
+    return CapturedDocument(
+        document_id="b",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/b",
+        capture_timestamp=datetime(2026, 1, 2, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"b",
+        content_hash="bb",
+    )
+' > /dev/null
+assert_fails "Multiple inline reingest-shape calls in one file fail"
+reset_tmpdir
+
+# ─── Test 8: Mixed pass+fail tree fails ──────────────────────────────────
+create_test_file "good_and_bad/good.py" 'from helpers.reingest import make_reingest_cap_doc
+
+def make():
+    return make_reingest_cap_doc(raw_content=b"x", scraper_id="ca-test")
+' > /dev/null
+create_test_file "good_and_bad/bad.py" 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+    )
+' > /dev/null
+assert_fails "Mixed pass+fail tree fails because of the bad file"
+reset_tmpdir
+
+# ─── Test 9: Empty file passes ───────────────────────────────────────────
+create_test_file "empty.py" '"""Empty module."""
+' > /dev/null
+assert_passes "Empty module passes"
+reset_tmpdir
+
+# ─── Test 10: Syntactically broken Python is skipped silently ────────────
+create_test_file "broken.py" 'class S(:  # syntax error
+    pass
+' > /dev/null
+assert_passes "Syntactically broken Python is skipped silently"
+reset_tmpdir
+
+# ─── Test 11: AST scan ignores .venv/ subdir ─────────────────────────────
+mkdir -p "$TMPDIR_TEST/.venv/lib/python3.12/site-packages"
+printf '%s\n' 'from framework import CapturedDocument, ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+    )
+' > "$TMPDIR_TEST/.venv/lib/python3.12/site-packages/vendored.py"
+assert_passes ".venv/ subdir is excluded from the scan"
+reset_tmpdir
+
+# ─── Test 12: framework.CapturedDocument(...) attribute call FAILS ───────
+create_test_file "attr.py" 'import framework
+from framework import ContentFormat
+from datetime import datetime, UTC
+
+def make():
+    return framework.CapturedDocument(
+        document_id="d1",
+        scraper_id="ca-test",
+        state="CA",
+        county="Test",
+        court="Test Superior Court",
+        source_url="https://example.com/x",
+        capture_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        content_format=ContentFormat.TEXT,
+        raw_content=b"hello",
+        content_hash="deadbeef" * 8,
+    )
+' > /dev/null
+assert_fails "Attribute call framework.CapturedDocument(...) is detected"
+reset_tmpdir
+
+# ─── Test 13: Direct production-tree run reports zero violations ─────────
+# Defense-in-depth — the production tree (the default scan root) is
+# clean today (after #4153, #4133, #4165 migrated the three known
+# consumers to the helper).
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: Production tests/courts/ tree passes the check"
+else
+    echo "FAIL: Production tests/courts/ tree fails the check (expected pass)"
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
+
+# ─── Test 14: No self-match on ci.yml step name ──────────────────────────
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-tests-use-reingest-helper.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Test-side analog of #4141 — adds an AST scanner + bash wrapper + CI hygiene job that flags inline reingest-shape `CapturedDocument(...)` calls under `packages/scraper-framework/tests/courts/`. Reingest-path regression tests must use the shared `make_reingest_cap_doc` helper from `tests/helpers/reingest.py` (#4153) instead of constructing the cap_doc inline. Closes the migration loop where #4134 had to be re-migrated in #4165 because it landed before the helper.

Closes #4190

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (26 pytest cases + 14 bash cases all pass locally)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check only; runs in GitHub Actions, no service deploy)
- [x] Verification evidence posted on issue (see A.8)
