### PR TITLE
ci(api): require statusCode assertion when test title names HTTP status (#4220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1268,6 +1268,26 @@ jobs:
         run: scripts/check-no-graphql-instanceof.sh
 
   # ---------------------------------------------------------------
+  # HTTP-status assertion guard: api test titles that name an HTTP
+  # status (e.g. "returns 400 for invalid UUID", "rejects with HTTP
+  # 401") must include a corresponding statusCode assertion in the
+  # test body. Without this, the title gives false confidence and
+  # regressions like #4129 (cost-cap rejections regressed from HTTP
+  # 400 to HTTP 500 between #4112 and #4218) slip through. PR #4218
+  # added the missing assertion; this guard prevents the recurrence.
+  # The step name intentionally avoids quoting the forbidden pattern
+  # (per docs/agent/code-standards.md §Hygiene-check CI steps).
+  # ---------------------------------------------------------------
+  test-statuscode-assertions-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Require response-status assertions in API tests that name a status
+        run: scripts/check-test-statuscode-assertions.sh
+
+  # ---------------------------------------------------------------
   # Dispatcher terminal-status sync guard (#2863)
   # ---------------------------------------------------------------
   dispatcher-terminal-statuses-check:
@@ -1769,7 +1789,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -142,6 +142,29 @@ except Exception:  # noqa: BLE001
 
 Prefer narrowing the handler (`except FileNotFoundError:`) or logging the exception over the escape hatch — the goal is to keep blind swallows out of assertion paths.
 
+### HTTP-status assertion hygiene (enforced in CI for `packages/api/`)
+
+A TypeScript API test whose title names a specific HTTP status — `it('returns 400 for invalid UUID', ...)`, `it('rejects with HTTP 401', ...)`, `it('responds with statusCode 404', ...)` — must include a corresponding `statusCode` assertion in the test body (e.g. `expect(res.statusCode).toBe(400)`). Without this, the title is decorative and the test can pass even when the handler returns a different status, which is exactly how #4129 slipped through (a test titled "rejects … with HTTP 400" only checked the JSON-body shape; PR #4218 added the missing assertion).
+
+CI enforces this via `scripts/check-test-statuscode-assertions.sh`, which scans `packages/api/tests/**/*.test.ts` and `packages/api/src/**/*.test.ts` for `it()`/`test()`/`it.each()` titles that match `HTTP <NNN>` / `returns <NNN>` / `responds with <NNN>` / `status(Code)? <NNN>`, then verifies the same `it()` block contains a `statusCode` reference paired with the matching status number.
+
+**Escape hatch.** If a test legitimately doesn't go through an HTTP boundary (e.g. it asserts on a thrown error rather than on an inject-response object), append `// status-assertion-noqa` to the same line as the `it()` / `test()` opening call:
+
+```typescript
+it('returns 400 via direct call', async () => { // status-assertion-noqa
+  await expect(callDirectly()).rejects.toThrow(/bad input/);
+});
+```
+
+The check job is `test-statuscode-assertions-check` (gated on `detect-changes.outputs.api`). Run it locally:
+
+```
+scripts/check-test-statuscode-assertions.sh             # default scan
+scripts/check-test-statuscode-assertions.sh --selftest  # embedded fixture self-test
+```
+
+Ref: #4220 (the issue that added the guard), #4129 (the regression that motivated it), #4218 (the original fix that added the missing assertion).
+
 ### Test marker convention (`scripts/tests/test_agent_runner_entrypoint.sh`)
 
 Each test block in `scripts/tests/test_agent_runner_entrypoint.sh` carries a unique marker tied to the GitHub issue that introduced the test. This avoids the sequential-numbering collision that occurred when two parallel agents (PRs #3661 and #3666) both claimed marker T65, causing a merge conflict.

--- a/scripts/check-test-statuscode-assertions.py
+++ b/scripts/check-test-statuscode-assertions.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""Forbid HTTP-status-naming test titles that lack a statusCode assertion.
+
+A TypeScript API test whose title names an HTTP status (e.g.
+``it('returns 400 for invalid UUID', ...)``) MUST assert on
+``res.statusCode`` for that status. Otherwise the title gives false
+confidence: the test can pass even when the handler returns a different
+status (notably 500), which is exactly how #4129 slipped through
+(see PR #4218 for the fix).
+
+Recognised title patterns: ``HTTP <NNN>``, ``returns <NNN>`` /
+``return <NNN>``, ``responds with <NNN>`` / ``respond with <NNN>``,
+``status <NNN>`` / ``statusCode <NNN>``. <NNN> is any 3-digit number.
+
+Recognised assertion patterns: any line in the same ``it()``/``test()``
+block where ``statusCode`` and the named status number co-occur (covers
+``expect(res.statusCode).toBe(NNN)``, ``assert.equal(res.statusCode, NNN)``,
+and equivalents across vitest/jest/node:assert).
+
+Escape hatch: append ``// status-assertion-noqa`` to the ``it()`` or
+``test()`` opening line to acknowledge a deliberate omission.
+
+Usage:
+    scripts/check-test-statuscode-assertions.py [PATH ...]
+    scripts/check-test-statuscode-assertions.py --selftest
+
+With no arguments, scans ``packages/api/tests`` and ``packages/api/src``.
+Exit 0 = no violations, 1 = one or more violations.
+
+Ref: https://github.com/judgemind/judgemind/issues/4220
+"""
+# permanent: true
+
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# Default directories to scan when no paths are supplied.
+_DEFAULT_DIRS: list[str] = [
+    "packages/api/tests",
+    "packages/api/src",
+]
+
+# Title pattern: matches an HTTP status reference inside the title string
+# of an ``it()`` / ``test()`` / ``it.each()`` / ``test.each()`` call. The
+# title is captured by ``_TEST_OPEN_RE``; the status numbers are pulled
+# out by ``_STATUS_IN_TITLE_RE``.
+_STATUS_IN_TITLE_RE = re.compile(
+    r"""(?ix)
+        \b
+        (?:
+            HTTP\s+(\d{3})                     # "HTTP 400"
+          | (?:returns?|responds?\s+with)      # "returns 400" / "responds with 400"
+            \s+ (\d{3})
+          | status(?:Code)?\s+(\d{3})          # "status 400" / "statusCode 400"
+        )
+        \b
+    """,
+)
+
+# Test-opening line pattern: matches ``it('title', ...)``, ``test('title', ...)``,
+# ``it.each(...)('title', ...)``, ``test.each(...)('title', ...)``,
+# ``it.skip('title')``, ``it.only('title')``, etc. The title is the first
+# string-literal argument; we capture it loosely (between the same quote
+# character it opened with), tolerating template literals and nested
+# escapes via a non-greedy match.
+_TEST_OPEN_RE = re.compile(
+    r"""(?x)
+        ^(?P<indent>\s*)
+        (?P<func>
+            (?:it|test)
+            (?:\.(?:skip|only|each|todo|concurrent|sequential))?
+            (?:\([^)]*\))?            # optional ``.each(table)`` arg
+        )
+        \(\s*
+        (?P<quote>['"`])
+        (?P<title>(?:\\.|(?!(?P=quote)).)*)
+        (?P=quote)
+    """,
+)
+
+# Escape-hatch marker — must appear on the same source line as the
+# ``it()`` / ``test()`` opening call.
+_NOQA_MARKER = "// status-assertion-noqa"
+
+# Assertion patterns inside a test body. We accept any line where a
+# ``statusCode`` reference and the expected status number appear together,
+# regardless of which assertion library style is in use.
+def _assertion_for_status(status: str) -> re.Pattern[str]:
+    # Look for ``statusCode`` (case-insensitive, allowing ``status_code``
+    # too even though TS convention is camelCase) plus the matching
+    # 3-digit number on the same line. The ``status`` argument is one
+    # specific number; we anchor on it to avoid false positives where a
+    # test asserts on a *different* status code than the one named in
+    # the title.
+    return re.compile(
+        rf"""
+        statusCode
+        .*?
+        \b{re.escape(status)}\b
+        |
+        \b{re.escape(status)}\b
+        .*?
+        statusCode
+        """,
+        re.VERBOSE,
+    )
+
+
+def _find_block_end(source_lines: list[str], open_lineno_idx: int) -> int:
+    """Find the line index where the test body ``})`` closes.
+
+    ``open_lineno_idx`` is the 0-indexed line containing the opening
+    ``it(`` or ``test(`` call. We walk forward, counting brace + paren
+    depth across all subsequent lines, and return the index of the line
+    where depth returns to its original value (or to zero, whichever
+    comes first). String literals and template literals are skipped so
+    their internal braces don't fool the counter.
+
+    Falls back to the last line of the file if the structure is malformed
+    — better to scan the whole tail than to silently miss a violation.
+    """
+    depth_paren = 0
+    depth_brace = 0
+    started = False
+    in_string: str | None = None  # quote char if inside a string literal
+    in_block_comment = False
+    in_line_comment = False
+    template_brace_depth = 0  # tracks ${...} nesting inside template literals
+
+    for idx in range(open_lineno_idx, len(source_lines)):
+        line = source_lines[idx]
+        in_line_comment = False
+        i = 0
+        while i < len(line):
+            ch = line[i]
+            nxt = line[i + 1] if i + 1 < len(line) else ""
+
+            if in_line_comment:
+                break  # rest of line is comment; skip
+
+            if in_block_comment:
+                if ch == "*" and nxt == "/":
+                    in_block_comment = False
+                    i += 2
+                    continue
+                i += 1
+                continue
+
+            if in_string is not None:
+                if ch == "\\":
+                    # Skip escaped char.
+                    i += 2
+                    continue
+                if in_string == "`" and ch == "$" and nxt == "{":
+                    template_brace_depth += 1
+                    in_string = None  # leave template literal mode
+                    i += 2
+                    continue
+                if ch == in_string:
+                    in_string = None
+                    i += 1
+                    continue
+                i += 1
+                continue
+
+            if ch == "/" and nxt == "/":
+                in_line_comment = True
+                break
+            if ch == "/" and nxt == "*":
+                in_block_comment = True
+                i += 2
+                continue
+            if ch in ("'", '"', "`"):
+                in_string = ch
+                i += 1
+                continue
+            if ch == "(":
+                depth_paren += 1
+                started = True
+            elif ch == ")":
+                depth_paren -= 1
+            elif ch == "{":
+                if template_brace_depth > 0:
+                    template_brace_depth += 1
+                else:
+                    depth_brace += 1
+                    started = True
+            elif ch == "}":
+                if template_brace_depth > 0:
+                    template_brace_depth -= 1
+                    if template_brace_depth == 0:
+                        # Re-enter template-literal string mode (we know
+                        # we left from one because template_brace_depth
+                        # was incremented from a `).
+                        in_string = "`"
+                else:
+                    depth_brace -= 1
+            i += 1
+
+        if started and depth_paren <= 0 and depth_brace <= 0:
+            return idx
+
+    return len(source_lines) - 1
+
+
+def find_violations(filepath: Path) -> list[tuple[int, str, str]]:
+    """Return ``(lineno, status, snippet)`` for each violation in the file.
+
+    A violation is a test whose title names HTTP status ``status`` but
+    whose body does not assert on ``statusCode`` for that status (and
+    does not carry the ``// status-assertion-noqa`` escape hatch on the
+    opening line).
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[tuple[int, str, str]] = []
+
+    for idx, line in enumerate(source_lines):
+        m = _TEST_OPEN_RE.match(line)
+        if not m:
+            continue
+
+        title = m.group("title")
+        # Pull every status number named in the title. A title can name
+        # more than one ("returns 400 or 401"); we require an assertion
+        # for each.
+        statuses_in_title: list[str] = []
+        for sm in _STATUS_IN_TITLE_RE.finditer(title):
+            for grp in sm.groups():
+                if grp is not None:
+                    statuses_in_title.append(grp)
+                    break
+        if not statuses_in_title:
+            continue
+
+        # Escape hatch: same-line noqa marker.
+        if _NOQA_MARKER in line:
+            continue
+
+        end_idx = _find_block_end(source_lines, idx)
+        body_text = "\n".join(source_lines[idx : end_idx + 1])
+
+        for status in statuses_in_title:
+            if not _assertion_for_status(status).search(body_text):
+                snippet = line.strip()
+                violations.append((idx + 1, status, snippet))
+
+    return violations
+
+
+def iter_test_files(paths: list[Path]) -> list[Path]:
+    """Yield ``*.test.ts`` / ``*.test.tsx`` files under each path.
+
+    A file passed directly is included if its name matches the test
+    pattern; directories are walked recursively.
+    """
+    suffixes = (".test.ts", ".test.tsx", ".test.mts")
+    files: list[Path] = []
+    for root in paths:
+        if not root.exists():
+            continue
+        if root.is_file():
+            if root.name.endswith(suffixes):
+                files.append(root)
+            continue
+        for candidate in root.rglob("*"):
+            if candidate.is_file() and candidate.name.endswith(suffixes):
+                files.append(candidate)
+    return files
+
+
+def _selftest() -> int:
+    """Run a self-test against synthetic fixture content.
+
+    Asserts:
+      * A fixture with a missing ``statusCode`` assertion produces a
+        violation.
+      * A fixture with the assertion present produces no violation.
+      * The escape hatch (``// status-assertion-noqa``) suppresses the
+        violation.
+      * A title that does NOT name an HTTP status produces no violation
+        even when the body has no statusCode assertion.
+
+    Exits 0 on success, 1 on failure.
+    """
+    bad_fixture = """\
+import { describe, it, expect } from 'vitest';
+
+describe('handler', () => {
+  it('returns 400 for invalid UUID', async () => {
+    const res = await app.inject({ url: '/foo' });
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+"""
+
+    good_fixture = """\
+import { describe, it, expect } from 'vitest';
+
+describe('handler', () => {
+  it('returns 400 for invalid UUID', async () => {
+    const res = await app.inject({ url: '/foo' });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+"""
+
+    noqa_fixture = """\
+import { describe, it, expect } from 'vitest';
+
+describe('handler', () => {
+  it('returns 400 for invalid UUID', async () => { // status-assertion-noqa
+    // Asserts on the thrown error, not the inject response.
+    await expect(callDirectly()).rejects.toThrow(/bad uuid/);
+  });
+});
+"""
+
+    not_a_status_fixture = """\
+import { describe, it, expect } from 'vitest';
+
+describe('handler', () => {
+  it('rejects gracefully', async () => {
+    const res = await app.inject({ url: '/foo' });
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+"""
+
+    multi_status_fixture = """\
+import { describe, it, expect } from 'vitest';
+
+describe('handler', () => {
+  it('returns 400 for invalid UUID and HTTP 401 for missing auth', async () => {
+    const res = await app.inject({ url: '/foo' });
+    expect(res.statusCode).toBe(400);
+    // 401 not asserted; this is a violation for status=401 only.
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+"""
+
+    cases: list[tuple[str, str, list[str]]] = [
+        ("bad", bad_fixture, ["400"]),
+        ("good", good_fixture, []),
+        ("noqa", noqa_fixture, []),
+        ("not_a_status", not_a_status_fixture, []),
+        ("multi_status", multi_status_fixture, ["401"]),
+    ]
+
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for label, content, expected_violations in cases:
+            fp = Path(tmpdir) / f"{label}.test.ts"
+            fp.write_text(content, encoding="utf-8")
+            got = find_violations(fp)
+            got_statuses = sorted(status for _, status, _ in got)
+            want_statuses = sorted(expected_violations)
+            if got_statuses != want_statuses:
+                failures.append(
+                    f"{label}: expected violations {want_statuses}, got {got_statuses} (raw={got})"
+                )
+
+    if failures:
+        print("SELFTEST FAILED:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+    print("SELFTEST OK: all 5 fixture cases produced expected violation lists.")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if argv and argv[0] == "--selftest":
+        return _selftest()
+
+    if argv:
+        paths = [Path(p) for p in argv]
+    else:
+        paths = [Path(p) for p in _DEFAULT_DIRS]
+
+    files = iter_test_files(paths)
+    violations: list[tuple[Path, int, str, str]] = []
+    for fp in files:
+        for lineno, status, snippet in find_violations(fp):
+            violations.append((fp, lineno, status, snippet))
+
+    if not violations:
+        return 0
+
+    print(
+        "ERROR: Test title names HTTP status but body lacks a `statusCode` assertion:",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for fp, lineno, status, snippet in violations:
+        print(f"  {fp}:{lineno}: missing assert on statusCode={status}", file=sys.stderr)
+        print(f"      {snippet}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "A test title that names an HTTP status code without a corresponding",
+        file=sys.stderr,
+    )
+    print(
+        "`expect(res.statusCode).toBe(<NNN>)` assertion gives false confidence",
+        file=sys.stderr,
+    )
+    print(
+        "— the bug it claims to catch can slip through (see #4129 / #4218 / #4220).",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(
+        "Either add the assertion, or — if the test legitimately doesn't go",
+        file=sys.stderr,
+    )
+    print(
+        f"through an HTTP boundary — append `{_NOQA_MARKER}` to the same line",
+        file=sys.stderr,
+    )
+    print("as the `it()` / `test()` opening call.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-test-statuscode-assertions.sh
+++ b/scripts/check-test-statuscode-assertions.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# check-test-statuscode-assertions.sh — Forbid HTTP-status-naming test titles
+# that lack a corresponding `statusCode` assertion in the test body.
+#
+# See scripts/check-test-statuscode-assertions.py for the full behaviour
+# description, the recognised title patterns, and the
+# `// status-assertion-noqa` escape hatch.
+#
+# Usage:
+#   scripts/check-test-statuscode-assertions.sh             # scans default API test dirs
+#   scripts/check-test-statuscode-assertions.sh PATH ...    # scans specific paths
+#   scripts/check-test-statuscode-assertions.sh --selftest  # runs embedded fixture self-test
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more violations found.
+#
+# Ref: https://github.com/judgemind/judgemind/issues/4220
+# permanent: true
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-test-statuscode-assertions.py" "$@"

--- a/scripts/tests/test_check_test_statuscode_assertions.sh
+++ b/scripts/tests/test_check_test_statuscode_assertions.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# test_check_test_statuscode_assertions.sh — Tests for
+# scripts/check-test-statuscode-assertions.{sh,py}.
+#
+# Covers the documented behaviour of the guard:
+#   * Missing assertion on a title that names HTTP <NNN>     → exit 1
+#   * Missing assertion on a title that says "returns <NNN>" → exit 1
+#   * Title with assertion present                           → exit 0
+#   * Title without an HTTP status reference                 → exit 0
+#   * Same-line `// status-assertion-noqa` opt-out           → exit 0
+#   * Multi-status title with one missing assertion          → exit 1
+#   * Embedded --selftest                                    → exit 0
+#   * Regression fixture mirroring #4129 / #4218             → exit 1 (pre-fix), exit 0 (post-fix)
+#
+# Usage:
+#   scripts/tests/test_check_test_statuscode_assertions.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-test-statuscode-assertions.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TMPDIR_TEST="$(mktemp -d)"
+
+cleanup() {
+    set +eu
+    if [[ -n "$TMPDIR_TEST" && -d "$TMPDIR_TEST" ]]; then
+        rm -rf "$TMPDIR_TEST"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"
+    mkdir -p "$TMPDIR_TEST"
+}
+
+# Run the guard against TMPDIR_TEST and capture exit code.
+run_guard() {
+    local exit_code=0
+    "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1 || exit_code=$?
+    echo "$exit_code"
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+    echo "FAIL: $CHECK_SCRIPT is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Test 1: Missing assertion on "HTTP 400" title fails ────────────────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/missing_http.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('rejects with HTTP 400 when input is bad', async () => {
+    const res = await app.inject({ url: '/foo' });
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 1 ]]; then
+    pass "exit 1 when title says HTTP 400 but body has no statusCode assertion"
+else
+    fail "exit 1 when title says HTTP 400 but body has no statusCode assertion" "got exit $got"
+fi
+
+# ── Test 2: Missing assertion on "returns 404" title fails ─────────────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/missing_returns.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('returns 404 when document does not exist', async () => {
+    const res = await app.inject({ url: '/foo' });
+    const body = JSON.parse(res.body);
+    expect(body).toEqual({});
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 1 ]]; then
+    pass "exit 1 when title says 'returns 404' but body has no statusCode assertion"
+else
+    fail "exit 1 when title says 'returns 404' but body has no statusCode assertion" "got exit $got"
+fi
+
+# ── Test 3: Title with assertion present passes ────────────────────────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/with_assert.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('returns 400 for invalid UUID', async () => {
+    const res = await app.inject({ url: '/foo' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 0 ]]; then
+    pass "exit 0 when title says 'returns 400' AND body asserts statusCode=400"
+else
+    fail "exit 0 when title says 'returns 400' AND body asserts statusCode=400" "got exit $got"
+fi
+
+# ── Test 4: Title without HTTP status reference passes (unchecked) ─────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/no_status_ref.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('rejects gracefully', async () => {
+    const res = await app.inject({ url: '/foo' });
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 0 ]]; then
+    pass "exit 0 when title doesn't reference an HTTP status"
+else
+    fail "exit 0 when title doesn't reference an HTTP status" "got exit $got"
+fi
+
+# ── Test 5: Same-line // status-assertion-noqa suppresses violation ────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/with_noqa.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('returns 400 via direct call', async () => { // status-assertion-noqa
+    await expect(callDirectly()).rejects.toThrow(/bad input/);
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 0 ]]; then
+    pass "exit 0 when // status-assertion-noqa is on the it() opening line"
+else
+    fail "exit 0 when // status-assertion-noqa is on the it() opening line" "got exit $got"
+fi
+
+# ── Test 6: Multi-status title — one asserted, one not — fails ─────────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/multi_status.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('returns 400 for invalid UUID and HTTP 401 for missing auth', async () => {
+    const res = await app.inject({ url: '/foo' });
+    expect(res.statusCode).toBe(400);
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 1 ]]; then
+    pass "exit 1 when multi-status title asserts only one of the named codes"
+else
+    fail "exit 1 when multi-status title asserts only one of the named codes" "got exit $got"
+fi
+
+# ── Test 7: Embedded --selftest passes ─────────────────────────────────────
+
+exit_code=0
+"$CHECK_SCRIPT" --selftest > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "embedded --selftest exits 0"
+else
+    fail "embedded --selftest exits 0" "got exit $exit_code"
+fi
+
+# ── Test 8: Regression fixture for #4129 / #4218 ───────────────────────────
+#
+# AC #2 of #4220: "the script catches the #4129 failure mode by parsing test
+# titles that name an HTTP status and requiring a corresponding statusCode
+# assertion in the test body." Mirror the pre-#4218 and post-#4218 shapes of
+# packages/api/src/graphql/cost-limit-plugin.unit.test.ts:190 here.
+
+reset_tmpdir
+# pre-#4218: title says "HTTP 400" but ONLY body shape is asserted. The bug
+# this would have caught (#4129: 400 → 500 regression) slipped through under
+# this exact shape. Guard MUST flag this.
+cat > "$TMPDIR_TEST/pre_4218.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('cost-limit-plugin', () => {
+  it('rejects a 40-unit-over-cap query with HTTP 400 + complexityLimitExceeded', async () => {
+    const res = await app.inject({ url: '/graphql' });
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+    const exceeded = body.errors[0];
+    expect(exceeded.extensions.complexityLimitExceeded).toBe(true);
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 1 ]]; then
+    pass "exit 1 on pre-#4218 fixture (would have caught #4129 regression)"
+else
+    fail "exit 1 on pre-#4218 fixture (would have caught #4129 regression)" "got exit $got"
+fi
+
+# post-#4218: same title, but `expect(res.statusCode).toBe(400)` added.
+# Guard MUST accept this — it's the fixed shape that ships today.
+reset_tmpdir
+cat > "$TMPDIR_TEST/post_4218.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('cost-limit-plugin', () => {
+  it('rejects a 40-unit-over-cap query with HTTP 400 + complexityLimitExceeded', async () => {
+    const res = await app.inject({ url: '/graphql' });
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+    const exceeded = body.errors[0];
+    expect(exceeded.extensions.complexityLimitExceeded).toBe(true);
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 0 ]]; then
+    pass "exit 0 on post-#4218 fixture (statusCode assertion added)"
+else
+    fail "exit 0 on post-#4218 fixture (statusCode assertion added)" "got exit $got"
+fi
+
+# ── Test 9: Wrong-status assertion still fails ─────────────────────────────
+# A title saying "returns 400" with `statusCode === 500` in the body is a
+# real bug, not a typo — the guard must catch it.
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/wrong_status.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it('returns 400 for invalid input', async () => {
+    const res = await app.inject({ url: '/foo' });
+    expect(res.statusCode).toBe(500);
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 1 ]]; then
+    pass "exit 1 when title says 400 but body asserts statusCode=500"
+else
+    fail "exit 1 when title says 400 but body asserts statusCode=500" "got exit $got"
+fi
+
+# ── Test 10: it.each table form ────────────────────────────────────────────
+
+reset_tmpdir
+cat > "$TMPDIR_TEST/each_form.test.ts" << 'EOF'
+import { describe, it, expect } from 'vitest';
+describe('x', () => {
+  it.each([['a'], ['b']])('returns 404 for %s', async (input) => {
+    const res = await app.inject({ url: input });
+    const body = JSON.parse(res.body);
+    expect(body.errors).toBeDefined();
+  });
+});
+EOF
+got=$(run_guard)
+if [[ "$got" -eq 1 ]]; then
+    pass "exit 1 on it.each() title without statusCode assertion"
+else
+    fail "exit 1 on it.each() title without statusCode assertion" "got exit $got"
+fi
+
+# ── Test 12: Self-match on CI step name ────────────────────────────────────
+# Per docs/agent/code-standards.md §Hygiene-check CI steps: the step's
+# `name:` in ci.yml must NOT trip the guard. For this guard, "tripping"
+# means the step name contains an HTTP-status reference (e.g. "HTTP 400",
+# "returns 404") without a corresponding statusCode assertion. We
+# synthesize a *.test.ts fixture whose `it()` title is the actual ci.yml
+# step name and run the guard against it — exit 0 means the step name is
+# safe; exit 1 means the step name itself would fail CI. See #2541/#2542
+# for the precedent (the test-except-pass guard had this exact failure
+# mode on its first wiring attempt).
+#
+# The check is best-effort: if no ci.yml step currently runs this guard
+# (e.g. running this test from a branch where the wiring hasn't landed
+# yet), we report PASS with a "nothing to self-match" note.
+
+reset_tmpdir
+GUARD_REPO_PATH="scripts/check-test-statuscode-assertions.sh"
+CI_YML_PATH="$(cd "$SCRIPT_DIR/.." && pwd)/.github/workflows/ci.yml"
+EXTRACTOR_AWK="$SCRIPT_DIR/tests/_extract_guard_step_names.awk"
+
+if [[ -f "$CI_YML_PATH" && -f "$EXTRACTOR_AWK" ]]; then
+    NAMES_FILE="$TMPDIR_TEST/ci_step_names.txt"
+    awk -v script="$GUARD_REPO_PATH" -f "$EXTRACTOR_AWK" "$CI_YML_PATH" > "$NAMES_FILE" 2>/dev/null || true
+
+    if [[ ! -s "$NAMES_FILE" ]]; then
+        pass "no ci.yml step references $GUARD_REPO_PATH yet (nothing to self-match)"
+    else
+        FIXTURE="$TMPDIR_TEST/ci_step_names.test.ts"
+        {
+            echo "import { describe, it, expect } from 'vitest';"
+            echo "describe('ci-yml-step-names', () => {"
+            while IFS= read -r step_name; do
+                step_name="${step_name//\"/}"
+                step_name="${step_name//\'/}"
+                echo "  it('${step_name}', async () => {"
+                echo "    expect(1).toBe(1);"
+                echo "  });"
+            done < "$NAMES_FILE"
+            echo "});"
+        } > "$FIXTURE"
+        rm -f "$NAMES_FILE"
+
+        exit_code=0
+        "$CHECK_SCRIPT" "$FIXTURE" > /dev/null 2>&1 || exit_code=$?
+        if [[ "$exit_code" -eq 0 ]]; then
+            pass "no self-match on ci.yml step name for $GUARD_REPO_PATH"
+        else
+            fail "no self-match on ci.yml step name for $GUARD_REPO_PATH" "guard exit $exit_code — step name itself trips the guard"
+        fi
+    fi
+else
+    pass "self-match check skipped (ci.yml or extractor missing)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-test-statuscode-assertions.{sh,py}` — a CI hygiene guard that scans `packages/api/tests/**/*.test.ts` and `packages/api/src/**/*.test.ts` for `it()`/`test()`/`it.each()` titles that name an HTTP status (`HTTP <NNN>`, `returns <NNN>`, `responds with <NNN>`, `status(Code)? <NNN>`) and verifies the same test block contains a `statusCode` reference paired with the matching status number. Wired into CI as `test-statuscode-assertions-check` (gated on `detect-changes.outputs.api`, alongside `apollo-keyfields-check` / `graphql-query-check` / `no-graphql-instanceof-check`). Same-line `// status-assertion-noqa` escape hatch is provided for tests that legitimately don't go through an HTTP boundary.

Motivation: in #4129 the cost-cap rejection regressed from HTTP 400 to HTTP 500 between #4112 and the fix in #4218. The existing test (`packages/api/src/graphql/cost-limit-plugin.unit.test.ts:190`) was titled "rejects … with HTTP 400" but only asserted on the JSON-body shape — so it passed even though the handler was returning 500. PR #4218 added the missing `expect(res.statusCode).toBe(400)` assertion; this guard prevents the recurrence by making title-vs-assertion mismatches a CI error.

Closes #4220

## Test plan

### Automated checks
- [x] Lint passes (bash scripts comply with `scripts/check-bash-compat.sh`; Python script uses stdlib only)
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_test_statuscode_assertions.sh` — 12/12 PASS; embedded `--selftest` — 5/5 PASS)
- [x] CI green (`ci-passed: SUCCESS`, `test-statuscode-assertions-check: SUCCESS`; the unrelated `Check major pages` failure is a 504 from the GitHub API in the smoke-test workflow's auto-close-issue post-step — not a required check, not in `ci.yml`'s `needs:` array)

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene guard + docs only)
