### PR TITLE
feat(audits): one-shot scan of agent/ready queue for shipped zombies (#4210)

### DIFF
--- a/scripts/audits/audit-shipped-zombies.py
+++ b/scripts/audits/audit-shipped-zombies.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""One-shot scan of the ``agent/ready`` queue for shipped zombies.
+
+A "shipped zombie" is an open ``agent/ready`` issue whose code already
+landed in a merged PR — typically a pre-#3994 placeholder-titled PR whose
+body lacked a ``Closes #N`` keyword, so the GitHub auto-close never fired
+and the issue stayed in the queue. Each zombie costs ~15 minutes of agent
+wall time + one ``/task`` slot when re-claimed; cleaning the backlog
+up-front keeps subsequent ``/task`` dispatches productive (#4210).
+
+This is a one-shot audit, not a scheduled cron, because the bug class is
+shrinking — ``.github/workflows/pr-title-check.yml`` (#3994) blocks new
+placeholder-titled PRs, so the zombie population is bounded by the
+pre-#3994 backlog.
+
+Manual review steps for the operator
+====================================
+
+1. Run the audit:
+
+       python3 scripts/audits/audit-shipped-zombies.py
+
+2. Skim the markdown report on stdout. Each match line names:
+
+   * the open ``agent/ready`` issue number + title,
+   * the merged PR that landed the issue's code,
+   * the file overlap (paths the PR's diff and the issue body both cite).
+
+3. For each match, run ``/task #N`` from a fresh session. ``/task`` will
+   itself re-run ``scripts/check-shipped-pr.sh`` as part of Step 4a.2 and
+   pivot to the verify-and-close path automatically — no manual close
+   required here. (See ``.claude/skills/task/SKILL.md`` §4a.2.)
+
+4. False positives are rare but possible (e.g. an issue that legitimately
+   extends a file an earlier PR shipped). The verify-and-close pivot in
+   ``/task`` requires the agent to confirm the issue's acceptance criteria
+   were actually satisfied by the named PR before closing — that is the
+   final guardrail.
+
+This script does NOT auto-close anything. It is a read-only report — the
+operator (or a follow-up ``/task`` invocation) drives the close.
+
+CLI
+===
+
+::
+
+    scripts/audits/audit-shipped-zombies.py [--limit N] [--dry-run]
+                                            [--repo OWNER/NAME]
+
+* ``--limit N`` — pass-through to ``gh issue list --limit N`` (default
+  200, the GitHub page-size cap).
+* ``--dry-run`` — accepted for backwards compatibility with the
+  acceptance criterion verb; the script is read-only by construction so
+  the flag is a no-op.
+* ``--repo OWNER/NAME`` — repository slug; defaults to
+  ``judgemind/judgemind``. Test fixtures override this.
+
+Exit codes
+==========
+
+* 0 — Audit completed (whether or not any zombies were found).
+* 1 — Pre-flight failure (``gh`` CLI unavailable, ``gh issue list``
+  failed, ``scripts/check-shipped-pr.sh`` not found).
+
+Environment hooks (for tests)
+=============================
+
+* ``AUDIT_SHIPPED_GH_BIN`` — override ``gh`` binary path.
+* ``AUDIT_SHIPPED_CHECK_BIN`` — override path to
+  ``scripts/check-shipped-pr.sh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_REPO = "judgemind/judgemind"
+DEFAULT_LIMIT = 200
+GH_LIST_TIMEOUT_SEC = 60
+CHECK_SHIPPED_TIMEOUT_SEC = 120
+
+
+def _resolve_check_shipped_bin() -> str:
+    """Return the path to ``scripts/check-shipped-pr.sh``.
+
+    Honours the ``AUDIT_SHIPPED_CHECK_BIN`` env var (used by tests). Falls
+    back to the sibling path ``../check-shipped-pr.sh`` relative to this
+    module so the script can be invoked from any cwd.
+    """
+
+    override = os.environ.get("AUDIT_SHIPPED_CHECK_BIN")
+    if override:
+        return override
+    return str(Path(__file__).resolve().parent.parent / "check-shipped-pr.sh")
+
+
+def _resolve_gh_bin() -> str:
+    """Return the ``gh`` binary path, honouring ``AUDIT_SHIPPED_GH_BIN``."""
+
+    return os.environ.get("AUDIT_SHIPPED_GH_BIN", "gh")
+
+
+def list_agent_ready_issues(repo: str, limit: int, gh_bin: str) -> list[dict]:
+    """Return the list of open ``agent/ready`` issues from ``repo``.
+
+    Calls ``gh issue list --label agent/ready --state open --json
+    number,title --limit <limit>`` and parses the JSON output.
+
+    Raises ``RuntimeError`` if the ``gh`` invocation fails or the output
+    cannot be parsed. The caller maps that to exit 1.
+    """
+
+    cmd = [
+        gh_bin,
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--label",
+        "agent/ready",
+        "--state",
+        "open",
+        "--json",
+        "number,title",
+        "--limit",
+        str(limit),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=GH_LIST_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"gh issue list invocation failed: {exc}") from exc
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            "gh issue list exited "
+            f"{result.returncode}: {result.stderr.strip() or '(no stderr)'}"
+        )
+
+    try:
+        issues = json.loads(result.stdout or "[]")
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise RuntimeError(f"gh issue list returned non-JSON output: {exc}") from exc
+
+    if not isinstance(issues, list):
+        raise RuntimeError("gh issue list JSON was not a list")
+    return issues
+
+
+def check_one_issue(issue_number: int, check_bin: str) -> dict | None:
+    """Run ``scripts/check-shipped-pr.sh`` for one issue.
+
+    Returns the parsed JSON summary dict on a high-confidence shipped
+    match (exit 0). Returns ``None`` for any other outcome (no match,
+    transient error, malformed output) — the audit is best-effort and
+    does not surface per-issue errors as a failure.
+
+    The wrapper's stdout on a match is two lines:
+
+    1. ``shipped: PR #N merged to main with K file overlap(s) ...``
+    2. A pretty-printed JSON object (the summary).
+
+    We slice off the leading ``shipped:`` line and parse the rest as
+    JSON. Robust against whitespace and additional trailing lines.
+    """
+
+    cmd = [check_bin, str(issue_number)]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CHECK_SHIPPED_TIMEOUT_SEC,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+
+    if result.returncode != 0:
+        # Exit 1 (no match) or exit 2 (error) — neither is a zombie.
+        return None
+
+    return _parse_shipped_summary(result.stdout)
+
+
+def _parse_shipped_summary(stdout: str) -> dict | None:
+    """Extract the JSON summary from a ``check-shipped-pr.sh`` exit-0 stdout.
+
+    Output shape (from the wrapper):
+
+    ::
+
+        shipped: PR #1234 merged to main with 1 file overlap(s) for issue #5678 (exit 0)
+        {
+          "issue": 5678,
+          "shipped_pr": 1234,
+          ...
+        }
+
+    We strip up to the first ``{`` and parse from there to end-of-input.
+    Returns ``None`` on any parse failure.
+    """
+
+    if not stdout:
+        return None
+    brace_idx = stdout.find("{")
+    if brace_idx < 0:
+        return None
+    candidate = stdout[brace_idx:]
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
+
+
+def render_report(
+    *,
+    issues_scanned: int,
+    matches: list[dict],
+    repo: str,
+) -> str:
+    """Render a markdown report summarising the audit run.
+
+    Always emits a header + scan summary. If ``matches`` is empty, prints
+    "no zombies found" with the scan count. If non-empty, prints one
+    table row per match.
+    """
+
+    lines: list[str] = []
+    lines.append("# Shipped-zombie audit report")
+    lines.append("")
+    lines.append(f"- Repository: `{repo}`")
+    lines.append(f"- Issues scanned: **{issues_scanned}**")
+    lines.append(f"- Zombies found: **{len(matches)}**")
+    lines.append("")
+
+    if not matches:
+        lines.append("No zombies found.")
+        lines.append("")
+        return "\n".join(lines)
+
+    lines.append("| Issue | Title | Shipped PR | Overlap (files) |")
+    lines.append("|---|---|---|---|")
+    for match in matches:
+        issue_num = match.get("issue", "?")
+        issue_title = match.get("issue_title", "")
+        pr_num = match.get("shipped_pr", "?")
+        overlap_files = match.get("overlap_files") or []
+        overlap_repr = ", ".join(f"`{f}`" for f in overlap_files) or "—"
+        lines.append(f"| #{issue_num} | {issue_title} | #{pr_num} | {overlap_repr} |")
+    lines.append("")
+    lines.append("## Next steps")
+    lines.append("")
+    lines.append(
+        "Run `/task #N` on each match. `/task`'s Step 4a.2 will re-run "
+        "`scripts/check-shipped-pr.sh` and pivot to the verify-and-close "
+        "path automatically. See `.claude/skills/task/SKILL.md` §4a.2."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def run_audit(
+    *,
+    repo: str,
+    limit: int,
+    gh_bin: str,
+    check_bin: str,
+) -> tuple[int, str]:
+    """Run the audit end-to-end.
+
+    Returns ``(exit_code, report)``. ``exit_code`` is 0 for a successful
+    scan (regardless of how many zombies were found) and 1 for a
+    pre-flight failure (gh missing, gh issue list failed,
+    check-shipped-pr.sh not executable).
+    """
+
+    if shutil.which(gh_bin) is None:
+        return (
+            1,
+            f"error: '{gh_bin}' CLI not found on PATH — cannot run audit\n",
+        )
+    if not Path(check_bin).exists() or not os.access(check_bin, os.X_OK):
+        return (
+            1,
+            f"error: '{check_bin}' is not executable or does not exist\n",
+        )
+
+    try:
+        issues = list_agent_ready_issues(repo, limit, gh_bin)
+    except RuntimeError as exc:
+        return (1, f"error: {exc}\n")
+
+    matches: list[dict] = []
+    for issue in issues:
+        number = issue.get("number")
+        title = issue.get("title", "")
+        if not isinstance(number, int):
+            continue
+        summary = check_one_issue(number, check_bin)
+        if summary is None:
+            continue
+        # Stitch the issue title into the summary so the report shows it.
+        summary = dict(summary)
+        summary.setdefault("issue", number)
+        summary["issue_title"] = title
+        matches.append(summary)
+
+    report = render_report(
+        issues_scanned=len(issues),
+        matches=matches,
+        repo=repo,
+    )
+    return (0, report)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="audit-shipped-zombies",
+        description=(
+            "One-shot scan of the agent/ready queue for shipped zombies "
+            "(open issues whose code already landed in a merged PR)."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help=(
+            "Max issues to scan (passed through to "
+            "`gh issue list --limit`). Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Accepted for backwards compatibility with the AC verb; the "
+            "script is read-only by construction so this is a no-op."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help="Repository slug (default: %(default)s).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(argv) if argv is not None else sys.argv[1:])
+    exit_code, report = run_audit(
+        repo=args.repo,
+        limit=args.limit,
+        gh_bin=_resolve_gh_bin(),
+        check_bin=_resolve_check_shipped_bin(),
+    )
+    sys.stdout.write(report)
+    if not report.endswith("\n"):
+        sys.stdout.write("\n")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_audit_shipped_zombies.py
+++ b/scripts/tests/test_audit_shipped_zombies.py
@@ -1,0 +1,454 @@
+# venv: none
+"""Tests for ``scripts/audits/audit-shipped-zombies.py``.
+
+Mocks ``gh`` and ``scripts/check-shipped-pr.sh`` via env hooks
+(``AUDIT_SHIPPED_GH_BIN`` and ``AUDIT_SHIPPED_CHECK_BIN``). The script
+under test is a pure-stdlib subprocess wrapper, so tests stay hermetic by
+pointing each binary hook at a tiny per-test bash mock.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "audits" / "audit-shipped-zombies.py"
+
+
+def _import_audit_module():
+    """Load the audit script as a module under a Python-safe name.
+
+    The on-disk filename uses dashes (``audit-shipped-zombies.py``) so it
+    cannot be imported via the normal ``import`` machinery — we use
+    ``importlib.util.spec_from_file_location`` to load it as
+    ``audit_shipped_zombies`` instead.
+    """
+
+    spec = importlib.util.spec_from_file_location("audit_shipped_zombies", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["audit_shipped_zombies"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def audit_module():
+    return _import_audit_module()
+
+
+def _write_executable(path: Path, body: str) -> Path:
+    """Write a bash script body and chmod +x it."""
+
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def _make_gh_mock(tmp_path: Path, issues: list[dict]) -> Path:
+    """Create a minimal ``gh`` mock that returns ``issues`` for ``gh issue list``."""
+
+    issues_json = json.dumps(issues)
+    # No textwrap.dedent here: the heredoc body must be at column 0 with no
+    # leading whitespace on the JSON line, so the whole script is written at
+    # column 0 directly.
+    body = (
+        "#!/usr/bin/env bash\n"
+        "# Mock gh: only handles `gh issue list ... --json number,title ...`\n"
+        'case "${1:-}" in\n'
+        "    issue)\n"
+        '        if [[ "${2:-}" == "list" ]]; then\n'
+        "            cat <<'JSON'\n"
+        f"{issues_json}\n"
+        "JSON\n"
+        "            exit 0\n"
+        "        fi\n"
+        "        ;;\n"
+        "esac\n"
+        'echo "mock-gh: unexpected args: $@" >&2\n'
+        "exit 99\n"
+    )
+    return _write_executable(tmp_path / "gh", body)
+
+
+def _make_check_shipped_mock(
+    tmp_path: Path,
+    *,
+    matches: dict[int, dict] | None = None,
+) -> Path:
+    """Create a mock for ``scripts/check-shipped-pr.sh``.
+
+    For each issue number passed in ``matches``, the mock prints the
+    documented ``shipped:`` line + JSON summary and exits 0. Any
+    unconfigured issue number falls through to a ``not-shipped:`` line +
+    exit 1, matching the wrapper's documented behaviour.
+
+    Body is built without ``textwrap.dedent`` so the JSON heredoc lines
+    sit at column 0 (any leading whitespace would be included in the
+    here-doc body, breaking JSON).
+    """
+
+    matches = matches or {}
+
+    case_lines: list[str] = []
+    for issue_num, summary in matches.items():
+        summary_json = json.dumps(summary, indent=2, sort_keys=True)
+        case_lines.append(f"    {issue_num})")
+        case_lines.append(
+            "        echo "
+            f"'shipped: PR #{summary['shipped_pr']} merged to main with "
+            f"{summary.get('overlap_count', 1)} file overlap(s) for "
+            f"issue #{issue_num} (exit 0)'"
+        )
+        case_lines.append("        cat <<'JSON'")
+        case_lines.append(summary_json)
+        case_lines.append("JSON")
+        case_lines.append("        exit 0")
+        case_lines.append("        ;;")
+
+    body_lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "# Mock for scripts/check-shipped-pr.sh — matches by issue number.",
+        'issue_arg="${1:-}"',
+        'issue_arg="${issue_arg#\\#}"',
+        'case "$issue_arg" in',
+        *case_lines,
+        "    *)",
+        '        echo "not-shipped: no candidate file paths in issue '
+        '#${issue_arg} body (exit 1)"',
+        "        exit 1",
+        "        ;;",
+        "esac",
+    ]
+    body = "\n".join(body_lines) + "\n"
+    return _write_executable(tmp_path / "check-shipped-pr.sh", body)
+
+
+# ─── Unit: _parse_shipped_summary ─────────────────────────────────────────
+
+
+def test_parse_shipped_summary_extracts_json(audit_module):
+    stdout = textwrap.dedent(
+        """\
+        shipped: PR #3229 merged to main with 1 file overlap(s) for issue #2831 (exit 0)
+        {
+          "issue": 2831,
+          "shipped_pr": 3229,
+          "overlap_count": 1,
+          "overlap_files": ["scripts/foo.sh"],
+          "added_files": ["scripts/foo.sh"],
+          "candidate_files": ["scripts/foo.sh"]
+        }
+        """
+    )
+    parsed = audit_module._parse_shipped_summary(stdout)
+    assert parsed is not None
+    assert parsed["shipped_pr"] == 3229
+    assert parsed["issue"] == 2831
+    assert parsed["overlap_files"] == ["scripts/foo.sh"]
+
+
+def test_parse_shipped_summary_returns_none_on_empty(audit_module):
+    assert audit_module._parse_shipped_summary("") is None
+
+
+def test_parse_shipped_summary_returns_none_when_no_brace(audit_module):
+    assert audit_module._parse_shipped_summary("not-shipped: nothing\n") is None
+
+
+def test_parse_shipped_summary_returns_none_on_invalid_json(audit_module):
+    stdout = "shipped: ...\n{not valid json"
+    assert audit_module._parse_shipped_summary(stdout) is None
+
+
+# ─── Unit: render_report ───────────────────────────────────────────────────
+
+
+def test_render_report_no_matches(audit_module):
+    report = audit_module.render_report(
+        issues_scanned=10,
+        matches=[],
+        repo="judgemind/judgemind",
+    )
+    assert "Issues scanned: **10**" in report
+    assert "Zombies found: **0**" in report
+    assert "No zombies found." in report
+    # No table when there are no matches.
+    assert "| Issue | Title |" not in report
+
+
+def test_render_report_with_matches(audit_module):
+    matches = [
+        {
+            "issue": 2831,
+            "issue_title": "dx: add scripts/foo.sh",
+            "shipped_pr": 3229,
+            "overlap_count": 1,
+            "overlap_files": ["scripts/foo.sh"],
+            "added_files": ["scripts/foo.sh"],
+            "candidate_files": ["scripts/foo.sh"],
+        },
+        {
+            "issue": 9001,
+            "issue_title": "dx: add packages/web/bar.ts",
+            "shipped_pr": 9050,
+            "overlap_count": 1,
+            "overlap_files": ["packages/web/bar.ts"],
+            "added_files": [],
+            "candidate_files": ["packages/web/bar.ts"],
+        },
+    ]
+    report = audit_module.render_report(
+        issues_scanned=20,
+        matches=matches,
+        repo="judgemind/judgemind",
+    )
+    assert "Issues scanned: **20**" in report
+    assert "Zombies found: **2**" in report
+    assert "| #2831 | dx: add scripts/foo.sh | #3229 |" in report
+    assert "`scripts/foo.sh`" in report
+    assert "| #9001 | dx: add packages/web/bar.ts | #9050 |" in report
+    assert "/task #N" in report  # next-steps section
+
+
+# ─── Integration: run_audit with mocks ─────────────────────────────────────
+
+
+def test_run_audit_no_zombies_in_queue(tmp_path, audit_module):
+    issues = [
+        {"number": 100, "title": "feat: foo"},
+        {"number": 101, "title": "feat: bar"},
+    ]
+    gh_bin = _make_gh_mock(tmp_path, issues)
+    check_bin = _make_check_shipped_mock(tmp_path, matches=None)
+
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(gh_bin),
+        check_bin=str(check_bin),
+    )
+    assert exit_code == 0
+    assert "Issues scanned: **2**" in report
+    assert "Zombies found: **0**" in report
+    assert "No zombies found." in report
+
+
+def test_run_audit_finds_zombie(tmp_path, audit_module):
+    issues = [
+        {"number": 2831, "title": "dx: add scripts/foo.sh"},
+        {"number": 100, "title": "feat: clean"},
+    ]
+    matches = {
+        2831: {
+            "issue": 2831,
+            "shipped_pr": 3229,
+            "overlap_count": 1,
+            "overlap_files": ["scripts/foo.sh"],
+            "added_files": ["scripts/foo.sh"],
+            "candidate_files": ["scripts/foo.sh"],
+        }
+    }
+    gh_bin = _make_gh_mock(tmp_path, issues)
+    check_bin = _make_check_shipped_mock(tmp_path, matches=matches)
+
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(gh_bin),
+        check_bin=str(check_bin),
+    )
+    assert exit_code == 0
+    assert "Issues scanned: **2**" in report
+    assert "Zombies found: **1**" in report
+    assert "| #2831 | dx: add scripts/foo.sh | #3229 |" in report
+    assert "`scripts/foo.sh`" in report
+
+
+def test_run_audit_empty_queue(tmp_path, audit_module):
+    gh_bin = _make_gh_mock(tmp_path, [])
+    check_bin = _make_check_shipped_mock(tmp_path, matches=None)
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(gh_bin),
+        check_bin=str(check_bin),
+    )
+    assert exit_code == 0
+    assert "Issues scanned: **0**" in report
+    assert "No zombies found." in report
+
+
+def test_run_audit_preflight_fails_when_gh_missing(tmp_path, audit_module):
+    # Point at a non-existent gh binary.
+    missing_gh = tmp_path / "definitely-not-installed-gh"
+    check_bin = _make_check_shipped_mock(tmp_path, matches=None)
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(missing_gh),
+        check_bin=str(check_bin),
+    )
+    assert exit_code == 1
+    assert "error" in report.lower()
+
+
+def test_run_audit_preflight_fails_when_check_bin_missing(tmp_path, audit_module):
+    gh_bin = _make_gh_mock(tmp_path, [])
+    missing_check = tmp_path / "missing-check.sh"
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(gh_bin),
+        check_bin=str(missing_check),
+    )
+    assert exit_code == 1
+    assert "error" in report.lower()
+
+
+def test_run_audit_preflight_fails_when_check_bin_not_executable(
+    tmp_path, audit_module
+):
+    gh_bin = _make_gh_mock(tmp_path, [])
+    not_exec = tmp_path / "not-exec.sh"
+    not_exec.write_text("#!/bin/bash\nexit 0\n")
+    # Deliberately do not chmod +x.
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(gh_bin),
+        check_bin=str(not_exec),
+    )
+    assert exit_code == 1
+    assert "error" in report.lower()
+
+
+def test_run_audit_skips_issues_with_non_int_number(tmp_path, audit_module):
+    # Defensive: gh is unlikely to ever return non-int numbers, but if a
+    # hand-crafted fixture or a future API change does, we should skip them
+    # rather than crash.
+    issues = [
+        {"number": "not-an-int", "title": "garbage"},
+        {"number": 200, "title": "real issue"},
+    ]
+    gh_bin = _make_gh_mock(tmp_path, issues)
+    check_bin = _make_check_shipped_mock(tmp_path, matches=None)
+    exit_code, report = audit_module.run_audit(
+        repo="judgemind/judgemind",
+        limit=10,
+        gh_bin=str(gh_bin),
+        check_bin=str(check_bin),
+    )
+    assert exit_code == 0
+    # Both rows are counted in issues_scanned (mirrors gh's view), but the
+    # non-int one is silently skipped during checking.
+    assert "Issues scanned: **2**" in report
+
+
+# ─── End-to-end: run the script as a subprocess ────────────────────────────
+
+
+def test_main_dry_run_exits_zero_and_prints_report(tmp_path, audit_module):
+    """Acceptance criterion #1: ``--dry-run`` exits 0 and prints markdown."""
+
+    issues = [{"number": 2831, "title": "dx: add scripts/foo.sh"}]
+    matches = {
+        2831: {
+            "issue": 2831,
+            "shipped_pr": 3229,
+            "overlap_count": 1,
+            "overlap_files": ["scripts/foo.sh"],
+            "added_files": ["scripts/foo.sh"],
+            "candidate_files": ["scripts/foo.sh"],
+        }
+    }
+    gh_bin = _make_gh_mock(tmp_path, issues)
+    check_bin = _make_check_shipped_mock(tmp_path, matches=matches)
+
+    env = os.environ.copy()
+    env["AUDIT_SHIPPED_GH_BIN"] = str(gh_bin)
+    env["AUDIT_SHIPPED_CHECK_BIN"] = str(check_bin)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--dry-run"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "# Shipped-zombie audit report" in result.stdout
+    assert "| #2831 |" in result.stdout
+    assert "#3229" in result.stdout
+
+
+def test_main_with_no_matches_states_no_zombies_found(tmp_path):
+    """Acceptance criterion #2 (negative case): explicit count when nothing matches."""
+
+    issues = [{"number": 9001, "title": "feat: nothing shipped"}]
+    gh_bin = _make_gh_mock(tmp_path, issues)
+    check_bin = _make_check_shipped_mock(tmp_path, matches=None)
+
+    env = os.environ.copy()
+    env["AUDIT_SHIPPED_GH_BIN"] = str(gh_bin)
+    env["AUDIT_SHIPPED_CHECK_BIN"] = str(check_bin)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "No zombies found." in result.stdout
+    assert "Issues scanned: **1**" in result.stdout
+
+
+# ─── Header / structure invariants ─────────────────────────────────────────
+
+
+def test_script_carries_permanent_marker():
+    """Acceptance criterion #1 (suffix): ``# permanent: true`` header present."""
+
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    head = "\n".join(text.splitlines()[:10])
+    assert "# permanent: true" in head
+
+
+def test_script_carries_venv_header():
+    """Acceptance criterion #1 (suffix): ``# venv:`` header present."""
+
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    head = "\n".join(text.splitlines()[:10])
+    # The issue allowed `# venv: scripts` or none; we used `# venv: none`
+    # because the script is pure stdlib + gh shell-out.
+    assert "# venv:" in head
+
+
+def test_script_is_executable():
+    """Acceptance criterion #1 (suffix): script is executable."""
+
+    mode = SCRIPT_PATH.stat().st_mode
+    assert mode & stat.S_IXUSR, f"{SCRIPT_PATH} is not executable"
+
+
+def test_docstring_lists_manual_review_steps():
+    """Acceptance criterion #3: top-of-file docstring lists manual review."""
+
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    # The docstring should reference: report skim, /task #N, §4a.2 pivot.
+    assert "/task #N" in text
+    assert "§4a.2" in text
+    assert "verify-and-close" in text


### PR DESCRIPTION
## Summary

Adds `scripts/audits/audit-shipped-zombies.py` — a one-shot, read-only audit that walks the open `agent/ready` queue via `gh issue list`, runs `scripts/check-shipped-pr.sh` (#4204) against each issue, and emits a markdown report listing every issue whose code already shipped via a merged-but-unclosed PR.

The script does NOT auto-close anything; the operator runs `/task #N` on each match, and `/task` Step 4a.2's verify-and-close pivot drives the close.

Closes #4210

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (19 new tests in `scripts/tests/test_audit_shipped_zombies.py`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (one-shot operator audit script; not invoked by any workflow or service)
