### PR TITLE
fix(dx): check-shipped-pr.sh extracts every (#N) token from headlines (#4214)

### DIFF
--- a/scripts/_check_shipped_pr_extract_pr_nums.py
+++ b/scripts/_check_shipped_pr_extract_pr_nums.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_extract_pr_nums.py — Extract every `(#N)` token from
+# commit headlines for scripts/check-shipped-pr.sh.
+#
+# Reads commit messages on stdin (one per line — typically the output of
+# `gh api /repos/.../commits?path=<file> --jq '.[] | .commit.message'`).
+# For each line, takes the headline (everything before the first newline,
+# but the input is already line-split so each line IS a headline) and
+# extracts EVERY `(#N)` token. Prints the resulting PR numbers, one per
+# line, deduplicated in first-seen order.
+#
+# venv: none
+# permanent: true
+#
+# Why this exists: the bash regex `[[ "$str" =~ \(#([0-9]+)\) ]]` only
+# captures the FIRST match in the string. On commit headlines like:
+#
+#     fix(ci): vercel-deploy-status no longer false-fails on squash-merge (#2837) (#3170)
+#
+# the bash version would extract only `2837` (the closed-by issue
+# referenced in the conventional-commits subject) and drop `3170` (the
+# actual squash-merge PR). The downstream `gh pr view 2837 --json files`
+# then errors out and the candidate is silently skipped — even though
+# PR #3170 absolutely shipped the change. Bash doesn't do iterative
+# regex matches natively, so we delegate to Python and let the
+# downstream vetting loop in check-shipped-pr.sh sort out which `(#N)`
+# is a real merged PR (issue numbers and unknown PRs return null
+# `mergedAt` and are dropped by _check_shipped_pr_overlap.py).
+#
+# See issue #4214 for the bug + fix design, and PR #3170's headline as
+# the canonical multi-`(#N)` example.
+
+import re
+import sys
+
+# Match every `(#NNN)` token in a string. Returns the captured number(s).
+PR_NUM_REGEX = re.compile(r"\(#(\d+)\)")
+
+
+def extract_pr_nums(commit_messages: list[str]) -> list[str]:
+    """Return unique PR numbers from `(#N)` tokens, in first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for message in commit_messages:
+        if not message:
+            continue
+        # Each input line is already a headline — but defensively grab
+        # only the first \n-delimited segment in case a multi-line commit
+        # message slipped through.
+        headline = message.split("\n", 1)[0]
+        for match in PR_NUM_REGEX.finditer(headline):
+            pr_num = match.group(1)
+            if pr_num not in seen:
+                seen.add(pr_num)
+                out.append(pr_num)
+    return out
+
+
+def main() -> int:
+    lines = sys.stdin.read().splitlines()
+    for pr_num in extract_pr_nums(lines):
+        print(pr_num)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -105,7 +105,11 @@ fi
 # ─── Find candidate PRs that touched any of those files ────────────────────
 
 # Collect (PR number, comma-separated unique). For each file path, list
-# recent commits on main; parse `(#N)` from the headline; accumulate.
+# recent commits on main; parse EVERY `(#N)` token from each headline
+# via the Python helper (bash regex match captures only the first
+# token, which silently drops the squash-merge PR when the conventional-
+# commits subject already references a closed-by issue, e.g.
+# `fix(ci): squash-merge fix (#2837) (#3170)` — see issue #4214).
 candidate_prs=""
 while IFS= read -r file_path; do
     [[ -z "$file_path" ]] && continue
@@ -117,24 +121,27 @@ while IFS= read -r file_path; do
         2>/dev/null); then
         continue
     fi
-    # Extract `(#N)` tokens from each headline.
-    while IFS= read -r commit_message; do
-        [[ -z "$commit_message" ]] && continue
-        # Get the first line only (headline)
-        headline="${commit_message%%$'\n'*}"
-        # Match `(#NNN)` at end-of-line or before whitespace
-        if [[ "$headline" =~ \(#([0-9]+)\) ]]; then
-            pr_num="${BASH_REMATCH[1]}"
-            # Append if not already present
-            if [[ ",${candidate_prs}," != *",${pr_num},"* ]]; then
-                if [[ -z "$candidate_prs" ]]; then
-                    candidate_prs="$pr_num"
-                else
-                    candidate_prs="${candidate_prs},${pr_num}"
-                fi
+    # Extract EVERY `(#N)` token across all headlines via the Python
+    # helper. The downstream vetting loop (lines below) filters out
+    # issue numbers and unknown PRs via `gh pr view --json mergedAt`
+    # (returns null for non-PR numbers).
+    pr_nums=""
+    if ! pr_nums=$(printf '%s\n' "$commits_json" | python3 \
+        "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_extract_pr_nums.py" \
+        2>/dev/null); then
+        continue
+    fi
+    while IFS= read -r pr_num; do
+        [[ -z "$pr_num" ]] && continue
+        # Append if not already present
+        if [[ ",${candidate_prs}," != *",${pr_num},"* ]]; then
+            if [[ -z "$candidate_prs" ]]; then
+                candidate_prs="$pr_num"
+            else
+                candidate_prs="${candidate_prs},${pr_num}"
             fi
         fi
-    done <<< "$commits_json"
+    done <<< "$pr_nums"
 done <<< "$candidate_files"
 
 if [[ -z "$candidate_prs" ]]; then

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -455,6 +455,80 @@ else
     fail "strips leading '#' from issue argument" "exit=$exit_code output=$output"
 fi
 
+# ─── Test 13: multi-`(#N)` headline picks up the squash-merge PR (#4214) ──
+
+# Regression for #4214. Commit headline contains TWO `(#N)` tokens — the
+# first is a closed-by issue reference baked into the conventional-
+# commits subject, the second is the auto-appended squash-merge PR.
+# Pre-fix, bash captured only the first token (`2837`) and the candidate
+# was silently skipped because `gh pr view 2837 --json files` errored
+# (2837 was an issue, not a PR). Post-fix, BOTH tokens are tried; the
+# downstream vetting loop drops the issue (`mergedAt: null`) and keeps
+# the PR (`mergedAt: <timestamp>`), so the script returns shipped.
+#
+# Mock behavior: `gh pr view 2837` returns `mergedAt: null` (simulating
+# the issue number being passed to `gh pr view` and returning a null
+# mergedAt — which is the same eligibility-fail path the overlap helper
+# already takes on closed-without-merge PRs). `gh pr view 3170` returns
+# the merged PR with the candidate file in its `files` list. The
+# downstream loop must reach 3170; pre-fix it could not.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "Bug in .github/workflows/vercel-deploy-status.yml — squash-merge false-fails.", "title": "fix(ci): vercel-deploy-status false-fails on squash-merge"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        # Single commit headline carrying TWO `(#N)` tokens — the
+        # closed-by issue (#2837) and the squash-merge PR (#3170).
+        echo "fix(ci): vercel-deploy-status no longer false-fails on squash-merge (#2837) (#3170)"
+        exit 0
+        ;;
+    pr)
+        # gh pr view <N> --repo ... — vary the response by PR number.
+        if [[ "${2:-}" == "view" ]]; then
+            case "${3:-}" in
+                2837)
+                    # The closed-by ISSUE — `gh pr view <issue-num>`
+                    # returns a null mergedAt because issues are not
+                    # mergeable. The overlap helper drops it.
+                    cat << 'JSON'
+{"baseRefName": "main", "files": [], "mergedAt": null, "number": 2837, "title": "[issue not PR]"}
+JSON
+                    exit 0
+                    ;;
+                3170)
+                    # The actual squash-merge PR — eligible. Mocked
+                    # with deletions=0 so the candidate registers as an
+                    # `added` overlap and clears the high-confidence
+                    # threshold (≥1 added OR ≥2 total) on a single
+                    # candidate path.
+                    cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": ".github/workflows/vercel-deploy-status.yml", "additions": 50, "deletions": 0}], "mergedAt": "2026-04-15T00:00:00Z", "number": 3170, "title": "fix(ci): vercel-deploy-status no longer false-fails on squash-merge"}
+JSON
+                    exit 0
+                    ;;
+            esac
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2979 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3170"* ]]; then
+    pass "extracts EVERY (#N) token from multi-token headline (regression #4214)"
+else
+    fail "extracts EVERY (#N) token from multi-token headline (regression #4214)" "exit=$exit_code output=$output"
+fi
+
 # Restore PATH for cleanup
 export PATH="$ORIG_PATH_SAVE"
 


### PR DESCRIPTION
## Summary

Fix `scripts/check-shipped-pr.sh` so it extracts EVERY `(#N)` token from
commit headlines, not just the first. Pre-fix, headlines like
`fix(ci): vercel-deploy-status no longer false-fails on squash-merge (#2837) (#3170)`
caused the script to grab the closed-by issue number (`2837`) and drop the
actual squash-merge PR (`3170`); the downstream `gh pr view 2837` errored,
the candidate was skipped, and the script returned `not-shipped` even when
the issue had shipped weeks ago. Replaces the single-match bash regex with
a Python helper (`_check_shipped_pr_extract_pr_nums.py`) that returns every
PR number; the downstream vetting loop already drops non-PR numbers via
`mergedAt: null`. Includes a regression test pinning the multi-`(#N)`
headline behavior.

Closes #4214

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/check-shipped-pr.sh 2979` from any worktree and confirm
      it returns `shipped: PR #...` (exit 0) with
      `.github/workflows/vercel-deploy-status.yml` in the overlap list.
      Pre-fix returns `not-shipped` (exit 1) — the bug being fixed.
- [x] Verification evidence posted on issue (see A.8)
