### PR TITLE
fix(scraping): derive CourtListener court via docket.court (#4247)

### DIFF
--- a/packages/scraper-framework/src/courts/federal/courtlistener.py
+++ b/packages/scraper-framework/src/courts/federal/courtlistener.py
@@ -492,10 +492,15 @@ class CourtListenerScraper(BaseScraper):
         if not plain_text_value and not html_text_value:
             return None
 
-        raw_content = json.dumps(
-            {"cluster": cluster, "opinion": opinion},
-            default=str,
-        ).encode("utf-8")
+        # Persist the resolved docket sub-resource alongside cluster + opinion
+        # so reingest / backfill paths can re-derive jurisdiction without
+        # re-fetching from the API.  cluster.court is empty in every
+        # CourtListener API response we capture today; the court reference
+        # is reachable only via docket.court (#4247).
+        envelope: dict[str, Any] = {"cluster": cluster, "opinion": opinion}
+        if docket:
+            envelope["docket"] = docket
+        raw_content = json.dumps(envelope, default=str).encode("utf-8")
 
         # Build source URL from the opinion's absolute_url or resource_uri
         opinion_id = opinion.get("id", "unknown")
@@ -579,13 +584,11 @@ class CourtListenerScraper(BaseScraper):
         )
         canonical_text = plain_text_value or html_text_value
 
-        # Extract court identifier from cluster.
-        # court field is typically a URL like "/api/rest/v4/courts/scotus/"
-        # — extract the short ID from the URL path.
-        court_id = cluster.get("court", "") or ""
-        if "/" in court_id:
-            parts = court_id.rstrip("/").split("/")
-            court_id = parts[-1] if parts else court_id
+        # Extract court identifier — prefer the resolved docket sub-resource
+        # because cluster.court is empty in every CourtListener API response
+        # we capture today (#4247).  Fall back to cluster.court for
+        # backward compatibility with old envelopes / future API shapes.
+        court_id = _resolve_court_id(cluster, docket)
 
         # Resolve jurisdiction from court_id mapping.
         # Default to ("Unknown", "Unknown") on miss and emit a structured warning
@@ -633,6 +636,42 @@ class CourtListenerScraper(BaseScraper):
             "precedential_status": cluster.get("precedential_status"),
             "citation_count": cluster.get("citation_count", 0),
         }
+
+
+def _resolve_court_id(
+    cluster: dict[str, Any],
+    docket: dict[str, Any] | None,
+) -> str:
+    """Resolve the CourtListener court short-id from a cluster + docket pair.
+
+    Resolution order (#4247):
+      1. ``docket.court`` if the docket sub-resource is present and the field is truthy.
+      2. ``cluster.court`` as backward-compat fallback.
+
+    The "court" field is typically a URL path like ``/api/rest/v4/courts/scotus/``;
+    the short-id is extracted from the last path segment.  Bare short-ids
+    (no slashes) are returned verbatim.
+
+    Returns an empty string when neither source has a usable reference.
+    The caller decides what to do on empty (today: fall back to config defaults).
+
+    Why docket-first: ``cluster.court`` is empty in every CourtListener API
+    response we capture today, so reading it first produces Federal/Federal
+    misclassification on every doc.  ``docket.court`` is reliably populated
+    on the resolved docket sub-resource.
+    """
+    candidates: list[str] = []
+    if docket:
+        candidates.append(str(docket.get("court") or ""))
+    candidates.append(str(cluster.get("court") or ""))
+    for raw in candidates:
+        if not raw:
+            continue
+        if "/" in raw:
+            parts = raw.rstrip("/").split("/")
+            return parts[-1] if parts and parts[-1] else raw
+        return raw
+    return ""
 
 
 def _extract_docket_number(

--- a/packages/scraper-framework/tests/courts/test_courtlistener.py
+++ b/packages/scraper-framework/tests/courts/test_courtlistener.py
@@ -32,6 +32,7 @@ from courts.federal.courtlistener import (
     _extract_judge_names,
     _map_opinion_type,
     _parse_date,
+    _resolve_court_id,
     default_config,
 )
 from framework import CapturedDocument, ContentFormat, ScraperConfig
@@ -507,6 +508,33 @@ class TestCourtListenerClient:
 
 class TestDataMapping:
     """Tests for the data mapping helper functions."""
+
+    def test_resolve_court_id_prefers_docket(self) -> None:
+        """Regression for #4247: when docket.court is populated, it wins."""
+        cluster = {"court": "/api/rest/v4/courts/parent/"}
+        docket = {"court": "/api/rest/v4/courts/texapp1/"}
+        assert _resolve_court_id(cluster, docket) == "texapp1"
+
+    def test_resolve_court_id_falls_back_to_cluster_when_docket_court_empty(self) -> None:
+        """Backward-compat: cluster.court is consulted when docket.court is empty."""
+        cluster = {"court": "/api/rest/v4/courts/scotus/"}
+        docket = {"court": ""}
+        assert _resolve_court_id(cluster, docket) == "scotus"
+
+    def test_resolve_court_id_uses_cluster_when_docket_is_none(self) -> None:
+        """Backward-compat: cluster.court is used when no docket sub-resource is present."""
+        cluster = {"court": "/api/rest/v4/courts/ca9/"}
+        assert _resolve_court_id(cluster, None) == "ca9"
+
+    def test_resolve_court_id_returns_empty_when_both_missing(self) -> None:
+        """When neither side has a court reference, empty string is returned."""
+        assert _resolve_court_id({"court": ""}, {"court": ""}) == ""
+        assert _resolve_court_id({}, None) == ""
+
+    def test_resolve_court_id_handles_bare_short_id(self) -> None:
+        """Some endpoints return the bare short-id rather than a URL path."""
+        assert _resolve_court_id({"court": ""}, {"court": "texapp14"}) == "texapp14"
+        assert _resolve_court_id({"court": "scotus"}, None) == "scotus"
 
     def test_extract_docket_number(self) -> None:
         """Extract docket number from cluster."""
@@ -1286,15 +1314,25 @@ class TestJurisdictionMapping:
 
     @respx.mock
     def test_empty_court_id_falls_back_to_config_defaults(self) -> None:
-        """Empty court field on cluster falls back to config state/county."""
+        """Empty court field on cluster falls back to config state/county.
+
+        Only triggers when both cluster.court AND docket.court are empty.
+        """
         cluster = _make_cluster(court="")
         opinion = _make_opinion(plain_text="Opinion text")
+        cluster_id = cluster["id"]
 
         respx.get(f"{API_BASE_URL}/clusters/").mock(
             return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
         )
         respx.get(f"{API_BASE_URL}/opinions/").mock(
             return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+        # Docket sub-resource also has no court — resolver falls through.
+        respx.get(f"{API_BASE_URL}/dockets/{cluster_id * 10}/").mock(
+            return_value=httpx.Response(
+                200, json={"id": cluster_id * 10, "court": "", "docket_number": "22-1234"}
+            )
         )
 
         config = _make_scraper_config()  # state="Federal", county="Federal"
@@ -1306,6 +1344,125 @@ class TestJurisdictionMapping:
         doc = docs[0]
         assert doc.state == "Federal"
         assert doc.county == "Federal"
+
+    @respx.mock
+    def test_docket_court_resolves_when_cluster_court_empty(self) -> None:
+        """Regression for #4247: when cluster.court is empty (the actual API
+        shape we receive today), the resolver must fall back to docket.court
+        and produce the correct (state, county) — NOT the config defaults.
+
+        Without the fix, every CourtListener opinion lands in Federal/Federal
+        regardless of true jurisdiction (the misclassification described in
+        the issue: 1507 → 2091 docs in 24h, all wrongly tagged Federal).
+        """
+        # cluster.court is EMPTY — exactly what the live API returns today.
+        cluster = _make_cluster(court="")
+        opinion = _make_opinion(plain_text="Texas appellate opinion text")
+        cluster_id = cluster["id"]
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+        # docket.court IS populated (e.g. Texas appellate court 14).
+        respx.get(f"{API_BASE_URL}/dockets/{cluster_id * 10}/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": cluster_id * 10,
+                    "court": "/api/rest/v4/courts/texapp14/",
+                    "docket_number": "01-22-00123-CV",
+                },
+            )
+        )
+
+        config = _make_scraper_config()  # defaults: state="Federal", county="Federal"
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        doc = docs[0]
+        # The doc must come out tagged Texas/Statewide via the docket fallback,
+        # NOT Federal/Federal via the config defaults.
+        assert doc.state == "Texas"
+        assert doc.county == "Statewide"
+        # Extra metadata must record the resolved court_id for downstream consumers.
+        assert doc.extra["courtlistener_court_id"] == "texapp14"
+
+    @respx.mock
+    def test_docket_court_takes_precedence_over_cluster_court(self) -> None:
+        """When BOTH cluster.court and docket.court are populated, docket.court wins.
+
+        The docket sub-resource is the canonical source of jurisdiction —
+        the cluster's court field is sometimes a stale reference to a
+        parent court rather than the specific deciding court.
+        """
+        # cluster.court points to a generic parent (Texas Supreme Court)
+        cluster = _make_cluster(court="/api/rest/v4/courts/tex/")
+        opinion = _make_opinion(plain_text="Opinion text")
+        cluster_id = cluster["id"]
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+        # docket.court points to a specific appellate court — should win.
+        respx.get(f"{API_BASE_URL}/dockets/{cluster_id * 10}/").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": cluster_id * 10,
+                    "court": "/api/rest/v4/courts/texapp1/",
+                    "docket_number": "12345",
+                },
+            )
+        )
+
+        config = _make_scraper_config()
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        doc = docs[0]
+        # Both Texas/Statewide today, but the recorded short-id must come
+        # from the docket so downstream callers can disambiguate.
+        assert doc.extra["courtlistener_court_id"] == "texapp1"
+        assert doc.state == "Texas"
+        assert doc.county == "Statewide"
+
+    @respx.mock
+    def test_cluster_court_used_when_no_docket(self) -> None:
+        """Backwards-compat: when there is no docket sub-resource, cluster.court still works.
+
+        Some clusters legitimately have no docket URL — the resolver must
+        not regress on those; cluster.court remains the fallback source.
+        """
+        cluster = _make_cluster(court="/api/rest/v4/courts/scotus/", docket="")
+        opinion = _make_opinion(plain_text="SCOTUS opinion text")
+
+        respx.get(f"{API_BASE_URL}/clusters/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([cluster]))
+        )
+        respx.get(f"{API_BASE_URL}/opinions/").mock(
+            return_value=httpx.Response(200, json=_make_paginated_response([opinion]))
+        )
+
+        config = _make_scraper_config()
+        client = CourtListenerClient(request_delay=0)
+        scraper = CourtListenerScraper(config, client=client, days_back=7)
+        docs = scraper.fetch_documents()
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc.state == "Federal"
+        assert doc.county == "Federal"
+        assert doc.extra["courtlistener_court_id"] == "scotus"
 
 
 # ---------------------------------------------------------------------------
@@ -1845,6 +2002,37 @@ class TestParseDocumentReingestPath:
         assert parsed.ruling_text.startswith("The motion is GRANTED.")
         # Sanity: respected the 10000-char cap matching _map_to_document.
         assert len(parsed.ruling_text) == 10000
+
+    def test_parse_document_resolves_court_via_docket_envelope_key(self) -> None:
+        """Regression for #4247: when raw_content contains a ``docket`` envelope
+        key with a populated ``court`` field, the reingest path resolves
+        jurisdiction from the docket — even when ``cluster.court`` is empty.
+
+        This covers the new envelope shape produced after the #4247 fix
+        (raw_content now includes the docket sub-resource so future
+        reingest/backfill runs do not need to re-fetch from the API).
+        """
+        cluster = _make_cluster(court="")  # Live API returns this empty.
+        opinion = {
+            "id": 2001,
+            "type": "010combined",
+            "plain_text": "Texas appellate opinion text",
+        }
+        docket = {
+            "id": 73251044,
+            "court": "/api/rest/v4/courts/texapp14/",
+            "docket_number": "01-22-00123-CV",
+        }
+        doc = self._make_envelope_doc(cluster=cluster, opinion=opinion, docket=docket)
+
+        scraper = self._make_scraper()
+        parsed = scraper.parse_document(doc)
+
+        # Reingest must resolve Texas/Statewide via docket.court — NOT the
+        # config defaults (Federal/Federal).
+        assert parsed.state == "Texas"
+        assert parsed.county == "Statewide"
+        assert parsed.extra["courtlistener_court_id"] == "texapp14"
 
     def test_parse_document_handles_none_raw_content(self) -> None:
         """Defensive: parse_document on a doc with raw_content=b'' returns unchanged."""

--- a/packages/scraper-framework/tests/test_backfill_courtlistener_jurisdiction.py
+++ b/packages/scraper-framework/tests/test_backfill_courtlistener_jurisdiction.py
@@ -1,0 +1,192 @@
+"""Regression tests for ``scripts/backfill_courtlistener_jurisdiction.py``.
+
+Filed under #4247: the original backfill read ``cluster.court`` from the S3
+envelope and reported ``0 rebucketed`` on every run because that field is
+empty in every CourtListener API response we capture.  The fix prefers
+``docket.court`` from the new envelope shape and falls back to a live
+docket fetch for old envelopes.
+
+Tests focus on ``_extract_court_id_from_envelope`` — the pure helper that
+maps an S3-envelope dict to a resolved court short-id.  The S3 read and
+the live CourtListener fallback are exercised via small fakes; the DB
+path is intentionally out of scope for these unit tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Ensure scraper-framework src is on path before importing the script.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "packages" / "scraper-framework" / "src"))
+
+
+def _load_backfill_module() -> object:
+    """Import scripts/backfill_courtlistener_jurisdiction.py without running main."""
+    script_path = _REPO_ROOT / "scripts" / "backfill_courtlistener_jurisdiction.py"
+    spec = importlib.util.spec_from_file_location(
+        "backfill_courtlistener_jurisdiction", script_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["backfill_courtlistener_jurisdiction"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+backfill = _load_backfill_module()
+
+
+# ---------------------------------------------------------------------------
+# _extract_court_id_from_envelope tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCourtIdFromEnvelope:
+    """Pure-function tests against the S3-envelope reader (#4247)."""
+
+    def test_prefers_docket_court_over_cluster_court(self) -> None:
+        """When the envelope has both, docket.court wins (the canonical source)."""
+        envelope = {
+            "cluster": {"id": 1, "court": "/api/rest/v4/courts/parent/"},
+            "opinion": {"id": 2},
+            "docket": {
+                "id": 73251044,
+                "court": "/api/rest/v4/courts/texapp14/",
+            },
+        }
+        assert backfill._extract_court_id_from_envelope(envelope) == "texapp14"
+
+    def test_uses_docket_court_when_cluster_court_empty(self) -> None:
+        """The actual CourtListener API shape: cluster.court is empty.
+
+        Without the #4247 fix the old code returned None on every doc and
+        produced "0 rebucketed".  This test asserts the new behavior.
+        """
+        envelope = {
+            "cluster": {"id": 1, "court": ""},
+            "opinion": {"id": 2},
+            "docket": {
+                "id": 73251044,
+                "court": "/api/rest/v4/courts/texapp14/",
+            },
+        }
+        assert backfill._extract_court_id_from_envelope(envelope) == "texapp14"
+
+    def test_falls_back_to_cluster_court_when_no_docket_envelope_key(self) -> None:
+        """Backward-compat: old envelopes (pre-#4247) lack a 'docket' key."""
+        envelope = {
+            "cluster": {"id": 1, "court": "/api/rest/v4/courts/scotus/"},
+            "opinion": {"id": 2},
+        }
+        assert backfill._extract_court_id_from_envelope(envelope) == "scotus"
+
+    def test_returns_none_when_both_empty_and_no_client(self) -> None:
+        """No docket envelope key, no cluster.court, no live client -> None."""
+        envelope = {"cluster": {"id": 1, "court": ""}, "opinion": {"id": 2}}
+        assert backfill._extract_court_id_from_envelope(envelope) is None
+
+    def test_live_docket_fetch_via_docket_url(self) -> None:
+        """For old envelopes, the optional CourtListener client live-fetches the docket."""
+        envelope = {
+            "cluster": {
+                "id": 1,
+                "court": "",
+                "docket": "https://www.courtlistener.com/api/rest/v4/dockets/99/",
+            },
+            "opinion": {"id": 2},
+        }
+        cl_client = MagicMock()
+        cl_client.fetch_docket.return_value = {
+            "id": 99,
+            "court": "/api/rest/v4/courts/texapp14/",
+        }
+
+        result = backfill._extract_court_id_from_envelope(envelope, cl_client=cl_client)
+
+        assert result == "texapp14"
+        cl_client.fetch_docket.assert_called_once_with(
+            "https://www.courtlistener.com/api/rest/v4/dockets/99/"
+        )
+
+    def test_live_docket_fetch_via_docket_id(self) -> None:
+        """When only cluster.docket_id is present, build the URL from API_BASE_URL."""
+        envelope = {
+            "cluster": {"id": 1, "court": "", "docket_id": 12345},
+            "opinion": {"id": 2},
+        }
+        cl_client = MagicMock()
+        cl_client.fetch_docket.return_value = {
+            "id": 12345,
+            "court": "/api/rest/v4/courts/ny/",
+        }
+
+        result = backfill._extract_court_id_from_envelope(envelope, cl_client=cl_client)
+
+        assert result == "ny"
+        # Verify the URL was constructed from API_BASE_URL + docket_id.
+        called_url = cl_client.fetch_docket.call_args[0][0]
+        assert called_url.endswith("/dockets/12345/")
+
+    def test_live_docket_fetch_skipped_when_no_docket_reference(self) -> None:
+        """If cluster has neither docket URL nor docket_id, return None without fetching."""
+        envelope = {"cluster": {"id": 1, "court": ""}, "opinion": {"id": 2}}
+        cl_client = MagicMock()
+
+        result = backfill._extract_court_id_from_envelope(envelope, cl_client=cl_client)
+
+        assert result is None
+        cl_client.fetch_docket.assert_not_called()
+
+    def test_live_docket_fetch_failure_returns_none(self) -> None:
+        """A failing live docket fetch returns None instead of raising."""
+        envelope = {
+            "cluster": {"id": 1, "court": "", "docket_id": 99},
+            "opinion": {"id": 2},
+        }
+        cl_client = MagicMock()
+        cl_client.fetch_docket.side_effect = Exception("HTTP 500")
+
+        result = backfill._extract_court_id_from_envelope(envelope, cl_client=cl_client)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_court_id_from_s3 — thin wrapper over the envelope reader
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCourtIdFromS3:
+    """Verify the S3 wrapper delegates to the pure helper."""
+
+    def _make_s3_client(self, envelope: dict) -> MagicMock:
+        body = MagicMock()
+        body.read.return_value = json.dumps(envelope).encode("utf-8")
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body}
+        return s3
+
+    def test_reads_docket_court_from_s3_envelope(self) -> None:
+        """End-to-end S3 read: envelope with docket.court resolves correctly."""
+        envelope = {
+            "cluster": {"id": 1, "court": ""},
+            "opinion": {"id": 2},
+            "docket": {
+                "id": 73251044,
+                "court": "/api/rest/v4/courts/texapp14/",
+            },
+        }
+        s3 = self._make_s3_client(envelope)
+        result = backfill._extract_court_id_from_s3(s3, "bucket", "key")
+        assert result == "texapp14"
+
+    def test_returns_none_when_s3_read_fails(self) -> None:
+        s3 = MagicMock()
+        s3.get_object.side_effect = Exception("NoSuchKey")
+        result = backfill._extract_court_id_from_s3(s3, "bucket", "missing-key")
+        assert result is None

--- a/scripts/backfill_courtlistener_jurisdiction.py
+++ b/scripts/backfill_courtlistener_jurisdiction.py
@@ -2,9 +2,16 @@
 """Backfill CourtListener documents to correct (state, county) jurisdiction.
 
 Selects all documents rows whose scraper_id starts with 'federal-courtlistener'
-then reads the raw JSON from S3, extracts cluster.court, resolves (state, county)
-via _CL_COURT_ID_TO_JURISDICTION, and updates documents.court_id (plus the
+then reads the raw JSON from S3, extracts the court reference (preferring
+docket.court over cluster.court — see #4247), resolves (state, county) via
+_CL_COURT_ID_TO_JURISDICTION, and updates documents.court_id (plus the
 joined rulings.court_id) inside a transaction.
+
+For old envelopes that pre-date docket capture (#4043 / #4247) the script
+falls back to the live CourtListener ``/api/rest/v4/dockets/<id>/`` endpoint
+using ``cluster.docket_id`` (or the absolute docket URL on ``cluster.docket``)
+when ``--fetch-missing-dockets`` is passed. This is opt-in because each
+fallback fetch costs an API call against the CourtListener daily quota.
 
 Emits per-court rebucket counts to stdout for the verify-phase evidence comment.
 
@@ -20,9 +27,12 @@ Usage (local):
            scripts/backfill_courtlistener_jurisdiction.py --dry-run
 
 Options:
-    --dry-run     Show what would change without writing to DB.
-    --limit N     Maximum number of documents to process (default: unbounded).
-    --batch-size  Documents per transaction batch (default: 100).
+    --dry-run                  Show what would change without writing to DB.
+    --limit N                  Maximum number of documents to process (default: unbounded).
+    --batch-size               Documents per transaction batch (default: 100).
+    --fetch-missing-dockets    For old envelopes without a docket key, fetch the
+                               docket sub-resource live from CourtListener.
+                               Each fetch costs one API request.
 """
 
 # venv: scraper-framework
@@ -49,7 +59,11 @@ import boto3  # noqa: E402
 import psycopg  # noqa: E402
 import structlog  # noqa: E402
 
-from courts.federal.courtlistener import _CL_COURT_ID_TO_JURISDICTION  # noqa: E402
+from courts.federal.courtlistener import (  # noqa: E402
+    _CL_COURT_ID_TO_JURISDICTION,
+    CourtListenerClient,
+    _resolve_court_id,
+)
 from framework.logging import configure_structlog  # noqa: E402
 from ingestion.db import upsert_court  # noqa: E402
 
@@ -83,6 +97,14 @@ def parse_args() -> argparse.Namespace:
         default=100,
         help="Documents per transaction batch (default: 100).",
     )
+    parser.add_argument(
+        "--fetch-missing-dockets",
+        action="store_true",
+        help=(
+            "For old envelopes without a 'docket' key, fetch the docket "
+            "sub-resource live from CourtListener (one API call per doc)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -91,25 +113,99 @@ def parse_args() -> argparse.Namespace:
 # ---------------------------------------------------------------------------
 
 
-def _extract_court_id_from_s3(
+def _read_envelope_from_s3(
     s3_client: Any, s3_bucket: str, s3_key: str
-) -> str | None:
-    """Read the raw JSON from S3 and extract the cluster.court short-id."""
+) -> dict[str, Any] | None:
+    """Read and parse the raw JSON envelope from S3.
+
+    Returns the parsed dict, or None on any failure (logged as a warning).
+    """
     try:
         response = s3_client.get_object(Bucket=s3_bucket, Key=s3_key)
         raw = response["Body"].read()
         data = json.loads(raw)
-        cluster = data.get("cluster", {})
-        court_raw = cluster.get("court", "") or ""
-        if "/" in court_raw:
-            parts = court_raw.rstrip("/").split("/")
-            court_id = parts[-1] if parts else court_raw
-        else:
-            court_id = court_raw
-        return court_id if court_id else None
-    except Exception as exc:
-        logger.warning("Failed to read S3 object", s3_bucket=s3_bucket, s3_key=s3_key, error=str(exc))
+        if isinstance(data, dict):
+            return data
         return None
+    except Exception as exc:
+        logger.warning(
+            "Failed to read S3 object",
+            s3_bucket=s3_bucket,
+            s3_key=s3_key,
+            error=str(exc),
+        )
+        return None
+
+
+def _extract_court_id_from_envelope(
+    envelope: dict[str, Any],
+    *,
+    cl_client: CourtListenerClient | None = None,
+) -> str | None:
+    """Extract the resolved CourtListener court short-id from an S3 envelope.
+
+    Resolution order (#4247):
+      1. ``envelope['docket']['court']`` if the docket sub-resource is in the
+         envelope (newer captures after #4247 store it alongside cluster+opinion).
+      2. ``envelope['cluster']['court']`` for backward compatibility.
+      3. If ``cl_client`` is provided AND neither of the above yields a court,
+         fall back to fetching the docket live from CourtListener using
+         ``cluster.docket_id`` or the absolute URL on ``cluster.docket``.
+
+    Returns the short-id (e.g. ``"texapp14"``) or ``None`` on miss.
+    """
+    cluster = envelope.get("cluster") or {}
+    docket = (
+        envelope.get("docket") if isinstance(envelope.get("docket"), dict) else None
+    )
+
+    court_id = _resolve_court_id(cluster, docket)
+    if court_id:
+        return court_id
+
+    if cl_client is None:
+        return None
+
+    # Old envelope (pre-#4247) — no docket captured.  Live-fetch.
+    docket_url = cluster.get("docket")
+    if not docket_url:
+        docket_id = cluster.get("docket_id")
+        if not docket_id:
+            return None
+        # Build the absolute URL — the API base lives on the client.
+        from courts.federal.courtlistener import API_BASE_URL  # noqa: E402
+
+        docket_url = f"{API_BASE_URL}/dockets/{docket_id}/"
+
+    try:
+        fetched_docket = cl_client.fetch_docket(docket_url)
+    except Exception as exc:
+        logger.warning(
+            "Live docket fetch failed during backfill",
+            docket_url=docket_url,
+            error=str(exc),
+        )
+        return None
+
+    court_id = _resolve_court_id(cluster, fetched_docket)
+    return court_id if court_id else None
+
+
+def _extract_court_id_from_s3(
+    s3_client: Any,
+    s3_bucket: str,
+    s3_key: str,
+    *,
+    cl_client: CourtListenerClient | None = None,
+) -> str | None:
+    """Read the raw JSON from S3 and extract the resolved court short-id.
+
+    Reads the envelope from S3 and delegates to ``_extract_court_id_from_envelope``.
+    """
+    envelope = _read_envelope_from_s3(s3_client, s3_bucket, s3_key)
+    if envelope is None:
+        return None
+    return _extract_court_id_from_envelope(envelope, cl_client=cl_client)
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +273,7 @@ def run_backfill(
     dry_run: bool,
     limit: int,
     batch_size: int,
+    cl_client: CourtListenerClient | None = None,
 ) -> dict[str, dict[str, int]]:
     """Run the backfill and return per-court rebucket counts.
 
@@ -188,7 +285,9 @@ def run_backfill(
     # Per-court stats: court_id -> {original_state: count}
     rebucket_counts: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
 
-    batch: list[tuple[str, str, str, str]] = []  # (doc_id, new_court_id, new_state, new_county)
+    batch: list[
+        tuple[str, str, str, str]
+    ] = []  # (doc_id, new_court_id, new_state, new_county)
 
     def _flush_batch(batch: list[tuple[str, str, str, str]]) -> None:
         if not batch or dry_run:
@@ -209,9 +308,13 @@ def run_backfill(
             rebucket_counts["_no_s3"]["skipped"] += 1
             continue
 
-        court_id = _extract_court_id_from_s3(s3_client, s3_bucket, s3_key)
+        court_id = _extract_court_id_from_s3(
+            s3_client, s3_bucket, s3_key, cl_client=cl_client
+        )
         if not court_id:
-            logger.warning("Could not extract court_id from S3 — skipping", doc_id=doc_id)
+            logger.warning(
+                "Could not extract court_id from S3 — skipping", doc_id=doc_id
+            )
             rebucket_counts["_unknown"]["skipped"] += 1
             continue
 
@@ -281,14 +384,18 @@ def main() -> None:
         logger.error("DATABASE_URL environment variable not set")
         sys.exit(1)
 
-    s3_bucket_env = os.environ.get("S3_BUCKET", "")
     s3_client = boto3.client("s3")
+
+    cl_client: CourtListenerClient | None = None
+    if args.fetch_missing_dockets:
+        cl_client = CourtListenerClient()
 
     logger.info(
         "Starting CourtListener jurisdiction backfill",
         dry_run=args.dry_run,
         limit=args.limit,
         batch_size=args.batch_size,
+        fetch_missing_dockets=args.fetch_missing_dockets,
     )
 
     with psycopg.connect(database_url) as conn:
@@ -298,6 +405,7 @@ def main() -> None:
             dry_run=args.dry_run,
             limit=args.limit,
             batch_size=args.batch_size,
+            cl_client=cl_client,
         )
 
     # Print summary table


### PR DESCRIPTION
## Summary

`cluster.court` is empty in every CourtListener API response we capture today, so every new opinion landed in Federal/Federal regardless of true jurisdiction (1,507 → 2,091 misclassified docs in 24h per the 5/2 → 5/3 spotcheck). This PR adds a `_resolve_court_id(cluster, docket)` helper that prefers `docket.court` (the canonical source on the resolved docket sub-resource) and falls back to `cluster.court` for backward compatibility, fixing both the live capture path and the reingest path. The backfill script now reads `docket.court` from the envelope and supports an opt-in live-fetch fallback for old envelopes that pre-date docket capture.

Closes #4247

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeded (`Deploy Scraper` run 25453274425, deploy SHA `3930775b`).
- [x] New code path exercised on deployed image (verified via the new `"Live docket fetch failed during backfill"` log event in `/ecs/judgemind-ingestion-worker-dev`, task `90d933c1ba854f92ac767bb9a7280d5f`).
- [x] Verification evidence posted on issue: https://github.com/judgemind/judgemind/issues/4247#issuecomment-4390911940
- [ ] AC4/AC5 (non-Federal rows after scrape, `>0` rebucketed) — blocked on #1626 (CourtListener API token 401, independent).
