### PR TITLE
feat(ingestion): instrument deterministic Gemini chunk failures (#4233)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -96,6 +96,17 @@ _MAX_RETRY_DEPTH = 1
 # Minimum chunk size (chars) to attempt a retry split.
 _MIN_RETRY_CHUNK_CHARS = 2000
 
+# Deterministic-chunk-failure instrumentation (#4233).
+# When the same document_id has accumulated this many ``_extract_chunk_google``
+# failures within a single reingest run, emit
+# ``llm_extract.deterministic_chunk_failure`` with the chunk's content
+# SHA-256 and a 200-char preview so future log queries can group by content
+# and identify documents that deterministically trip the LLM provider.
+_DETERMINISTIC_FAILURE_THRESHOLD = 3
+# Number of leading chars from the failing chunk to include in the structured
+# log event.  Bounded so the log line stays cheap to ingest.
+_DETERMINISTIC_FAILURE_PREVIEW_CHARS = 200
+
 # Patterns for natural split boundaries.
 _PAGE_BREAK_RE = re.compile(r"\f")
 _CASE_BOUNDARY_RE = re.compile(
@@ -2669,6 +2680,17 @@ class LlmExtractor:
             else None
         )
 
+        # Per-document Google API failure counter (#4233).  Maps
+        # ``document_id`` -> count of ``_extract_chunk_google`` calls that
+        # returned ``None`` within this extractor's lifetime (typically one
+        # reingest run).  Used to fire the
+        # ``llm_extract.deterministic_chunk_failure`` structured log event
+        # exactly once when the count crosses
+        # ``_DETERMINISTIC_FAILURE_THRESHOLD``.  Counter is best-effort: only
+        # populated when callers pass ``document_id`` to ``extract()``.
+        self._google_chunk_failure_counts: dict[str, int] = {}
+        self._deterministic_failure_fired: set[str] = set()
+
     @staticmethod
     def _get_cache_s3_client() -> object:
         """Return an S3 client for the LLM cache.
@@ -2691,6 +2713,7 @@ class LlmExtractor:
         metadata: dict[str, str] | None = None,
         system_prompt: str | None = None,
         bust_cache: bool = False,
+        document_id: str | None = None,
     ) -> list[ExtractedRuling]:
         """Extract structured rulings from raw calendar page text.
 
@@ -2713,6 +2736,14 @@ class LlmExtractor:
                 from the fresh result.  See ``self._bust_cache`` for a
                 persistent instance-level default.  Used by the
                 ``--bust-llm-cache`` reingest flag (#2424).
+            document_id: Optional source ``derived.documents`` UUID.  When
+                provided, ``_extract_chunk_google`` failures for this doc
+                are counted; once
+                ``_DETERMINISTIC_FAILURE_THRESHOLD`` is reached within
+                a single reingest run, ``llm_extract.deterministic_chunk_failure``
+                is emitted with the failing chunk's content SHA-256 and a
+                200-char preview so future log queries can group by content
+                (#4233).  Has no effect on cache key (kept out of metadata).
 
         Returns:
             A list of ``ExtractedRuling`` instances.  Returns an empty list
@@ -2738,7 +2769,11 @@ class LlmExtractor:
 
         if len(chunks) == 1:
             results = self._extract_chunk_with_retry(
-                chunks[0], metadata=metadata, usage=usage, system_prompt=system_prompt
+                chunks[0],
+                metadata=metadata,
+                usage=usage,
+                system_prompt=system_prompt,
+                document_id=document_id,
             )
             self._log_usage(usage)
             if not results:
@@ -2760,6 +2795,7 @@ class LlmExtractor:
                     usage=usage,
                     chunk_index=i,
                     system_prompt=system_prompt,
+                    document_id=document_id,
                 )
                 all_results.extend(results)
 
@@ -2811,6 +2847,7 @@ class LlmExtractor:
         metadata: dict[str, str] | None = None,
         max_pages: int = 50,
         bust_cache: bool = False,
+        document_id: str | None = None,
     ) -> list[ExtractedRuling]:
         """Extract structured rulings from PDF page images (multimodal).
 
@@ -2836,6 +2873,13 @@ class LlmExtractor:
                 from the fresh result.  See ``self._bust_cache`` for a
                 persistent instance-level default.  Used by the
                 ``--bust-llm-cache`` reingest flag (#2424).
+            document_id: Optional source ``derived.documents`` UUID.  When
+                provided, ``_extract_single_page`` failures for this doc
+                are counted; once
+                ``_DETERMINISTIC_FAILURE_THRESHOLD`` is reached within
+                a single reingest run, ``llm_extract.deterministic_chunk_failure``
+                is emitted with the failing page's image SHA-256 so future
+                log queries can group by content (#4233).
 
         Returns:
             A list of ``ExtractedRuling`` instances.  Returns an empty list
@@ -2868,7 +2912,12 @@ class LlmExtractor:
         any_page_failed = False
         for page_idx, (img_bytes, media_type) in enumerate(page_images):
             page_rows = self._extract_single_page(
-                img_bytes, media_type, metadata=metadata, usage=usage, page_index=page_idx
+                img_bytes,
+                media_type,
+                metadata=metadata,
+                usage=usage,
+                page_index=page_idx,
+                document_id=document_id,
             )
             if page_rows:
                 all_rows.extend(page_rows)
@@ -2920,6 +2969,7 @@ class LlmExtractor:
         usage: TokenUsage,
         chunk_index: int = 0,
         system_prompt: str | None = None,
+        document_id: str | None = None,
     ) -> ExtractionResult | None:
         """Call the LLM API for a single text chunk and parse the result.
 
@@ -2942,6 +2992,8 @@ class LlmExtractor:
                 usage=usage,
                 chunk_index=chunk_index,
                 metadata=metadata,
+                document_id=document_id,
+                chunk_text=text,
             )
 
         for attempt in range(1, self._max_retries + 1):
@@ -3052,6 +3104,8 @@ class LlmExtractor:
         usage: TokenUsage,
         chunk_index: int = 0,
         metadata: dict[str, str] | None = None,
+        document_id: str | None = None,
+        chunk_text: str | None = None,
     ) -> ExtractionResult | None:
         """Call the Google GenAI API for a single text chunk.
 
@@ -3073,6 +3127,12 @@ class LlmExtractor:
             logger.warning(
                 "llm_extractor.google_api_failure",
                 chunk_index=chunk_index,
+                document_id=document_id,
+            )
+            self._record_google_chunk_failure(
+                document_id=document_id,
+                chunk_index=chunk_index,
+                chunk_text=chunk_text,
             )
             return None
 
@@ -3081,6 +3141,71 @@ class LlmExtractor:
         usage.api_calls += 1
 
         return self._parse_response(response.text, metadata)
+
+    def _record_google_chunk_failure(
+        self,
+        *,
+        document_id: str | None,
+        chunk_index: int,
+        chunk_text: str | None,
+        chunk_bytes: bytes | None = None,
+    ) -> None:
+        """Increment the per-document Google chunk-failure counter (#4233).
+
+        When the same ``document_id`` accumulates
+        ``_DETERMINISTIC_FAILURE_THRESHOLD`` failed Google API calls
+        (text-chunk or per-page-image) within this extractor's lifetime,
+        emit ``llm_extract.deterministic_chunk_failure`` exactly once with
+        the current chunk's content SHA-256 and (for text chunks) a
+        200-char preview, so operators can group log entries by content
+        and identify the documents that deterministically trip the LLM
+        provider.
+
+        Either ``chunk_text`` (text-chunk path) or ``chunk_bytes`` (PDF
+        per-page multimodal path) may be provided; SHA-256 is taken over
+        whichever is present.  The text preview field stays empty for
+        the multimodal path since the binary is image data.
+
+        No-op when ``document_id`` is ``None`` (legacy callers), so this
+        instrumentation is opt-in per call site.
+        """
+        if not document_id:
+            return
+
+        new_count = self._google_chunk_failure_counts.get(document_id, 0) + 1
+        self._google_chunk_failure_counts[document_id] = new_count
+
+        if (
+            new_count >= _DETERMINISTIC_FAILURE_THRESHOLD
+            and document_id not in self._deterministic_failure_fired
+        ):
+            self._deterministic_failure_fired.add(document_id)
+            preview = ""
+            content_sha256 = ""
+            content_len = 0
+            content_kind = "unknown"
+            if chunk_text is not None:
+                preview = chunk_text[:_DETERMINISTIC_FAILURE_PREVIEW_CHARS]
+                content_sha256 = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+                content_len = len(chunk_text)
+                content_kind = "text"
+            elif chunk_bytes is not None:
+                content_sha256 = hashlib.sha256(chunk_bytes).hexdigest()
+                content_len = len(chunk_bytes)
+                content_kind = "image"
+            logger.warning(
+                "llm_extract.deterministic_chunk_failure",
+                document_id=document_id,
+                chunk_index=chunk_index,
+                failure_count=new_count,
+                threshold=_DETERMINISTIC_FAILURE_THRESHOLD,
+                provider=self._provider,
+                model=self._model,
+                chunk_content_sha256=content_sha256,
+                chunk_preview=preview,
+                chunk_len=content_len,
+                chunk_kind=content_kind,
+            )
 
     def _extract_chunk_with_retry(
         self,
@@ -3091,6 +3216,7 @@ class LlmExtractor:
         chunk_index: int = 0,
         system_prompt: str | None = None,
         _depth: int = 0,
+        document_id: str | None = None,
     ) -> list[ExtractionResult]:
         """Extract a chunk, retrying with smaller sub-chunks on parse failure.
 
@@ -3115,6 +3241,7 @@ class LlmExtractor:
             usage=usage,
             chunk_index=chunk_index,
             system_prompt=system_prompt,
+            document_id=document_id,
         )
         if result is not None:
             return [result]
@@ -3149,6 +3276,7 @@ class LlmExtractor:
                     chunk_index=chunk_index * 10 + i,
                     system_prompt=system_prompt,
                     _depth=_depth + 1,
+                    document_id=document_id,
                 )
             )
         return sub_results
@@ -3209,6 +3337,7 @@ class LlmExtractor:
         metadata: dict[str, str] | None = None,
         usage: TokenUsage,
         page_index: int = 0,
+        document_id: str | None = None,
     ) -> list[dict]:
         """Send a single page image to the LLM and return extracted table rows.
 
@@ -3246,6 +3375,19 @@ class LlmExtractor:
                             max_retries=self._max_retries,
                             retry_in=wait,
                             page_index=page_index,
+                            document_id=document_id,
+                        )
+                        # Count failed page-attempts toward the
+                        # deterministic-failure instrumentation (#4233).
+                        # Each retry attempt is its own data point —
+                        # ``call_llm_with_images`` was invoked with
+                        # ``max_retries=0`` so this loop is the only
+                        # retry layer for the multimodal path.
+                        self._record_google_chunk_failure(
+                            document_id=document_id,
+                            chunk_index=page_index,
+                            chunk_text=None,
+                            chunk_bytes=img_bytes,
                         )
                         time.sleep(wait)
                         delay *= 2
@@ -3253,6 +3395,13 @@ class LlmExtractor:
                     logger.error(
                         "llm_extractor.page_api_exhausted",
                         page_index=page_index,
+                        document_id=document_id,
+                    )
+                    self._record_google_chunk_failure(
+                        document_id=document_id,
+                        chunk_index=page_index,
+                        chunk_text=None,
+                        chunk_bytes=img_bytes,
                     )
                     return []
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -3164,7 +3164,9 @@ class IngestionWorker:
             if multimodal_extractor is not None:
                 try:
                     extracted_rulings = multimodal_extractor.extract_from_pdf(
-                        raw_pdf_bytes, metadata=metadata or None
+                        raw_pdf_bytes,
+                        metadata=metadata or None,
+                        document_id=document_id,
                     )
                     extraction_method = "multimodal"
                     if extracted_rulings:
@@ -3232,6 +3234,7 @@ class IngestionWorker:
                     ruling_text,
                     metadata=metadata or None,
                     system_prompt=county_prompt,
+                    document_id=document_id,
                 )
             except Exception as exc:
                 llm_latency_ms = round((time.monotonic() - t0) * 1000)

--- a/packages/scraper-framework/tests/test_citation_filter.py
+++ b/packages/scraper-framework/tests/test_citation_filter.py
@@ -494,6 +494,7 @@ class TestExtractUsesCitationFilter:
             usage: object,  # noqa: ARG001
             chunk_index: int = 0,  # noqa: ARG001
             system_prompt: str | None = None,  # noqa: ARG001
+            document_id: str | None = None,  # noqa: ARG001
         ) -> list[ExtractionResult]:
             # Bypass the actual API + retry logic: return the stub directly.
             return [stub_result]

--- a/packages/scraper-framework/tests/test_llm_extractor.py
+++ b/packages/scraper-framework/tests/test_llm_extractor.py
@@ -803,6 +803,191 @@ class TestGoogleProvider:
 
 
 # ---------------------------------------------------------------------------
+# Deterministic chunk-failure instrumentation (#4233)
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicChunkFailure:
+    """Verify the deterministic-chunk-failure structured log event (#4233).
+
+    When the same ``document_id`` accumulates 3+ failed
+    ``_extract_chunk_google`` calls within a single reingest run, the
+    extractor emits ``llm_extract.deterministic_chunk_failure`` with
+    the failing chunk's content SHA-256 and a 200-char preview so
+    operators can group log queries by content.
+    """
+
+    @staticmethod
+    def _make_extractor() -> LlmExtractor:
+        with patch("framework.llm_extractor._create_google_client"):
+            return LlmExtractor(provider="google")
+
+    def test_no_event_below_threshold(self) -> None:
+        """Two consecutive failures stay below the 3-failure threshold — no event fires."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                # Two failed extracts on the same doc; threshold = 3.
+                extractor.extract("some text", document_id="doc-A")
+                extractor.extract("some text", document_id="doc-A")
+
+                events = [c.args[0] for c in mock_logger.warning.call_args_list]
+                assert "llm_extract.deterministic_chunk_failure" not in events
+
+    def test_event_fires_at_threshold(self) -> None:
+        """Third failure on the same doc fires the deterministic-chunk-failure event."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        chunk_text = "Case No. 30-2024-0123456 multi-case ruling boilerplate" * 4
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                # Three failed extracts on the same doc — threshold reached on call 3.
+                extractor.extract(chunk_text, document_id="doc-B")
+                extractor.extract(chunk_text, document_id="doc-B")
+                extractor.extract(chunk_text, document_id="doc-B")
+
+                # Find the deterministic-chunk-failure call — there must be
+                # exactly one (event fires once per document_id per run).
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                ]
+                assert len(fail_events) == 1, (
+                    "Expected exactly one deterministic_chunk_failure event, "
+                    f"got {len(fail_events)}"
+                )
+
+                payload = fail_events[0].kwargs
+                assert payload["document_id"] == "doc-B"
+                assert payload["failure_count"] == 3
+                assert payload["threshold"] == 3
+                assert payload["provider"] == "google"
+                assert payload["chunk_kind"] == "text"
+                # SHA-256 of the chunk content must be present and well-formed.
+                import hashlib
+
+                expected_sha = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+                assert payload["chunk_content_sha256"] == expected_sha
+                assert len(payload["chunk_content_sha256"]) == 64
+                # Preview is bounded.
+                assert len(payload["chunk_preview"]) <= 200
+                assert payload["chunk_preview"] == chunk_text[:200]
+                assert payload["chunk_len"] == len(chunk_text)
+
+    def test_event_fires_only_once_per_document(self) -> None:
+        """Failures beyond threshold for the same doc do not re-fire the event."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                for _ in range(5):
+                    extractor.extract("some text", document_id="doc-C")
+
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                ]
+                assert len(fail_events) == 1
+
+    def test_no_event_without_document_id(self) -> None:
+        """Failures without a document_id are not counted — instrumentation is opt-in."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                for _ in range(5):
+                    extractor.extract("some text")  # no document_id
+
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                ]
+                assert fail_events == []
+
+    def test_counts_are_per_document(self) -> None:
+        """Failure counts are scoped per document_id — distinct docs accumulate separately."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                # 2 failures for doc-D, 3 for doc-E — only doc-E should fire.
+                extractor.extract("text", document_id="doc-D")
+                extractor.extract("text", document_id="doc-E")
+                extractor.extract("text", document_id="doc-D")
+                extractor.extract("text", document_id="doc-E")
+                extractor.extract("text", document_id="doc-E")
+
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                ]
+                assert len(fail_events) == 1
+                assert fail_events[0].kwargs["document_id"] == "doc-E"
+
+    def test_extract_threads_document_id_to_call_chain(self) -> None:
+        """``extract(document_id=...)`` reaches ``_record_google_chunk_failure``."""
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(
+                extractor,
+                "_record_google_chunk_failure",
+                wraps=extractor._record_google_chunk_failure,
+            ) as spy:
+                extractor.extract("some text", document_id="doc-thread")
+
+            spy.assert_called_once()
+            kwargs = spy.call_args.kwargs
+            assert kwargs["document_id"] == "doc-thread"
+            assert kwargs["chunk_index"] == 0
+            assert kwargs["chunk_text"] == "some text"
+
+    def test_event_payload_schema_has_required_fields(self) -> None:
+        """Log payload exposes all fields the issue's grouping queries depend on (#4233 AC)."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                for _ in range(3):
+                    extractor.extract("some text", document_id="doc-schema")
+
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                ]
+                assert len(fail_events) == 1
+                payload = fail_events[0].kwargs
+                # Required fields per AC: document_id + chunk_index keying,
+                # chunk_content_sha256 for grouping, plus the supporting
+                # provenance/preview fields.
+                required_keys = {
+                    "document_id",
+                    "chunk_index",
+                    "failure_count",
+                    "threshold",
+                    "provider",
+                    "model",
+                    "chunk_content_sha256",
+                    "chunk_preview",
+                    "chunk_len",
+                    "chunk_kind",
+                }
+                missing = required_keys - payload.keys()
+                assert not missing, f"Missing required log payload fields: {missing}"
+
+
+# ---------------------------------------------------------------------------
 # Retry with smaller chunks (#2136)
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -5053,3 +5053,89 @@ class TestAppendRulingFromCaseMetadataFallback:
         )
         assert len(rulings) == 1
         assert rulings[0].extracted_case_number is None
+
+
+# ---------------------------------------------------------------------------
+# Multimodal deterministic chunk-failure instrumentation (#4233)
+# ---------------------------------------------------------------------------
+
+
+class TestMultimodalDeterministicChunkFailure:
+    """Verify the multimodal per-page-image failure path also fires the
+    ``llm_extract.deterministic_chunk_failure`` event after 3+ failures
+    on the same document_id (#4233).
+    """
+
+    def test_pdf_page_failures_fire_deterministic_event(self, sample_pdf_bytes: bytes) -> None:
+        """Three consecutive per-page failures with a document_id fire the event."""
+        from framework import llm_extractor as mod
+
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key")
+        ext._base_delay = 0.0
+        # max_retries=3 -> the loop in _extract_single_page records up to 3
+        # failures (attempts 1, 2 record into the retry branch; attempt 3
+        # records into the exhaustion branch). That's enough to cross the
+        # threshold of 3 for a single PDF page.
+        ext._max_retries = 3
+
+        page_image = b"\x89PNG_only_page"
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[(page_image, "image/png")],
+            ),
+            patch(
+                "ingestion.llm_providers.call_llm_with_images",
+                return_value=None,
+            ),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            rulings = ext.extract_from_pdf(sample_pdf_bytes, document_id="multimodal-doc")
+
+        assert rulings == []
+        fail_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+        ]
+        assert len(fail_events) == 1
+        payload = fail_events[0].kwargs
+        assert payload["document_id"] == "multimodal-doc"
+        assert payload["chunk_kind"] == "image"
+        # SHA-256 of the image bytes is recorded.
+        import hashlib
+
+        assert payload["chunk_content_sha256"] == hashlib.sha256(page_image).hexdigest()
+        # Image path leaves the text preview empty by design.
+        assert payload["chunk_preview"] == ""
+        assert payload["chunk_len"] == len(page_image)
+
+    def test_pdf_no_event_without_document_id(self, sample_pdf_bytes: bytes) -> None:
+        """Multimodal failures without document_id do not fire the event."""
+        from framework import llm_extractor as mod
+
+        with patch.object(anthropic, "Anthropic"):
+            ext = LlmExtractor(api_key="test-key")
+        ext._base_delay = 0.0
+        ext._max_retries = 3
+
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[(b"\x89PNG_x", "image/png")],
+            ),
+            patch(
+                "ingestion.llm_providers.call_llm_with_images",
+                return_value=None,
+            ),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            ext.extract_from_pdf(sample_pdf_bytes)  # no document_id
+
+        fail_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+        ]
+        assert fail_events == []

--- a/packages/scraper-framework/tests/test_ventura_framework_over_segmentation.py
+++ b/packages/scraper-framework/tests/test_ventura_framework_over_segmentation.py
@@ -54,6 +54,7 @@ def _make_extractor_with_stub(
         usage: object,  # noqa: ARG001
         chunk_index: int = 0,  # noqa: ARG001
         system_prompt: str | None = None,  # noqa: ARG001
+        document_id: str | None = None,  # noqa: ARG001
     ) -> list[ExtractionResult]:
         return [stub_result]
 


### PR DESCRIPTION
## Summary

Add a `llm_extract.deterministic_chunk_failure` structured warning log event that fires once per `document_id` after 3+ consecutive Google API failures within a single reingest run. The event carries the failing chunk's content SHA-256 plus a 200-char text preview so future log queries can group hits by content (per the #3205 instrument-before-guess pattern). Threaded via a new optional `document_id` kwarg on `extract()` / `extract_from_pdf()`; existing callers stay no-op.

Closes #4233

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Re-run the #3629 reingest command on dev (`scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county Orange --department-in C20 C23 C25 C27 C31 C32 CM2 C34 N15 --case-number-like 'UNKNOWN-%' --bust-llm-cache`) and confirm the `deterministic_chunk_failure` event fires for the 4 listed docs via `scripts/ecs-logs.sh /ecs/judgemind-ingestion-worker-dev --filter 'deterministic_chunk_failure' --lines 20`.
- [ ] Verification evidence posted on issue (see A.8)
