### PR TITLE
ci: tolerate transient GitHub-API 5xx in cleanup-step branches across workflows (#4238)

### DIFF
--- a/.github/workflows/api-error-check.yml
+++ b/.github/workflows/api-error-check.yml
@@ -313,6 +313,12 @@ jobs:
 
       - name: Auto-close resolved error issues
         if: steps.check.outputs.healthy == 'true'
+        # Best-effort cleanup — the API error check already passed at this
+        # point, so a transient GitHub-API 5xx (e.g. GraphQL 504) here should
+        # NOT fail the workflow run. The auto-close step is idempotent: any
+        # api-error-alert issue it doesn't get to close on this run will be
+        # closed on the next workflow trigger. See #4234 / #4238.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/s3-orphan-rate-check.yml
+++ b/.github/workflows/s3-orphan-rate-check.yml
@@ -283,6 +283,12 @@ jobs:
 
       - name: Auto-close resolved orphan-rate issues
         if: steps.check.outputs.healthy == 'true'
+        # Best-effort cleanup — the orphan-rate check already passed at this
+        # point, so a transient GitHub-API 5xx here should NOT fail the
+        # workflow run. The auto-close step is idempotent: any
+        # s3-orphan-rate-alert issue it doesn't get to close on this run will
+        # be closed on the next workflow trigger. See #4234 / #4238.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/scraper-zero-record-check.yml
+++ b/.github/workflows/scraper-zero-record-check.yml
@@ -285,6 +285,12 @@ jobs:
 
       - name: Auto-close resolved zero-record issues
         if: steps.check.outputs.healthy == 'true'
+        # Best-effort cleanup — the zero-record streak check already passed
+        # at this point, so a transient GitHub-API 5xx here should NOT fail
+        # the workflow run. The auto-close step is idempotent: any
+        # scraper-zero-record-alert issue it doesn't get to close on this run
+        # will be closed on the next workflow trigger. See #4234 / #4238.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/short-unsubstantive-ruling-check.yml
+++ b/.github/workflows/short-unsubstantive-ruling-check.yml
@@ -285,6 +285,12 @@ jobs:
 
       - name: Auto-close resolved issues
         if: steps.check.outputs.healthy == 'true'
+        # Best-effort cleanup — the short-unsubstantive ruling check already
+        # passed at this point, so a transient GitHub-API 5xx here should NOT
+        # fail the workflow run. The auto-close step is idempotent: any
+        # short-unsubstantive-ruling-alert issue it doesn't get to close on
+        # this run will be closed on the next workflow trigger. See #4234 / #4238.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/site-quality-check.yml
+++ b/.github/workflows/site-quality-check.yml
@@ -142,6 +142,12 @@ jobs:
 
       - name: Auto-close resolved quality issues
         if: success() && steps.quality.outputs.has_failures == 'false'
+        # Best-effort cleanup — the site quality checks already passed at
+        # this point, so a transient GitHub-API 5xx here should NOT fail the
+        # workflow run. The auto-close step is idempotent: any
+        # site-quality-failure issue it doesn't get to close on this run will
+        # be closed on the next workflow trigger. See #4234 / #4238.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/unblock-issues.yml
+++ b/.github/workflows/unblock-issues.yml
@@ -157,6 +157,12 @@ jobs:
 
       - name: Post-run audit — check for remaining blocked issues
         if: always()
+        # Best-effort observability — the actual unblock step has already
+        # completed by this point. This audit only emits warnings about
+        # potentially-misfired blocks; a transient GitHub-API 5xx in the
+        # `gh issue list` calls below should NOT fail the workflow run. See
+        # #4234 / #4238.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}


### PR DESCRIPTION
## Summary

Audited the seven workflows listed in #4238 for cleanup-style branches that call `gh issue *` on the workflow's primary success path. Six were missing `continue-on-error: true`; added the flag plus a one-line rationale comment matching the wording landed in #4237. `issue-triage.yml` is a security gate (not cleanup) and was intentionally left unchanged.

Closes #4238.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — workflow YAML edits only; no deployed component. The next scheduled run of each affected workflow will exercise the new `continue-on-error: true` only when the corresponding cleanup step actually hits a 5xx, which is unobservable on a healthy run. Verification evidence comment will state this skip reason.
- [x] Verification evidence posted on issue (see A.8)
