### PR TITLE
feat(dx): scripts/spotcheck/inspect.py — filter and summarise spotcheck JSON results (#4235)

### DIFF
--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -70,6 +70,8 @@ Without the `derived.documents` join + `d.status = 'active'` filter, supersede c
 
 This applies to any AC that gates "the cleanup is done" on a row count — file/issue authors filing such ACs and agents implementing them should both verify the SELECT carries the `derived.documents` join + `d.status = 'active'` filter before treating the count as authoritative.
 
+When the verification reads the bidirectional spotcheck JSON in `s3://judgemind-document-archive-dev/spotcheck/<TS>.json`, use `scripts/spotcheck/inspect.py <s3-uri-or-local-path> [--unknown-only] [--null-judge-only] [--department-in C20 C23 …] [--format table|json]` to filter and summarise the result without writing custom one-liners (#4235).
+
 ## Verify the gap exists before filing
 
 Before filing a "does X" / "enable X" / "add X" issue, run a single command that verifies X is not already the case. This rule exists because an agent-runner cycle spent re-creating state that already exists is pure waste — the canonical example is #3146, where an issue was filed to "enable Container Insights on the ECS cluster" after the Terraform attribute `enable_container_insights = true` had already shipped in a prior PR. The agent spent a full cycle discovering, through probing, that there was nothing to do. A thirty-second check before filing would have surfaced that immediately. This is a sibling of the external-integration feasibility note in §Writing Acceptance Criteria (line 15): both rules say "verify the precondition before you ask an agent to build on top of it."

--- a/scripts/spotcheck/inspect.py
+++ b/scripts/spotcheck/inspect.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Filter and summarise ``run_spotcheck.py`` JSON results.
+
+After ``scripts/ecs-run-task.sh scripts/spotcheck/run_spotcheck.py -- --n 10
+--county Orange`` writes a result to ``s3://<archive-bucket>/spotcheck/<TS>.json``,
+this script answers ad-hoc "is the data quality OK in scope X?" questions
+without writing custom one-liners.
+
+Examples (#3629 verification case):
+
+    # Are there UNKNOWN samples in the regressed Orange-County department set?
+    scripts/run-py.sh scripts/spotcheck/inspect.py \\
+        s3://judgemind-document-archive-dev/spotcheck/20260506T161159Z.json \\
+        --county Orange --unknown-only \\
+        --department-in C20 C23 C25 C27 C31 C32 CM2 C34 N15
+
+    # All UNKNOWN samples across every county in the result.
+    scripts/run-py.sh scripts/spotcheck/inspect.py tmp/spotcheck/data.json \\
+        --unknown-only
+
+    # Pipe filtered rows as JSON for further processing.
+    scripts/run-py.sh scripts/spotcheck/inspect.py s3://.../result.json \\
+        --null-judge-only --format json | jq '.[].case_number'
+
+The result JSON shape comes from ``run_spotcheck.py``: each county has a
+``rulings_by_county[<county>]`` list of ruling dicts, and each
+``originals_by_county[<county>][i]['derived_rulings']`` list of ruling dicts
+from the bidirectional originals side. ``inspect.py`` walks both sides so a
+single filter pass surfaces hits from either direction.
+
+See: https://github.com/judgemind/judgemind/issues/4235
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Pure helpers — testable without boto3
+# ---------------------------------------------------------------------------
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Parse ``s3://bucket/key/path`` into ``(bucket, key)``.
+
+    Raises ``ValueError`` if the URI is malformed.
+    """
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Not an S3 URI: {uri!r}")
+    rest = uri[len("s3://") :]
+    if "/" not in rest:
+        raise ValueError(f"S3 URI missing key: {uri!r}")
+    bucket, _, key = rest.partition("/")
+    if not bucket or not key:
+        raise ValueError(f"S3 URI bucket or key empty: {uri!r}")
+    return bucket, key
+
+
+def is_s3_uri(uri: str) -> bool:
+    """Return True if ``uri`` looks like an ``s3://...`` URI."""
+    return uri.startswith("s3://")
+
+
+def iter_rulings(
+    result: dict[str, Any],
+    counties: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Walk both sides of a ``run_spotcheck.py`` result and yield ruling dicts.
+
+    Each yielded dict is augmented with two keys for downstream display:
+
+    - ``__source``: ``"rulings"`` or ``"originals.derived"`` — which side of
+      the bidirectional spotcheck the row came from. Useful for diagnosing
+      which sampling path surfaced a problem.
+    - ``__county``: county name from the enclosing dict (the rows themselves
+      do not carry county directly).
+
+    Args:
+        result: Parsed JSON from ``run_spotcheck.py``'s S3 output.
+        counties: If non-empty, restrict to these county names
+            (case-insensitive). ``None``/empty walks every county present.
+
+    Returns:
+        Flat list of ruling dicts with the two ``__source`` / ``__county``
+        keys added.
+    """
+    wanted: set[str] | None = None
+    if counties:
+        wanted = {c.lower() for c in counties}
+
+    rows: list[dict[str, Any]] = []
+
+    for county, rulings in (result.get("rulings_by_county") or {}).items():
+        if wanted is not None and county.lower() not in wanted:
+            continue
+        for r in rulings or []:
+            row = dict(r)
+            row["__source"] = "rulings"
+            row["__county"] = county
+            rows.append(row)
+
+    for county, originals in (result.get("originals_by_county") or {}).items():
+        if wanted is not None and county.lower() not in wanted:
+            continue
+        for orig in originals or []:
+            for r in orig.get("derived_rulings") or []:
+                row = dict(r)
+                row["__source"] = "originals.derived"
+                row["__county"] = county
+                # Originals' derived rulings don't carry s3_key directly —
+                # surface the parent original's s3_key for display so the
+                # operator can locate the source document quickly.
+                if orig.get("s3_key") and "s3_key" not in row:
+                    row["s3_key"] = orig["s3_key"]
+                rows.append(row)
+
+    return rows
+
+
+def is_unknown_case_number(row: dict[str, Any]) -> bool:
+    """Return True if ``row['case_number']`` is an UNKNOWN-* placeholder."""
+    cn = row.get("case_number")
+    return isinstance(cn, str) and cn.startswith("UNKNOWN")
+
+
+def is_null_judge(row: dict[str, Any]) -> bool:
+    """Return True if ``row['judge_name']`` is missing/empty."""
+    j = row.get("judge_name")
+    return j is None or (isinstance(j, str) and not j.strip())
+
+
+def is_null_department(row: dict[str, Any]) -> bool:
+    """Return True if ``row['department']`` is missing/empty."""
+    d = row.get("department")
+    return d is None or (isinstance(d, str) and not d.strip())
+
+
+def is_empty_text(row: dict[str, Any]) -> bool:
+    """Return True if ``row['ruling_text_length']`` is 0/missing."""
+    n = row.get("ruling_text_length")
+    return n is None or n == 0
+
+
+def in_departments(row: dict[str, Any], departments: list[str]) -> bool:
+    """Return True if ``row['department']`` matches any of ``departments``.
+
+    Case-sensitive (court department codes are codes, not names). A row whose
+    department is null/empty matches only if the literal string ``null`` is in
+    the list — operators filtering for null department should use
+    ``--null-department-only`` instead.
+    """
+    if not departments:
+        return True  # no filter active
+    dept = row.get("department")
+    if dept is None:
+        return "null" in departments
+    return dept in departments
+
+
+def filter_rows(
+    rows: list[dict[str, Any]],
+    *,
+    unknown_only: bool = False,
+    null_judge_only: bool = False,
+    null_department_only: bool = False,
+    empty_text_only: bool = False,
+    departments: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Apply filters in AND fashion. All filters compose."""
+    out = []
+    depts = departments or []
+    for row in rows:
+        if unknown_only and not is_unknown_case_number(row):
+            continue
+        if null_judge_only and not is_null_judge(row):
+            continue
+        if null_department_only and not is_null_department(row):
+            continue
+        if empty_text_only and not is_empty_text(row):
+            continue
+        if depts and not in_departments(row, depts):
+            continue
+        out.append(row)
+    return out
+
+
+def render_table(rows: list[dict[str, Any]]) -> str:
+    """Render filtered rows as a pipe-separated table.
+
+    Columns: county | source | dept | case_number | case_title | s3_key.
+    Truncates long fields to keep the table readable; full data is
+    available via ``--format json``.
+    """
+    if not rows:
+        return "(no rows)"
+
+    columns = [
+        ("county", "__county", 16),
+        ("source", "__source", 18),
+        ("dept", "department", 6),
+        ("case_number", "case_number", 22),
+        ("case_title", "case_title", 50),
+        ("s3_key", "s3_key", 60),
+    ]
+
+    def cell(row: dict[str, Any], key: str, width: int) -> str:
+        v = row.get(key)
+        if v is None:
+            v = "null"
+        s = str(v)
+        if len(s) > width:
+            s = s[: width - 1] + "…"
+        return s.ljust(width)
+
+    header = " | ".join(name.ljust(width) for name, _, width in columns)
+    sep = "-+-".join("-" * width for _, _, width in columns)
+    lines = [header, sep]
+    for row in rows:
+        lines.append(" | ".join(cell(row, key, width) for _, key, width in columns))
+    lines.append("")
+    lines.append(f"({len(rows)} row{'s' if len(rows) != 1 else ''})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# I/O — load from S3 URI or local path
+# ---------------------------------------------------------------------------
+
+
+def load_result(source: str) -> dict[str, Any]:
+    """Load the spotcheck JSON from an S3 URI or a local file path.
+
+    S3 URIs are auto-resolved via ``boto3`` — no need to ``aws s3 cp`` first.
+    """
+    if is_s3_uri(source):
+        bucket, key = parse_s3_uri(source)
+        # Lazy import: ``inspect.py`` is importable in test envs without boto3.
+        import boto3  # noqa: PLC0415
+
+        s3 = boto3.client("s3")
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        body = obj["Body"].read()
+        return json.loads(body)
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"Spotcheck file not found: {source}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Filter and summarise run_spotcheck.py JSON results "
+            "(s3:// URI or local path). See #4235."
+        ),
+    )
+    parser.add_argument(
+        "source",
+        help="S3 URI (s3://bucket/key/...) or local path to spotcheck JSON.",
+    )
+    parser.add_argument(
+        "--county",
+        action="append",
+        default=[],
+        help=(
+            "Restrict to one county (repeatable). Default: every county in the result."
+        ),
+    )
+    parser.add_argument(
+        "--unknown-only",
+        action="store_true",
+        help="Keep only rows where case_number is UNKNOWN-*.",
+    )
+    parser.add_argument(
+        "--null-judge-only",
+        action="store_true",
+        help="Keep only rows where judge_name is null/empty.",
+    )
+    parser.add_argument(
+        "--null-department-only",
+        action="store_true",
+        help="Keep only rows where department is null/empty.",
+    )
+    parser.add_argument(
+        "--empty-text-only",
+        action="store_true",
+        help="Keep only rows where ruling_text_length is 0/missing.",
+    )
+    parser.add_argument(
+        "--department-in",
+        nargs="+",
+        default=[],
+        metavar="DEPT",
+        help="Keep only rows whose department is in this list (case-sensitive).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["table", "json"],
+        default="table",
+        help="Output format (default: table).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = load_result(args.source)
+    except (FileNotFoundError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    rows = iter_rulings(result, counties=args.county or None)
+    filtered = filter_rows(
+        rows,
+        unknown_only=args.unknown_only,
+        null_judge_only=args.null_judge_only,
+        null_department_only=args.null_department_only,
+        empty_text_only=args.empty_text_only,
+        departments=args.department_in,
+    )
+
+    if args.format == "json":
+        # Strip the ``__`` augment keys from the JSON output so downstream
+        # consumers see the original ruling shape, but preserve county /
+        # source as plain keys for traceability.
+        cleaned = []
+        for row in filtered:
+            out = {k: v for k, v in row.items() if not k.startswith("__")}
+            out["county"] = row.get("__county")
+            out["source"] = row.get("__source")
+            cleaned.append(out)
+        print(json.dumps(cleaned, indent=2, default=str))
+    else:
+        print(render_table(filtered))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_inspect.py
+++ b/scripts/tests/test_inspect.py
@@ -1,0 +1,482 @@
+"""Tests for ``scripts/spotcheck/inspect.py``.
+
+Covers the filter helpers (pure, testable without boto3), the S3 URI parser,
+and the table renderer. Mirrors the test layout used by
+``scripts/tests/test_run_spotcheck.py`` — adds the spotcheck dir to
+``sys.path`` so ``import inspect`` resolves to the spotcheck module rather
+than the stdlib ``inspect``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Resolve to scripts/spotcheck/inspect.py, not the stdlib ``inspect``.
+_SPOTCHECK_DIR = Path(__file__).resolve().parent.parent / "spotcheck"
+sys.path.insert(0, str(_SPOTCHECK_DIR))
+
+# The stdlib ``inspect`` module may already be cached. Pop it so the
+# directory we just inserted wins, then re-pop on teardown so other tests
+# (and the test runner itself) get the stdlib back.
+_HAD_STDLIB_INSPECT = sys.modules.pop("inspect", None)
+import inspect as spotcheck_inspect  # noqa: E402
+
+# Make sure subsequent ``import inspect`` calls in the test process get the
+# stdlib back — anything that runs after this module is loaded relies on the
+# real ``inspect`` for traceback rendering, dataclass introspection, etc.
+sys.modules["inspect"] = _HAD_STDLIB_INSPECT or __import__("importlib").import_module(
+    "inspect"
+)
+# But keep our handle to the spotcheck module accessible to the tests below.
+sys.modules["spotcheck_inspect"] = spotcheck_inspect
+
+
+# ---------------------------------------------------------------------------
+# parse_s3_uri / is_s3_uri
+# ---------------------------------------------------------------------------
+
+
+class TestParseS3Uri:
+    def test_simple_uri(self) -> None:
+        bucket, key = spotcheck_inspect.parse_s3_uri(
+            "s3://judgemind-document-archive-dev/spotcheck/20260506T161159Z.json"
+        )
+        assert bucket == "judgemind-document-archive-dev"
+        assert key == "spotcheck/20260506T161159Z.json"
+
+    def test_nested_key(self) -> None:
+        bucket, key = spotcheck_inspect.parse_s3_uri("s3://b/a/b/c.json")
+        assert bucket == "b"
+        assert key == "a/b/c.json"
+
+    def test_missing_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Not an S3 URI"):
+            spotcheck_inspect.parse_s3_uri("/local/path.json")
+
+    def test_missing_key_rejected(self) -> None:
+        with pytest.raises(ValueError, match="missing key"):
+            spotcheck_inspect.parse_s3_uri("s3://bucket-only")
+
+    def test_empty_bucket_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            spotcheck_inspect.parse_s3_uri("s3:///key/only")
+
+    def test_is_s3_uri_truthy(self) -> None:
+        assert spotcheck_inspect.is_s3_uri("s3://b/k") is True
+        assert spotcheck_inspect.is_s3_uri("/local/path") is False
+        assert spotcheck_inspect.is_s3_uri("https://example.com") is False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — sample run_spotcheck.py result shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def result_fixture() -> dict:
+    """Tiny result resembling ``run_spotcheck.py``'s JSON output."""
+    return {
+        "timestamp": "2026-05-06T16:11:59Z",
+        "n_per_county": 5,
+        "counties_requested": ["Orange"],
+        "rulings_by_county": {
+            "Orange": [
+                {
+                    "ruling_id": "r1",
+                    "department": "C20",
+                    "case_number": "30-2025-12345",
+                    "case_title": "Smith v Jones",
+                    "judge_name": "Judge Smith",
+                    "ruling_text_length": 500,
+                    "s3_key": "ca/orange/oc/raw/aaa.pdf",
+                },
+                {
+                    "ruling_id": "r2",
+                    "department": "N15",
+                    "case_number": "UNKNOWN-592b",
+                    "case_title": "Nguyen vs Beach Grove Dentistry",
+                    "judge_name": None,
+                    "ruling_text_length": 300,
+                    "s3_key": "ca/orange/oc/raw/bbb.pdf",
+                },
+                {
+                    "ruling_id": "r3",
+                    "department": None,
+                    "case_number": "UNKNOWN-0ade",
+                    "case_title": "Gomez vs. BGN Acquisitions La Habra",
+                    "judge_name": "Judge Gomez",
+                    "ruling_text_length": 0,
+                    "s3_key": "ca/orange/oc/raw/ccc.pdf",
+                },
+                {
+                    "ruling_id": "r4",
+                    "department": "C10",
+                    "case_number": "UNKNOWN-35ff",
+                    "case_title": "Grossman v. State Farm",
+                    "judge_name": "Judge Grossman",
+                    "ruling_text_length": 800,
+                    "s3_key": "ca/orange/oc/raw/ddd.pdf",
+                },
+            ],
+        },
+        "originals_by_county": {
+            "Orange": [
+                {
+                    "s3_key": "ca/orange/oc/raw/eee.pdf",
+                    "derived_count": 1,
+                    "derived_rulings": [
+                        {
+                            "ruling_id": "r5",
+                            "department": "C23",
+                            "case_number": "UNKNOWN-zzzz",
+                            "case_title": "Hidden v Default",
+                            "judge_name": None,
+                            "ruling_text_length": 10,
+                        },
+                    ],
+                },
+            ],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# iter_rulings — walks both bidirectional sides
+# ---------------------------------------------------------------------------
+
+
+class TestIterRulings:
+    def test_walks_rulings_and_originals_derived(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        # 4 rulings_by_county + 1 originals.derived = 5 total
+        assert len(rows) == 5
+        sources = {r["__source"] for r in rows}
+        assert sources == {"rulings", "originals.derived"}
+
+    def test_county_filter_case_insensitive(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture, counties=["orange"])
+        assert len(rows) == 5
+        rows = spotcheck_inspect.iter_rulings(result_fixture, counties=["Los Angeles"])
+        assert rows == []
+
+    def test_originals_derived_inherits_parent_s3_key(
+        self, result_fixture: dict
+    ) -> None:
+        """Originals' derived_rulings don't carry s3_key directly — the parent
+        original's s3_key should surface on each derived row so operators can
+        locate the source PDF."""
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        derived = [r for r in rows if r["__source"] == "originals.derived"]
+        assert len(derived) == 1
+        assert derived[0]["s3_key"] == "ca/orange/oc/raw/eee.pdf"
+
+    def test_handles_missing_buckets(self) -> None:
+        """Empty / missing rulings_by_county or originals_by_county is fine."""
+        assert spotcheck_inspect.iter_rulings({}) == []
+        assert spotcheck_inspect.iter_rulings({"rulings_by_county": {}}) == []
+
+
+# ---------------------------------------------------------------------------
+# filter_rows — composable filters
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRows:
+    def test_unknown_only(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(rows, unknown_only=True)
+        # r2, r3, r4, r5 are UNKNOWN; r1 is not
+        assert {r["ruling_id"] for r in out} == {"r2", "r3", "r4", "r5"}
+
+    def test_null_judge_only(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(rows, null_judge_only=True)
+        assert {r["ruling_id"] for r in out} == {"r2", "r5"}
+
+    def test_null_department_only(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(rows, null_department_only=True)
+        assert {r["ruling_id"] for r in out} == {"r3"}
+
+    def test_empty_text_only(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(rows, empty_text_only=True)
+        assert {r["ruling_id"] for r in out} == {"r3"}
+
+    def test_department_in(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(rows, departments=["C20", "N15"])
+        assert {r["ruling_id"] for r in out} == {"r1", "r2"}
+
+    def test_filters_compose_unknown_and_department_in(
+        self, result_fixture: dict
+    ) -> None:
+        """The motivating #3629 case — UNKNOWN rows in the regressed dept set."""
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(
+            rows,
+            unknown_only=True,
+            departments=["C20", "C23", "C25", "C27", "C31", "C32", "CM2", "C34", "N15"],
+        )
+        # Only r2 (N15, UNKNOWN) and r5 (C23, UNKNOWN) match.
+        assert {r["ruling_id"] for r in out} == {"r2", "r5"}
+
+    def test_filters_compose_unknown_and_null_judge(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        out = spotcheck_inspect.filter_rows(
+            rows, unknown_only=True, null_judge_only=True
+        )
+        # r2 (UNKNOWN, null judge) and r5 (UNKNOWN, null judge).
+        assert {r["ruling_id"] for r in out} == {"r2", "r5"}
+
+    def test_no_filters_returns_all(self, result_fixture: dict) -> None:
+        rows = spotcheck_inspect.iter_rulings(result_fixture)
+        assert spotcheck_inspect.filter_rows(rows) == rows
+
+
+# ---------------------------------------------------------------------------
+# Predicate helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPredicates:
+    def test_unknown_case_number_handles_non_string(self) -> None:
+        assert spotcheck_inspect.is_unknown_case_number({"case_number": None}) is False
+        assert spotcheck_inspect.is_unknown_case_number({"case_number": 12345}) is False
+        assert (
+            spotcheck_inspect.is_unknown_case_number({"case_number": "UNKNOWN-abc"})
+            is True
+        )
+        assert (
+            spotcheck_inspect.is_unknown_case_number({"case_number": "30-2025-1"})
+            is False
+        )
+
+    def test_null_judge_treats_empty_string_as_null(self) -> None:
+        assert spotcheck_inspect.is_null_judge({"judge_name": None}) is True
+        assert spotcheck_inspect.is_null_judge({"judge_name": ""}) is True
+        assert spotcheck_inspect.is_null_judge({"judge_name": "   "}) is True
+        assert spotcheck_inspect.is_null_judge({"judge_name": "Judge Smith"}) is False
+
+    def test_in_departments_no_filter(self) -> None:
+        # Empty filter list = no filter active.
+        assert spotcheck_inspect.in_departments({"department": "C20"}, []) is True
+
+    def test_in_departments_null_dept_with_explicit_null(self) -> None:
+        assert (
+            spotcheck_inspect.in_departments({"department": None}, ["C20", "null"])
+            is True
+        )
+        assert spotcheck_inspect.in_departments({"department": None}, ["C20"]) is False
+
+
+# ---------------------------------------------------------------------------
+# render_table
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTable:
+    def test_no_rows(self) -> None:
+        assert spotcheck_inspect.render_table([]) == "(no rows)"
+
+    def test_single_row_has_header_and_count(self) -> None:
+        rows = [
+            {
+                "__county": "Orange",
+                "__source": "rulings",
+                "department": "C20",
+                "case_number": "UNKNOWN-x",
+                "case_title": "A v B",
+                "s3_key": "ca/orange/raw/x.pdf",
+            }
+        ]
+        out = spotcheck_inspect.render_table(rows)
+        assert "county" in out
+        assert "case_number" in out
+        assert "Orange" in out
+        assert "UNKNOWN-x" in out
+        assert "(1 row)" in out
+
+    def test_truncates_long_fields(self) -> None:
+        rows = [
+            {
+                "__county": "Orange",
+                "__source": "rulings",
+                "department": "C20",
+                "case_number": "UNKNOWN-x",
+                "case_title": "A" * 500,
+                "s3_key": "k",
+            }
+        ]
+        out = spotcheck_inspect.render_table(rows)
+        # Truncation marker present somewhere in the table body.
+        assert "…" in out
+
+    def test_null_renders_as_null_string(self) -> None:
+        rows = [
+            {
+                "__county": "Orange",
+                "__source": "rulings",
+                "department": None,
+                "case_number": "UNKNOWN-y",
+                "case_title": "X",
+                "s3_key": "k",
+            }
+        ]
+        out = spotcheck_inspect.render_table(rows)
+        assert "null" in out
+
+
+# ---------------------------------------------------------------------------
+# load_result — local file path branch (S3 branch needs boto3 which we mock
+# in the integration test below)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadResult:
+    def test_local_path_round_trip(self, tmp_path: Path, result_fixture: dict) -> None:
+        path = tmp_path / "spotcheck.json"
+        path.write_text(json.dumps(result_fixture), encoding="utf-8")
+        loaded = spotcheck_inspect.load_result(str(path))
+        assert loaded["n_per_county"] == 5
+
+    def test_missing_local_path_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            spotcheck_inspect.load_result(str(tmp_path / "nope.json"))
+
+    def test_s3_uri_uses_boto3(
+        self, monkeypatch: pytest.MonkeyPatch, result_fixture: dict
+    ) -> None:
+        """load_result with an s3:// URI must call boto3.client('s3').get_object."""
+        body = json.dumps(result_fixture).encode("utf-8")
+        calls: dict = {}
+
+        class FakeClient:
+            def get_object(self, Bucket: str, Key: str) -> dict:
+                calls["bucket"] = Bucket
+                calls["key"] = Key
+                return {"Body": io.BytesIO(body)}
+
+        class FakeBoto3:
+            @staticmethod
+            def client(svc: str) -> FakeClient:
+                calls["service"] = svc
+                return FakeClient()
+
+        monkeypatch.setitem(sys.modules, "boto3", FakeBoto3)
+        loaded = spotcheck_inspect.load_result(
+            "s3://judgemind-document-archive-dev/spotcheck/X.json"
+        )
+        assert loaded["n_per_county"] == 5
+        assert calls["service"] == "s3"
+        assert calls["bucket"] == "judgemind-document-archive-dev"
+        assert calls["key"] == "spotcheck/X.json"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — go through main() with a local fixture file
+# ---------------------------------------------------------------------------
+
+
+class TestMainCli:
+    def test_help_lists_every_flag(self, capsys: pytest.CaptureFixture) -> None:
+        """AC#1: ``inspect.py --help`` prints all flags."""
+        with pytest.raises(SystemExit):
+            spotcheck_inspect.main(["--help"])
+        out = capsys.readouterr().out
+        for flag in [
+            "--county",
+            "--unknown-only",
+            "--null-judge-only",
+            "--null-department-only",
+            "--empty-text-only",
+            "--department-in",
+            "--format",
+        ]:
+            assert flag in out, f"--help is missing {flag}"
+
+    def test_default_format_is_table(
+        self,
+        tmp_path: Path,
+        result_fixture: dict,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        path = tmp_path / "r.json"
+        path.write_text(json.dumps(result_fixture), encoding="utf-8")
+        rc = spotcheck_inspect.main([str(path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "county" in out
+        assert "case_number" in out
+
+    def test_unknown_only_dept_in_filters_compose(
+        self,
+        tmp_path: Path,
+        result_fixture: dict,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The #3629 verification scenario, end-to-end through main()."""
+        path = tmp_path / "r.json"
+        path.write_text(json.dumps(result_fixture), encoding="utf-8")
+        rc = spotcheck_inspect.main(
+            [
+                str(path),
+                "--unknown-only",
+                "--department-in",
+                "C20",
+                "C23",
+                "C25",
+                "C27",
+                "C31",
+                "C32",
+                "CM2",
+                "C34",
+                "N15",
+                "--format",
+                "json",
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        rows = json.loads(out)
+        assert {r["ruling_id"] for r in rows} == {"r2", "r5"}
+        # Each row should also carry a ``county`` and ``source`` for traceability.
+        assert all(r["county"] == "Orange" for r in rows)
+        assert {r["source"] for r in rows} == {"rulings", "originals.derived"}
+
+    def test_format_json_strips_double_underscore_keys(
+        self,
+        tmp_path: Path,
+        result_fixture: dict,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        path = tmp_path / "r.json"
+        path.write_text(json.dumps(result_fixture), encoding="utf-8")
+        rc = spotcheck_inspect.main([str(path), "--format", "json"])
+        assert rc == 0
+        rows = json.loads(capsys.readouterr().out)
+        for row in rows:
+            assert not any(k.startswith("__") for k in row), (
+                "JSON output must strip __source / __county augment keys"
+            )
+
+    def test_missing_file_returns_exit_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        rc = spotcheck_inspect.main([str(tmp_path / "nope.json")])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "ERROR" in err
+
+    def test_malformed_s3_uri_returns_exit_2(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        rc = spotcheck_inspect.main(["s3://bucket-only-no-key"])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "ERROR" in err


### PR DESCRIPTION
## Summary

Adds `scripts/spotcheck/inspect.py` — a standalone CLI for filtering and summarising `run_spotcheck.py` JSON results from S3 or a local path. Walks both bidirectional sides of the spotcheck and applies composable filters (`--unknown-only`, `--null-judge-only`, `--null-department-only`, `--empty-text-only`, `--department-in`, `--county`) before rendering as a pipe-separated table or filtered JSON. Also adds a 1-line example to `docs/agent/issue-authoring.md` §Cleanup AC queries pointing at the new script.

Closes #4235

## Test plan

### Automated checks
- [x] Lint passes (ruff check on new files clean locally)
- [x] Format check passes (ruff format applied locally)
- [x] Tests pass (35 new tests in `scripts/tests/test_inspect.py` all green locally)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (operator script + tests + docs only)
