### PR TITLE
ci(api): forbid instanceof GraphQL*Type in graphql walker source (#4198)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1243,6 +1243,27 @@ jobs:
         run: scripts/check-no-api-github-fetch.sh
 
   # ---------------------------------------------------------------
+  # Realm-stable type discriminator guard: api graphql walker source
+  # must use Symbol.toStringTag, not instanceof, against graphql-js
+  # type classes (#4198). Vitest's ESM loader and Apollo Server's CJS
+  # realm produce two class identities for the same conceptual type;
+  # instanceof silently returns false across the gap and collapses
+  # every type to a scalar leaf. Recurred in #4101 after #4112 first
+  # documented the workaround — the docstring isn't load-bearing
+  # without a CI-enforced guard. The step name below intentionally
+  # avoids quoting the forbidden token (per docs/agent/code-standards.md
+  # §Hygiene-check CI steps and #2541/#2542).
+  # ---------------------------------------------------------------
+  no-graphql-instanceof-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce realm-stable type discriminators in api graphql walker
+        run: scripts/check-no-graphql-instanceof.sh
+
+  # ---------------------------------------------------------------
   # Dispatcher terminal-status sync guard (#2863)
   # ---------------------------------------------------------------
   dispatcher-terminal-statuses-check:
@@ -1744,7 +1765,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/api/src/graphql/cost-breakdown.ts
+++ b/packages/api/src/graphql/cost-breakdown.ts
@@ -62,6 +62,16 @@ import {
   type SelectionSetNode,
   Kind,
 } from 'graphql';
+// Realm-stable type discriminators — see realm-stable-type-checks.ts
+// for the full background. CI guards against a future regression
+// reaching for `instanceof GraphQLObjectType` again
+// (`scripts/check-no-graphql-instanceof.sh`, issue #4198).
+import {
+  type CompositeTypeLike,
+  isComposite,
+  isObjectOrInterface,
+  typeTag,
+} from './realm-stable-type-checks';
 
 /**
  * Default cost-rule options must match the constants exported by
@@ -114,59 +124,13 @@ const SELF_SUFFIX = ':__self';
 const TRUNCATED_KEY = '__truncated';
 
 /**
- * Read `Symbol.toStringTag` on a graphql-js type, falling back to the
- * constructor name. graphql-js sets `[Symbol.toStringTag]` on every
- * type class (e.g. `'GraphQLNonNull'`, `'GraphQLList'`,
- * `'GraphQLObjectType'`), so this is a realm-stable discriminator —
- * unlike `instanceof`, which is bound to a specific realm's class
- * identity.
- *
- * Same approach as `cost-rule-estimator.ts` — vitest's ESM loader can
- * resolve `graphql` and `graphql/index.mjs` as distinct module
- * instances, which makes `field.type instanceof GraphQLObjectType`
- * return `false` for a structurally-correct object type and silently
- * collapse everything to scalar leaf cost. The `costLimitPlugin`
- * passes its Apollo-Server-built (CJS realm) schema into
- * `computeBreakdown`, which in test runs ESM — the realm gap is real
- * and verified.
- */
-function typeTag(t: unknown): string | undefined {
-  if (t == null || typeof t !== 'object') return undefined;
-  const sym = (t as { [Symbol.toStringTag]?: string })[Symbol.toStringTag];
-  if (typeof sym === 'string') return sym;
-  const ctor = (t as { constructor?: { name?: string } }).constructor;
-  return ctor?.name;
-}
-
-function isComposite(named: GraphQLOutputType): boolean {
-  const tag = typeTag(named);
-  return (
-    tag === 'GraphQLObjectType' ||
-    tag === 'GraphQLInterfaceType' ||
-    tag === 'GraphQLUnionType'
-  );
-}
-
-/**
- * Composite type as duck-typed by graphql-js's Object/Interface
- * surface (the only methods this module needs). Using a structural
- * type instead of the realm-bound `GraphQLObjectType | GraphQLInterfaceType`
- * union keeps the walker realm-stable — see the `typeTag` docstring.
- */
-interface CompositeTypeLike {
-  name: string;
-  getFields(): Record<string, { type: GraphQLOutputType }>;
-}
-
-/** True only for Object/Interface types — Union types have no `.getFields()`. */
-function isObjectOrInterface(t: unknown): t is CompositeTypeLike {
-  const tag = typeTag(t);
-  return tag === 'GraphQLObjectType' || tag === 'GraphQLInterfaceType';
-}
-
-/**
  * Unwrap NonNull/List wrappers and return the unwrapped (named) type
  * plus the cumulative list-factor multiplier picked up along the way.
+ *
+ * `typeTag` (and the `isComposite` / `isObjectOrInterface` helpers
+ * used elsewhere in this file) come from
+ * `realm-stable-type-checks.ts` — see that file's docstring for the
+ * realm-clash rationale.
  */
 function unwrapType(
   type: GraphQLOutputType,

--- a/packages/api/src/graphql/cost-rule-estimator.ts
+++ b/packages/api/src/graphql/cost-rule-estimator.ts
@@ -53,6 +53,11 @@ import type { GraphQLOutputType } from 'graphql';
 // this file. The signature comes from the same `/cjs` subpath the
 // production wiring uses, for consistency.
 import type { ComplexityEstimator } from 'graphql-query-complexity/cjs';
+// Realm-stable type discriminators — see realm-stable-type-checks.ts
+// for the full background. CI guards against a future regression
+// reaching for `instanceof GraphQLObjectType` again
+// (`scripts/check-no-graphql-instanceof.sh`, issue #4198).
+import { typeTag } from './realm-stable-type-checks';
 
 /**
  * Cost of one scalar / enum / `__typename` leaf, before list factor is
@@ -74,22 +79,6 @@ export const OBJECT_COST = 0;
  * `listFactor: 10` default.
  */
 export const LIST_FACTOR = 10;
-
-/**
- * Read `Symbol.toStringTag` on a type, falling back to the
- * constructor name. graphql-js sets `[Symbol.toStringTag]` on every
- * type class (e.g. `'GraphQLNonNull'`, `'GraphQLList'`,
- * `'GraphQLObjectType'`), so this is a realm-stable discriminator —
- * unlike `instanceof`, which is bound to a specific realm's class
- * identity.
- */
-function typeTag(t: unknown): string | undefined {
-  if (t == null || typeof t !== 'object') return undefined;
-  const sym = (t as { [Symbol.toStringTag]?: string })[Symbol.toStringTag];
-  if (typeof sym === 'string') return sym;
-  const ctor = (t as { constructor?: { name?: string } }).constructor;
-  return ctor?.name;
-}
 
 /**
  * Unwrap `NonNull`/`List` wrappers and return the named (innermost)

--- a/packages/api/src/graphql/realm-stable-type-checks.ts
+++ b/packages/api/src/graphql/realm-stable-type-checks.ts
@@ -1,0 +1,90 @@
+/**
+ * Realm-stable graphql-js type discriminators.
+ *
+ * Why this file exists
+ * --------------------
+ * graphql-js maintains separate class identities across its CJS and
+ * ESM builds. The library's own `instanceOf` helper at
+ * `graphql/jsutils/instanceOf.mjs` even throws when both realms have
+ * loaded. Vitest's ESM loader can resolve `graphql` and
+ * `graphql/index.mjs` as distinct module instances, and Apollo Server
+ * pins itself to the CJS realm (see the `/cjs` subpath import in
+ * `cost-limit-plugin.ts`). Consequence: a check like
+ *
+ *   field.type instanceof GraphQLObjectType
+ *
+ * silently returns `false` for a structurally-correct object type
+ * when the schema and the walker live in different realms — every
+ * type collapses to a scalar leaf with no error or warning.
+ *
+ * The realm-stable workaround is `Symbol.toStringTag`. graphql-js
+ * sets it on every type class (e.g. `'GraphQLObjectType'`,
+ * `'GraphQLNonNull'`), and the symbol value is the same string
+ * regardless of which realm produced the class. This file centralizes
+ * the helpers so the api graphql walker source has exactly one place
+ * to maintain them — and `scripts/check-no-graphql-instanceof.sh`
+ * enforces by CI that no future walker reaches for `instanceof`
+ * again. See issues #4101 and #4198.
+ *
+ * Scope: `packages/api/src/graphql/`. Other directories do not
+ * import from `graphql` directly so the realm question does not
+ * arise.
+ */
+
+import type { GraphQLOutputType } from 'graphql';
+
+/**
+ * Read `Symbol.toStringTag` on a graphql-js type, falling back to
+ * the constructor name. Returns `undefined` for non-objects.
+ *
+ * graphql-js sets `[Symbol.toStringTag]` on every type class, so
+ * this is a realm-stable discriminator — unlike `instanceof`, which
+ * is bound to a specific realm's class identity.
+ */
+export function typeTag(t: unknown): string | undefined {
+  if (t == null || typeof t !== 'object') return undefined;
+  const sym = (t as { [Symbol.toStringTag]?: string })[Symbol.toStringTag];
+  if (typeof sym === 'string') return sym;
+  const ctor = (t as { constructor?: { name?: string } }).constructor;
+  return ctor?.name;
+}
+
+/**
+ * Composite type as duck-typed by graphql-js's Object/Interface
+ * surface (the only methods the api graphql walker source needs).
+ * Using a structural type instead of the realm-bound
+ * `GraphQLObjectType | GraphQLInterfaceType` union keeps the walker
+ * realm-stable — see the file-level docstring.
+ */
+export interface CompositeTypeLike {
+  name: string;
+  getFields(): Record<string, { type: GraphQLOutputType }>;
+}
+
+/**
+ * True for Object, Interface, AND Union types — i.e. anything whose
+ * leaf cost in the cost-rule walker is `OBJECT_COST` rather than
+ * `SCALAR_COST`. Note: Union types do NOT satisfy
+ * `CompositeTypeLike` (they have no `.getFields()`); use
+ * `isObjectOrInterface` when you need to narrow to something with
+ * `.getFields()`.
+ */
+export function isComposite(named: GraphQLOutputType): boolean {
+  const tag = typeTag(named);
+  return (
+    tag === 'GraphQLObjectType' ||
+    tag === 'GraphQLInterfaceType' ||
+    tag === 'GraphQLUnionType'
+  );
+}
+
+/**
+ * Type predicate narrowing to `CompositeTypeLike` — true only for
+ * Object/Interface types (Union has no `.getFields()`). Use this
+ * when you need to descend into a selection set; use `isComposite`
+ * when you only need to know "does this type cost `OBJECT_COST`?".
+ */
+export function isObjectOrInterface(t: unknown): t is CompositeTypeLike {
+  const tag = typeTag(t);
+  return tag === 'GraphQLObjectType' || tag === 'GraphQLInterfaceType';
+}

--- a/packages/api/src/graphql/realm-stable-type-checks.unit.test.ts
+++ b/packages/api/src/graphql/realm-stable-type-checks.unit.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the realm-stable graphql-js type discriminators
+ * (issue #4198).
+ *
+ * The helpers in `realm-stable-type-checks.ts` exist because
+ * `instanceof GraphQLObjectType` silently returns `false` across the
+ * vitest-ESM / Apollo-CJS realm gap. Tests here cover the
+ * Symbol.toStringTag-based replacements directly.
+ *
+ * The cross-realm scenario itself is exercised end-to-end by the
+ * cost-limit-plugin and cost-breakdown unit tests — they build a
+ * schema in one realm and walk it in another. These tests pin the
+ * pure-function semantics of `typeTag`, `isComposite`, and
+ * `isObjectOrInterface` against synthesized objects so a future
+ * refactor cannot quietly change their meaning.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  typeTag,
+  isComposite,
+  isObjectOrInterface,
+} from './realm-stable-type-checks';
+
+/** Synthesize a graphql-js-shaped object with a given Symbol.toStringTag. */
+function tagged(tag: string, extra: Record<string, unknown> = {}): unknown {
+  return { [Symbol.toStringTag]: tag, ...extra };
+}
+
+describe('typeTag', () => {
+  it('returns the Symbol.toStringTag value when present', () => {
+    expect(typeTag(tagged('GraphQLObjectType'))).toBe('GraphQLObjectType');
+    expect(typeTag(tagged('GraphQLNonNull'))).toBe('GraphQLNonNull');
+    expect(typeTag(tagged('GraphQLList'))).toBe('GraphQLList');
+  });
+
+  it('falls back to the constructor name when the symbol is missing', () => {
+    class GraphQLEnumType {}
+    const inst = new GraphQLEnumType();
+    expect(typeTag(inst)).toBe('GraphQLEnumType');
+  });
+
+  it('returns undefined for null, undefined, primitives', () => {
+    expect(typeTag(null)).toBeUndefined();
+    expect(typeTag(undefined)).toBeUndefined();
+    expect(typeTag('GraphQLObjectType')).toBeUndefined();
+    expect(typeTag(42)).toBeUndefined();
+    expect(typeTag(true)).toBeUndefined();
+  });
+});
+
+describe('isComposite', () => {
+  it('is true for Object, Interface, and Union', () => {
+    // We cast through unknown because the helpers accept any
+    // graphql-js-shaped object — the realm-bound GraphQLOutputType
+    // type is irrelevant at runtime.
+    expect(isComposite(tagged('GraphQLObjectType') as never)).toBe(true);
+    expect(isComposite(tagged('GraphQLInterfaceType') as never)).toBe(true);
+    expect(isComposite(tagged('GraphQLUnionType') as never)).toBe(true);
+  });
+
+  it('is false for Scalar, Enum, NonNull, List', () => {
+    expect(isComposite(tagged('GraphQLScalarType') as never)).toBe(false);
+    expect(isComposite(tagged('GraphQLEnumType') as never)).toBe(false);
+    expect(isComposite(tagged('GraphQLNonNull') as never)).toBe(false);
+    expect(isComposite(tagged('GraphQLList') as never)).toBe(false);
+  });
+});
+
+describe('isObjectOrInterface', () => {
+  it('is true for Object and Interface, NOT for Union', () => {
+    // Union types do not have `.getFields()`, so this narrower
+    // predicate excludes them. cost-breakdown.ts relies on this when
+    // it descends into a selection set.
+    expect(isObjectOrInterface(tagged('GraphQLObjectType'))).toBe(true);
+    expect(isObjectOrInterface(tagged('GraphQLInterfaceType'))).toBe(true);
+    expect(isObjectOrInterface(tagged('GraphQLUnionType'))).toBe(false);
+  });
+
+  it('is false for non-types', () => {
+    expect(isObjectOrInterface(null)).toBe(false);
+    expect(isObjectOrInterface(undefined)).toBe(false);
+    expect(isObjectOrInterface({})).toBe(false);
+    expect(isObjectOrInterface('GraphQLObjectType')).toBe(false);
+  });
+});

--- a/scripts/check-no-graphql-instanceof.sh
+++ b/scripts/check-no-graphql-instanceof.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# check-no-graphql-instanceof.sh — Forbid `instanceof GraphQL*Type`
+# discriminator checks in the api graphql walker source.
+#
+# Background — the realm clash
+# ────────────────────────────
+# graphql-js maintains separate class identities across its CJS and ESM
+# builds (the `instanceOf` helper at `graphql/jsutils/instanceOf.mjs`
+# even throws when both realms have loaded). Vitest's ESM loader can
+# resolve `graphql` and `graphql/index.mjs` as distinct module
+# instances; Apollo Server pins itself to the CJS realm via the
+# `/cjs` subpath import in `cost-limit-plugin.ts`. This means
+# `field.type instanceof GraphQLObjectType` silently returns `false`
+# for a structurally-correct object type when the schema was built in
+# one realm and the walker imports `GraphQLObjectType` from the other —
+# every type collapses to a scalar leaf with no error or warning.
+#
+# Issue #4101 hit this exact bug a second time (after #4112 first
+# documented the workaround in `cost-rule-estimator.ts`). The cure is
+# `Symbol.toStringTag` — graphql-js sets it on every type class, so it
+# is realm-stable. See `packages/api/src/graphql/realm-stable-type-checks.ts`
+# for the canonical helpers.
+#
+# What this guard scans
+# ─────────────────────
+# Any `instanceof GraphQLObjectType` / `GraphQLInterfaceType` /
+# `GraphQLUnionType` / `GraphQLList` / `GraphQLNonNull` in any
+# `packages/api/src/graphql/**/*.ts` file (excluding `*.test.ts` and
+# `*.unit.test.ts`, where the realm is internally consistent because
+# vitest builds the schema in the same realm that the test imports
+# the type class from).
+#
+# Note on naming: graphql-js exports `GraphQLList` and `GraphQLNonNull`
+# without the `Type` suffix; the three composite type classes carry
+# `Type`. The pattern below permits the suffix to be optional for the
+# wrapper classes so both shapes are caught.
+#
+# Comment lines (first non-whitespace is `//`, `*`, or `/*`) are
+# skipped so docstrings explaining "why we avoid `instanceof
+# GraphQLObjectType`" — like the ones already in
+# `cost-rule-estimator.ts` and `cost-breakdown.ts` — do not trip the
+# guard.
+#
+# What is NOT scanned
+# ───────────────────
+# - `instanceof GraphQLError` is fine — it is an error class, not a
+#   schema-type discriminator. The realm gap discussed above only
+#   applies to `Symbol.toStringTag`-tagged type classes used for
+#   selection-set walking. `GraphQLError` is a thrown-error class with
+#   a distinct identity per realm, but resolvers always throw and
+#   catch within the same realm (Apollo's CJS world), so `instanceof`
+#   on errors works in practice.
+# - Test files (`*.test.ts`, `*.unit.test.ts`) — vitest builds its
+#   schema in the same realm it imports the type classes from, so
+#   `instanceof` is safe inside tests. The walker source files that
+#   are imported BY the tests (and BY production Apollo wiring) are
+#   the ones that must avoid `instanceof`.
+# - Code outside `packages/api/src/graphql/`. Other directories do
+#   not import from `graphql` directly.
+#
+# Usage
+# ─────
+#   scripts/check-no-graphql-instanceof.sh                # scan default dir
+#   scripts/check-no-graphql-instanceof.sh [dir]          # scan a specific directory
+#
+# Exit codes
+# ──────────
+#   0 — No violations found.
+#   1 — One or more files contain a forbidden `instanceof GraphQL*` use.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT/packages/api/src/graphql}"
+
+# ─── Pattern ─────────────────────────────────────────────────────────────
+# Match `instanceof` followed by one of the realm-fragile graphql-js
+# type classes. `Type` is required for the composite trio
+# (Object/Interface/Union) and optional for the wrapper pair
+# (List/NonNull) since graphql-js exports `GraphQLList` and
+# `GraphQLNonNull` without a `Type` suffix.
+PATTERN='instanceof[[:space:]]+GraphQL(ObjectType|InterfaceType|UnionType|List(Type)?|NonNull(Type)?)\b'
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    "__pycache__"
+    "tmp"
+    ".next"
+    "dist"
+    "build"
+)
+
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Scan ────────────────────────────────────────────────────────────────
+violations=0
+
+# Restrict to .ts files. The `--include` filter is honored by GNU grep
+# AND by macOS BSD grep when given as a single argument.
+raw_matches=$(grep -rnE "$PATTERN" "$SCAN_DIR" \
+    --include='*.ts' \
+    "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$raw_matches" ]]; then
+    while IFS= read -r line; do
+        # grep -rn output: <path>:<lineno>:<content>
+        file_path="${line%%:*}"
+        rest="${line#*:}"
+        content="${rest#*:}"
+
+        # Skip test files — vitest builds and consumes the schema in
+        # the same realm, so `instanceof` is realm-stable inside tests.
+        if [[ "$file_path" == *.test.ts ]] || [[ "$file_path" == *.unit.test.ts ]]; then
+            continue
+        fi
+
+        # Skip TS/JS comment lines (first non-whitespace is //, /*, or *).
+        # Covers JSDoc references to the forbidden pattern that
+        # explain why it must be avoided.
+        if [[ "$content" =~ ^[[:space:]]*(//|\*|/\*) ]]; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found forbidden 'instanceof GraphQL*' usage in api graphql walker source."
+            echo ""
+            echo "  graphql-js types must be discriminated by Symbol.toStringTag,"
+            echo "  not 'instanceof'. Vitest's ESM loader can resolve 'graphql'"
+            echo "  and 'graphql/index.mjs' as distinct module instances, and"
+            echo "  Apollo Server pins itself to the CJS realm via the /cjs"
+            echo "  subpath import in cost-limit-plugin.ts. 'instanceof' against"
+            echo "  the wrong realm's class identity silently returns false and"
+            echo "  collapses every type to a scalar leaf — see #4101 for the"
+            echo "  recurrence after #4112 first documented the workaround."
+            echo ""
+            echo "  Use the realm-stable helpers from:"
+            echo "    packages/api/src/graphql/realm-stable-type-checks.ts"
+            echo ""
+            echo "  Examples:"
+            echo "    typeTag(field.type) === 'GraphQLObjectType'"
+            echo "    isObjectOrInterface(named)   // narrows to CompositeTypeLike"
+            echo "    isComposite(named)           // includes union types"
+            echo ""
+        fi
+
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$raw_matches"
+fi
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of forbidden 'instanceof GraphQL*'."
+    echo ""
+    echo "  Fix: import the realm-stable helpers from"
+    echo "  packages/api/src/graphql/realm-stable-type-checks.ts and replace"
+    echo "  every 'instanceof GraphQLObjectType' (etc.) call with a"
+    echo "  Symbol.toStringTag-based check."
+    echo ""
+    echo "  See cost-rule-estimator.ts and cost-breakdown.ts for prior art."
+    echo "  Test files (*.test.ts, *.unit.test.ts) are exempt — vitest builds"
+    echo "  the schema in the same realm the tests import the type class"
+    echo "  from, so 'instanceof' is safe inside tests."
+    exit 1
+fi
+
+echo "All clean — no forbidden 'instanceof GraphQL*' usage in $SCAN_DIR."
+exit 0

--- a/scripts/tests/test_check_no_graphql_instanceof.sh
+++ b/scripts/tests/test_check_no_graphql_instanceof.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# test_check_no_graphql_instanceof.sh — Tests for
+# check-no-graphql-instanceof.sh.
+#
+# Issue #4198. The guard forbids `instanceof GraphQL(Object|Interface|
+# Union|List|NonNull)Type` in the api graphql walker source — vitest's
+# ESM loader and Apollo Server's CJS realm produce two class
+# identities for the same conceptual graphql-js type, so `instanceof`
+# silently returns `false` for a structurally-correct type. The
+# realm-stable workaround is `Symbol.toStringTag`. Centralized helpers
+# live in `packages/api/src/graphql/realm-stable-type-checks.ts`.
+#
+# Tests below build temp files in TMPDIR_TEST and point the guard at
+# that directory, mirroring the test_check_no_api_github_fetch.sh
+# pattern.
+#
+# Usage:
+#   scripts/tests/test_check_no_graphql_instanceof.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-graphql-instanceof.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test a: instanceof GraphQLObjectType in a .ts file should fail ──────
+create_test_file "walker.ts" 'function isObj(t: unknown): boolean { return t instanceof GraphQLObjectType; }'
+assert_fails "instanceof GraphQLObjectType in a .ts file is detected"
+reset_tmpdir
+
+# ─── Test b: instanceof GraphQLInterfaceType should fail ─────────────────
+create_test_file "walker.ts" 'if (named instanceof GraphQLInterfaceType) { return true; }'
+assert_fails "instanceof GraphQLInterfaceType is detected"
+reset_tmpdir
+
+# ─── Test c: instanceof GraphQLUnionType should fail ─────────────────────
+create_test_file "walker.ts" 'if (named instanceof GraphQLUnionType) { return true; }'
+assert_fails "instanceof GraphQLUnionType is detected"
+reset_tmpdir
+
+# ─── Test d: instanceof GraphQLList (no Type suffix) should fail ─────────
+# graphql-js exports GraphQLList without a Type suffix; the regex
+# permits the suffix to be optional for the wrapper pair so both
+# `GraphQLList` and `GraphQLListType` (if a future graphql-js fork
+# added one) would be caught.
+create_test_file "walker.ts" 'if (t instanceof GraphQLList) { return unwrap(t.ofType); }'
+assert_fails "instanceof GraphQLList (no Type suffix) is detected"
+reset_tmpdir
+
+# ─── Test e: instanceof GraphQLNonNull (no Type suffix) should fail ──────
+create_test_file "walker.ts" 'if (t instanceof GraphQLNonNull) { return unwrap(t.ofType); }'
+assert_fails "instanceof GraphQLNonNull (no Type suffix) is detected"
+reset_tmpdir
+
+# ─── Test f: typeTag-based discrimination should pass ────────────────────
+create_test_file "walker.ts" 'if (typeTag(t) === "GraphQLObjectType") { return true; }'
+assert_passes "typeTag(t) === 'GraphQLObjectType' (the realm-stable replacement) is not flagged"
+reset_tmpdir
+
+# ─── Test g: instanceof GraphQLError should pass ─────────────────────────
+# GraphQLError is an error class, not a schema-type discriminator. The
+# realm gap only applies to type classes used for selection-set
+# walking. `auth-resolvers.ts:351` legitimately throws/catches
+# GraphQLError within Apollo's CJS world.
+create_test_file "auth.ts" 'if (err instanceof GraphQLError) throw err;'
+assert_passes "instanceof GraphQLError (error class) is not flagged"
+reset_tmpdir
+
+# ─── Test h: comment lines referencing the pattern should pass ───────────
+create_test_file "doc.ts" '// instanceof GraphQLObjectType is forbidden — use Symbol.toStringTag.'
+assert_passes "// comment line is not flagged"
+reset_tmpdir
+
+create_test_file "doc.ts" ' * `field.type instanceof GraphQLObjectType` returns false across realms.'
+assert_passes "JSDoc * comment line is not flagged"
+reset_tmpdir
+
+create_test_file "doc.ts" '/* instanceof GraphQLObjectType is forbidden — see #4198. */'
+assert_passes "/* block-comment line is not flagged"
+reset_tmpdir
+
+# ─── Test i: test files (*.test.ts) should be exempt ─────────────────────
+# Vitest builds the schema in the same realm it imports the type
+# class from, so `instanceof` is realm-stable inside tests. The
+# walker source files imported BY the tests are the ones that must
+# avoid `instanceof`.
+create_test_file "walker.test.ts" 'expect(t instanceof GraphQLObjectType).toBe(true);'
+assert_passes "*.test.ts files are exempt"
+reset_tmpdir
+
+create_test_file "walker.unit.test.ts" 'expect(t instanceof GraphQLObjectType).toBe(true);'
+assert_passes "*.unit.test.ts files are exempt"
+reset_tmpdir
+
+# ─── Test j: non-.ts files should not be scanned ─────────────────────────
+# The walker source under packages/api/src/graphql/ is exclusively
+# TypeScript. A .md file that mentions the forbidden pattern as
+# documentation must not trip the guard.
+create_test_file "README.md" 'Avoid `instanceof GraphQLObjectType` — use Symbol.toStringTag.'
+assert_passes "*.md files are not scanned"
+reset_tmpdir
+
+# ─── Test k: unrelated code with `instanceof Map` should pass ────────────
+create_test_file "walker.ts" 'if (t instanceof Map) { return [...t.entries()]; }'
+assert_passes "instanceof on unrelated classes (Map) is not flagged"
+reset_tmpdir
+
+# ─── Test l: empty directory should pass ─────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test m: .git, node_modules, dist, .next should be excluded ──────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf 'const x = t instanceof GraphQLObjectType;\n' > "$TMPDIR_TEST/.git/objects/badfile.ts"
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf 'const x = t instanceof GraphQLObjectType;\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.ts"
+mkdir -p "$TMPDIR_TEST/dist"
+printf 'const x = t instanceof GraphQLObjectType;\n' > "$TMPDIR_TEST/dist/built.ts"
+mkdir -p "$TMPDIR_TEST/.next"
+printf 'const x = t instanceof GraphQLObjectType;\n' > "$TMPDIR_TEST/.next/cached.ts"
+assert_passes ".git, node_modules, dist, .next are excluded"
+reset_tmpdir
+
+# ─── Test n: file:line message names the violation clearly ───────────────
+# The error output must include `<file>:<lineno>:<content>` for each
+# violation so an operator can jump straight to the offending line.
+create_test_file "src/walker.ts" 'function isObj(t: unknown): boolean { return t instanceof GraphQLObjectType; }'
+TESTS=$((TESTS + 1))
+output=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1 || true)
+if printf '%s' "$output" | grep -qE 'src/walker\.ts:[0-9]+:.*instanceof GraphQLObjectType'; then
+    echo "PASS: error output names file:line of violation"
+else
+    echo "FAIL: error output did not include file:line for violation"
+    echo "  output was:"
+    printf '%s\n' "$output" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
+
+# ─── Test o: No self-match on ci.yml step name ───────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the forbidden pattern. If it does, the guard
+# fails on its first CI run (#2541/#2542).
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-graphql-instanceof.sh" "ts"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI hygiene check (`scripts/check-no-graphql-instanceof.sh`) that forbids `instanceof GraphQL(Object|Interface|Union|List|NonNull)Type?` inside `packages/api/src/graphql/**/*.ts` (excluding test files), wired into `.github/workflows/ci.yml` as `no-graphql-instanceof-check`. Extracts the previously-duplicated `typeTag` / `isComposite` / `isObjectOrInterface` / `CompositeTypeLike` helpers from `cost-rule-estimator.ts` and `cost-breakdown.ts` into a shared `packages/api/src/graphql/realm-stable-type-checks.ts` module so `Symbol.toStringTag` discrimination has exactly one definition. The realm clash documented in `cost-rule-estimator.ts` recurred in #4101 — the docstring was not load-bearing, this guard is.

Closes #4198

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green (incl. the new `no-graphql-instanceof-check` job, which runs against this PR's diff)

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only)
