### PR TITLE
docs(issue-authoring): require derived.documents.status = 'active' filter on cleanup-AC queries (#4236)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -425,6 +425,8 @@ Each issue body should include:
 - **Suggested fix:** concrete steps to resolve
 - **Related PRs:** if found during adversarial review, link the PR that introduced the issue
 
+**Cleanup AC SQL rule.** When filing an issue whose acceptance criteria gate "the cleanup is done" on a row count from `derived.rulings`, `derived.cases`, `derived.judges`, or any other table whose source-of-truth is a `derived.documents` row, every `Verify:` SELECT MUST `JOIN derived.documents d ON d.id = <row>.document_id WHERE d.status = 'active'`. Supersede chains (post-#3722 multimodal-fix and similar reingest events) leave OLD-case-number / OLD-case-title rows behind as `status = 'superseded'`; a naive count picks them up as live regression and the AC reads as failing long after the fix has shipped. See `docs/agent/issue-authoring.md` §Cleanup AC queries — anchor on document status (and #4236 / #3629 for the incident) for the full pattern and a worked example.
+
 ---
 
 ## Step 4 — Write summary report

--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -258,6 +258,8 @@ Title rule: never `"X is broken"`. Always frame as `"X is broken because Y"` or 
 
 Priority rule: `p1` for things actively producing wrong data or blocking workflow; `p2` for most user-visible quality bugs; `p3` for hygiene / docstring / dx. No `p0`.
 
+Cleanup AC SQL rule: any `Verify:` SELECT that counts/filters `derived.rulings`, `derived.cases`, `derived.judges`, etc. to gate "the cleanup is done" MUST `JOIN derived.documents d ON d.id = <row>.document_id WHERE d.status = 'active'`. Supersede chains leave OLD-case-number / OLD-case-title rows behind as `status = 'superseded'`; a naive count picks them up as live regression and the AC reads as failing long after the fix has landed. See `docs/agent/issue-authoring.md` §Cleanup AC queries — anchor on document status (and #4236 / #3629 for the incident) for the full pattern and a worked example.
+
 If the new issue is blocked by another open issue, run `scripts/block-issue.sh <new-issue> <blocker>` after filing — adds `status/blocked` and the `Blocked by #N` mechanic that auto-unblocks on merge.
 
 ### 4c — Comment on existing issue (for new evidence)

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -51,6 +51,25 @@ Use one of these three approved forms instead, in preference order:
    ```
    The `{worktree}/tmp/` directory is the approved location for agent temp files (not `/tmp/`).
 
+### Cleanup AC queries — anchor on document status
+
+When writing an AC that counts/filters `derived.rulings`, `derived.cases`, `derived.judges`, `derived.attorneys`, `derived.parties`, or any other row whose source-of-truth is a `derived.documents` row, always join `derived.documents` and filter `d.status = 'active'`. Supersede chains (post-#3722 multimodal-fix and similar reingest events) routinely leave rows with the OLD case_number / OLD case_title / null judge_id behind under `status = 'superseded'`, and a naive count picks up that noise as if it were live regression. The cleanup AC then looks unmet long after the fix has actually landed and re-extracted everything.
+
+Required shape — join + status filter on every cleanup-driving SELECT:
+
+```sql
+SELECT COUNT(*)
+FROM derived.rulings r
+JOIN derived.cases c ON c.id = r.case_id
+JOIN derived.documents d ON d.id = r.document_id  -- ← required
+WHERE d.status = 'active'                          -- ← required
+  AND c.case_number LIKE 'UNKNOWN-%';
+```
+
+Without the `derived.documents` join + `d.status = 'active'` filter, supersede children inflate the count and the cleanup AC reads as failing even after the fix has shipped. Concrete example surfaced via #3629 verification (2026-05-06): an AC#2 query against Orange County department `N15` returned `10/12 (83.3%) UNKNOWN` until the active-status filter was added — then `0/2 (0%)`. All 10 UNKNOWN rows were `status = 'superseded'` from the post-#3722 supersede chain and not visible in any user-facing surface. See #4236 for the full incident.
+
+This applies to any AC that gates "the cleanup is done" on a row count — file/issue authors filing such ACs and agents implementing them should both verify the SELECT carries the `derived.documents` join + `d.status = 'active'` filter before treating the count as authoritative.
+
 ## Verify the gap exists before filing
 
 Before filing a "does X" / "enable X" / "add X" issue, run a single command that verifies X is not already the case. This rule exists because an agent-runner cycle spent re-creating state that already exists is pure waste — the canonical example is #3146, where an issue was filed to "enable Container Insights on the ECS cluster" after the Terraform attribute `enable_container_insights = true` had already shipped in a prior PR. The agent spent a full cycle discovering, through probing, that there was nothing to do. A thirty-second check before filing would have surfaced that immediately. This is a sibling of the external-integration feasibility note in §Writing Acceptance Criteria (line 15): both rules say "verify the precondition before you ask an agent to build on top of it."


### PR DESCRIPTION
## Summary

Adds a "Cleanup AC queries — anchor on document status" subsection to `docs/agent/issue-authoring.md` documenting that any cleanup-AC SELECT against `derived.rulings` / `derived.cases` / `derived.judges` / etc. must `JOIN derived.documents d ON d.id = <row>.document_id WHERE d.status = 'active'` to avoid supersede-chain noise. Cross-referenced from `/spotcheck` SKILL §4b and `/audit` SKILL Step 3 so daemon-authored issues pick up the convention.

Concrete incident behind the rule: AC#2 of #3629 returned `N15: 10/12 (83.3%) UNKNOWN` against Orange County until the active-status filter was added — then `0/2 (0%)`. All 10 UNKNOWN rows were `status='superseded'` from the post-#3722 supersede chain and not visible in any user-facing surface.

Closes #4236

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs / SKILL.md only)
