### PR TITLE
fix(deps): align anthropic SDK lower bound to >=0.40 (#3297)

### DIFF
--- a/packages/nlp-pipeline/pyproject.toml
+++ b/packages/nlp-pipeline/pyproject.toml
@@ -12,7 +12,7 @@ description = "NLP processing pipeline for Judgemind court documents"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-    "anthropic>=0.21",
+    "anthropic>=0.40",
     "boto3>=1.34",
     "pydantic>=2.6",
     "structlog>=24.1",


### PR DESCRIPTION
## Summary

Bumps the `anthropic` SDK lower bound in `packages/nlp-pipeline/pyproject.toml` from `>=0.21` to `>=0.40` to match `packages/scraper-framework/pyproject.toml`. Eliminates the sub-SDK divergence flagged by `/audit` Category 1.7 (Dependency Health) — both packages now resolve to the same SDK generation in shared installs and CI.

Closes #3297

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (build-time dependency pin only; affected only at install/CI time, no runtime behavior change since `anthropic 0.99.0` was already being resolved against the open `>=0.21` floor)
