### PR TITLE
fix(ingestion): fold deterministic_chunk_failure into chunk_api_failure (#4253)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -96,16 +96,14 @@ _MAX_RETRY_DEPTH = 1
 # Minimum chunk size (chars) to attempt a retry split.
 _MIN_RETRY_CHUNK_CHARS = 2000
 
-# Deterministic-chunk-failure instrumentation (#4233).
-# When the same document_id has accumulated this many ``_extract_chunk_google``
-# failures within a single reingest run, emit
-# ``llm_extract.deterministic_chunk_failure`` with the chunk's content
-# SHA-256 and a 200-char preview so future log queries can group by content
-# and identify documents that deterministically trip the LLM provider.
-_DETERMINISTIC_FAILURE_THRESHOLD = 3
-# Number of leading chars from the failing chunk to include in the structured
-# log event.  Bounded so the log line stays cheap to ingest.
-_DETERMINISTIC_FAILURE_PREVIEW_CHARS = 200
+# Number of leading chars from a failing chunk's text (or bytes count
+# for image data) to include in structured log events.  Bounded so each
+# log line stays cheap to ingest.  See #4253 — this enrichment was
+# previously gated behind a 3-failure threshold
+# (``deterministic_chunk_failure``); the threshold was structurally too
+# strict for typical 2-chunk docs and has been removed.  Every Google
+# API failure now gets the rich payload directly.
+_CHUNK_FAILURE_PREVIEW_CHARS = 200
 
 # Patterns for natural split boundaries.
 _PAGE_BREAK_RE = re.compile(r"\f")
@@ -2680,17 +2678,6 @@ class LlmExtractor:
             else None
         )
 
-        # Per-document Google API failure counter (#4233).  Maps
-        # ``document_id`` -> count of ``_extract_chunk_google`` calls that
-        # returned ``None`` within this extractor's lifetime (typically one
-        # reingest run).  Used to fire the
-        # ``llm_extract.deterministic_chunk_failure`` structured log event
-        # exactly once when the count crosses
-        # ``_DETERMINISTIC_FAILURE_THRESHOLD``.  Counter is best-effort: only
-        # populated when callers pass ``document_id`` to ``extract()``.
-        self._google_chunk_failure_counts: dict[str, int] = {}
-        self._deterministic_failure_fired: set[str] = set()
-
     @staticmethod
     def _get_cache_s3_client() -> object:
         """Return an S3 client for the LLM cache.
@@ -2736,14 +2723,13 @@ class LlmExtractor:
                 from the fresh result.  See ``self._bust_cache`` for a
                 persistent instance-level default.  Used by the
                 ``--bust-llm-cache`` reingest flag (#2424).
-            document_id: Optional source ``derived.documents`` UUID.  When
-                provided, ``_extract_chunk_google`` failures for this doc
-                are counted; once
-                ``_DETERMINISTIC_FAILURE_THRESHOLD`` is reached within
-                a single reingest run, ``llm_extract.deterministic_chunk_failure``
-                is emitted with the failing chunk's content SHA-256 and a
-                200-char preview so future log queries can group by content
-                (#4233).  Has no effect on cache key (kept out of metadata).
+            document_id: Optional source ``derived.documents`` UUID.  Echoed
+                into the ``llm_extractor.google_api_failure`` structured log
+                event whenever ``_extract_chunk_google`` returns ``None``,
+                so future log queries can correlate failures back to the
+                source document and group by ``chunk_content_sha256``
+                (#4233 / #4253).  Has no effect on cache key (kept out of
+                metadata).
 
         Returns:
             A list of ``ExtractedRuling`` instances.  Returns an empty list
@@ -2873,13 +2859,13 @@ class LlmExtractor:
                 from the fresh result.  See ``self._bust_cache`` for a
                 persistent instance-level default.  Used by the
                 ``--bust-llm-cache`` reingest flag (#2424).
-            document_id: Optional source ``derived.documents`` UUID.  When
-                provided, ``_extract_single_page`` failures for this doc
-                are counted; once
-                ``_DETERMINISTIC_FAILURE_THRESHOLD`` is reached within
-                a single reingest run, ``llm_extract.deterministic_chunk_failure``
-                is emitted with the failing page's image SHA-256 so future
-                log queries can group by content (#4233).
+            document_id: Optional source ``derived.documents`` UUID.  Echoed
+                into the ``llm_extractor.page_api_failure`` and
+                ``llm_extractor.page_api_exhausted`` structured log events
+                whenever ``_extract_single_page`` cannot get a usable
+                response, so future log queries can correlate failures
+                back to the source document and group by the page-image
+                ``chunk_content_sha256`` (#4233 / #4253).
 
         Returns:
             A list of ``ExtractedRuling`` instances.  Returns an empty list
@@ -3124,15 +3110,28 @@ class LlmExtractor:
         )
 
         if response is None:
+            # Self-diagnosing API-failure payload (#4253).  ``call_llm``
+            # already represents 3 exhausted internal Google retries, so
+            # a single failure deserves the full diagnostic blob (SHA-256
+            # + preview) rather than waiting for an N-failure threshold —
+            # which the typical 2-chunk doc never reached.
+            chunk_preview = ""
+            chunk_content_sha256 = ""
+            chunk_len = 0
+            if chunk_text is not None:
+                chunk_preview = chunk_text[:_CHUNK_FAILURE_PREVIEW_CHARS]
+                chunk_content_sha256 = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+                chunk_len = len(chunk_text)
             logger.warning(
                 "llm_extractor.google_api_failure",
                 chunk_index=chunk_index,
                 document_id=document_id,
-            )
-            self._record_google_chunk_failure(
-                document_id=document_id,
-                chunk_index=chunk_index,
-                chunk_text=chunk_text,
+                provider=self._provider,
+                model=self._model,
+                chunk_content_sha256=chunk_content_sha256,
+                chunk_preview=chunk_preview,
+                chunk_len=chunk_len,
+                chunk_kind="text",
             )
             return None
 
@@ -3141,71 +3140,6 @@ class LlmExtractor:
         usage.api_calls += 1
 
         return self._parse_response(response.text, metadata)
-
-    def _record_google_chunk_failure(
-        self,
-        *,
-        document_id: str | None,
-        chunk_index: int,
-        chunk_text: str | None,
-        chunk_bytes: bytes | None = None,
-    ) -> None:
-        """Increment the per-document Google chunk-failure counter (#4233).
-
-        When the same ``document_id`` accumulates
-        ``_DETERMINISTIC_FAILURE_THRESHOLD`` failed Google API calls
-        (text-chunk or per-page-image) within this extractor's lifetime,
-        emit ``llm_extract.deterministic_chunk_failure`` exactly once with
-        the current chunk's content SHA-256 and (for text chunks) a
-        200-char preview, so operators can group log entries by content
-        and identify the documents that deterministically trip the LLM
-        provider.
-
-        Either ``chunk_text`` (text-chunk path) or ``chunk_bytes`` (PDF
-        per-page multimodal path) may be provided; SHA-256 is taken over
-        whichever is present.  The text preview field stays empty for
-        the multimodal path since the binary is image data.
-
-        No-op when ``document_id`` is ``None`` (legacy callers), so this
-        instrumentation is opt-in per call site.
-        """
-        if not document_id:
-            return
-
-        new_count = self._google_chunk_failure_counts.get(document_id, 0) + 1
-        self._google_chunk_failure_counts[document_id] = new_count
-
-        if (
-            new_count >= _DETERMINISTIC_FAILURE_THRESHOLD
-            and document_id not in self._deterministic_failure_fired
-        ):
-            self._deterministic_failure_fired.add(document_id)
-            preview = ""
-            content_sha256 = ""
-            content_len = 0
-            content_kind = "unknown"
-            if chunk_text is not None:
-                preview = chunk_text[:_DETERMINISTIC_FAILURE_PREVIEW_CHARS]
-                content_sha256 = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
-                content_len = len(chunk_text)
-                content_kind = "text"
-            elif chunk_bytes is not None:
-                content_sha256 = hashlib.sha256(chunk_bytes).hexdigest()
-                content_len = len(chunk_bytes)
-                content_kind = "image"
-            logger.warning(
-                "llm_extract.deterministic_chunk_failure",
-                document_id=document_id,
-                chunk_index=chunk_index,
-                failure_count=new_count,
-                threshold=_DETERMINISTIC_FAILURE_THRESHOLD,
-                provider=self._provider,
-                model=self._model,
-                chunk_content_sha256=content_sha256,
-                chunk_preview=preview,
-                chunk_len=content_len,
-                chunk_kind=content_kind,
-            )
 
     def _extract_chunk_with_retry(
         self,
@@ -3367,6 +3301,17 @@ class LlmExtractor:
                 )
 
                 if response is None:
+                    # Self-diagnosing page-failure payload (#4253).
+                    # ``call_llm_with_images`` was invoked with
+                    # ``max_retries=0`` so this loop is the only retry
+                    # layer for the multimodal path; every failure here
+                    # already represents the exhausted internal retries
+                    # for one attempt.  Emit the rich payload (image
+                    # SHA-256 + byte length) on every failure so future
+                    # log queries can group by content without waiting
+                    # for a counter threshold.
+                    image_sha256 = hashlib.sha256(img_bytes).hexdigest()
+                    image_len = len(img_bytes)
                     if attempt < self._max_retries:
                         wait = min(delay, self._max_delay)
                         logger.warning(
@@ -3376,18 +3321,12 @@ class LlmExtractor:
                             retry_in=wait,
                             page_index=page_index,
                             document_id=document_id,
-                        )
-                        # Count failed page-attempts toward the
-                        # deterministic-failure instrumentation (#4233).
-                        # Each retry attempt is its own data point —
-                        # ``call_llm_with_images`` was invoked with
-                        # ``max_retries=0`` so this loop is the only
-                        # retry layer for the multimodal path.
-                        self._record_google_chunk_failure(
-                            document_id=document_id,
-                            chunk_index=page_index,
-                            chunk_text=None,
-                            chunk_bytes=img_bytes,
+                            provider=self._provider,
+                            model=self._model,
+                            chunk_content_sha256=image_sha256,
+                            chunk_preview="",
+                            chunk_len=image_len,
+                            chunk_kind="image",
                         )
                         time.sleep(wait)
                         delay *= 2
@@ -3396,12 +3335,12 @@ class LlmExtractor:
                         "llm_extractor.page_api_exhausted",
                         page_index=page_index,
                         document_id=document_id,
-                    )
-                    self._record_google_chunk_failure(
-                        document_id=document_id,
-                        chunk_index=page_index,
-                        chunk_text=None,
-                        chunk_bytes=img_bytes,
+                        provider=self._provider,
+                        model=self._model,
+                        chunk_content_sha256=image_sha256,
+                        chunk_preview="",
+                        chunk_len=image_len,
+                        chunk_kind="image",
                     )
                     return []
 

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -629,90 +629,13 @@ _MAX_CHUNKS = 10
 # Overlap characters between consecutive chunks for context continuity.
 _CHUNK_OVERLAP = 500
 
-# Deterministic-chunk-failure instrumentation (#4233).
-# When the same ``document_id`` accumulates this many ``call_llm`` failures
-# (i.e. ``llm_extract.chunk_api_failure`` events) within a single reingest
-# run, emit ``llm_extract.deterministic_chunk_failure`` once with the
-# failing chunk's content SHA-256 and a 200-char preview so future log
-# queries can group hits by content and identify the documents that
-# deterministically trip the LLM provider.
-_DETERMINISTIC_FAILURE_THRESHOLD = 3
-_DETERMINISTIC_FAILURE_PREVIEW_CHARS = 200
-
-# Process-local counters for the deterministic-chunk-failure instrumentation.
-# The reingest worker is a per-task ECS process — these dicts live for the
-# duration of the run.  Thread-safe under the ``_DETERMINISTIC_FAILURE_LOCK``
-# because multi-chunk documents fan out via ``ThreadPoolExecutor``.
-_DETERMINISTIC_FAILURE_LOCK = threading.Lock()
-_DETERMINISTIC_FAILURE_COUNTS: dict[str, int] = {}
-_DETERMINISTIC_FAILURE_FIRED: set[str] = set()
-
-
-def _record_deterministic_chunk_failure(
-    *,
-    document_id: str | None,
-    chunk_index: int,
-    chunk_text: str,
-    provider: str | None,
-    model: str | None,
-) -> None:
-    """Increment the per-document chunk-failure counter (#4233).
-
-    When the same ``document_id`` accumulates
-    ``_DETERMINISTIC_FAILURE_THRESHOLD`` failed ``call_llm`` invocations
-    within this process's lifetime, emit
-    ``llm_extract.deterministic_chunk_failure`` once with the current
-    chunk's content SHA-256 and a 200-char preview so operators can
-    group log entries by content and identify the documents that
-    deterministically trip the LLM provider.
-
-    No-op when ``document_id`` is ``None`` (legacy callers).  Thread-safe
-    via the module-level lock — concurrent chunk extractions for the
-    same document_id race-correctly.
-    """
-    if not document_id:
-        return
-
-    with _DETERMINISTIC_FAILURE_LOCK:
-        new_count = _DETERMINISTIC_FAILURE_COUNTS.get(document_id, 0) + 1
-        _DETERMINISTIC_FAILURE_COUNTS[document_id] = new_count
-        already_fired = document_id in _DETERMINISTIC_FAILURE_FIRED
-        if new_count >= _DETERMINISTIC_FAILURE_THRESHOLD and not already_fired:
-            _DETERMINISTIC_FAILURE_FIRED.add(document_id)
-            should_emit = True
-        else:
-            should_emit = False
-
-    if not should_emit:
-        return
-
-    preview = chunk_text[:_DETERMINISTIC_FAILURE_PREVIEW_CHARS]
-    content_sha256 = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
-    logger.warning(
-        "llm_extract.deterministic_chunk_failure",
-        document_id=document_id,
-        chunk_index=chunk_index,
-        failure_count=new_count,
-        threshold=_DETERMINISTIC_FAILURE_THRESHOLD,
-        provider=provider,
-        model=model,
-        chunk_content_sha256=content_sha256,
-        chunk_preview=preview,
-        chunk_len=len(chunk_text),
-        chunk_kind="text",
-    )
-
-
-def reset_deterministic_chunk_failure_state() -> None:
-    """Reset the per-process deterministic-failure counters (#4233).
-
-    Used by tests and by long-lived processes that want to scope the
-    counter to a particular run.  No-op if no failures have been
-    recorded yet.
-    """
-    with _DETERMINISTIC_FAILURE_LOCK:
-        _DETERMINISTIC_FAILURE_COUNTS.clear()
-        _DETERMINISTIC_FAILURE_FIRED.clear()
+# Number of leading chars of the failing chunk to include in the
+# ``chunk_api_failure`` structured log event.  Bounded so the log line
+# stays cheap to ingest.  See #4253 — this enrichment was previously
+# gated behind a 3-failure threshold (``deterministic_chunk_failure``);
+# the threshold was structurally too strict for typical 2-chunk docs and
+# was removed.  Every chunk failure now gets the rich payload directly.
+_CHUNK_FAILURE_PREVIEW_CHARS = 200
 
 
 # Patterns that indicate natural split boundaries in text.
@@ -943,15 +866,12 @@ def extract_fields_llm(
             from the fresh result.  Used by the ``--bust-llm-cache``
             reingest flag (#2424) to force fresh LLM output after a
             prompt change, without invalidating the cache permanently.
-        document_id: Optional source ``derived.documents`` UUID.  When
-            provided, ``call_llm`` failures for this doc are counted in
-            a process-local map; once
-            ``_DETERMINISTIC_FAILURE_THRESHOLD`` is reached within
-            a single reingest run,
-            ``llm_extract.deterministic_chunk_failure`` is emitted with
-            the failing chunk's content SHA-256 and a 200-char preview
-            so future log queries can group by content (#4233).  Has no
-            effect on cache key.
+        document_id: Optional source ``derived.documents`` UUID.  Echoed
+            into the ``llm_extract.chunk_api_failure`` structured log
+            event when a chunk's LLM call returns ``None``, so future log
+            queries can correlate failures back to the source document
+            and group by ``chunk_content_sha256`` (#4233 / #4253).  Has
+            no effect on cache key.
 
     Returns:
         An ``LLMExtractionResult`` with extracted fields, or ``None`` if
@@ -1027,17 +947,26 @@ def extract_fields_llm(
             max_tokens=max_tokens,
         )
         if llm_response is None:
+            # Self-diagnosing chunk-failure payload (#4253).  Each
+            # ``call_llm`` already represents 3 exhausted internal Google
+            # retries, so a single failure here is enough to deserve the
+            # full diagnostic blob (SHA-256 + preview) rather than waiting
+            # for an N-failure threshold.  The 97KB / 2-chunk #4233 docs
+            # never accumulated 3 failures in a single run, which made the
+            # prior threshold-based event silent on the very docs it was
+            # added to diagnose.
+            chunk_preview = chunk[:_CHUNK_FAILURE_PREVIEW_CHARS]
+            chunk_content_sha256 = hashlib.sha256(chunk.encode("utf-8")).hexdigest()
             logger.warning(
                 "llm_extract.chunk_api_failure",
                 chunk_index=i,
                 document_id=document_id,
-            )
-            _record_deterministic_chunk_failure(
-                document_id=document_id,
-                chunk_index=i,
-                chunk_text=chunk,
                 provider=provider,
                 model=model,
+                chunk_content_sha256=chunk_content_sha256,
+                chunk_preview=chunk_preview,
+                chunk_len=len(chunk),
+                chunk_kind="text",
             )
             return None
         if token_tracker is not None:

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -992,46 +992,25 @@ class TestExtractFieldsLlm:
 
 
 # ---------------------------------------------------------------------------
-# Deterministic chunk-failure instrumentation (#4233)
+# Enriched chunk_api_failure payload (#4253)
+#
+# The threshold-based ``deterministic_chunk_failure`` event was removed
+# (#4253) — it required 3 ``call_llm`` failures on the same doc within a
+# single run before firing the rich payload, but the actual #4233 docs
+# only chunk to 2 pieces and never accumulated 3 failures, so the event
+# was silent on the very docs that motivated it.  Each ``call_llm``
+# already represents 3 exhausted internal Google retries, so a single
+# chunk failure is now sufficient to deserve the full diagnostic blob;
+# the rich payload is folded directly into the existing
+# ``chunk_api_failure`` event.
 # ---------------------------------------------------------------------------
 
 
-class TestDeterministicChunkFailure:
-    """Verify the `llm_extract.deterministic_chunk_failure` event (#4233).
+class TestChunkApiFailureEnrichedPayload:
+    """Every ``llm_extract.chunk_api_failure`` event carries the rich payload (#4253)."""
 
-    When the same `document_id` accumulates 3+ failed `call_llm` calls
-    within a single reingest run, `extract_fields_llm` emits a
-    structured warning log event with the failing chunk's content
-    SHA-256 and a 200-char preview so future log queries can group
-    hits by content.
-    """
-
-    def setup_method(self) -> None:
-        from ingestion.llm_extract import reset_deterministic_chunk_failure_state
-
-        reset_deterministic_chunk_failure_state()
-
-    def teardown_method(self) -> None:
-        from ingestion.llm_extract import reset_deterministic_chunk_failure_state
-
-        reset_deterministic_chunk_failure_state()
-
-    def test_no_event_below_threshold(self) -> None:
-        """Two consecutive failures stay below the 3-failure threshold."""
-        from ingestion import llm_extract as mod
-
-        with (
-            patch("ingestion.llm_extract.call_llm", return_value=None),
-            patch.object(mod, "logger") as mock_logger,
-        ):
-            extract_fields_llm(document_text="some text", content_format="pdf", document_id="doc-A")
-            extract_fields_llm(document_text="some text", content_format="pdf", document_id="doc-A")
-
-            events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
-            assert "llm_extract.deterministic_chunk_failure" not in events
-
-    def test_event_fires_at_threshold(self) -> None:
-        """Third failure on the same doc fires the deterministic-chunk-failure event."""
+    def test_single_failure_emits_enriched_payload(self) -> None:
+        """One failure (no threshold!) fires the enriched chunk_api_failure event."""
         from ingestion import llm_extract as mod
 
         chunk_text = "Case No. 30-2024-0123456 boilerplate ruling text" * 3
@@ -1039,166 +1018,136 @@ class TestDeterministicChunkFailure:
             patch("ingestion.llm_extract.call_llm", return_value=None),
             patch.object(mod, "logger") as mock_logger,
         ):
-            for _ in range(3):
-                extract_fields_llm(
-                    document_text=chunk_text,
-                    content_format="pdf",
-                    document_id="doc-B",
-                    provider="google",
-                    model="gemini-2.5-flash-lite",
-                )
-
-            fail_events = [
-                c
-                for c in mock_logger.warning.call_args_list
-                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-            ]
-            assert len(fail_events) == 1, (
-                f"Expected exactly one deterministic_chunk_failure event, got {len(fail_events)}"
+            extract_fields_llm(
+                document_text=chunk_text,
+                content_format="pdf",
+                document_id="doc-single",
+                provider="google",
+                model="gemini-2.5-flash-lite",
             )
 
-            payload = fail_events[0].kwargs
-            assert payload["document_id"] == "doc-B"
-            assert payload["failure_count"] == 3
-            assert payload["threshold"] == 3
-            assert payload["provider"] == "google"
-            assert payload["model"] == "gemini-2.5-flash-lite"
-            assert payload["chunk_kind"] == "text"
+        fail_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extract.chunk_api_failure"
+        ]
+        assert len(fail_events) == 1, (
+            f"Expected exactly one chunk_api_failure event, got {len(fail_events)}"
+        )
 
-            import hashlib
+        payload = fail_events[0].kwargs
+        assert payload["document_id"] == "doc-single"
+        assert payload["chunk_index"] == 0
+        assert payload["provider"] == "google"
+        assert payload["model"] == "gemini-2.5-flash-lite"
+        assert payload["chunk_kind"] == "text"
 
-            expected_sha = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
-            assert payload["chunk_content_sha256"] == expected_sha
-            assert len(payload["chunk_content_sha256"]) == 64
-            assert len(payload["chunk_preview"]) <= 200
-            assert payload["chunk_preview"] == chunk_text[:200]
-            assert payload["chunk_len"] == len(chunk_text)
+        import hashlib
 
-    def test_event_fires_only_once_per_document(self) -> None:
-        """Failures beyond threshold for the same doc do not re-fire the event."""
-        from ingestion import llm_extract as mod
-
-        with (
-            patch("ingestion.llm_extract.call_llm", return_value=None),
-            patch.object(mod, "logger") as mock_logger,
-        ):
-            for _ in range(5):
-                extract_fields_llm(
-                    document_text="some text",
-                    content_format="pdf",
-                    document_id="doc-C",
-                )
-
-            fail_events = [
-                c
-                for c in mock_logger.warning.call_args_list
-                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-            ]
-            assert len(fail_events) == 1
-
-    def test_no_event_without_document_id(self) -> None:
-        """Failures without a document_id are not counted — instrumentation is opt-in."""
-        from ingestion import llm_extract as mod
-
-        with (
-            patch("ingestion.llm_extract.call_llm", return_value=None),
-            patch.object(mod, "logger") as mock_logger,
-        ):
-            for _ in range(5):
-                extract_fields_llm(
-                    document_text="some text", content_format="pdf"
-                )  # no document_id
-
-            fail_events = [
-                c
-                for c in mock_logger.warning.call_args_list
-                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-            ]
-            assert fail_events == []
-
-    def test_counts_are_per_document(self) -> None:
-        """Failure counts are scoped per document_id — distinct docs accumulate separately."""
-        from ingestion import llm_extract as mod
-
-        with (
-            patch("ingestion.llm_extract.call_llm", return_value=None),
-            patch.object(mod, "logger") as mock_logger,
-        ):
-            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-D")
-            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-E")
-            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-D")
-            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-E")
-            extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-E")
-
-            fail_events = [
-                c
-                for c in mock_logger.warning.call_args_list
-                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-            ]
-            assert len(fail_events) == 1
-            assert fail_events[0].kwargs["document_id"] == "doc-E"
+        expected_sha = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+        assert payload["chunk_content_sha256"] == expected_sha
+        assert len(payload["chunk_content_sha256"]) == 64
+        assert payload["chunk_preview"] == chunk_text[:200]
+        assert len(payload["chunk_preview"]) <= 200
+        assert payload["chunk_len"] == len(chunk_text)
 
     def test_event_payload_schema_has_required_fields(self) -> None:
-        """Log payload exposes all fields the issue's grouping queries depend on (#4233 AC)."""
+        """Log payload exposes the fields log queries depend on (#4253 AC)."""
         from ingestion import llm_extract as mod
 
         with (
             patch("ingestion.llm_extract.call_llm", return_value=None),
             patch.object(mod, "logger") as mock_logger,
         ):
-            for _ in range(3):
+            extract_fields_llm(
+                document_text="some text",
+                content_format="pdf",
+                document_id="doc-schema",
+            )
+
+        fail_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extract.chunk_api_failure"
+        ]
+        assert len(fail_events) == 1
+        payload = fail_events[0].kwargs
+        required_keys = {
+            "document_id",
+            "chunk_index",
+            "provider",
+            "model",
+            "chunk_content_sha256",
+            "chunk_preview",
+            "chunk_len",
+            "chunk_kind",
+        }
+        missing = required_keys - payload.keys()
+        assert not missing, f"Missing required log payload fields: {missing}"
+
+    def test_no_threshold_event_emitted(self) -> None:
+        """The legacy ``deterministic_chunk_failure`` event must never fire (#4253)."""
+        from ingestion import llm_extract as mod
+
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            for _ in range(5):
                 extract_fields_llm(
-                    document_text="some text",
+                    document_text="repeated failure text",
                     content_format="pdf",
-                    document_id="doc-schema",
+                    document_id="doc-no-threshold",
                 )
 
-            fail_events = [
-                c
-                for c in mock_logger.warning.call_args_list
-                if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-            ]
-            assert len(fail_events) == 1
-            payload = fail_events[0].kwargs
-            required_keys = {
-                "document_id",
-                "chunk_index",
-                "failure_count",
-                "threshold",
-                "provider",
-                "model",
-                "chunk_content_sha256",
-                "chunk_preview",
-                "chunk_len",
-                "chunk_kind",
-            }
-            missing = required_keys - payload.keys()
-            assert not missing, f"Missing required log payload fields: {missing}"
+        events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+        assert "llm_extract.deterministic_chunk_failure" not in events
 
-    def test_reset_clears_state(self) -> None:
-        """reset_deterministic_chunk_failure_state() clears counters between runs."""
+    def test_event_fires_without_document_id(self) -> None:
+        """Failures without a document_id still emit the rich payload (document_id=None)."""
         from ingestion import llm_extract as mod
-        from ingestion.llm_extract import reset_deterministic_chunk_failure_state
 
-        with patch("ingestion.llm_extract.call_llm", return_value=None):
-            for _ in range(3):
-                extract_fields_llm(document_text="text", content_format="pdf", document_id="doc-R")
-            # First fire happened — second batch with same doc_id, post-reset,
-            # should fire again.
-            reset_deterministic_chunk_failure_state()
+        chunk_text = "anonymous chunk text"
+        with (
+            patch("ingestion.llm_extract.call_llm", return_value=None),
+            patch.object(mod, "logger") as mock_logger,
+        ):
+            extract_fields_llm(
+                document_text=chunk_text,
+                content_format="pdf",
+            )  # no document_id
 
-            with patch.object(mod, "logger") as mock_logger:
-                for _ in range(3):
-                    extract_fields_llm(
-                        document_text="text", content_format="pdf", document_id="doc-R"
-                    )
+        fail_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extract.chunk_api_failure"
+        ]
+        assert len(fail_events) == 1
+        payload = fail_events[0].kwargs
+        assert payload["document_id"] is None
+        # SHA-256 + preview are still present — they are content-derived,
+        # not document_id-derived, so they always populate.
+        import hashlib
 
-                fail_events = [
-                    c
-                    for c in mock_logger.warning.call_args_list
-                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-                ]
-                assert len(fail_events) == 1
+        assert (
+            payload["chunk_content_sha256"]
+            == hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+        )
+        assert payload["chunk_preview"] == chunk_text[:200]
+        assert payload["chunk_kind"] == "text"
+
+    def test_legacy_helpers_removed(self) -> None:
+        """The threshold-based helper API was removed in #4253."""
+        from ingestion import llm_extract as mod
+
+        # Public reset helper is gone.
+        assert not hasattr(mod, "reset_deterministic_chunk_failure_state")
+        # Counter constants and module-level state are gone.
+        assert not hasattr(mod, "_DETERMINISTIC_FAILURE_THRESHOLD")
+        assert not hasattr(mod, "_DETERMINISTIC_FAILURE_COUNTS")
+        assert not hasattr(mod, "_DETERMINISTIC_FAILURE_FIRED")
+        assert not hasattr(mod, "_DETERMINISTIC_FAILURE_LOCK")
+        assert not hasattr(mod, "_record_deterministic_chunk_failure")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_llm_extractor.py
+++ b/packages/scraper-framework/tests/test_llm_extractor.py
@@ -803,179 +803,81 @@ class TestGoogleProvider:
 
 
 # ---------------------------------------------------------------------------
-# Deterministic chunk-failure instrumentation (#4233)
+# Enriched google_api_failure payload (#4253)
+#
+# The threshold-based ``deterministic_chunk_failure`` event was removed
+# (#4253) — it required 3 ``_extract_chunk_google`` failures on the
+# same doc within a single run before firing the rich payload, but
+# typical 2-chunk docs never accumulated 3 failures, so the event was
+# silent on the very docs that motivated it (#4233).  Each ``call_llm``
+# already represents 3 exhausted internal Google retries, so a single
+# chunk failure is now sufficient to deserve the full diagnostic blob;
+# the rich payload is folded directly into the existing
+# ``llm_extractor.google_api_failure`` event.
 # ---------------------------------------------------------------------------
 
 
-class TestDeterministicChunkFailure:
-    """Verify the deterministic-chunk-failure structured log event (#4233).
-
-    When the same ``document_id`` accumulates 3+ failed
-    ``_extract_chunk_google`` calls within a single reingest run, the
-    extractor emits ``llm_extract.deterministic_chunk_failure`` with
-    the failing chunk's content SHA-256 and a 200-char preview so
-    operators can group log queries by content.
-    """
+class TestChunkFailureEnrichedPayload:
+    """Every ``llm_extractor.google_api_failure`` event carries the rich payload (#4253)."""
 
     @staticmethod
     def _make_extractor() -> LlmExtractor:
         with patch("framework.llm_extractor._create_google_client"):
             return LlmExtractor(provider="google")
 
-    def test_no_event_below_threshold(self) -> None:
-        """Two consecutive failures stay below the 3-failure threshold — no event fires."""
-        from framework import llm_extractor as mod
-
-        extractor = self._make_extractor()
-        with patch("ingestion.llm_providers.call_llm", return_value=None):
-            with patch.object(mod, "logger") as mock_logger:
-                # Two failed extracts on the same doc; threshold = 3.
-                extractor.extract("some text", document_id="doc-A")
-                extractor.extract("some text", document_id="doc-A")
-
-                events = [c.args[0] for c in mock_logger.warning.call_args_list]
-                assert "llm_extract.deterministic_chunk_failure" not in events
-
-    def test_event_fires_at_threshold(self) -> None:
-        """Third failure on the same doc fires the deterministic-chunk-failure event."""
+    def test_single_failure_emits_enriched_payload(self) -> None:
+        """One failure (no threshold!) fires the enriched google_api_failure event."""
         from framework import llm_extractor as mod
 
         extractor = self._make_extractor()
         chunk_text = "Case No. 30-2024-0123456 multi-case ruling boilerplate" * 4
         with patch("ingestion.llm_providers.call_llm", return_value=None):
             with patch.object(mod, "logger") as mock_logger:
-                # Three failed extracts on the same doc — threshold reached on call 3.
-                extractor.extract(chunk_text, document_id="doc-B")
-                extractor.extract(chunk_text, document_id="doc-B")
-                extractor.extract(chunk_text, document_id="doc-B")
+                extractor.extract(chunk_text, document_id="doc-single")
 
-                # Find the deterministic-chunk-failure call — there must be
-                # exactly one (event fires once per document_id per run).
                 fail_events = [
                     c
                     for c in mock_logger.warning.call_args_list
-                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                    if c.args and c.args[0] == "llm_extractor.google_api_failure"
                 ]
                 assert len(fail_events) == 1, (
-                    "Expected exactly one deterministic_chunk_failure event, "
-                    f"got {len(fail_events)}"
+                    f"Expected exactly one google_api_failure event, got {len(fail_events)}"
                 )
 
                 payload = fail_events[0].kwargs
-                assert payload["document_id"] == "doc-B"
-                assert payload["failure_count"] == 3
-                assert payload["threshold"] == 3
+                assert payload["document_id"] == "doc-single"
+                assert payload["chunk_index"] == 0
                 assert payload["provider"] == "google"
                 assert payload["chunk_kind"] == "text"
-                # SHA-256 of the chunk content must be present and well-formed.
+                # SHA-256 + preview are present on every failure.
                 import hashlib
 
                 expected_sha = hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
                 assert payload["chunk_content_sha256"] == expected_sha
                 assert len(payload["chunk_content_sha256"]) == 64
-                # Preview is bounded.
-                assert len(payload["chunk_preview"]) <= 200
                 assert payload["chunk_preview"] == chunk_text[:200]
+                assert len(payload["chunk_preview"]) <= 200
                 assert payload["chunk_len"] == len(chunk_text)
 
-    def test_event_fires_only_once_per_document(self) -> None:
-        """Failures beyond threshold for the same doc do not re-fire the event."""
-        from framework import llm_extractor as mod
-
-        extractor = self._make_extractor()
-        with patch("ingestion.llm_providers.call_llm", return_value=None):
-            with patch.object(mod, "logger") as mock_logger:
-                for _ in range(5):
-                    extractor.extract("some text", document_id="doc-C")
-
-                fail_events = [
-                    c
-                    for c in mock_logger.warning.call_args_list
-                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-                ]
-                assert len(fail_events) == 1
-
-    def test_no_event_without_document_id(self) -> None:
-        """Failures without a document_id are not counted — instrumentation is opt-in."""
-        from framework import llm_extractor as mod
-
-        extractor = self._make_extractor()
-        with patch("ingestion.llm_providers.call_llm", return_value=None):
-            with patch.object(mod, "logger") as mock_logger:
-                for _ in range(5):
-                    extractor.extract("some text")  # no document_id
-
-                fail_events = [
-                    c
-                    for c in mock_logger.warning.call_args_list
-                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-                ]
-                assert fail_events == []
-
-    def test_counts_are_per_document(self) -> None:
-        """Failure counts are scoped per document_id — distinct docs accumulate separately."""
-        from framework import llm_extractor as mod
-
-        extractor = self._make_extractor()
-        with patch("ingestion.llm_providers.call_llm", return_value=None):
-            with patch.object(mod, "logger") as mock_logger:
-                # 2 failures for doc-D, 3 for doc-E — only doc-E should fire.
-                extractor.extract("text", document_id="doc-D")
-                extractor.extract("text", document_id="doc-E")
-                extractor.extract("text", document_id="doc-D")
-                extractor.extract("text", document_id="doc-E")
-                extractor.extract("text", document_id="doc-E")
-
-                fail_events = [
-                    c
-                    for c in mock_logger.warning.call_args_list
-                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-                ]
-                assert len(fail_events) == 1
-                assert fail_events[0].kwargs["document_id"] == "doc-E"
-
-    def test_extract_threads_document_id_to_call_chain(self) -> None:
-        """``extract(document_id=...)`` reaches ``_record_google_chunk_failure``."""
-        extractor = self._make_extractor()
-        with patch("ingestion.llm_providers.call_llm", return_value=None):
-            with patch.object(
-                extractor,
-                "_record_google_chunk_failure",
-                wraps=extractor._record_google_chunk_failure,
-            ) as spy:
-                extractor.extract("some text", document_id="doc-thread")
-
-            spy.assert_called_once()
-            kwargs = spy.call_args.kwargs
-            assert kwargs["document_id"] == "doc-thread"
-            assert kwargs["chunk_index"] == 0
-            assert kwargs["chunk_text"] == "some text"
-
     def test_event_payload_schema_has_required_fields(self) -> None:
-        """Log payload exposes all fields the issue's grouping queries depend on (#4233 AC)."""
+        """Log payload exposes the fields log queries depend on (#4253 AC)."""
         from framework import llm_extractor as mod
 
         extractor = self._make_extractor()
         with patch("ingestion.llm_providers.call_llm", return_value=None):
             with patch.object(mod, "logger") as mock_logger:
-                for _ in range(3):
-                    extractor.extract("some text", document_id="doc-schema")
+                extractor.extract("some text", document_id="doc-schema")
 
                 fail_events = [
                     c
                     for c in mock_logger.warning.call_args_list
-                    if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
+                    if c.args and c.args[0] == "llm_extractor.google_api_failure"
                 ]
                 assert len(fail_events) == 1
                 payload = fail_events[0].kwargs
-                # Required fields per AC: document_id + chunk_index keying,
-                # chunk_content_sha256 for grouping, plus the supporting
-                # provenance/preview fields.
                 required_keys = {
                     "document_id",
                     "chunk_index",
-                    "failure_count",
-                    "threshold",
                     "provider",
                     "model",
                     "chunk_content_sha256",
@@ -985,6 +887,59 @@ class TestDeterministicChunkFailure:
                 }
                 missing = required_keys - payload.keys()
                 assert not missing, f"Missing required log payload fields: {missing}"
+
+    def test_no_threshold_event_emitted(self) -> None:
+        """The legacy ``deterministic_chunk_failure`` event must never fire (#4253)."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                for _ in range(5):
+                    extractor.extract("repeated failure text", document_id="doc-no-threshold")
+
+                events = [c.args[0] for c in mock_logger.warning.call_args_list if c.args]
+                assert "llm_extract.deterministic_chunk_failure" not in events
+
+    def test_event_fires_without_document_id(self) -> None:
+        """Failures without a document_id still emit the rich payload."""
+        from framework import llm_extractor as mod
+
+        extractor = self._make_extractor()
+        chunk_text = "anonymous chunk text"
+        with patch("ingestion.llm_providers.call_llm", return_value=None):
+            with patch.object(mod, "logger") as mock_logger:
+                extractor.extract(chunk_text)  # no document_id
+
+                fail_events = [
+                    c
+                    for c in mock_logger.warning.call_args_list
+                    if c.args and c.args[0] == "llm_extractor.google_api_failure"
+                ]
+                assert len(fail_events) == 1
+                payload = fail_events[0].kwargs
+                assert payload["document_id"] is None
+                import hashlib
+
+                assert (
+                    payload["chunk_content_sha256"]
+                    == hashlib.sha256(chunk_text.encode("utf-8")).hexdigest()
+                )
+                assert payload["chunk_preview"] == chunk_text[:200]
+                assert payload["chunk_kind"] == "text"
+
+    def test_legacy_helpers_removed(self) -> None:
+        """The threshold-based helper API was removed in #4253."""
+        from framework import llm_extractor as mod
+
+        # Module-level constants are gone.
+        assert not hasattr(mod, "_DETERMINISTIC_FAILURE_THRESHOLD")
+        assert not hasattr(mod, "_DETERMINISTIC_FAILURE_PREVIEW_CHARS")
+        # Per-instance state is gone.
+        extractor = self._make_extractor()
+        assert not hasattr(extractor, "_google_chunk_failure_counts")
+        assert not hasattr(extractor, "_deterministic_failure_fired")
+        assert not hasattr(extractor, "_record_google_chunk_failure")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -5056,28 +5056,29 @@ class TestAppendRulingFromCaseMetadataFallback:
 
 
 # ---------------------------------------------------------------------------
-# Multimodal deterministic chunk-failure instrumentation (#4233)
+# Multimodal page-failure rich payload (#4253)
+#
+# The threshold-based ``deterministic_chunk_failure`` event was removed.
+# Every ``page_api_failure`` (retry branch) and ``page_api_exhausted``
+# (terminal branch) log emission now carries the page-image SHA-256,
+# byte length, and ``chunk_kind="image"`` so log queries can group by
+# content without waiting for a counter to cross.
 # ---------------------------------------------------------------------------
 
 
-class TestMultimodalDeterministicChunkFailure:
-    """Verify the multimodal per-page-image failure path also fires the
-    ``llm_extract.deterministic_chunk_failure`` event after 3+ failures
-    on the same document_id (#4233).
-    """
+class TestMultimodalChunkFailureEnrichedPayload:
+    """Multimodal per-page failure events carry the rich payload (#4253)."""
 
-    def test_pdf_page_failures_fire_deterministic_event(self, sample_pdf_bytes: bytes) -> None:
-        """Three consecutive per-page failures with a document_id fire the event."""
+    def test_page_api_failure_and_exhausted_carry_image_payload(
+        self, sample_pdf_bytes: bytes
+    ) -> None:
+        """Every retry-branch warning AND the terminal error get the image SHA-256."""
         from framework import llm_extractor as mod
 
         with patch.object(anthropic, "Anthropic"):
             ext = LlmExtractor(api_key="test-key")
         ext._base_delay = 0.0
-        # max_retries=3 -> the loop in _extract_single_page records up to 3
-        # failures (attempts 1, 2 record into the retry branch; attempt 3
-        # records into the exhaustion branch). That's enough to cross the
-        # threshold of 3 for a single PDF page.
-        ext._max_retries = 3
+        ext._max_retries = 3  # 2 retry-branch warnings + 1 terminal error
 
         page_image = b"\x89PNG_only_page"
         with (
@@ -5094,25 +5095,42 @@ class TestMultimodalDeterministicChunkFailure:
             rulings = ext.extract_from_pdf(sample_pdf_bytes, document_id="multimodal-doc")
 
         assert rulings == []
-        fail_events = [
-            c
-            for c in mock_logger.warning.call_args_list
-            if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
-        ]
-        assert len(fail_events) == 1
-        payload = fail_events[0].kwargs
-        assert payload["document_id"] == "multimodal-doc"
-        assert payload["chunk_kind"] == "image"
-        # SHA-256 of the image bytes is recorded.
+
         import hashlib
 
-        assert payload["chunk_content_sha256"] == hashlib.sha256(page_image).hexdigest()
-        # Image path leaves the text preview empty by design.
+        expected_sha = hashlib.sha256(page_image).hexdigest()
+
+        # Retry-branch warnings: every page_api_failure carries the rich payload.
+        warn_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extractor.page_api_failure"
+        ]
+        assert len(warn_events) == ext._max_retries - 1  # attempts 1, 2
+        for ev in warn_events:
+            payload = ev.kwargs
+            assert payload["document_id"] == "multimodal-doc"
+            assert payload["chunk_kind"] == "image"
+            assert payload["chunk_content_sha256"] == expected_sha
+            assert payload["chunk_preview"] == ""
+            assert payload["chunk_len"] == len(page_image)
+
+        # Terminal exhaustion: page_api_exhausted also carries the rich payload.
+        err_events = [
+            c
+            for c in mock_logger.error.call_args_list
+            if c.args and c.args[0] == "llm_extractor.page_api_exhausted"
+        ]
+        assert len(err_events) == 1
+        payload = err_events[0].kwargs
+        assert payload["document_id"] == "multimodal-doc"
+        assert payload["chunk_kind"] == "image"
+        assert payload["chunk_content_sha256"] == expected_sha
         assert payload["chunk_preview"] == ""
         assert payload["chunk_len"] == len(page_image)
 
-    def test_pdf_no_event_without_document_id(self, sample_pdf_bytes: bytes) -> None:
-        """Multimodal failures without document_id do not fire the event."""
+    def test_pdf_event_fires_without_document_id(self, sample_pdf_bytes: bytes) -> None:
+        """Multimodal failures without document_id still emit rich payloads (document_id=None)."""
         from framework import llm_extractor as mod
 
         with patch.object(anthropic, "Anthropic"):
@@ -5120,10 +5138,11 @@ class TestMultimodalDeterministicChunkFailure:
         ext._base_delay = 0.0
         ext._max_retries = 3
 
+        page_image = b"\x89PNG_x"
         with (
             patch(
                 "framework.llm_extractor._render_pdf_pages",
-                return_value=[(b"\x89PNG_x", "image/png")],
+                return_value=[(page_image, "image/png")],
             ),
             patch(
                 "ingestion.llm_providers.call_llm_with_images",
@@ -5133,9 +5152,26 @@ class TestMultimodalDeterministicChunkFailure:
         ):
             ext.extract_from_pdf(sample_pdf_bytes)  # no document_id
 
-        fail_events = [
+        # The legacy threshold-based event must never fire.
+        threshold_events = [
             c
             for c in mock_logger.warning.call_args_list
             if c.args and c.args[0] == "llm_extract.deterministic_chunk_failure"
         ]
-        assert fail_events == []
+        assert threshold_events == []
+
+        # The rich payload still shows up on the per-attempt warnings, just with document_id=None.
+        warn_events = [
+            c
+            for c in mock_logger.warning.call_args_list
+            if c.args and c.args[0] == "llm_extractor.page_api_failure"
+        ]
+        assert warn_events, "expected at least one page_api_failure warning"
+        import hashlib
+
+        expected_sha = hashlib.sha256(page_image).hexdigest()
+        for ev in warn_events:
+            payload = ev.kwargs
+            assert payload["document_id"] is None
+            assert payload["chunk_content_sha256"] == expected_sha
+            assert payload["chunk_kind"] == "image"


### PR DESCRIPTION
## Summary

Folds the rich-payload diagnostics from the threshold-based
`llm_extract.deterministic_chunk_failure` event directly into the existing
chunk-failure log emissions and removes the deterministic event entirely.
The threshold of 3 was structurally too strict — typical 2-chunk docs
(the very ones in #4233) never accumulated enough failures to fire the
rich payload, defeating its purpose. Each `call_llm` already represents
3 exhausted internal Google retries, so one failure here is plenty.

Closes #4253

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (12 new tests across `test_llm_extract.py`,
      `test_llm_extractor.py`, `test_llm_extractor_multimodal.py`;
      full scraper-framework suite 7420 passed / 3 skipped locally)
- [x] CI green

### Post-deploy verification
- [x] Run the #4233 reproduction command on dev:
      ```
      scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- \
          --county Orange \
          --department-in C20 C23 C25 C27 C31 C32 CM2 C34 N15 \
          --case-number-like 'UNKNOWN-%' \
          --bust-llm-cache
      ```
      and confirm at least one `chunk_api_failure` (or
      `google_api_failure` / `page_api_failure` / `page_api_exhausted`)
      log line on the affected docs carries the `chunk_content_sha256`
      field. Confirmed — both affected docs (`6f9ee11e-...` and
      `4e5c3f4e-...`) emitted `llm_extract.chunk_api_failure` with
      `chunk_content_sha256: 26dadee9509dfcc4cb68c17daf01a5a260eaae637513263a25585b3aaff19972`,
      proving content-deterministic failure on the same chunk.
- [x] Verification evidence posted on issue (see A.8)
