### PR TITLE
feat(dx): add check-shipped-pr.sh to detect zombie issues before claiming (#4204)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -303,6 +303,44 @@ Evaluate:
 
 The adoption-to-merge path should be the common case when this check fires — if a prior agent got far enough to open a PR, they almost always got far enough to need someone to push the merge button.
 
+#### 4a.2 — Already-shipped check (zombie-issue pivot, MANDATORY when 4a returned exit 1)
+
+**Why this runs after 4a:** `check-duplicate-pr.sh` only finds *open* PRs. It cannot catch the case where the issue's code already shipped via a *closed and merged* PR that didn't auto-close the issue — typically because the PR carried a placeholder title (`WIP: ralph output`) or a null body with no `Closes #N` keyword, so GitHub's auto-close never fired and the issue stayed `agent/ready` indefinitely. Issue #2831 ↔ PR #3229 is the canonical example: PR shipped 2026-04-24, issue stayed `agent/ready` for 12 days until a human noticed and closed it manually. CLAUDE.md and `pr-title-check.yml` (#3994) now ban placeholder titles, so the bug class stops accruing — but the back-catalog of pre-#3994 issues can keep re-entering the queue. This check finds them in one cheap `gh issue view` + a few `gh api commits` calls per file path in the issue body, and pivots /task to a "verify and close" path.
+
+Run the check as a single tool call (only after `check-duplicate-pr.sh` returned exit 1):
+
+```
+{worktree}/scripts/check-shipped-pr.sh <N>
+```
+
+Exit codes:
+
+- **Exit 1 (`not-shipped:` line on stdout) — no high-confidence shipped match.** Continue to Step 4b. This is the common case.
+- **Exit 0 (`shipped:` line on stdout + JSON summary) — a closed PR merged onto `main` already shipped this issue's work.** Do NOT proceed to Step 4b / A.1 / ralph. Pivot to the verify-and-close decision below.
+- **Exit 2 (`error:` line on stderr) — check failed (gh unavailable, API error, etc.).** Fail-open: continue to Step 4b.
+
+The high-confidence threshold the script applies is **≥1 added overlap OR ≥2 total overlap** between the file paths in the issue body and the file paths the candidate PR landed (with the PR's `mergedAt` non-null and `baseRefName == main`). A single *modified*-file overlap is intentionally below the threshold — that case routinely fires on adjacent scripts the issue cites as references rather than load-bearing targets.
+
+##### 4a.2.1 — Verify-and-close pivot (only runs on exit 0)
+
+Read the JSON summary from stdout (the `shipped_pr` field names the merged PR; `overlap_files` and `added_files` show what landed). Then:
+
+1. **Run any acceptance-criteria `Verify:` commands that look mechanical.** Walk the issue body, extract each `Verify:` line, and run only those that are concrete commands (e.g. `Verify: scripts/foo.sh exits 0`, `Verify: pytest -k test_x`, `Verify: grep -n <pattern> <file>`). Skip free-form prose verifies ("Verify: manual sanity — flip a hex...") — those need a human.
+2. **All-green path:** if every mechanical `Verify:` command exits clean, the issue is done. Post a verification-evidence comment quoting the verify commands + their output + naming the shipped PR, close the issue with `--reason completed`, run `scripts/unblock-dependents.sh <N>`, and remove `status/in-progress`. Skip Path A entirely — there is no PR to file.
+
+   ```
+   gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/verification_evidence.txt
+   gh issue close <N> --repo judgemind/judgemind --reason completed
+   {worktree}/scripts/unblock-dependents.sh <N>
+   gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
+   ```
+
+   This is exactly the manual flow that closed #2831 today — turning that flow into a one-shot pivot is the entire point of this check.
+3. **Any-failure path:** if any mechanical `Verify:` command fails (or the issue has no mechanical verifies and a human-judgment residual remains), post a comment naming the partially-shipped PR + the failed verify line, leave the issue open with `agent/ready` re-attached, and **fall through to Step 4b.** Normal /task flow continues from there. The comment should make explicit that the agent ran `check-shipped-pr.sh`, found PR #N, but at least one AC is still unmet — so a human or a follow-up agent can decide whether to file a follow-up issue or close.
+4. **Reduced docs-only PR is NOT the default here.** The verify-and-close pivot is for "the AC's intent has already been satisfied by the shipped PR; we just need to close the loop." If a docs delta is genuinely missing (e.g. the AC said "wire this into SKILL.md and ship a Verify command" and only the script shipped), treat it as the any-failure path: post a comment, leave the issue open, fall through.
+
+The verify-and-close path should be the common case when this check fires — pre-#3994 placeholder-title PRs almost always landed everything the AC asked for, the only thing missing is the issue closure.
+
 ---
 
 ### Step 4b — Verify gap is real (current state probe)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Use `/task` to claim and work on an issue: `/task`, `/task #42`, or `/task scrap
 - **All commits on the worktree branch.** Every change goes through a PR.
 - **Scope completeness check before implementing.** Grep for all locations affected by the change.
 - **Ralph for testable code only** (Python, TypeScript). Non-testable tasks implement directly, then run pre-PR checks and self-review the diff.
-- **Check for duplicate PRs** — `scripts/check-duplicate-pr.sh <N>`.
+- **Check for duplicate PRs** — `scripts/check-duplicate-pr.sh <N>` (open PRs) and `scripts/check-shipped-pr.sh <N>` (already-shipped via merged PR with no `Closes` keyword — pivots /task to verify-and-close per `.claude/skills/task/SKILL.md` §4a.2; #4204).
 - **CI watch is non-negotiable.** `gh run watch <id> --interval 60 --exit-status --compact`. Fix and re-push until CI is green.
 - **Verify `mergeable: MERGEABLE` and `statusCheckRollup` all SUCCESS/SKIPPED before merging.**
 - **Verification evidence comment is MANDATORY on every task completion.** For deployed services: curl / DB query / log lines / screenshot. For docs/CI/tooling: state the skip reason.

--- a/scripts/_check_shipped_pr_extract_files.py
+++ b/scripts/_check_shipped_pr_extract_files.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_extract_files.py — Extract candidate file paths from an
+# issue body for scripts/check-shipped-pr.sh.
+#
+# Reads JSON {"body": "...", "title": "..."} on stdin, prints unique candidate
+# file paths (one per line) to stdout. Pure stdlib — no external imports —
+# so it runs from any worktree without venv setup.
+#
+# venv: none
+# permanent: true
+#
+# The regex matches the four conventional repo roots
+#   scripts/, packages/, docs/, infra/
+# plus `.github/`. It stops at whitespace, `]`, `)`, backticks, or quotes —
+# the boundaries that terminate inline file references in markdown bodies.
+# A trailing punctuation strip removes `.`, `,`, `:`, `;` (sentence
+# punctuation that often follows an inline file reference).
+
+import json
+import re
+import sys
+
+# Match (?:scripts/|packages/|docs/|infra/|\.github/) followed by any
+# non-terminator characters. Note: the spec calls for these five roots; we
+# intentionally omit `.claude/` and other roots here because issue bodies
+# rarely cite them as the locus of changes — the five chosen roots cover
+# the vast majority of "this lands at <path>" references.
+PATH_REGEX = re.compile(
+    r"(?:scripts/|packages/|docs/|infra/|\.github/)[^\s\]\)`\"',]+"
+)
+
+# Strip these trailing characters from a hit (sentence punctuation that
+# often follows an inline file reference but is not part of the path).
+TRAILING_STRIP = ".,:;"
+
+
+def extract_files(body: str) -> list[str]:
+    """Return unique candidate file paths from `body` in first-seen order."""
+    if not body:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    for match in PATH_REGEX.finditer(body):
+        path = match.group(0)
+        # Strip trailing punctuation
+        while path and path[-1] in TRAILING_STRIP:
+            path = path[:-1]
+        # Skip glob-y entries (`scripts/tests/*.sh`) — the commits API
+        # rejects globs and they would just produce 404s.
+        if "*" in path or "?" in path:
+            continue
+        # Skip suspiciously short hits (<6 chars after the root prefix)
+        # to suppress false positives like `docs/`. The shortest legit
+        # repo paths run ~10+ chars (e.g. "docs/A.md", "scripts/x.sh").
+        if len(path) < 8:
+            continue
+        if path not in seen:
+            seen.add(path)
+            out.append(path)
+    return out
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 1
+    body = data.get("body") or ""
+    title = data.get("title") or ""
+    # Combine title + body for extraction (title rarely cites paths but
+    # cheap to include).
+    combined = f"{title}\n{body}"
+    for path in extract_files(combined):
+        print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_check_shipped_pr_overlap.py
+++ b/scripts/_check_shipped_pr_overlap.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_overlap.py — Compute issue↔PR file overlap for
+# scripts/check-shipped-pr.sh.
+#
+# Reads `gh pr view --json mergedAt,baseRefName,files` JSON on stdin. Reads
+# the candidate-files list from CHECK_SHIPPED_CANDIDATE_FILES (comma-
+# separated). Prints "<count>\t<comma-separated-overlap-paths>" on stdout,
+# or empty stdout if the PR is not eligible (not merged, not on main).
+#
+# venv: none
+# permanent: true
+#
+# Eligibility:
+#   - mergedAt must be non-null (PR is actually merged, not just closed).
+#   - baseRefName must be "main" (we only count main-branch landings).
+#
+# Overlap is path-prefix-friendly:
+#   - Exact match counts (e.g. PR's "scripts/check-foo.sh" == candidate
+#     "scripts/check-foo.sh").
+#   - Candidate-as-prefix-of-PR-file counts (e.g. candidate "docs/" — but
+#     extract_files filters out paths under 8 chars, so a bare "docs/"
+#     wouldn't reach this stage; the prefix path is here for legit longer
+#     prefixes like "docs/agent/" intentionally cited as the directory
+#     scope).
+#
+# Anything else (only PR-as-prefix-of-candidate) does NOT count, because
+# that direction is the wrong way around (the PR landed something narrower
+# than the issue mentioned, which suggests the issue's broader work is
+# still incomplete).
+
+import json
+import os
+import sys
+
+
+def compute_overlap(
+    pr_files: list[dict], candidates: list[str]
+) -> tuple[list[str], list[str]]:
+    """Return (overlap_paths, added_overlap_paths) given pr_files vs candidates.
+
+    `pr_files` items have shape {"path": "...", "additions": N, "deletions": M}
+    when fetched via `gh pr view --json files`. `added_overlap_paths` is the
+    subset of overlap_paths that the PR newly *created* — derived
+    heuristically from `deletions == 0 && additions > 0`. (`gh pr view --json
+    files` does not surface a discrete `status` field; the deletions==0
+    heuristic is the most direct equivalent that also works against the raw
+    GitHub API where `status: "added"` is the canonical signal.)
+
+    These newly-created overlaps are dispositive — when the AC names a script
+    that doesn't exist yet and a closed PR created exactly that script, the
+    issue is unambiguously shipped.
+    """
+    pr_paths = {f.get("path") for f in pr_files if f.get("path")}
+    added_paths: set[str] = set()
+    for f in pr_files:
+        path = f.get("path")
+        if not path:
+            continue
+        # Either the explicit GitHub-API `status: "added"` field (when the
+        # caller passes raw API output) or the gh-CLI heuristic (deletions
+        # == 0 && additions > 0).
+        if f.get("status") == "added":
+            added_paths.add(path)
+            continue
+        deletions = f.get("deletions")
+        additions = f.get("additions")
+        if (
+            isinstance(deletions, int)
+            and deletions == 0
+            and isinstance(additions, int)
+            and additions > 0
+        ):
+            added_paths.add(path)
+    overlap: list[str] = []
+    added_overlap: list[str] = []
+    for cand in candidates:
+        match_path: str | None = None
+        if cand in pr_paths:
+            match_path = cand
+        elif cand.endswith("/"):
+            # Prefix match: candidate is a directory prefix and PR has a
+            # file under it.
+            for pp in pr_paths:
+                if pp.startswith(cand):
+                    match_path = cand
+                    break
+        if match_path is None:
+            continue
+        overlap.append(match_path)
+        # Treat as `added` overlap if the candidate (or any path under a
+        # directory candidate) was added by the PR.
+        if cand in added_paths:
+            added_overlap.append(cand)
+        elif cand.endswith("/"):
+            for ap in added_paths:
+                if ap.startswith(cand):
+                    added_overlap.append(cand)
+                    break
+    return overlap, added_overlap
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 1
+
+    merged_at = data.get("mergedAt")
+    base_ref = data.get("baseRefName")
+    if not merged_at:
+        # PR closed without merging — not a shipped match.
+        return 0
+    if base_ref != "main":
+        # Merged onto a feature branch, not main.
+        return 0
+
+    candidate_csv = os.environ.get("CHECK_SHIPPED_CANDIDATE_FILES", "")
+    candidates = [c for c in candidate_csv.split(",") if c]
+    if not candidates:
+        return 0
+
+    pr_files = data.get("files") or []
+    overlap, added_overlap = compute_overlap(pr_files, candidates)
+    if not overlap:
+        return 0
+
+    # High-confidence threshold: at least one ADDED overlap (PR created a
+    # file the issue prescribed), OR ≥2 total overlaps. A single overlap
+    # on a *modified* file is too weak — it routinely fires on adjacent
+    # scripts that the issue cites as references rather than load-bearing
+    # targets (e.g. issue #4204 references scripts/check-duplicate-pr.sh
+    # only as the file it extends, and the PR that originally created
+    # that script then trips a 1-file-modified false positive).
+    if len(added_overlap) < 1 and len(overlap) < 2:
+        return 0
+
+    # Output format: <count>\t<comma-separated-overlap>\t<comma-separated-added>
+    # The fix-CI / pivot path consumes this as best_overlap_count and
+    # best_overlap_list; added_overlap is informational for the JSON
+    # summary downstream.
+    overlap_csv = ",".join(overlap)
+    added_csv = ",".join(added_overlap)
+    print(f"{len(overlap)}\t{overlap_csv}\t{added_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_check_shipped_pr_summary.py
+++ b/scripts/_check_shipped_pr_summary.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_summary.py — Emit JSON summary for a shipped match
+# detected by scripts/check-shipped-pr.sh.
+#
+# venv: none
+# permanent: true
+#
+# Reads metadata from environment variables (so the parent shell does not
+# have to construct JSON via heredocs or printf escapes):
+#   CHECK_SHIPPED_ISSUE          — issue number (string)
+#   CHECK_SHIPPED_PR             — PR number (string)
+#   CHECK_SHIPPED_OVERLAP_COUNT  — number of overlapping files (string int)
+#   CHECK_SHIPPED_OVERLAP_FILES  — comma-separated overlap file paths
+#   CHECK_SHIPPED_CANDIDATE_FILES — comma-separated all-candidate paths
+#
+# Prints a pretty JSON object to stdout. The shape is stable so callers
+# (e.g. /task SKILL.md's pivot path) can `jq` against it.
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    issue = os.environ.get("CHECK_SHIPPED_ISSUE", "")
+    pr = os.environ.get("CHECK_SHIPPED_PR", "")
+    overlap_count_str = os.environ.get("CHECK_SHIPPED_OVERLAP_COUNT", "0")
+    overlap_files_csv = os.environ.get("CHECK_SHIPPED_OVERLAP_FILES", "")
+    added_files_csv = os.environ.get("CHECK_SHIPPED_ADDED_FILES", "")
+    candidate_files_csv = os.environ.get("CHECK_SHIPPED_CANDIDATE_FILES", "")
+
+    try:
+        overlap_count = int(overlap_count_str)
+    except ValueError:
+        overlap_count = 0
+
+    overlap_files = [f for f in overlap_files_csv.split(",") if f]
+    added_files = [f for f in added_files_csv.split(",") if f]
+    candidate_files = [f for f in candidate_files_csv.split(",") if f]
+
+    summary = {
+        "issue": int(issue) if issue.isdigit() else issue,
+        "shipped_pr": int(pr) if pr.isdigit() else pr,
+        "overlap_count": overlap_count,
+        "overlap_files": overlap_files,
+        "added_files": added_files,
+        "candidate_files": candidate_files,
+    }
+
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# check-shipped-pr.sh — Detect already-shipped issues before claiming.
+#
+# venv: none
+# permanent: true
+#
+# Companion to scripts/check-duplicate-pr.sh. The duplicate-PR check finds
+# *open* PRs; this one finds *merged-but-unclosed* PRs whose code already
+# shipped the issue's work. It exists because pre-#3994 PRs sometimes landed
+# without a `Closes #N` keyword (placeholder titles like "WIP: ralph
+# output", null bodies, or operator-edited titles), so the GitHub auto-close
+# never fired and the originating issue stayed `agent/ready` indefinitely.
+# Result: agents pay the full claim + worktree-setup + ralph cycle on a
+# task whose code shipped weeks ago. See #4204 (this issue) and #2831 (the
+# canonical zombie that triggered the work).
+#
+# Algorithm:
+#   1. Fetch the issue body via `gh issue view`.
+#   2. Extract candidate file paths from the body using a fixed regex
+#      that covers the four conventional repo roots
+#      (scripts/, packages/, docs/, infra/) plus `.github/`.
+#   3. For each unique file path, query the commits API on `main` to find
+#      commits that touched it (`gh api /repos/.../commits?path=<file>`),
+#      and parse the squash-merge PR number from each commit headline
+#      (the trailing `(#N)` token).
+#   4. For each candidate PR, fetch its merge metadata and changed files
+#      via `gh pr view --json mergedAt,baseRefName,files`. Drop the
+#      candidate if `mergedAt` is null or `baseRefName != main`.
+#   5. Compute overlap of the candidate PR's changed files vs the file
+#      paths extracted from the issue body. Treat ≥1 file overlap as a
+#      high-confidence shipped match.
+#   6. On match: print a `shipped:` line and a JSON summary to stdout,
+#      exit 0. On no match: print a `not-shipped:` line, exit 1. On
+#      error: print an `error:` line to stderr, exit 2.
+#
+# Usage:
+#   scripts/check-shipped-pr.sh <issue_number>
+#   scripts/check-shipped-pr.sh 2831
+#   scripts/check-shipped-pr.sh '#2831'         # leading # stripped
+#
+# Environment variables (testing hooks):
+#   CHECK_SHIPPED_REPO     — override "judgemind/judgemind" (for tests)
+#   CHECK_SHIPPED_GH_BIN   — override "gh" binary path (for tests)
+#
+# Exit codes:
+#   0 — High-confidence shipped match. A `shipped:` line and a JSON
+#       summary are printed to stdout. Caller pivots to the
+#       "verify and close" path documented in .claude/skills/task/
+#       SKILL.md Step 4a.
+#   1 — No high-confidence match. A `not-shipped:` line is printed to
+#       stdout. Caller proceeds with normal /task flow.
+#   2 — Error (missing argument, gh CLI unavailable, API failure). An
+#       `error:` line is printed to stderr.
+
+set -uo pipefail
+
+REPO="${CHECK_SHIPPED_REPO:-judgemind/judgemind}"
+GH_BIN="${CHECK_SHIPPED_GH_BIN:-gh}"
+
+# ─── Argument parsing ──────────────────────────────────────────────────────
+
+issue_arg="${1:-}"
+if [[ -z "$issue_arg" ]]; then
+    echo "error: check-shipped-pr.sh requires an issue number argument (exit 2)" >&2
+    echo "  usage: scripts/check-shipped-pr.sh <issue_number>" >&2
+    exit 2
+fi
+
+issue_num="${issue_arg#\#}"
+if ! [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+    echo "error: '$issue_arg' is not a valid issue number (exit 2)" >&2
+    exit 2
+fi
+
+# ─── gh CLI availability ───────────────────────────────────────────────────
+
+if ! command -v "$GH_BIN" >/dev/null 2>&1; then
+    echo "error: '$GH_BIN' CLI not found on PATH — cannot check shipped PRs (exit 2)" >&2
+    exit 2
+fi
+
+# ─── Fetch issue body ──────────────────────────────────────────────────────
+
+issue_json=""
+if ! issue_json=$("$GH_BIN" issue view "$issue_num" --repo "$REPO" --json body,title 2>/dev/null); then
+    echo "error: failed to fetch issue #${issue_num} from ${REPO} (exit 2)" >&2
+    exit 2
+fi
+
+# Extract candidate file paths from the issue body via Python (so the regex
+# dialect is portable across BSD vs GNU grep).
+candidate_files=""
+if ! candidate_files=$(printf '%s' "$issue_json" | python3 \
+    "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_extract_files.py" \
+    2>/dev/null); then
+    echo "error: failed to extract candidate file paths from issue #${issue_num} (exit 2)" >&2
+    exit 2
+fi
+
+if [[ -z "$candidate_files" ]]; then
+    echo "not-shipped: no candidate file paths in issue #${issue_num} body (exit 1)"
+    exit 1
+fi
+
+# ─── Find candidate PRs that touched any of those files ────────────────────
+
+# Collect (PR number, comma-separated unique). For each file path, list
+# recent commits on main; parse `(#N)` from the headline; accumulate.
+candidate_prs=""
+while IFS= read -r file_path; do
+    [[ -z "$file_path" ]] && continue
+    # gh api may fail for non-existent paths — that's expected, just skip.
+    commits_json=""
+    if ! commits_json=$("$GH_BIN" api \
+        "/repos/${REPO}/commits?path=${file_path}&per_page=30" \
+        --jq '.[] | .commit.message' \
+        2>/dev/null); then
+        continue
+    fi
+    # Extract `(#N)` tokens from each headline.
+    while IFS= read -r commit_message; do
+        [[ -z "$commit_message" ]] && continue
+        # Get the first line only (headline)
+        headline="${commit_message%%$'\n'*}"
+        # Match `(#NNN)` at end-of-line or before whitespace
+        if [[ "$headline" =~ \(#([0-9]+)\) ]]; then
+            pr_num="${BASH_REMATCH[1]}"
+            # Append if not already present
+            if [[ ",${candidate_prs}," != *",${pr_num},"* ]]; then
+                if [[ -z "$candidate_prs" ]]; then
+                    candidate_prs="$pr_num"
+                else
+                    candidate_prs="${candidate_prs},${pr_num}"
+                fi
+            fi
+        fi
+    done <<< "$commits_json"
+done <<< "$candidate_files"
+
+if [[ -z "$candidate_prs" ]]; then
+    echo "not-shipped: no candidate PRs found for issue #${issue_num} files (exit 1)"
+    exit 1
+fi
+
+# ─── Vet each candidate PR for high-confidence match ───────────────────────
+
+best_pr=""
+best_overlap_count=0
+best_overlap_list=""
+best_added_list=""
+
+# Convert candidate_files (newline-separated) into a comma-list for the
+# overlap helper.
+candidate_files_csv=$(printf '%s' "$candidate_files" | tr '\n' ',' | sed 's/,$//')
+
+# Iterate candidate PRs (comma-separated)
+IFS=',' read -ra prs_array <<< "$candidate_prs"
+for pr_num in "${prs_array[@]}"; do
+    [[ -z "$pr_num" ]] && continue
+    pr_json=""
+    if ! pr_json=$("$GH_BIN" pr view "$pr_num" --repo "$REPO" \
+        --json number,title,mergedAt,baseRefName,files \
+        2>/dev/null); then
+        continue
+    fi
+
+    # Compute overlap and merged-on-main check via Python helper.
+    # The helper applies the threshold (≥1 added overlap OR ≥2 total
+    # overlap) and emits a tab-separated line on match, empty on miss.
+    overlap_result=""
+    if ! overlap_result=$(printf '%s' "$pr_json" | CHECK_SHIPPED_CANDIDATE_FILES="$candidate_files_csv" python3 \
+        "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_overlap.py" \
+        2>/dev/null); then
+        continue
+    fi
+
+    # overlap_result is "<count>\t<overlap-csv>\t<added-csv>" or empty.
+    if [[ -z "$overlap_result" ]]; then
+        continue
+    fi
+    # Tab-split into count, overlap_list, added_list.
+    IFS=$'\t' read -r count overlap_list added_list <<< "$overlap_result"
+    if [[ "$count" =~ ^[0-9]+$ && "$count" -gt "$best_overlap_count" ]]; then
+        best_overlap_count="$count"
+        best_pr="$pr_num"
+        best_overlap_list="$overlap_list"
+        best_added_list="$added_list"
+    fi
+done
+
+if [[ -z "$best_pr" || "$best_overlap_count" -lt 1 ]]; then
+    echo "not-shipped: no merged PR has ≥1 file overlap with issue #${issue_num} (exit 1)"
+    exit 1
+fi
+
+# ─── Emit shipped: line + JSON summary ─────────────────────────────────────
+
+# Pretty JSON via Python (avoids quoting issues in pure bash).
+summary_json=""
+summary_json=$(CHECK_SHIPPED_ISSUE="$issue_num" \
+                CHECK_SHIPPED_PR="$best_pr" \
+                CHECK_SHIPPED_OVERLAP_COUNT="$best_overlap_count" \
+                CHECK_SHIPPED_OVERLAP_FILES="$best_overlap_list" \
+                CHECK_SHIPPED_ADDED_FILES="$best_added_list" \
+                CHECK_SHIPPED_CANDIDATE_FILES="$candidate_files_csv" \
+                python3 "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_summary.py" \
+                2>/dev/null) || {
+    echo "error: failed to format shipped summary JSON (exit 2)" >&2
+    exit 2
+}
+
+echo "shipped: PR #${best_pr} merged to main with ${best_overlap_count} file overlap(s) for issue #${issue_num} (exit 0)"
+echo "$summary_json"
+exit 0

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# test_check_shipped_pr.sh — Tests for scripts/check-shipped-pr.sh.
+#
+# Mocks the gh CLI on PATH and asserts the documented exit codes:
+#   0 — high-confidence shipped match (≥1 added overlap or ≥2 total overlap)
+#   1 — no high-confidence match
+#   2 — error (missing argument, gh CLI unavailable, malformed input)
+#
+# Usage:
+#   scripts/tests/test_check_shipped_pr.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/check-shipped-pr.sh"
+FAILURES=0
+TESTS=0
+
+# ─── Helpers ──────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+ORIG_PATH_SAVE=""
+
+cleanup() {
+    set +eu
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Reset PATH/env for each scenario (mock_gh writes a fresh gh script).
+ORIG_PATH_SAVE="$PATH"
+MOCK_BIN_DIR=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR")
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+# Path to the mock gh script that test cases overwrite.
+MOCK_GH="$MOCK_BIN_DIR/gh"
+
+# ─── Precondition: wrapper exists and is executable ───────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ─── Test 1: exit 2 when called with no argument ──────────────────────────
+
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 with no argument"
+else
+    fail "exits 2 with no argument" "expected exit 2, got $exit_code"
+fi
+
+# ─── Test 2: exit 2 with non-numeric argument ─────────────────────────────
+
+exit_code=0
+"$WRAPPER" not-a-number > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 with non-numeric argument"
+else
+    fail "exits 2 with non-numeric argument" "expected exit 2, got $exit_code"
+fi
+
+# ─── Test 3: high-confidence shipped match (added overlap = 1) ────────────
+
+# Issue body cites scripts/foo.sh (one path); merged PR #3229 added that
+# exact file. Expect exit 0 + "shipped:" line on stdout.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+# Top-level dispatcher: mimic gh subcommands the wrapper calls.
+case "${1:-}" in
+    issue)
+        # gh issue view <N> --repo ... --json body,title
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.\n\nVerify: scripts/foo.sh exits 0.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        # gh api /repos/<repo>/commits?path=<file>... --jq .[].commit.message
+        # Return one commit headline that names PR 3229.
+        echo "Closes the widget loop (#3229)"
+        exit 0
+        ;;
+    pr)
+        # gh pr view <N> --repo ... --json number,title,mergedAt,baseRefName,files
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-24T15:39:47Z", "number": 3229, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "exits 0 on high-confidence shipped match (added overlap)"
+else
+    fail "exits 0 on high-confidence shipped match (added overlap)" "expected exit 0, got $exit_code; output: $output"
+fi
+
+if [[ "$output" == *"shipped:"* && "$output" == *"3229"* ]]; then
+    pass "prints 'shipped:' line with PR number on match"
+else
+    fail "prints 'shipped:' line with PR number on match" "got: $output"
+fi
+
+if [[ "$output" == *'"shipped_pr": 3229'* ]]; then
+    pass "JSON summary names the shipped PR"
+else
+    fail "JSON summary names the shipped PR" "got: $output"
+fi
+
+if [[ "$output" == *'"added_files"'* && "$output" == *'"scripts/foo.sh"'* ]]; then
+    pass "JSON summary includes added_files with scripts/foo.sh"
+else
+    fail "JSON summary includes added_files with scripts/foo.sh" "got: $output"
+fi
+
+# ─── Test 4: PR mentions issue but file overlap is empty → exit 1 ─────────
+
+# Issue body cites scripts/foo.sh; PR touches a totally different file.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        # No commits touched scripts/foo.sh — return empty.
+        exit 0
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when no commits touch the candidate files"
+else
+    fail "exits 1 when no commits touch the candidate files" "expected exit 1, got $exit_code; output: $output"
+fi
+
+if [[ "$output" == *"not-shipped:"* ]]; then
+    pass "prints 'not-shipped:' line on miss"
+else
+    fail "prints 'not-shipped:' line on miss" "got: $output"
+fi
+
+# ─── Test 5: 1-file MODIFIED overlap below threshold → exit 1 ─────────────
+
+# Issue body cites scripts/foo.sh; a closed PR exists that *modified* it
+# (deletions > 0). Single modified-file overlap is below the high-
+# confidence threshold (≥1 added OR ≥2 total).
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need to extend scripts/foo.sh.", "title": "dx: extend scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "refactor scripts/foo.sh (#1234)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 5, "deletions": 5}], "mergedAt": "2026-04-01T00:00:00Z", "number": 1234, "title": "refactor scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when the only overlap is a single MODIFIED file"
+else
+    fail "exits 1 when the only overlap is a single MODIFIED file" "expected exit 1, got $exit_code; output: $output"
+fi
+
+# ─── Test 6: 2-file MODIFIED overlap above threshold → exit 0 ─────────────
+
+# Issue body cites two files; a closed PR modified both. ≥2 total overlap
+# — even without an `added` overlap — clears the threshold (the second
+# branch of the OR).
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "Update scripts/foo.sh and packages/web/bar.ts together.", "title": "dx: update foo and bar"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "refactor foo+bar (#5678)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 10, "deletions": 5}, {"path": "packages/web/bar.ts", "additions": 8, "deletions": 3}], "mergedAt": "2026-04-15T00:00:00Z", "number": 5678, "title": "refactor foo+bar"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "exits 0 when 2 files overlap (modified, threshold cleared via total≥2)"
+else
+    fail "exits 0 when 2 files overlap" "expected exit 0, got $exit_code; output: $output"
+fi
+
+# ─── Test 7: PR not merged (mergedAt null) → exit 1 ───────────────────────
+
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: add foo"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "wip (#9999)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": null, "number": 9999, "title": "wip"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+"$WRAPPER" 2831 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when candidate PR was closed without merging (mergedAt null)"
+else
+    fail "exits 1 when candidate PR was closed without merging" "expected exit 1, got $exit_code"
+fi
+
+# ─── Test 8: PR merged onto a feature branch (baseRef != main) → exit 1 ───
+
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: add foo"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "feature work (#777)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "feature/wip", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-30T00:00:00Z", "number": 777, "title": "feature work"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+"$WRAPPER" 2831 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when candidate PR merged onto a feature branch"
+else
+    fail "exits 1 when candidate PR merged onto a feature branch" "expected exit 1, got $exit_code"
+fi
+
+# ─── Test 9: issue body has no candidate file paths → exit 1 ──────────────
+
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "Pure prose with no file references at all.", "title": "Just thinking out loud"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when issue body has no candidate file paths"
+else
+    fail "exits 1 when issue body has no candidate file paths" "expected exit 1, got $exit_code; output: $output"
+fi
+
+if [[ "$output" == *"not-shipped:"* && "$output" == *"no candidate file paths"* ]]; then
+    pass "prints 'no candidate file paths' miss reason"
+else
+    fail "prints 'no candidate file paths' miss reason" "got: $output"
+fi
+
+# ─── Test 10: gh issue view fails → exit 2 ────────────────────────────────
+
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+# Always fail.
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+"$WRAPPER" 2831 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 when gh issue view fails"
+else
+    fail "exits 2 when gh issue view fails" "expected exit 2, got $exit_code"
+fi
+
+# ─── Test 11: gh CLI not installed → exit 2 ───────────────────────────────
+
+# Remove the mock and restrict PATH so the wrapper cannot find gh.
+rm -f "$MOCK_GH"
+
+if command -v gh > /dev/null 2>&1 && PATH="/bin:/usr/bin" command -v gh > /dev/null 2>&1; then
+    echo "SKIP: gh is on /bin or /usr/bin; cannot simulate 'gh not installed'"
+else
+    exit_code=0
+    PATH="/bin:/usr/bin" "$WRAPPER" 2831 > /dev/null 2>&1 || exit_code=$?
+    if [[ "$exit_code" -eq 2 ]]; then
+        pass "exits 2 when gh CLI is not installed"
+    else
+        fail "exits 2 when gh CLI is not installed" "expected exit 2, got $exit_code"
+    fi
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ─── Test 12: '#' prefix is stripped from the issue argument ──────────────
+
+# Use the high-confidence-match mock from Test 3 with a leading '#'.
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Closes the widget loop (#3229)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-24T15:39:47Z", "number": 3229, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" "#2831" 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* ]]; then
+    pass "strips leading '#' from issue argument"
+else
+    fail "strips leading '#' from issue argument" "exit=$exit_code output=$output"
+fi
+
+# Restore PATH for cleanup
+export PATH="$ORIG_PATH_SAVE"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-shipped-pr.sh` — a sibling of `scripts/check-duplicate-pr.sh` that detects "issue already shipped via a closed-and-merged PR with no `Closes #N` keyword" (the canonical zombie pattern that re-claimed #2831 today).

The check fetches the issue body, extracts file paths via a fixed regex covering the five conventional repo roots (`scripts/`, `packages/`, `docs/`, `infra/`, `.github/`), walks each path's commit history on `main` to find candidate squash-merge PRs (parsing `(#N)` from each commit headline), then vets each candidate via `gh pr view --json mergedAt,baseRefName,files` and computes the issue↔PR file overlap.

**Threshold:** ≥1 added overlap OR ≥2 total overlap. The added-vs-modified split is the dispositive bit — when the AC names a script that didn't exist yet and a closed PR created exactly that script, the issue is unambiguously shipped. A single *modified*-file overlap is intentionally below threshold to suppress the adjacent-file false positive observed against #4204 itself (which references `scripts/check-duplicate-pr.sh` as the file it extends, not as a re-shipped target).

Wired into `.claude/skills/task/SKILL.md §4a.2` with a documented verify-and-close pivot — when the check fires, /task runs the issue's mechanical `Verify:` AC commands and on all-green posts evidence, closes the issue, and unblocks dependents (no PR needed). On any-failure or no mechanical verifies, /task falls through to Step 4b normally.

Closes #4204

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (17/17 in `scripts/tests/test_check_shipped_pr.sh`; existing 9/9 in `test_check_duplicate_pr.sh` still green)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (agent tooling under `scripts/` + SKILL.md doc only; does not deploy to dev/prod)
- [ ] Verification evidence posted on issue (see A.8)

## Live integration evidence

```
$ scripts/check-shipped-pr.sh 2831
shipped: PR #3229 merged to main with 2 file overlap(s) for issue #2831 (exit 0)
{
  "added_files": [
    "scripts/check-brand-md-tokens.sh",
    "scripts/tests/test_check_brand_md_tokens.sh"
  ],
  "candidate_files": [
    "docs/BRAND.md",
    "packages/web/tailwind.config.ts",
    "scripts/check-brand-md-tokens.sh",
    "scripts/tests/test_check_brand_md_tokens.sh"
  ],
  "issue": 2831,
  "overlap_count": 2,
  "overlap_files": [
    "scripts/check-brand-md-tokens.sh",
    "scripts/tests/test_check_brand_md_tokens.sh"
  ],
  "shipped_pr": 3229
}

$ scripts/check-shipped-pr.sh 4204
not-shipped: no merged PR has ≥1 file overlap with issue #4204 (exit 1)
```
