### PR TITLE
feat(ingestion): instrument llm_extract chunk failures (#4233 follow-up)

### DIFF
--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -629,6 +629,92 @@ _MAX_CHUNKS = 10
 # Overlap characters between consecutive chunks for context continuity.
 _CHUNK_OVERLAP = 500
 
+# Deterministic-chunk-failure instrumentation (#4233).
+# When the same ``document_id`` accumulates this many ``call_llm`` failures
+# (i.e. ``llm_extract.chunk_api_failure`` events) within a single reingest
+# run, emit ``llm_extract.deterministic_chunk_failure`` once with the
+# failing chunk's content SHA-256 and a 200-char preview so future log
+# queries can group hits by content and identify the documents that
+# deterministically trip the LLM provider.
+_DETERMINISTIC_FAILURE_THRESHOLD = 3
+_DETERMINISTIC_FAILURE_PREVIEW_CHARS = 200
+
+# Process-local counters for the deterministic-chunk-failure instrumentation.
+# The reingest worker is a per-task ECS process — these dicts live for the
+# duration of the run.  Thread-safe under the ``_DETERMINISTIC_FAILURE_LOCK``
+# because multi-chunk documents fan out via ``ThreadPoolExecutor``.
+_DETERMINISTIC_FAILURE_LOCK = threading.Lock()
+_DETERMINISTIC_FAILURE_COUNTS: dict[str, int] = {}
+_DETERMINISTIC_FAILURE_FIRED: set[str] = set()
+
+
+def _record_deterministic_chunk_failure(
+    *,
+    document_id: str | None,
+    chunk_index: int,
+    chunk_text: str,
+    provider: str | None,
+    model: str | None,
+) -> None:
+    """Increment the per-document chunk-failure counter (#4233).
+
+    When the same ``document_id`` accumulates
+    ``_DETERMINISTIC_FAILURE_THRESHOLD`` failed ``call_llm`` invocations
+    within this process's lifetime, emit
+    ``llm_extract.deterministic_chunk_failure`` once with the current
+    chunk's content SHA-256 and a 200-char preview so operators can
+    group log entries by content and identify the documents that
+    deterministically trip the LLM provider.
+
+    No-op when ``document_id`` is ``None`` (legacy callers).  Thread-safe
+    via the module-level lock — concurrent chunk extractions for the
+    same document_id race-correctly.
+    """
+    if not document_id:
+        return
+
+    with _DETERMINISTIC_FAILURE_LOCK:
+        new_count = _DETERMINISTIC_FAILURE_COUNTS.get(document_id, 0) + 1
+        _DETERMINISTIC_FAILURE_COUNTS[document_id] = new_count
+        already_fired = document_id in _DETERMINISTIC_FAILURE_FIRED
+        if new_count >= _DETERMINISTIC_FAILURE_THRESHOLD and not already_fired:
+            _DETERMINISTIC_FAILURE_FIRED.add(document_id)
+            should_emit = True
+        else:
+            should_emit = False
+
+    if not should_emit:
+        return
+
+    preview = chunk_text[:_DETERMINISTIC_FAILURE_PREVIEW_CHARS]
+    content_sha256 = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+    logger.warning(
+        "llm_extract.deterministic_chunk_failure",
+        document_id=document_id,
+        chunk_index=chunk_index,
+        failure_count=new_count,
+        threshold=_DETERMINISTIC_FAILURE_THRESHOLD,
+        provider=provider,
+        model=model,
+        chunk_content_sha256=content_sha256,
+        chunk_preview=preview,
+        chunk_len=len(chunk_text),
+        chunk_kind="text",
+    )
+
+
+def reset_deterministic_chunk_failure_state() -> None:
+    """Reset the per-process deterministic-failure counters (#4233).
+
+    Used by tests and by long-lived processes that want to scope the
+    counter to a particular run.  No-op if no failures have been
+    recorded yet.
+    """
+    with _DETERMINISTIC_FAILURE_LOCK:
+        _DETERMINISTIC_FAILURE_COUNTS.clear()
+        _DETERMINISTIC_FAILURE_FIRED.clear()
+
+
 # Patterns that indicate natural split boundaries in text.
 _PAGE_BREAK_RE = re.compile(r"\f")  # Form feed (pymupdf page separator)
 _HR_RE = re.compile(r"<HR[^>]*>", re.IGNORECASE)
@@ -806,6 +892,7 @@ def extract_fields_llm(
     token_tracker: TokenTracker | None = None,
     max_tokens: int = 4096,
     bust_cache: bool = False,
+    document_id: str | None = None,
 ) -> LLMExtractionResult | None:
     """Extract structured fields from a court ruling via a configurable LLM.
 
@@ -856,6 +943,15 @@ def extract_fields_llm(
             from the fresh result.  Used by the ``--bust-llm-cache``
             reingest flag (#2424) to force fresh LLM output after a
             prompt change, without invalidating the cache permanently.
+        document_id: Optional source ``derived.documents`` UUID.  When
+            provided, ``call_llm`` failures for this doc are counted in
+            a process-local map; once
+            ``_DETERMINISTIC_FAILURE_THRESHOLD`` is reached within
+            a single reingest run,
+            ``llm_extract.deterministic_chunk_failure`` is emitted with
+            the failing chunk's content SHA-256 and a 200-char preview
+            so future log queries can group by content (#4233).  Has no
+            effect on cache key.
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -931,7 +1027,18 @@ def extract_fields_llm(
             max_tokens=max_tokens,
         )
         if llm_response is None:
-            logger.warning("llm_extract.chunk_api_failure", chunk_index=i)
+            logger.warning(
+                "llm_extract.chunk_api_failure",
+                chunk_index=i,
+                document_id=document_id,
+            )
+            _record_deterministic_chunk_failure(
+                document_id=document_id,
+                chunk_index=i,
+                chunk_text=chunk,
+                provider=provider,
+                model=model,
+            )
             return None
         if token_tracker is not None:
             token_tracker.add(llm_response.input_tokens, llm_response.output_tokens)

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1912,6 +1912,7 @@ class IngestionWorker:
                 model=self._llm_model,
                 timeout=self._llm_timeout,
                 max_tokens=_llm_max_tokens,
+                document_id=document_id,
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -992,6 +992,216 @@ class TestExtractFieldsLlm:
 
 
 # ---------------------------------------------------------------------------
+# Deterministic chunk-failure instrumentation (#4233)
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicChunkFailure:
+    """Verify the `llm_extract.deterministic_chunk_failure` event (#4233).
+
+    When the same `document_id` accumulates 3+ failed `call_llm` calls
+    within a single reingest run, `extract_fields_llm` emits a
+    structured warning log event with the failing chunk's content
+    SHA-256 and a 200-char preview so future log queries can group
+    hits by content.
+    """
+
+    def setup_method(self) -> None:
+        from ingestion.llm_extract import reset_deterministic_chunk_failure_state
+
+        reset_deterministic_chunk_failure_state()
+
+    def teardown_method(self) -> None:
+        from ingestion.llm_extract import reset_deterministic_chunk_failure_state
+
+        reset_deterministic_chunk_failure_state()
+
+    def test_no_event_below_threshold(self) -> None:
+        """Two consecutive failures stay below the 3-failure threshold."""
+        from ingestion import llm_extract as mod
+
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            extract_fields_llm(document_text="some text", content_format="pdf", document_id="doc-A")
+            extract_fields_llm(document_text="some text", content_format="pdf", document_id="doc-A")
+
+            events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+            assert "llm_extract.deterministic_chunk_failure" not in events
+
+    def test_event_fires_at_threshold(self) -> None:
+        """Third failure on the same doc fires the deterministic-chunk-failure event."""
+        from ingestion import llm_extract as mod
+
+        chunk_text = "Case No. 30-2024-0123456 boilerplate ruling text" * 3
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            for _ in range(3):
+                extract_fields_llm(
+                    document_text=chunk_text,
+                    content_format="pdf",
+                    document_id="doc-B",
+                    provider="google",
+                    model="gemini-2.5-flash-lite",
+                )
+
+            fail_events = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+            ]
+            assert len(fail_events) == 1, (
+                f"Expected exactly one deterministic_chunk_failure event, got {len(fail_events)}"
+            )
+
+            payload = fail_events[0].kwargs
+            assert payload["document_id"] == "doc-B"
+            assert payload["failure_count"] == 3
+            assert payload["threshold"] == 3
+            assert payload["provider"] == "google"
+            assert payload["model"] == "gemini-2.5-flash-lite"
+            assert payload["chunk_kind"] == "text"
+
+            import hashlib
+
+            expected_sha = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+            assert payload["chunk_content_sha256"] == expected_sha
+            assert len(payload["chunk_content_sha256"]) == 64
+            assert len(payload["chunk_preview"]) <= 200
+            assert payload["chunk_preview"] == chunk_text[:200]
+            assert payload["chunk_len"] == len(chunk_text)
+
+    def test_event_fires_only_once_per_document(self) -> None:
+        """Failures beyond threshold for the same doc do not re-fire the event."""
+        from ingestion import llm_extract as mod
+
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            for _ in range(5):
+                extract_fields_llm(
+                    document_text="some text",
+                    content_format="pdf",
+                    document_id="doc-C",
+                )
+
+            fail_events = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+            ]
+            assert len(fail_events) == 1
+
+    def test_no_event_without_document_id(self) -> None:
+        """Failures without a document_id are not counted — instrumentation is opt-in."""
+        from ingestion import llm_extract as mod
+
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            for _ in range(5):
+                extract_fields_llm(
+                    document_text="some text", content_format="pdf"
+                )  # no document_id
+
+            fail_events = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+            ]
+            assert fail_events == []
+
+    def test_counts_are_per_document(self) -> None:
+        """Failure counts are scoped per document_id — distinct docs accumulate separately."""
+        from ingestion import llm_extract as mod
+
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-D")
+            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-E")
+            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-D")
+            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-E")
+            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-E")
+
+            fail_events = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+            ]
+            assert len(fail_events) == 1
+            assert fail_events[0].kwargs["document_id"] == "doc-E"
+
+    def test_event_payload_schema_has_required_fields(self) -> None:
+        """Log payload exposes all fields the issue's grouping queries depend on (#4233 AC)."""
+        from ingestion import llm_extract as mod
+
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            for _ in range(3):
+                extract_fields_llm(
+                    document_text="some text",
+                    content_format="pdf",
+                    document_id="doc-schema",
+                )
+
+            fail_events = [
+                c
+                for c in mock_logger.warning.call_args_list
+                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+            ]
+            assert len(fail_events) == 1
+            payload = fail_events[0].kwargs
+            required_keys = {
+                "document_id",
+                "chunk_index",
+                "failure_count",
+                "threshold",
+                "provider",
+                "model",
+                "chunk_content_sha256",
+                "chunk_preview",
+                "chunk_len",
+                "chunk_kind",
+            }
+            missing = required_keys - payload.keys()
+            assert not missing, f"Missing required log payload fields: {missing}"
+
+    def test_reset_clears_state(self) -> None:
+        """reset_deterministic_chunk_failure_state() clears counters between runs."""
+        from ingestion import llm_extract as mod
+        from ingestion.llm_extract import reset_deterministic_chunk_failure_state
+
+        with patch("ingestion.llm_extract.call_llm", return_value=None):
+            for _ in range(3):
+                extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-R")
+            # First fire happened — second batch with same doc_id, post-reset,
+            # should fire again.
+            reset_deterministic_chunk_failure_state()
+
+            with patch.object(mod, "logger") as mock_logger:
+                for _ in range(3):
+                    extract_fields_llm(
+                        document_text="text", content_format="pdf", document_id="doc-R"
+                    )
+
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                ]
+                assert len(fail_events) == 1
+
+
+# ---------------------------------------------------------------------------
 # Real fixture tests (mocked API, real HTML preprocessing)
 # ---------------------------------------------------------------------------
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1260,6 +1260,7 @@ def _reparse_document(
                 token_tracker=token_tracker,
                 max_tokens=_llm_max_tokens,
                 bust_cache=bust_llm_cache,
+                document_id=doc_meta["document_id"],
             )
             llm_latency_ms = round((time.monotonic() - t0) * 1000)
 


### PR DESCRIPTION
## Summary

Follow-up to #4246. Post-deploy verification of #4246 surfaced that the affected docs in the original #4233 reproduction go through `ingestion.llm_extract.extract_fields_llm`, not the `framework.llm_extractor.LlmExtractor` path #4246 instrumented. This adds the same `llm_extract.deterministic_chunk_failure` instrumentation to `ingestion/llm_extract.py` so the per-document "missing fields" extraction path also self-diagnoses after 3+ consecutive same-doc failures within a single reingest run.

Closes #4233

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Re-run the #3629 reingest command on dev (`scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county Orange --department-in C20 C23 C25 C27 C31 C32 CM2 C34 N15 --case-number-like 'UNKNOWN-%' --bust-llm-cache`) and confirm `deterministic_chunk_failure` events fire when ≥3 consecutive `chunk_api_failure` events on the same `document_id` accumulate. Note: the failure pattern is intermittent (504s correlated with Gemini upstream availability) — verification may need multiple runs to land 3+ failures on a single doc.
- [ ] Verification evidence posted on issue (see A.8)
