### PR TITLE
ci: catch stale ci-passed.needs entries in coverage guard (#4207)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -469,6 +469,29 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 done
 
 # -------------------------------------------------------------------
+# ci-passed coverage check — run whenever .github/workflows/ci.yml changes
+# -------------------------------------------------------------------
+# Mirrors the CI `ci-passed-coverage-check` job (#3919) so a missing or
+# stale entry in `ci-passed.needs:` is caught locally before the push
+# reaches CI. Runs BEFORE actionlint so the targeted message fires first:
+# actionlint's `[job-needs]` lint also catches stale entries, but with a
+# generic message that doesn't point at the array — see #2832 / #4207.
+changed_ci_yml_for_coverage=$(echo "$changed_files" | grep -E '^\.github/workflows/ci\.yml$' || true)
+if [ -n "$changed_ci_yml_for_coverage" ]; then
+    echo "pre-push: checking ci-passed.needs: coverage (#3919, #4207)..." >&2
+    if [ -x scripts/check-ci-passed-coverage.py ]; then
+        if ! run_check "_" "scripts/check-ci-passed-coverage.py" \
+            python3 scripts/check-ci-passed-coverage.py; then
+            echo "  Fix the ci-passed.needs: array in .github/workflows/ci.yml" >&2
+            echo "  before pushing. See #3919 (missing) and #2832 (stale)." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-ci-passed-coverage.py not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # GitHub Actions workflow lint (actionlint)
 # -------------------------------------------------------------------
 changed_workflows=$(echo "$changed_files" | grep '^\.github/workflows/' || true)

--- a/scripts/check-ci-passed-coverage.py
+++ b/scripts/check-ci-passed-coverage.py
@@ -2,20 +2,36 @@
 # venv: none
 # permanent: true
 """
-check-ci-passed-coverage.py — Assert every top-level CI job appears in the
-`ci-passed.needs:` array so missing entries (like the #3919 gap) are caught
+check-ci-passed-coverage.py — Assert `ci-passed.needs:` and the top-level
+`jobs:` block in `.github/workflows/ci.yml` agree in both directions, so
+gaps like #3919 (missing entry) and #2832 (stale/renamed entry) are caught
 before merge.
 
-Motivation (#3919): The `ci-passed` aggregator job is the sole required
-status check for branch protection. If a job is defined in ci.yml but absent
-from `ci-passed.needs:`, CI can be green on a PR even when that job fails,
-giving a false green signal.
+Motivation: The `ci-passed` aggregator job is the sole required status
+check for branch protection. Two ways the array can fall out of sync with
+the real job set, both of which this script flags:
+
+  1. Missing entry (#3919): a job is defined in ci.yml but absent from
+     `ci-passed.needs:`. CI can be green on a PR even when that job fails,
+     giving a false green signal. The original failure mode this guard
+     was created for.
+
+  2. Stale entry (#2832): `ci-passed.needs:` references a job name that
+     no longer exists as a top-level `jobs:` entry — typically because a
+     job was renamed or deleted but the array was not updated. actionlint
+     also flags this at push time with `job "ci-passed" needs job "X"
+     which does not exist in this workflow [job-needs]`, but actionlint
+     runs after most other pre-push hooks, so a targeted check at the
+     same hygiene layer that already enforces direction (1) gives a
+     faster, more specific error.
 
 This script:
 1. Parses `.github/workflows/ci.yml` (simple line-oriented parser).
 2. Enumerates every top-level job name.
 3. Reads the `ci-passed.needs:` array.
-4. Asserts every job (excluding an explicit allow-list) is present.
+4. Asserts every non-allow-listed job is present (direction 1 — missing).
+5. Asserts every entry in `needs:` corresponds to a real top-level job
+   (direction 2 — stale / renamed / removed / nonexistent).
 
 Allow-list (jobs that legitimately do not need to be in ci-passed.needs:):
   - detect-changes       (orchestrator; always succeeds)
@@ -31,8 +47,10 @@ Usage:
     scripts/check-ci-passed-coverage.py --help
 
 Exit codes:
-    0 — Every top-level job is covered by ci-passed.needs:.
-    1 — One or more jobs are missing from ci-passed.needs:.
+    0 — `ci-passed.needs:` and the jobs block agree in both directions.
+    1 — One or more jobs are missing from ci-passed.needs:, OR
+        one or more entries in ci-passed.needs: do not correspond to a
+        real top-level job (stale / renamed / removed).
     2 — Script error (cannot parse ci.yml, etc.).
 """
 
@@ -153,7 +171,10 @@ def main() -> int:
         print(f"ERROR: failed to parse ci-passed.needs: {exc}", file=sys.stderr)
         return 2
 
+    job_set = set(all_jobs)
     needs_set = set(needs)
+
+    # Direction 1 (#3919): every real job must appear in ci-passed.needs:.
     missing: list[str] = []
     for job in all_jobs:
         if job in ALLOW_LIST:
@@ -161,24 +182,52 @@ def main() -> int:
         if job not in needs_set:
             missing.append(job)
 
-    if not missing:
+    # Direction 2 (#2832): every entry in ci-passed.needs: must correspond
+    # to a real top-level job. A stale entry indicates a job was renamed or
+    # removed but the array was not updated.
+    stale: list[str] = []
+    for entry in needs:
+        if entry not in job_set:
+            stale.append(entry)
+
+    if not missing and not stale:
         print(f"check-ci-passed-coverage: all {len(all_jobs)} jobs covered.")
         return 0
 
+    if missing:
+        print(
+            "check-ci-passed-coverage: the following jobs are NOT listed in "
+            "ci-passed.needs: and will not block merge if they fail:",
+            file=sys.stderr,
+        )
+        for name in missing:
+            print(f"  - {name}", file=sys.stderr)
+        print(
+            "\nFix: add the missing job name(s) to the ci-passed.needs: array in "
+            ".github/workflows/ci.yml.",
+            file=sys.stderr,
+        )
+
+    if stale:
+        if missing:
+            print("", file=sys.stderr)
+        print(
+            "check-ci-passed-coverage: the following entries in "
+            "ci-passed.needs: do not correspond to any top-level job in "
+            "ci.yml (stale / renamed / removed):",
+            file=sys.stderr,
+        )
+        for name in stale:
+            print(f"  - {name}", file=sys.stderr)
+        print(
+            "\nFix: remove the stale entry from the ci-passed.needs: array, "
+            "or update it to the current job name.",
+            file=sys.stderr,
+        )
+
     print(
-        "check-ci-passed-coverage: the following jobs are NOT listed in "
-        "ci-passed.needs: and will not block merge if they fail:",
-        file=sys.stderr,
-    )
-    for name in missing:
-        print(f"  - {name}", file=sys.stderr)
-    print(
-        "\nFix: add the missing job name(s) to the ci-passed.needs: array in "
-        ".github/workflows/ci.yml.",
-        file=sys.stderr,
-    )
-    print(
-        "\nSee https://github.com/judgemind/judgemind/issues/3919 for background.",
+        "\nSee https://github.com/judgemind/judgemind/issues/3919 (missing) "
+        "and #2832 (stale) for background.",
         file=sys.stderr,
     )
     return 1

--- a/scripts/tests/test_check_ci_passed_coverage.sh
+++ b/scripts/tests/test_check_ci_passed_coverage.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# test_check_ci_passed_coverage.sh — Integration test for check-ci-passed-coverage.py (#3919)
+# test_check_ci_passed_coverage.sh — Integration test for check-ci-passed-coverage.py (#3919, #4207)
 #
-# Runs the check against two synthetic ci.yml fixtures:
-#   Fixture A — has a job missing from ci-passed.needs:  → must exit 1
-#   Fixture B — all jobs covered                         → must exit 0
+# Runs the check against synthetic ci.yml fixtures covering both directions:
+#   Fixture A — has a job missing from ci-passed.needs:    → must exit 1 (#3919)
+#   Fixture B — all jobs covered                           → must exit 0
+#   Fixture C — ci-passed.needs: has a stale/renamed entry → must exit 1 (#4207)
+#   Fixture D — both missing AND stale entries             → must exit 1 (both messages)
 #
 # Usage:
 #   scripts/tests/test_check_ci_passed_coverage.sh
@@ -93,6 +95,75 @@ jobs:
 EOF
 }
 
+# Fixture C — ci-passed.needs: contains a stale/renamed entry that no
+# longer exists as a top-level job. Models the #2832 failure mode.
+write_fixture_stale() {
+    cat > "$TMPDIR_TEST/.github/workflows/ci.yml" <<'EOF'
+name: CI
+on:
+  push:
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo detecting
+
+  scripts-tests:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+
+  bare-shadcn-accent-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo accent
+
+  ci-passed:
+    needs: [scripts-tests, admin-dispatcher-brand-accent-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs passed or were skipped
+        run: echo ok
+EOF
+}
+
+# Fixture D — both directions wrong: scripts-tests is missing AND
+# admin-dispatcher-brand-accent-check is stale. The script must report
+# both failure modes in a single run.
+write_fixture_both() {
+    cat > "$TMPDIR_TEST/.github/workflows/ci.yml" <<'EOF'
+name: CI
+on:
+  push:
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo detecting
+
+  scripts-tests:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+
+  bare-shadcn-accent-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo accent
+
+  ci-passed:
+    needs: [admin-dispatcher-brand-accent-check, bare-shadcn-accent-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs passed or were skipped
+        run: echo ok
+EOF
+}
+
 run_check() {
     python3 "$CHECK_SCRIPT" --ci-yml "$TMPDIR_TEST/.github/workflows/ci.yml"
 }
@@ -129,6 +200,29 @@ assert_passes() {
     fi
 }
 
+# Assert the check exits 1 AND its combined output contains a substring.
+# Used to verify the new failure-mode message names the offending entry.
+assert_fails_with() {
+    local desc="$1"
+    local needle="$2"
+    TESTS=$((TESTS + 1))
+    local out
+    local rc
+    out=$(run_check 2>&1)
+    rc=$?
+    if [[ "$rc" -ne 1 ]]; then
+        echo "FAIL: $desc (expected exit 1, got $rc)"
+        echo "  output: $out"
+        FAILURES=$((FAILURES + 1))
+    elif ! grep -qF "$needle" <<<"$out"; then
+        echo "FAIL: $desc (output did not contain '$needle')"
+        echo "  output: $out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
 # ─── Test 1: job missing from ci-passed.needs: is flagged ────────────────────
 write_fixture_missing
 assert_fails "extra-job missing from ci-passed.needs: is flagged"
@@ -137,7 +231,41 @@ assert_fails "extra-job missing from ci-passed.needs: is flagged"
 write_fixture_complete
 assert_passes "all jobs listed in ci-passed.needs: passes"
 
-# ─── Test 3: help flag works ──────────────────────────────────────────────────
+# ─── Test 3: stale entry in ci-passed.needs: is flagged (#4207) ──────────────
+# A renamed/deleted job whose old name is still in ci-passed.needs:
+# must exit 1 with a message naming the stale entry.
+write_fixture_stale
+assert_fails_with \
+    "stale entry in ci-passed.needs: is flagged" \
+    "admin-dispatcher-brand-accent-check"
+
+# ─── Test 4: stale entry message tells reader to update array ────────────────
+write_fixture_stale
+assert_fails_with \
+    "stale-entry message points reader to update the array" \
+    "Fix: remove the stale entry"
+
+# ─── Test 5: missing + stale fixture reports both directions (#4207) ─────────
+write_fixture_both
+assert_fails_with \
+    "both missing and stale are reported in a single run (missing message)" \
+    "are NOT listed in ci-passed.needs:"
+write_fixture_both
+assert_fails_with \
+    "both missing and stale are reported in a single run (stale message)" \
+    "do not correspond to any top-level job"
+
+# ─── Test 6: docstring documents both directions (#4207) ─────────────────────
+TESTS=$((TESTS + 1))
+header=$(head -60 "$CHECK_SCRIPT")
+if grep -qE 'stale|removed|renamed|nonexistent' <<<"$header"; then
+    echo "PASS: docstring documents the stale/renamed/removed direction"
+else
+    echo "FAIL: docstring does not document the stale/removed direction"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 7: help flag works ──────────────────────────────────────────────────
 TESTS=$((TESTS + 1))
 if python3 "$CHECK_SCRIPT" --help 2>&1 | grep -q "ci-passed"; then
     echo "PASS: --help describes the script"

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -32,6 +32,7 @@
 #  12. Migration-only push skips TS lint  no 'checking TypeScript package' (#2877 AC1)
 #  13. Real TS change still fires lint    'checking TypeScript package' present (#2877 AC2)
 #  18. Non-ASCII tf description rejected  em-dash in description -> hook fails (#3923)
+#  19. Stale ci-passed.needs entry rejected  hook fails before actionlint (#4207)
 #
 # Run:
 #   scripts/tests/test_pre_push.sh
@@ -893,6 +894,80 @@ else
         report_fail "expected 'FAILED: check-no-nonascii-tf-descriptions for terraform' in output (#3923)" "$hook_out"
     else
         report_pass "hook rejects push with non-ASCII Terraform description field (#3923)"
+    fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 19: ci.yml with a stale ci-passed.needs: entry rejected (#4207)
+# ───────────────────────────────────────────────────────────────────────
+# Seeds .github/workflows/ci.yml with an entry in ci-passed.needs: that
+# does not correspond to any top-level job. The pre-push hook must run
+# scripts/check-ci-passed-coverage.py and fail with the targeted message
+# naming the stale entry — BEFORE actionlint, since actionlint also
+# catches this but with a less specific message that doesn't point at
+# the array. Mirrors scenario 18's "copy script into work tree" pattern.
+echo "[scenario 19] ci.yml with stale ci-passed.needs: entry — hook rejects push (#4207)"
+init_workspace
+
+CI_PASSED_PY="$REPO_ROOT/scripts/check-ci-passed-coverage.py"
+if [ ! -x "$CI_PASSED_PY" ]; then
+    report_skip "scripts/check-ci-passed-coverage.py unavailable — cannot exercise"
+else
+    git -C "$WORK" checkout --quiet -b feature-stale-needs
+    mkdir -p "$WORK/.github/workflows" "$WORK/scripts"
+    cp "$CI_PASSED_PY" "$WORK/scripts/check-ci-passed-coverage.py"
+    chmod +x "$WORK/scripts/check-ci-passed-coverage.py"
+    # Write a ci.yml whose ci-passed.needs: array references a job
+    # that does not exist in the workflow. The intended-job
+    # `bare-shadcn-accent-check` IS defined; the stale entry models
+    # the #2832 case where a job was renamed and the array was not
+    # updated.
+    cat > "$WORK/.github/workflows/ci.yml" <<'YML'
+name: CI
+on:
+  push:
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo detecting
+
+  scripts-tests:
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    steps:
+      - run: pytest
+
+  bare-shadcn-accent-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo accent
+
+  ci-passed:
+    needs: [scripts-tests, admin-dispatcher-brand-accent-check, bare-shadcn-accent-check]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all jobs passed or were skipped
+        run: echo ok
+YML
+    git -C "$WORK" add .github/workflows/ci.yml scripts/check-ci-passed-coverage.py
+    git -C "$WORK" commit --quiet -m "ci: stale ci-passed.needs entry"
+    feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+    # Run without actionlint so the failure must come from our targeted
+    # check, not from actionlint's generic [job-needs] lint.
+    run_hook_without actionlint \
+        "refs/heads/feature-stale-needs $feat_sha refs/heads/feature-stale-needs $ZERO_SHA"
+
+    if [ "$hook_rc" -eq 0 ]; then
+        report_fail "expected hook to reject stale ci-passed.needs entry (#4207), exit was 0" "$hook_out"
+    elif ! echo "$hook_out" | grep -q "admin-dispatcher-brand-accent-check"; then
+        report_fail "expected hook output to name the stale entry 'admin-dispatcher-brand-accent-check' (#4207)" "$hook_out"
+    elif ! echo "$hook_out" | grep -q "do not correspond to any top-level job"; then
+        report_fail "expected hook output to include the stale-direction message (#4207)" "$hook_out"
+    else
+        report_pass "hook rejects push with stale ci-passed.needs entry and names it (#4207)"
     fi
 fi
 


### PR DESCRIPTION
## Summary

Extends `scripts/check-ci-passed-coverage.py` to enforce *bidirectional* coverage between `ci-passed.needs:` and the top-level `jobs:` block in `.github/workflows/ci.yml`. The script already caught real jobs missing from the array (#3919); it now also flags entries in the array that no longer correspond to a real job (stale / renamed / removed — the #2832 case where `admin-dispatcher-brand-accent-check` was renamed to `bare-shadcn-accent-check` but `ci-passed.needs:` still referenced the old name). Wires the script into `.githooks/pre-push` so the targeted message fires before `actionlint`'s generic `[job-needs]` lint when `ci.yml` is in the push.

Closes #4207

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI guard / git hook only)
- [x] Verification evidence posted on issue (see A.8)
