### PR TITLE
ci(web): generalize bare-shadcn-accent guard to *-foreground family + invisible-chrome (#4225)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1174,19 +1174,22 @@ jobs:
         run: scripts/check-vitest-environment-deps.sh
 
   # ---------------------------------------------------------------
-  # Repo-wide brand-accent guard: block bare shadcn accent tokens
-  # anywhere under packages/web/src/ so readability regressions like
-  # #2816 (invisible gray issue/PR links on /admin/dispatcher) don't
-  # recur on any other surface. The narrow #2816 guard has been
-  # superseded by this repo-wide expansion (#2832); legitimate
-  # selected-row idioms are waived via inline
+  # Repo-wide shadcn token-pair guard: block bare shadcn tokens
+  # anywhere under packages/web/src/ so invisible-chrome regressions
+  # like #2816 (gray issue/PR links on /admin/dispatcher) don't recur
+  # on any other surface. The narrow #2816 guard was superseded by the
+  # repo-wide accent expansion (#2832); the #4225 expansion (parent
+  # of this comment) generalises to the foreground family
+  # (primary, secondary, card, popover, destructive, accent) plus
+  # the symmetric background/foreground swap. Legitimate selected-row
+  # and parent-paired idioms are waived via inline
   # `shadcn-accent: intentional` comments.
   # ---------------------------------------------------------------
   bare-shadcn-accent-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Enforce brand-accent on always-visible web chrome
+      - name: Enforce shadcn token pairing on always-visible web chrome
         run: scripts/check-bare-shadcn-accent.sh
 
   # ---------------------------------------------------------------

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -108,6 +108,18 @@ A `bg-stone-200` in production code will fail CI.
 > surfaces (sidebar active nav, filter pills) waive the check with an
 > inline `shadcn-accent: intentional` comment. When in doubt, grep the
 > Wordmark component for the canonical brand-accent pattern.
+>
+> The same guard was generalised in #4225 to cover the broader
+> invisible-chrome family: bare `(text|bg|border|ring)-X-foreground`
+> for X in {`primary`, `secondary`, `card`, `popover`, `destructive`,
+> `accent`} unless paired with the corresponding `(bg|text|border|ring)-X`
+> surface on the same element, plus the symmetric `text-background` /
+> `bg-foreground` token swap (white-on-white in light mode,
+> near-black-on-near-black in dark mode). `text-muted-foreground` is
+> allowlisted unconditionally — it is the legitimate body-color
+> idiom (Stone 500 in §Color Palette). The same
+> `shadcn-accent: intentional` marker waives violations across the
+> full family.
 
 ```
 // packages/web/tailwind.config.ts

--- a/packages/web/src/components/Autocomplete.tsx
+++ b/packages/web/src/components/Autocomplete.tsx
@@ -186,6 +186,7 @@ export function Autocomplete({
               className={`cursor-pointer px-3 py-2 text-sm ${
                 i === activeIndex
                   ? 'bg-brand-accent-surface text-amber-900 dark:bg-amber-900/30 dark:text-amber-100'
+                  // shadcn-accent: intentional - text-popover-foreground sits on the parent <ul>'s bg-popover surface (line 174); hover:bg-accent is the canonical shadcn hover idiom (#4225).
                   : 'text-popover-foreground hover:bg-accent'
               }`}
             >

--- a/scripts/_check_bare_shadcn_strip_pairs.py
+++ b/scripts/_check_bare_shadcn_strip_pairs.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+Implementation core for `scripts/check-bare-shadcn-accent.sh`.
+
+Scans `*.tsx` / `*.ts` files under a target directory for bare shadcn
+surface or foreground Tailwind tokens that produce invisible chrome on
+default surfaces. The bash entrypoint
+(`scripts/check-bare-shadcn-accent.sh`) is a thin wrapper that
+invokes this module — the actual matching, allowlisting, and pair
+detection happens here so the per-line conditional logic is expressible
+without a fragile multi-pass sed.
+
+This script is invoked by `scripts/check-bare-shadcn-accent.sh`. Direct
+invocation is supported for the peer test only:
+
+    python3 scripts/_check_bare_shadcn_strip_pairs.py <dir>
+
+Behaviour
+---------
+The detailed algorithm (allowlist marker, modifier-prefix masking,
+surface-pair detection, body-color allowlisting) is documented in the
+header comment of `scripts/check-bare-shadcn-accent.sh`. This module
+mirrors that behaviour and is the source of truth — keep the two in
+sync when extending either.
+
+Exit codes:
+    0 — No violations found.
+    1 — One or more violations found (printed to stdout).
+
+History
+-------
+    - #4225 — moved the entire per-line scan into Python so the
+      "if line contains surface-X, mask foreground-X" conditional
+      can be expressed cleanly. The previous bash + sed pipeline was
+      too slow when invoked once per line and could not express
+      pair-detection without an external helper.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+# ───────────────────────────────────────────────────────────────────────
+# Configuration
+# ───────────────────────────────────────────────────────────────────────
+
+# X-class tokens with paired surface + foreground variants.
+PAIRED_TOKENS: tuple[str, ...] = (
+    "primary",
+    "secondary",
+    "card",
+    "popover",
+    "destructive",
+    "accent",
+)
+
+# Allowlist marker — name preserved from #2832 so existing waivers in
+# Sidebar.tsx and JudgeProfile.tsx continue to work after the #4225
+# expansion.
+ALLOWLIST_MARKER = "shadcn-accent: intentional"
+
+# Skip pure-comment lines so allowlist-adjacent comment paragraphs that
+# happen to mention forbidden tokens (e.g. the warning paragraph in a
+# JSDoc block) don't trip the guard.
+#
+# Recognised comment styles:
+#   - `//`   - TSX/TS line comment.
+#   - `*`    - JSDoc continuation line.
+#   - `/*`   - TSX/TS block comment opener.
+#   - `#`    - Python/bash line comment. Included so the guard, when
+#              run defensively against its own (non-TSX) source files
+#              renamed as .tsx, does not flag forbidden tokens that
+#              appear in source-file docstrings (#4225 self-match).
+#              TSX legitimately starts a line with `#` only for private
+#              class fields, which never carry a token name.
+COMMENT_LINE_RE = re.compile(r"^\s*(//|\*|/\*|#)")
+
+# Modifier-prefixed token usages are legitimate shadcn idioms
+# (`hover:bg-accent`, `data-[selected=true]:text-accent-foreground`,
+# `dark:hover:bg-primary text-primary-foreground`, etc.). The prefix
+# is any character run that does not contain whitespace, quote, colon,
+# or backtick, followed by `:`.
+_MODIFIER_PREFIX = r"[^\s\"'`:]+:"
+
+MODIFIER_PREFIXED_RE = re.compile(
+    rf"{_MODIFIER_PREFIX}(text|bg|border|ring)-(?:{'|'.join(PAIRED_TOKENS)})(?:-foreground)?\b"
+)
+
+# `text-muted-foreground` is the legitimate body-color idiom (Stone 500
+# in `docs/BRAND.md` §Color Palette, 170+ usages). It is allowlisted
+# unconditionally.
+MUTED_FOREGROUND_RE = re.compile(r"\btext-muted-foreground\b")
+
+# Surface tokens (NOT followed by `-foreground`). The trailing
+# negative lookahead allows opacity modifiers like `bg-primary/80` to
+# count as a surface pair (the `80` opacity suffix doesn't change
+# whether the surface is painted).
+def _surface_re(x: str) -> re.Pattern[str]:
+    return re.compile(rf"\b(bg|text|border|ring)-{re.escape(x)}(?![a-zA-Z0-9_-])")
+
+
+# Foreground tokens, the form we want to mask when paired.
+def _foreground_re(x: str) -> re.Pattern[str]:
+    return re.compile(rf"\b(text|bg|border|ring)-{re.escape(x)}-foreground\b")
+
+
+SURFACE_RES = {x: _surface_re(x) for x in PAIRED_TOKENS}
+FOREGROUND_RES = {x: _foreground_re(x) for x in PAIRED_TOKENS}
+
+# Bare-bad-token detector run on the masked line. Three groups:
+#
+#   1. The `(text|bg|border|ring)` x `accent` form (the original #2832
+#      case).
+#   2. `(text|bg|border|ring)-X-foreground` for X in PAIRED_TOKENS
+#      (the #4225 generalisation).
+#   3. The `text` x `background` and `(bg|border|ring)` x `foreground`
+#      symmetric typo case from #4208.
+#
+# Trailing `($|[^a-zA-Z0-9_-])` ensures we don't false-match on
+# longer identifiers like `text-accentish` (none exist today, but
+# defensive).
+#
+# The regex is assembled from token-name fragments rather than literal
+# joined strings so the script's own source does not self-match when
+# scanned (#2541/#2542/#4225 self-match defense). Treating the token
+# names as data keeps the source file regex-clean while preserving the
+# user-facing regex semantics.
+_BG = "background"
+_FG = "foreground"
+BAD_TOKEN_RE = re.compile(
+    r"(?:"
+    r"(?:text|bg|border|ring)-accent"
+    r"|"
+    rf"(?:text|bg|border|ring)-(?:{'|'.join(PAIRED_TOKENS)})-{_FG}"
+    r"|"
+    rf"text-{_BG}"
+    r"|"
+    rf"(?:bg|border|ring)-{_FG}"
+    r")(?:$|[^a-zA-Z0-9_-])"
+)
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Core algorithm
+# ───────────────────────────────────────────────────────────────────────
+
+
+def mask_allowed(line: str) -> str:
+    """Mask all legitimate token uses so the surviving line can be scanned."""
+    masked = line
+
+    # 1. Modifier-prefixed forms are always legitimate.
+    masked = MODIFIER_PREFIXED_RE.sub("__MASKED_MODIFIER__", masked)
+
+    # Re-run a couple of times to catch modifier-prefixed forms whose
+    # prefix happens to contain a previously-stripped token. In
+    # practice one pass is enough — chained `dark:hover:` is a single
+    # `[^...]+:` match — but two passes cost nothing.
+    masked = MODIFIER_PREFIXED_RE.sub("__MASKED_MODIFIER__", masked)
+
+    # 2. `text-muted-foreground` is allowlisted unconditionally.
+    masked = MUTED_FOREGROUND_RE.sub("__MASKED_MUTED__", masked)
+
+    # 3. `(text|bg|border|ring)-accent-foreground` alone is fine —
+    #    it's the foreground partner of the shadcn hover surface
+    #    and shows up in `text-accent-foreground` test assertions etc.
+    masked = re.sub(
+        r"\b(text|bg|border|ring)-accent-foreground\b",
+        "__MASKED_ACCENT_FG__",
+        masked,
+    )
+
+    # 4. Surface-pair strip: for each X, if the (post-modifier-strip)
+    #    line contains `(bg|text|border|ring)-X` (NOT followed by
+    #    `-foreground`), mask the corresponding `*-X-foreground` on
+    #    the same line — that is the legitimate paired idiom.
+    for x in PAIRED_TOKENS:
+        if SURFACE_RES[x].search(masked):
+            masked = FOREGROUND_RES[x].sub("__MASKED_PAIRED_FG__", masked)
+
+    return masked
+
+
+def scan_line(line: str) -> bool:
+    """Return True if the line contains a bare bad token after masking."""
+    masked = mask_allowed(line)
+    return bool(BAD_TOKEN_RE.search(masked))
+
+
+def is_comment_line(line: str) -> bool:
+    return bool(COMMENT_LINE_RE.match(line))
+
+
+def find_files(target: Path) -> list[Path]:
+    """Find all .tsx/.ts files under target, excluding tests."""
+    if not target.is_dir():
+        return []
+    files: list[Path] = []
+    for root, dirnames, filenames in os.walk(target):
+        # Exclude any __tests__ subdirectories.
+        dirnames[:] = [d for d in dirnames if d != "__tests__"]
+        for name in filenames:
+            if name.endswith((".test.tsx", ".test.ts")):
+                continue
+            if name.endswith((".tsx", ".ts")):
+                files.append(Path(root) / name)
+    files.sort()
+    return files
+
+
+def scan_file(path: Path, repo_root: Path) -> list[tuple[str, int, str]]:
+    """Scan a file, returning a list of (rel_path, line_no, line) violations."""
+    violations: list[tuple[str, int, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return violations
+
+    # Sliding window of the previous 3 lines so the `shadcn-accent:
+    # intentional` allowlist marker can be picked up on the same line
+    # OR up to 3 lines above.
+    prev3 = ""
+    prev2 = ""
+    prev1 = ""
+
+    for line_no, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line
+
+        # Skip comment lines, but rotate them into the window so the
+        # allowlist marker on a `// ...` comment line carries forward
+        # to the next non-comment line.
+        if is_comment_line(line):
+            prev3, prev2, prev1 = prev2, prev1, line
+            continue
+
+        if scan_line(line):
+            # Allowlist check — same-line, prev1, prev2, or prev3.
+            if (
+                ALLOWLIST_MARKER in line
+                or ALLOWLIST_MARKER in prev1
+                or ALLOWLIST_MARKER in prev2
+                or ALLOWLIST_MARKER in prev3
+            ):
+                prev3, prev2, prev1 = prev2, prev1, line
+                continue
+
+            try:
+                rel_path = str(path.relative_to(repo_root))
+            except ValueError:
+                rel_path = str(path)
+            violations.append((rel_path, line_no, line))
+
+        prev3, prev2, prev1 = prev2, prev1, line
+
+    return violations
+
+
+# ───────────────────────────────────────────────────────────────────────
+# Output
+# ───────────────────────────────────────────────────────────────────────
+
+# The user-facing help text mentions the forbidden tokens. Build it
+# from fragment concatenation so this source file does not self-match
+# when scanned (#2541/#2542/#4225 self-match defense). The fragments
+# rejoin to plain English at runtime.
+_T = "text-"
+_BGP = "bg-"
+ERROR_HEADER = f"""\
+ERROR: Bare shadcn token under packages/web/src/.
+
+  Bare shadcn surface or foreground tokens produce invisible chrome on
+  default surfaces:
+
+    {_T}accent  -> shadcn near-gray hover surface, not brand amber.
+                    Use text-brand-accent dark:text-brand-accent-light.
+
+    {_T}X-{_FG} (X = primary, secondary, card, popover,
+                          destructive, accent)
+                 -> designed to sit on bg-X. Bare on a default surface
+                    it inverts to invisible. Pair with bg-X / text-X /
+                    border-X / ring-X on the same element, or use a
+                    modifier such as hover: / focus: / data-[...]:.
+
+    {_T}{_BG} / {_BGP}{_FG} -> swapped tokens. Both paint
+                    same-color-on-same-color (invisible).
+
+  Allowlists:
+    text-muted-{_FG} is allowed (legitimate body color).
+    Modifier-prefixed forms are allowed (hover:, focus:, etc.).
+
+  If this is a legitimate selected-row surface (sidebar active nav,
+  filter pill, etc.) or a deliberate parent-paired className, add an
+  inline allowlist comment on the preceding or same line:
+    {{/* shadcn-accent: intentional - selected-row chrome */}}
+
+  See issues #2816, #2832, #4208, #4225 and
+  packages/web/src/components/Wordmark.tsx.
+
+  Violations:
+"""
+
+ERROR_FOOTER = """\
+
+  Reference: https://github.com/judgemind/judgemind/issues/4225"""
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 2:
+        print(f"Usage: {argv[0]} [target-dir]", file=sys.stderr)
+        return 2
+
+    repo_root = Path(__file__).resolve().parent.parent
+    default_target = repo_root / "packages" / "web" / "src"
+    target = Path(argv[1]).resolve() if len(argv) == 2 else default_target
+
+    if not target.is_dir():
+        print(f"All clean - target directory not found: {target}")
+        return 0
+
+    files = find_files(target)
+    if not files:
+        print(f"All clean - no .tsx/.ts files under {target}")
+        return 0
+
+    all_violations: list[tuple[str, int, str]] = []
+    for file in files:
+        all_violations.extend(scan_file(file, repo_root))
+
+    if not all_violations:
+        print("All clean - no bare shadcn tokens under packages/web/src/.")
+        return 0
+
+    print(ERROR_HEADER)
+    for rel_path, line_no, line in all_violations:
+        print(f"    {rel_path}:{line_no}:{line}")
+    print()
+    print(f"  Found {len(all_violations)} occurrence(s) of bare shadcn tokens.")
+    print(ERROR_FOOTER)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/check-bare-shadcn-accent.sh
+++ b/scripts/check-bare-shadcn-accent.sh
@@ -1,62 +1,47 @@
 #!/usr/bin/env bash
-# check-bare-shadcn-accent.sh — Repo-wide guard for the brand-accent vs
-# shadcn-accent footgun.
+# check-bare-shadcn-accent.sh - Repo-wide guard for the shadcn token-pair
+# footgun family.
 #
-# The shadcn `accent` Tailwind token (mapped via `hsl(var(--accent))` in
-# packages/web/tailwind.config.ts) is a near-gray *hover surface* — not
+# Bash entrypoint - delegates the actual scan to
+# `scripts/_check_bare_shadcn_strip_pairs.py`. The script name is
+# preserved from #2832 so the existing CI step, peer test, and four
+# in-repo waivers in
+# `packages/web/src/components/layout/Sidebar.tsx` and
+# `packages/web/src/app/(main)/judges/[id]/JudgeProfile.tsx` continue
+# to work after the #4225 expansion.
+#
+# WHY THIS BUG CLASS IS SEVERE
+# ----------------------------
+# The shadcn `accent` token (mapped via `hsl(var(--accent))` in
+# packages/web/tailwind.config.ts) is a near-gray *hover surface* - not
 # the brand amber. The brand amber lives on the separate `brand-accent`
-# token (see `docs/BRAND.md §Tailwind Token Mapping` and the canonical
+# token (see `docs/BRAND.md` Tailwind Token Mapping and the canonical
 # usage in `packages/web/src/components/Wordmark.tsx`). The two classes
 # are one character apart, which is a persistent footgun: PR #2811
 # shipped `text-accent` on issue/PR links on `/admin/dispatcher` and
 # they rendered as nearly-invisible gray on both light and dark mode
-# (#2816). The bug is easy to make and hard to spot in code review.
+# (#2816).
 #
-# This guard blocks bare `text-accent`, `bg-accent`, `border-accent`,
-# and `ring-accent` anywhere under `packages/web/src/`. It does NOT
-# block hover-surface idioms like
-# `hover:bg-accent hover:text-accent-foreground` — those are intentional
-# shadcn patterns (button, dropdown, select, command, sidebar primitives
-# all use them). Only bare always-visible `*-accent` usages trip the
-# check.
+# The same shape applies repo-wide for two other one-word typos
+# (audited in #4208 / #4225):
 #
-# Allowlist mechanism
-# -------------------
-# Some legitimate "selected-row" surfaces use `bg-accent` or
-# `bg-accent text-accent-foreground` deliberately as the selected-state
-# chrome (see Sidebar's active nav link, JudgeProfile's motion-type
-# filter pill). These are intentional shadcn idioms, not the bug class
-# this check is for.
+#   1. The `*-foreground` family without a paired surface.
+#      `text-primary-foreground` is designed to sit on `bg-primary`.
+#      Bare on a default-cascade surface it inverts: white-on-white in
+#      light mode, near-black-on-near-black in dark mode.
 #
+#   2. `text-background` and `bg-foreground`. Single-word swap, same
+#      length, autocomplete-adjacent. Today there are 0 usages, so the
+#      bug hasn't shipped yet - but the next hand-rolled element is
+#      one autocomplete away.
+#
+# Allowlist mechanism (preserved from #2832)
+# ------------------------------------------
 # To allowlist a specific line, place an inline opt-out comment on the
-# same line OR within the three preceding lines:
-#
-#     // shadcn-accent: intentional — selected-row chrome
-#     <span
-#       className="bg-accent text-accent-foreground"
-#     >
-#
-# The 3-line lookback handles JSX where the comment must sit above the
-# opening tag and the className wraps to the next line. Same-line
-# comments work too:
-#
-#     <span className="bg-accent" /* shadcn-accent: intentional */>
-#
-# The opt-out token is the literal string `shadcn-accent: intentional`.
-# It appears in the diff and code review, so reviewers see exactly which
-# lines were waived and why.
-#
-# Algorithm (per line)
-# --------------------
-#   1. Skip lines that contain `shadcn-accent: intentional` on the
-#      same line OR on any of the three preceding lines.
-#   2. Pre-process the line with sed to delete any modifier-prefixed
-#      usage (`hover:`, `focus:`, `data-[...]:`, etc.) and any
-#      `*-accent-foreground` suffix usage. Modifier-prefixed and
-#      foreground-paired accent usages are legitimate shadcn idioms.
-#   3. On the remaining line, look for `text-accent`, `bg-accent`,
-#      `border-accent`, or `ring-accent` followed by a non-identifier
-#      char.
+# same line OR within the three preceding lines. The opt-out token is
+# the literal string `shadcn-accent: intentional`. It appears in the
+# diff and code review, so reviewers see exactly which lines were
+# waived and why.
 #
 # Usage
 # -----
@@ -65,168 +50,29 @@
 #
 # Exit codes
 # ----------
-#   0 — No violations.
-#   1 — One or more files use a bare shadcn accent token without an
-#       allowlist comment.
+#   0 - No violations.
+#   1 - One or more files use a bare shadcn token without an allowlist
+#       comment.
 #
 # History
 # -------
 #   - #2816 introduced the narrow `/admin/dispatcher`-only guard.
 #   - #2832 expanded to repo-wide and added the
 #     `shadcn-accent: intentional` allowlist mechanism.
+#   - #4225 generalised to the `*-foreground` family and the
+#     `text-background` / `bg-foreground` symmetric typos. Moved the
+#     scan into Python (`_check_bare_shadcn_strip_pairs.py`) so the
+#     conditional pair-on-line strip could be expressed without a
+#     fragile multi-pass sed.
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SCAN_DIR="${1:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_PY="$SCRIPT_DIR/_check_bare_shadcn_strip_pairs.py"
 
-# ─── Target directory ──────────────────────────────────────────────────
-DEFAULT_TARGET="$REPO_ROOT/packages/web/src"
-if [[ -n "$SCAN_DIR" ]]; then
-    target="$SCAN_DIR"
-else
-    target="$DEFAULT_TARGET"
+if [[ ! -f "$HELPER_PY" ]]; then
+    echo "ERROR: helper missing at $HELPER_PY" >&2
+    exit 2
 fi
 
-if [[ ! -d "$target" ]]; then
-    echo "All clean — target directory not found: $target"
-    exit 0
-fi
-
-# ─── Allowlist marker ──────────────────────────────────────────────────
-# The literal string we look for on a preceding line or same line to
-# waive the check on a specific occurrence. Spelled with a leading
-# space-or-non-alphanum boundary so we don't match prose like
-# "the shadcn-accent: intentional pattern is" inside a paragraph in
-# unrelated files (we still scan only .tsx/.ts so the practical
-# concern is comments adjacent to a flagged line).
-ALLOWLIST_MARKER='shadcn-accent: intentional'
-
-# ─── sed pre-processor ──────────────────────────────────────────────────
-# Strip every occurrence of:
-#   - `<prefix>:(text|bg|border|ring)-accent`  (any non-space modifier,
-#     e.g. `hover:`, `focus:`, `group-hover:`, `data-[selected=true]:`,
-#     `dark:hover:`, etc.). Three passes handle chained modifiers like
-#     `dark:hover:bg-accent`.
-#   - `(text|bg|border|ring)-accent-foreground`  (shadcn's
-#     foreground-on-surface pairing).
-#
-# After stripping, any surviving `(text|bg|border|ring)-accent`
-# followed by a non-identifier character is a bare shadcn accent token
-# and a violation.
-strip_allowed() {
-    sed -E \
-        -e 's/([^[:space:]"'\'':`]+:)(text|bg|border|ring)-accent/__MASKED__/g' \
-        -e 's/(text|bg|border|ring)-accent-foreground/__MASKED__/g' \
-        -e 's/([^[:space:]"'\'':`]+:)(text|bg|border|ring)-accent/__MASKED__/g' \
-        -e 's/(text|bg|border|ring)-accent-foreground/__MASKED__/g' \
-        -e 's/([^[:space:]"'\'':`]+:)(text|bg|border|ring)-accent/__MASKED__/g' \
-        -e 's/(text|bg|border|ring)-accent-foreground/__MASKED__/g'
-}
-
-# Regex for bare, surviving `(text|bg|border|ring)-accent` followed by a
-# non-identifier character. Using grep -E for portability (macOS/BSD sed
-# vs GNU sed word boundaries differ).
-BAD_TOKEN_RE='(text|bg|border|ring)-accent($|[^a-zA-Z0-9_-])'
-
-# ─── Scan ──────────────────────────────────────────────────────────────
-violations=0
-
-# Find all .tsx/.ts files under the target, excluding tests.
-# Avoid `mapfile -d ''` (bash 4+) so the script runs on macOS bash 3.2
-# too — same constraint observed by the predecessor
-# `check-admin-dispatcher-brand-accent.sh` (#3082).
-files=()
-while IFS= read -r -d '' file; do
-    files+=("$file")
-done < <(
-    find "$target" \
-        -type f \
-        \( -name '*.tsx' -o -name '*.ts' \) \
-        ! -path '*/__tests__/*' \
-        ! -name '*.test.tsx' \
-        ! -name '*.test.ts' \
-        -print0
-)
-
-if [[ ${#files[@]} -eq 0 ]]; then
-    echo "All clean — no .tsx/.ts files under $target"
-    exit 0
-fi
-
-for file in "${files[@]}"; do
-    line_no=0
-    # Sliding window of the previous 3 lines (most recent last).
-    # Empty strings prefill so the lookback at line 1 is well-defined.
-    prev1=""  # line at line_no-1
-    prev2=""  # line at line_no-2
-    prev3=""  # line at line_no-3
-    while IFS= read -r line || [[ -n "$line" ]]; do
-        line_no=$((line_no + 1))
-
-        # Skip comment lines — best-effort: `//`, ` * ` (JSDoc), `/*`.
-        # Note: comment lines are also rotated into the lookback
-        # window so the allowlist marker on a `// ...` comment line
-        # carries forward to the next non-comment line.
-        trimmed="${line#"${line%%[![:space:]]*}"}"
-        case "$trimmed" in
-            '//'*|'*'*|'/*'*)
-                prev3="$prev2"; prev2="$prev1"; prev1="$line"
-                continue
-                ;;
-        esac
-
-        masked=$(printf '%s' "$line" | strip_allowed)
-
-        if printf '%s\n' "$masked" | grep -qE "$BAD_TOKEN_RE"; then
-            # Allowlist check: is the current line OR any of the three
-            # preceding lines marked with `shadcn-accent: intentional`?
-            if [[ "$line"  == *"$ALLOWLIST_MARKER"* ]] \
-                || [[ "$prev1" == *"$ALLOWLIST_MARKER"* ]] \
-                || [[ "$prev2" == *"$ALLOWLIST_MARKER"* ]] \
-                || [[ "$prev3" == *"$ALLOWLIST_MARKER"* ]]; then
-                prev3="$prev2"; prev2="$prev1"; prev1="$line"
-                continue
-            fi
-
-            if [[ $violations -eq 0 ]]; then
-                echo "ERROR: Bare shadcn accent token under packages/web/src/."
-                echo ""
-                echo "  The shadcn accent token is a near-gray hover surface,"
-                echo "  NOT the brand amber. Use brand-accent for always-visible"
-                echo "  amber chrome:"
-                echo ""
-                echo "    text-accent                -> text-brand-accent dark:text-brand-accent-light"
-                echo "    bg-accent   (not hover:)   -> bg-brand-accent (see docs/BRAND.md)"
-                echo ""
-                echo "  If you actually meant the shadcn hover surface, pair the"
-                echo "  token with a modifier such as:"
-                echo "    hover:bg-accent hover:text-accent-foreground"
-                echo ""
-                echo "  If this is a legitimate selected-row surface (sidebar"
-                echo "  active nav, filter pill, etc.), add an inline allowlist"
-                echo "  comment on the preceding or same line:"
-                echo "    {/* shadcn-accent: intentional — selected-row chrome */}"
-                echo ""
-                echo "  See issue #2816, #2832 and packages/web/src/components/Wordmark.tsx."
-                echo ""
-                echo "  Violations:"
-                echo ""
-            fi
-            rel_path="${file#"$REPO_ROOT/"}"
-            echo "    $rel_path:$line_no:$line"
-            violations=$((violations + 1))
-        fi
-        prev3="$prev2"; prev2="$prev1"; prev1="$line"
-    done < "$file"
-done
-
-if [[ $violations -gt 0 ]]; then
-    echo ""
-    echo "  Found $violations occurrence(s) of bare shadcn accent tokens."
-    echo "  Reference: https://github.com/judgemind/judgemind/issues/2816"
-    exit 1
-fi
-
-echo "All clean — no bare shadcn accent tokens under packages/web/src/."
-exit 0
+exec python3 "$HELPER_PY" "$@"

--- a/scripts/tests/test_check_bare_shadcn_accent.sh
+++ b/scripts/tests/test_check_bare_shadcn_accent.sh
@@ -231,7 +231,169 @@ export const Two = () => (
 assert_fails "Allowlist on one violation does not cover unrelated later violation"
 reset_tmpdir
 
-# ─── Test 21: Self-match on ci.yml step name ─────────────────────────────
+# ─── #4225 expansion: *-foreground family + invisible-chrome typos ──────
+#
+# The guard expansion in #4225 adds:
+#   - bare `(text|bg|border|ring)-X-foreground` for X in
+#     {primary, secondary, card, popover, destructive, accent}
+#   - `text-background` / `(bg|border|ring)-foreground` symmetric typos
+#   - `text-muted-foreground` allowlist (legitimate body color)
+# Tests 22-37 below cover the new cases. The marker name is preserved
+# from #2832 so existing waivers continue to work (already covered by
+# tests 16-20 above).
+# ─────────────────────────────────────────────────────────────────────────
+
+# ─── Test 22: Bare text-primary-foreground is flagged ────────────────────
+create_test_file "BadFgPrimary.tsx" \
+    'export const Bad = () => <span className="text-primary-foreground">hi</span>;' > /dev/null
+assert_fails "Bare text-primary-foreground (no paired bg-primary) is flagged"
+reset_tmpdir
+
+# ─── Test 23: bg-primary text-primary-foreground pair passes ─────────────
+# Same-element pairing is the canonical shadcn idiom (button.tsx,
+# badge.tsx); the foreground sits on its paired surface.
+create_test_file "GoodPairPrimary.tsx" \
+    'export const Ok = () => <button className="bg-primary text-primary-foreground hover:bg-primary/90">hi</button>;' > /dev/null
+assert_passes "bg-primary text-primary-foreground on same element passes (paired idiom)"
+reset_tmpdir
+
+# ─── Test 24: Bare text-secondary-foreground is flagged ──────────────────
+create_test_file "BadFgSecondary.tsx" \
+    'export const Bad = () => <span className="text-secondary-foreground">hi</span>;' > /dev/null
+assert_fails "Bare text-secondary-foreground is flagged"
+reset_tmpdir
+
+# ─── Test 25: Bare text-card-foreground is flagged ───────────────────────
+create_test_file "BadFgCard.tsx" \
+    'export const Bad = () => <div className="rounded-lg p-4 text-card-foreground">hi</div>;' > /dev/null
+assert_fails "Bare text-card-foreground without bg-card is flagged"
+reset_tmpdir
+
+# ─── Test 26: bg-card text-card-foreground pair passes ───────────────────
+# Mirrors `packages/web/src/components/ui/card.tsx`.
+create_test_file "GoodPairCard.tsx" \
+    "export const Ok = () => <div className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} />;" > /dev/null
+assert_passes "bg-card text-card-foreground inside cn() passes (paired idiom)"
+reset_tmpdir
+
+# ─── Test 27: Bare text-popover-foreground is flagged ────────────────────
+create_test_file "BadFgPopover.tsx" \
+    'export const Bad = () => <span className="text-popover-foreground">hi</span>;' > /dev/null
+assert_fails "Bare text-popover-foreground is flagged"
+reset_tmpdir
+
+# ─── Test 28: Bare text-destructive-foreground is flagged ────────────────
+create_test_file "BadFgDestructive.tsx" \
+    'export const Bad = () => <span className="text-destructive-foreground">hi</span>;' > /dev/null
+assert_fails "Bare text-destructive-foreground is flagged"
+reset_tmpdir
+
+# ─── Test 29: Modifier-prefixed *-foreground passes ──────────────────────
+# Mirrors `packages/web/src/components/ui/checkbox.tsx` - the
+# `data-[state=checked]:` modifier marks a state-conditional that is
+# legitimate even without an unmodified surface partner.
+create_test_file "ModifierFg.tsx" \
+    'export const Ok = () => <button className="data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground">hi</button>;' > /dev/null
+assert_passes "data-[state=checked]:text-primary-foreground passes (modifier-prefixed)"
+reset_tmpdir
+
+# ─── Test 30: dark: chained modifier-prefixed *-foreground passes ────────
+create_test_file "DarkModifierFg.tsx" \
+    'export const Ok = () => <span className="dark:hover:text-secondary-foreground">hi</span>;' > /dev/null
+assert_passes "dark:hover:text-secondary-foreground passes (chained modifier)"
+reset_tmpdir
+
+# ─── Test 31: text-muted-foreground on <p> passes ────────────────────────
+create_test_file "MutedP.tsx" \
+    'export const Ok = () => <p className="text-muted-foreground">hi</p>;' > /dev/null
+assert_passes "text-muted-foreground on <p> passes (legitimate body color)"
+reset_tmpdir
+
+# ─── Test 32: text-muted-foreground on <span> passes ─────────────────────
+create_test_file "MutedSpan.tsx" \
+    'export const Ok = () => <span className="text-muted-foreground">hi</span>;' > /dev/null
+assert_passes "text-muted-foreground on <span> passes (legitimate body color)"
+reset_tmpdir
+
+# ─── Test 33: text-muted-foreground inside cn(...) passes ────────────────
+create_test_file "MutedCn.tsx" \
+    "export const Ok = ({className}: any) => <span className={cn('text-sm text-muted-foreground', className)}>hi</span>;" > /dev/null
+assert_passes "text-muted-foreground inside cn(...) passes"
+reset_tmpdir
+
+# ─── Test 34: Bare bg-foreground is flagged ──────────────────────────────
+# Symmetric typo - `bg-foreground` paints the foreground color as a
+# surface. On a default-cascade page this is near-black-on-near-black
+# (light mode) or white-on-white (dark mode). 0 current usages.
+create_test_file "BadBgFg.tsx" \
+    'export const Bad = () => <div className="bg-foreground p-4">hi</div>;' > /dev/null
+assert_fails "Bare bg-foreground is flagged (symmetric typo)"
+reset_tmpdir
+
+# ─── Test 35: Bare text-background is flagged ────────────────────────────
+# Symmetric typo - `text-background` paints text in the surface color.
+create_test_file "BadTextBg.tsx" \
+    'export const Bad = () => <span className="text-background">hi</span>;' > /dev/null
+assert_fails "Bare text-background is flagged (symmetric typo)"
+reset_tmpdir
+
+# ─── Test 36: Bare border-foreground is flagged ──────────────────────────
+create_test_file "BadBorderFg.tsx" \
+    'export const Bad = () => <div className="border border-foreground">hi</div>;' > /dev/null
+assert_fails "Bare border-foreground is flagged (symmetric typo)"
+reset_tmpdir
+
+# ─── Test 37: Bare ring-foreground is flagged ────────────────────────────
+create_test_file "BadRingFg.tsx" \
+    'export const Bad = () => <input className="ring-2 ring-foreground" />;' > /dev/null
+assert_fails "Bare ring-foreground is flagged (symmetric typo)"
+reset_tmpdir
+
+# ─── Test 38: text-foreground (legitimate body text) passes ──────────────
+# `text-foreground` is the default body-text token and the symmetric
+# partner of `bg-background` (default page surface). It is NOT in the
+# forbidden list - only `text-background` (swap) and
+# `bg-foreground` (swap) are flagged.
+create_test_file "TextFg.tsx" \
+    'export const Ok = () => <h1 className="text-xl font-bold text-foreground">hi</h1>;' > /dev/null
+assert_passes "Bare text-foreground passes (legitimate body text token)"
+reset_tmpdir
+
+# ─── Test 39: bg-background passes ───────────────────────────────────────
+# Symmetric to test 38 - `bg-background` is the default surface and is
+# not in the forbidden list.
+create_test_file "BgBackground.tsx" \
+    'export const Ok = () => <body className="bg-background text-foreground">hi</body>;' > /dev/null
+assert_passes "bg-background passes (default surface token)"
+reset_tmpdir
+
+# ─── Test 40: Allowlist marker waives a *-foreground violation ────────────
+# Mirrors the parent-paired pattern from
+# `packages/web/src/components/Autocomplete.tsx` where the surface lives
+# on a parent <ul> and the foreground lives on the <li> child. The
+# `shadcn-accent: intentional` marker (preserved from #2832) waives the
+# guard.
+create_test_file "AllowFg.tsx" \
+    'export const Ok = () => (
+  <ul className="bg-popover">
+    {/* shadcn-accent: intentional - parent-paired chrome */}
+    <li className="text-popover-foreground hover:bg-accent">hi</li>
+  </ul>
+);' > /dev/null
+assert_passes "shadcn-accent: intentional waives a *-foreground parent-pair violation"
+reset_tmpdir
+
+# ─── Test 41: bg-primary/80 opacity counts as a paired surface ───────────
+# Mirrors `packages/web/src/components/ui/badge.tsx` line 11:
+# 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80'.
+# The `/80` opacity modifier doesn't change whether the surface is
+# painted, so the foreground pair should pass.
+create_test_file "BadgeOpacity.tsx" \
+    "export const Ok = () => <span className=\"border-transparent bg-primary text-primary-foreground hover:bg-primary/80\">hi</span>;" > /dev/null
+assert_passes "bg-primary text-primary-foreground hover:bg-primary/80 (opacity) passes"
+reset_tmpdir
+
+# ─── Test 42: Self-match on ci.yml step name ─────────────────────────────
 # Mirrors the #2541/#2542 self-match guard used by every string-forbidding
 # check. If a ci.yml step name quotes the forbidden pattern, the guard
 # matches itself on first CI run — describe what the check does, not what
@@ -240,6 +402,27 @@ reset_tmpdir
 source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
 assert_no_self_match_on_ci_step_name \
     "scripts/check-bare-shadcn-accent.sh" "yml"
+
+# ─── Test 43: Self-match on guard's own source files (#4225) ─────────────
+# The guard now exists across two files (the bash entrypoint and the
+# Python helper) that both contain the forbidden token names as literal
+# strings inside regex patterns and docstrings. Running the guard
+# against itself should pass - the source files live under scripts/, not
+# packages/web/src/, so they're outside the default scan scope; but as
+# a defensive assertion we copy them into the tmpdir as `.tsx` and
+# verify the guard handles its own source verbatim.
+TESTS=$((TESTS + 1))
+mkdir -p "$TMPDIR_TEST"
+# The guard scans .ts/.tsx; rename to .tsx so it's picked up.
+cp "$SCRIPT_DIR/check-bare-shadcn-accent.sh" "$TMPDIR_TEST/guard_source.tsx"
+cp "$SCRIPT_DIR/_check_bare_shadcn_strip_pairs.py" "$TMPDIR_TEST/guard_helper_source.tsx"
+if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+    echo "PASS: Guard does not flag its own source files (#4225 self-match)"
+else
+    echo "FAIL: Guard flags its own source files (#4225 self-match — see #2541/#2542)"
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
 
 # ─── Summary ──────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Generalises `scripts/check-bare-shadcn-accent.sh` (the existing #2832 guard) to cover the broader invisible-chrome family identified in #4208: bare `*-X-foreground` without a paired surface, plus the symmetric `text-background` / `bg-foreground` token swap. `text-muted-foreground` is allowlisted unconditionally as the legitimate body-color idiom.

**Approach: extend the existing script in place** (rather than add a sibling guard). Rationale: same bug class, same allowlist mechanism, and the path preserves all 7 in-repo references (`docs/BRAND.md`, `code-standards.md`, `check-terminal-routing-comments.sh`, `check-bash-compat.sh`, `ci.yml`, the peer test, the script itself) without renames.

The matching logic moved into a Python helper (`scripts/_check_bare_shadcn_strip_pairs.py`) because the new "if line contains surface-X then mask foreground-X" conditional is awkward in portable sed. The bash entrypoint is now a thin `exec python3 ...` wrapper.

Closes #4225

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (CI guard / docs only). Verification evidence will state the skip reason after merge.
