### PR TITLE
ci(smoke-test): tolerate transient GitHub-API 5xx in auto-close cleanup step (#4234)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -320,6 +320,13 @@ jobs:
         if: >-
           steps.smoke.outputs.has_failures == 'false' &&
           steps.rest-smoke.outputs.has_failures == 'false'
+        # Best-effort cleanup — the actual smoke tests already passed at this
+        # point, so a transient GitHub-API 5xx (e.g. GraphQL 504) here should
+        # NOT fail the workflow run. The auto-close step is idempotent: any
+        # smoke-test-failure issue it doesn't get to close on this run will be
+        # closed on the next workflow trigger. See #4234 (and #4231 for the
+        # observed flake class).
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Summary

The `Auto-close resolved smoke test issues` step in `.github/workflows/smoke-test.yml` is best-effort cleanup — it runs only when all smoke tests pass and closes already-resolved `smoke-test-failure` issues. A transient GitHub GraphQL 5xx (e.g. 504 Gateway Timeout, observed on smoke run 25446584665 in #4234) currently fails the whole workflow even though the actual smoke tests passed.

Add `continue-on-error: true` so transient API flakes in this optional cleanup branch no longer fail the run. The auto-close step is idempotent — issues not closed on this run will be closed on the next trigger. The `if:` guard that skips the step on real smoke-test failures is unchanged, so failure-path behavior is preserved.

Closes #4234.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow change only). The next smoke-test workflow trigger on `main` will exercise the new directive in production; if it hits a GitHub-API 5xx during the auto-close step, the workflow run will now succeed instead of failing.
- [x] Verification evidence posted on issue (see A.8)
