### PR TITLE
feat(dx): audit captured S3 envelopes against scraper field-mapping assumptions (#4255)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -826,6 +826,47 @@ output "zero_record_check_schedule_arn" {
   value       = module.scraper_zero_record_check.schedule_arn
 }
 
+# ─── Scraper field-population audit (EventBridge, #4255) ─────────────────────
+# Daily probe that samples recent S3 envelopes and asserts that load-
+# bearing JSON fields (e.g. CourtListener's docket.court) are non-empty.
+# Catches the silent-drift bug class behind #4247 and #3885 within ~24 h
+# instead of weeks.
+#
+# Reuses the dispatcher PAT (judgemind/dispatcher/github-token) -- same
+# secret already wired into scraper-zero-record-check for issue-write.
+module "scraper_field_population_audit" {
+  source = "../../modules/scraper-field-population-audit"
+
+  environment        = "dev"
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_cluster_arn    = module.compute.cluster_arn
+
+  ecr_repository_url       = module.ecr.repository_url
+  task_execution_role_arn  = module.compute.task_execution_role_arn
+  db_connection_secret_arn = module.database.db_connection_secret_arn
+
+  document_archive_bucket_name = module.document_archive.bucket_id
+  document_archive_bucket_arn  = module.document_archive.bucket_arn
+
+  # Reuse the dispatcher PAT -- already has issues:write per #2700.
+  github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
+
+  gh_repo            = "judgemind/judgemind"
+  log_retention_days = 14
+  schedule_enabled   = true
+}
+
+output "field_population_audit_log_group" {
+  description = "Dev CloudWatch log group for field-population audit output"
+  value       = module.scraper_field_population_audit.log_group_name
+}
+
+output "field_population_audit_schedule_arn" {
+  description = "Dev EventBridge schedule ARN for the daily field-population audit"
+  value       = module.scraper_field_population_audit.schedule_arn
+}
+
 output "scraper_log_group" {
   description = "Dev CloudWatch log group for scraper output"
   value       = module.compute.log_group_name

--- a/infra/terraform/modules/scraper-field-population-audit/main.tf
+++ b/infra/terraform/modules/scraper-field-population-audit/main.tf
@@ -1,0 +1,290 @@
+# EventBridge-scheduled ECS task for the scraper field-population audit.
+#
+# Daily probe that samples recent S3 envelopes per scraper and asserts
+# that load-bearing JSON fields (e.g. CourtListener's docket.court) are
+# populated.  Catches the silent-drift bug class behind #4247 and #3885
+# (a documented field that has gone empty in production responses
+# without anyone noticing for weeks).
+#
+# Mirrors the scraper-zero-record-check module's pattern: a Fargate
+# one-shot task driven by EventBridge Scheduler, sharing the scraper
+# image with one Python entrypoint per check.  The runner script
+# (scripts/audit_scraper_field_population.py) handles DB sampling, S3
+# fetches, drift detection, and GitHub issue creation entirely inside
+# the container.
+#
+# Schedule: daily at 15:00 UTC (after the 14:30 zero-record check so
+# fresh capture data is in the DB).
+#
+# See https://github.com/judgemind/judgemind/issues/4255 for context.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ─── CloudWatch Log Group ──────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "field_population_audit" {
+  name              = "/ecs/judgemind-field-population-audit-${var.environment}"
+  retention_in_days = var.log_retention_days
+}
+
+# ─── Security Group ────────────────────────────────────────────────────────
+# Outbound HTTPS to S3, GitHub API, AWS APIs; Postgres for the sampling
+# query.
+
+resource "aws_security_group" "field_population_audit" {
+  name        = "judgemind-field-population-audit-${var.environment}"
+  description = "Field-population audit ECS task -- outbound HTTPS and Postgres"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "HTTPS to S3, GitHub API, AWS APIs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL database (sampling query)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ─── Task Role ─────────────────────────────────────────────────────────────
+# Read-only S3 GetObject on the document archive bucket so the audit can
+# fetch sample envelopes.  No PutObject / DeleteObject -- this is a
+# pure-observation task.
+
+resource "aws_iam_role" "task_role" {
+  name        = "judgemind-field-population-audit-task-${var.environment}"
+  description = "Task role for the field-population audit -- read-only S3 + DB"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_s3_read" {
+  name = "judgemind-field-population-audit-task-s3-read-${var.environment}"
+  role = aws_iam_role.task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadDocumentArchive"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:ListBucket",
+        ]
+        Resource = [
+          var.document_archive_bucket_arn,
+          "${var.document_archive_bucket_arn}/*",
+        ]
+      }
+    ]
+  })
+}
+
+# ─── Execution Role — secrets ──────────────────────────────────────────────
+# Allow the task execution role to fetch DATABASE_URL and GITHUB_TOKEN so
+# ECS can inject them into the container at launch.
+
+locals {
+  execution_role_name = element(
+    split("/", var.task_execution_role_arn),
+    length(split("/", var.task_execution_role_arn)) - 1
+  )
+
+  # Compact + count-guard pattern (#2739 / #2740): if both ARNs were
+  # somehow blank, the policy would render with an empty Resource
+  # list -- a silent IAM misconfiguration.  Both vars are required at
+  # the variable layer, but the count-guard is defense-in-depth.
+  execution_secret_arns = compact([
+    var.db_connection_secret_arn,
+    var.github_token_secret_arn,
+  ])
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  count = length(local.execution_secret_arns) > 0 ? 1 : 0
+
+  name = "judgemind-field-population-audit-execution-secrets-${var.environment}"
+  role = local.execution_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadFieldPopulationAuditSecrets"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = local.execution_secret_arns
+      }
+    ]
+  })
+}
+
+# ─── Task Definition ───────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "field_population_audit" {
+  family                   = "judgemind-field-population-audit-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = var.task_execution_role_arn
+  task_role_arn            = aws_iam_role.task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "field-population-audit"
+      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      command   = ["python3", "scripts/audit_scraper_field_population.py", "--json"]
+      essential = true
+
+      environment = [
+        { name = "AWS_REGION", value = data.aws_region.current.id },
+        { name = "GH_REPO", value = var.gh_repo },
+        { name = "S3_BUCKET", value = var.document_archive_bucket_name },
+      ]
+
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${var.db_connection_secret_arn}:url::"
+        },
+        {
+          name      = "GITHUB_TOKEN"
+          valueFrom = var.github_token_secret_arn
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.field_population_audit.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "field-population-audit"
+        }
+      }
+    }
+  ])
+
+  # Content-level postconditions on the rendered container_definitions
+  # JSON.  Defense-in-depth against the #2840 silent-drop class of bug
+  # (an apply that produces a task-def revision without a required
+  # secret entry, despite the corresponding ARN variable being non-
+  # empty).
+  lifecycle {
+    postcondition {
+      condition     = strcontains(self.container_definitions, "DATABASE_URL")
+      error_message = "field-population-audit: rendered container_definitions is missing DATABASE_URL. See #3764 / parent #2840 for the silent-drop bug class this guards against."
+    }
+    postcondition {
+      condition     = strcontains(self.container_definitions, "GITHUB_TOKEN")
+      error_message = "field-population-audit: rendered container_definitions is missing GITHUB_TOKEN. See #3764 / parent #2840 for the silent-drop bug class this guards against."
+    }
+  }
+}
+
+# ─── EventBridge Scheduler ─────────────────────────────────────────────────
+# Daily at 15:00 UTC -- runs after the 14:30 zero-record check so any
+# fresh captures are visible in the DB sampling query.
+
+resource "aws_iam_role" "scheduler_execution" {
+  name        = "judgemind-field-population-audit-scheduler-${var.environment}"
+  description = "Allows EventBridge Scheduler to run the field-population audit ECS task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "scheduler_run_task" {
+  name        = "judgemind-field-population-audit-scheduler-run-task-${var.environment}"
+  description = "Allows EventBridge Scheduler to run the field-population audit ECS task and pass roles"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowRunTask"
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.field_population_audit.family}:*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        Sid    = "AllowPassRole"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          var.task_execution_role_arn,
+          aws_iam_role.task_role.arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "scheduler_run_task" {
+  role       = aws_iam_role.scheduler_execution.name
+  policy_arn = aws_iam_policy.scheduler_run_task.arn
+}
+
+resource "aws_scheduler_schedule" "field_population_audit" {
+  name        = "judgemind-field-population-audit-${var.environment}"
+  description = "Daily scraper field-population audit for ${var.environment} (15:00 UTC)"
+
+  # Daily at 15:00 UTC.  EventBridge Scheduler cron requires a year
+  # field; "?" matches every year.
+  schedule_expression          = "cron(0 15 * * ? *)"
+  schedule_expression_timezone = "UTC"
+  state                        = var.schedule_enabled ? "ENABLED" : "DISABLED"
+
+  flexible_time_window {
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 30
+  }
+
+  target {
+    arn      = var.ecs_cluster_arn
+    role_arn = aws_iam_role.scheduler_execution.arn
+
+    ecs_parameters {
+      task_definition_arn = aws_ecs_task_definition.field_population_audit.arn
+      launch_type         = "FARGATE"
+      task_count          = 1
+
+      network_configuration {
+        subnets          = var.private_subnet_ids
+        security_groups  = [aws_security_group.field_population_audit.id]
+        assign_public_ip = false
+      }
+    }
+  }
+}

--- a/infra/terraform/modules/scraper-field-population-audit/outputs.tf
+++ b/infra/terraform/modules/scraper-field-population-audit/outputs.tf
@@ -1,0 +1,39 @@
+output "task_definition_arn" {
+  description = "ARN of the field-population audit ECS task definition"
+  value       = aws_ecs_task_definition.field_population_audit.arn
+}
+
+output "task_definition_family" {
+  description = "Family name of the field-population audit ECS task definition"
+  value       = aws_ecs_task_definition.field_population_audit.family
+}
+
+output "schedule_arn" {
+  description = "ARN of the EventBridge Scheduler schedule"
+  value       = aws_scheduler_schedule.field_population_audit.arn
+}
+
+output "schedule_name" {
+  description = "Name of the EventBridge Scheduler schedule (used for `aws scheduler get-schedule` smoke checks)"
+  value       = aws_scheduler_schedule.field_population_audit.name
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name for field-population audit output"
+  value       = aws_cloudwatch_log_group.field_population_audit.name
+}
+
+output "security_group_id" {
+  description = "ID of the field-population audit security group"
+  value       = aws_security_group.field_population_audit.id
+}
+
+output "task_role_arn" {
+  description = "ARN of the field-population audit task role"
+  value       = aws_iam_role.task_role.arn
+}
+
+output "scheduler_role_arn" {
+  description = "ARN of the EventBridge Scheduler execution role"
+  value       = aws_iam_role.scheduler_execution.arn
+}

--- a/infra/terraform/modules/scraper-field-population-audit/variables.tf
+++ b/infra/terraform/modules/scraper-field-population-audit/variables.tf
@@ -1,0 +1,78 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production"
+  }
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where ECS tasks run"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of the private subnets for ECS task placement"
+  type        = list(string)
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the existing ECS cluster to run the audit task on"
+  type        = string
+}
+
+variable "ecr_repository_url" {
+  description = "ECR repository URL for the scraper container image (must contain scripts/audit_scraper_field_population.py)"
+  type        = string
+}
+
+variable "task_execution_role_arn" {
+  description = "ARN of the ECS task execution role (ECR pull + CloudWatch log writes)"
+  type        = string
+}
+
+variable "db_connection_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the DATABASE_URL (JSON key: url)"
+  type        = string
+}
+
+variable "github_token_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the GitHub PAT (plain string) used for issue creation"
+  type        = string
+}
+
+variable "document_archive_bucket_name" {
+  description = "Name of the S3 document-archive bucket the audit samples envelopes from"
+  type        = string
+}
+
+variable "document_archive_bucket_arn" {
+  description = "ARN of the S3 document-archive bucket. Used to scope the task role's S3:GetObject + S3:ListBucket permissions."
+  type        = string
+}
+
+variable "scraper_image_tag" {
+  description = "Container image tag to deploy (e.g. latest, sha-abc1234)"
+  type        = string
+  default     = "latest"
+}
+
+variable "gh_repo" {
+  description = "GitHub repository slug (org/repo) for issue creation"
+  type        = string
+  default     = "judgemind/judgemind"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events"
+  type        = number
+  default     = 30
+}
+
+variable "schedule_enabled" {
+  description = "Whether the EventBridge scheduled task is enabled"
+  type        = bool
+  default     = true
+}

--- a/scripts/audit_scraper_field_population.py
+++ b/scripts/audit_scraper_field_population.py
@@ -1,0 +1,705 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Audit captured S3 envelopes against scraper field-mapping assumptions.
+
+For each registered scraper that produces a JSON envelope, sample N recent
+S3 objects and assert that every "load-bearing" field — i.e. a field the
+scraper reads to extract jurisdiction, case number, judge name, etc. — is
+populated in at least one sample. When 0/N samples have a field
+populated, that field has silently drifted to "always empty" and the
+scraper is producing wrong/incomplete data without warning.
+
+This is the structural fix for the bug class behind #4247 and #3885 (the
+CourtListener ``cluster.court`` field documented as canonical but empty
+in every actual API response). Running this audit daily catches drift
+within ~24 h instead of weeks.
+
+Scope (initial registry):
+  - ``federal-courtlistener-opinions`` -- envelope is JSON
+    {cluster, opinion, docket}; load-bearing field is ``docket.court``.
+  - ``ca-sf-civil-tentatives`` -- envelope is a flat JSON dict of
+    ParsedRuling fields plus ruling_id/department. Load-bearing fields
+    are ``case_number`` and ``department``.
+  - ``ca-cc-tentatives-portal`` -- envelope is JSON
+    {row, detail_html_b64, pdf_url, pdf_bytes_b64, judge_id,
+    judge_name_dropdown}. Load-bearing fields are ``judge_id`` and
+    ``judge_name_dropdown``.
+
+PDF-binary and bare-HTML scrapers (OC, LA, SD, Ventura, Riverside, etc.)
+are intentionally excluded from this audit -- their S3 raw is not JSON
+and the audit's introspection cannot meaningfully reach into them.  The
+analogous bug class for those scrapers is link-text parse failure, which
+is already covered by validation/regression tests at capture time.
+
+Sampling source:
+  Documents are sampled from ``derived.documents`` filtered by
+  ``scraper_id``, ordered by capture timestamp DESC, taking the most
+  recent N (default 10). Samples are deterministic for reproducibility:
+  a fresh run on an unchanged DB picks the same envelopes.
+
+Failure handling:
+  When at least one load-bearing field is empty in 10/10 samples, the
+  audit:
+    - returns a non-zero exit (1)
+    - emits machine-readable JSON when --json is set
+    - (when GITHUB_TOKEN + ECS-runner mode) files a GitHub issue tagged
+      ``priority/p1,area/scraping,scraper-field-drift,agent/ready`` so
+      a /task agent can pick up the regression.
+
+Usage:
+    # Local dry-run against synthetic envelopes (no DB / no S3 calls):
+    packages/scraper-framework/.venv/bin/python3 \\
+        scripts/audit_scraper_field_population.py --dry-run --json
+
+    # Against dev DB + S3 (read-only):
+    scripts/ecs-run-task.sh scripts/audit_scraper_field_population.py -- \\
+        --json --sample-size 10
+
+Options:
+    --json              Machine-readable JSON output.
+    --sample-size N     Envelopes to sample per scraper (default 10).
+    --min-captures N    Skip scrapers with < N captures in last 7 days
+                        (default 50).
+    --scraper SID       Audit only the specified scraper id; can be
+                        repeated.
+    --dry-run           Skip DB + S3 calls; emit a synthetic empty-field
+                        report. Used for AC verification + tests.
+
+Exit codes:
+    0   No drift detected.
+    1   At least one load-bearing field is empty across all samples.
+    2   Configuration error (missing DATABASE_URL, etc.).
+
+See https://github.com/judgemind/judgemind/issues/4255 for context.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json as json_mod
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
+DEFAULT_SAMPLE_SIZE = 10
+DEFAULT_MIN_CAPTURES = 50
+DEFAULT_LOOKBACK_DAYS = 7
+
+ALERT_LABEL = "scraper-field-drift"
+ISSUE_LABELS = "priority/p1,area/scraping,scraper-field-drift,agent/ready"
+ISSUE_TITLE = "Scraper field-mapping drift: load-bearing field empty in samples"
+GITHUB_API_BASE = "https://api.github.com"
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScraperFieldSpec:
+    """Declares load-bearing fields for one scraper's S3 envelope.
+
+    Attributes:
+        scraper_id: The registry id (matches ``ScraperConfig.scraper_id``).
+        envelope_format: ``"json"`` -- the S3 raw is UTF-8 JSON. Other
+            formats (``"pdf"``, ``"html"``) are not auditable here.
+        field_paths: Dotted paths into the JSON envelope. A path like
+            ``"docket.court"`` resolves ``payload["docket"]["court"]``.
+            Each path is a "load-bearing" field the scraper reads to
+            populate a structured column.
+        rationale: One-line description of why each field matters.
+    """
+
+    scraper_id: str
+    envelope_format: str
+    field_paths: tuple[str, ...]
+    rationale: str
+
+
+# Initial registry (issue #4255 acceptance criterion: cover the
+# 3 highest-volume JSON-envelope scrapers).  CourtListener is the
+# motivating case (#4247).  SF civil and CC portal are the other two
+# JSON-envelope scrapers in the codebase today; OC / LA / SD store
+# binary PDFs or bare HTML that don't admit field-path introspection
+# from S3 alone.
+REGISTRY: tuple[ScraperFieldSpec, ...] = (
+    ScraperFieldSpec(
+        scraper_id="federal-courtlistener-opinions",
+        envelope_format="json",
+        field_paths=("docket.court",),
+        rationale=(
+            "docket.court is the canonical jurisdiction signal after "
+            "#4247.  cluster.court (the previous source-of-truth) is "
+            "empty in every CourtListener API response we capture."
+        ),
+    ),
+    ScraperFieldSpec(
+        scraper_id="ca-sf-civil-tentatives",
+        envelope_format="json",
+        field_paths=("case_number", "department"),
+        rationale=(
+            "SF civil envelope is flat -- case_number identifies the "
+            "case and department drives judge resolution.  Either "
+            "going empty silently produces UNKNOWN-prefixed case "
+            "numbers + missing judge attribution."
+        ),
+    ),
+    ScraperFieldSpec(
+        scraper_id="ca-cc-tentatives-portal",
+        envelope_format="json",
+        field_paths=("judge_id", "judge_name_dropdown"),
+        rationale=(
+            "CC portal envelope encodes the judge identity in two "
+            "fields scraped from the dropdown.  Both empty means we "
+            "land judge-less rulings into the DB."
+        ),
+    ),
+)
+
+
+def get_spec(scraper_id: str) -> ScraperFieldSpec | None:
+    """Return the registry entry for a scraper, or None if unregistered."""
+    for spec in REGISTRY:
+        if spec.scraper_id == scraper_id:
+            return spec
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Field-path lookup
+# ---------------------------------------------------------------------------
+
+
+def lookup_field(payload: dict[str, Any], path: str) -> Any:
+    """Resolve a dotted path against a nested dict.
+
+    Returns the value if every segment exists, else None.  Empty string,
+    empty list, empty dict, and explicit None are all returned as-is so
+    the caller can decide whether they count as "populated".
+
+    Args:
+        payload: Decoded JSON envelope (must be a dict at the top level).
+        path: Dotted path like "docket.court" or "case_number".
+    """
+    if not isinstance(payload, dict):
+        return None
+    cur: Any = payload
+    for segment in path.split("."):
+        if not isinstance(cur, dict):
+            return None
+        if segment not in cur:
+            return None
+        cur = cur[segment]
+    return cur
+
+
+def is_populated(value: Any) -> bool:
+    """Return True iff *value* is a non-empty meaningful field value.
+
+    Empty string / empty list / empty dict / None all count as NOT
+    populated.  Zero (int 0) is treated as populated -- it is a valid
+    judge_id or department in some courts.
+    """
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, dict)):
+        return len(value) > 0
+    # int, float, bool -- 0 / False count as populated.
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Result model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldResult:
+    """Audit result for one (scraper, field-path) tuple."""
+
+    scraper_id: str
+    field_path: str
+    populated: int
+    sampled: int
+    sample_keys: list[str] = field(default_factory=list)
+
+    @property
+    def drifted(self) -> bool:
+        """True when this field is empty in EVERY sample (0/N populated)."""
+        return self.sampled > 0 and self.populated == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scraper_id": self.scraper_id,
+            "field_path": self.field_path,
+            "populated": self.populated,
+            "sampled": self.sampled,
+            "drifted": self.drifted,
+            "sample_keys": self.sample_keys,
+        }
+
+
+@dataclass
+class AuditResult:
+    """Full audit run result (all scrapers, all fields)."""
+
+    field_results: list[FieldResult] = field(default_factory=list)
+    skipped: list[dict[str, Any]] = field(default_factory=list)
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    )
+
+    @property
+    def drift_count(self) -> int:
+        return sum(1 for r in self.field_results if r.drifted)
+
+    @property
+    def healthy(self) -> bool:
+        return self.drift_count == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "timestamp": self.timestamp,
+            "healthy": self.healthy,
+            "drift_count": self.drift_count,
+            "field_results": [r.to_dict() for r in self.field_results],
+            "skipped": list(self.skipped),
+        }
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_capture_count(conn: object, scraper_id: str, since: datetime) -> int:
+    """Return the count of derived.documents rows for *scraper_id* since *since*.
+
+    Used for the --min-captures gate: if a scraper has < N captures in
+    the lookback window, skip it (the audit's signal-to-noise is too low
+    on small samples).
+    """
+    with conn.cursor() as cur:  # type: ignore[attr-defined]
+        cur.execute(
+            "SELECT COUNT(*) FROM derived.documents "
+            "WHERE scraper_id = %s AND capture_timestamp >= %s",
+            (scraper_id, since),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+def fetch_sample_keys(conn: object, scraper_id: str, sample_size: int) -> list[str]:
+    """Return up to *sample_size* recent s3_key values for *scraper_id*.
+
+    Ordered by capture_timestamp DESC so the audit always inspects the
+    freshest envelopes -- field drift is most visible at the leading
+    edge of capture.  Empty s3_key rows are excluded.
+    """
+    with conn.cursor() as cur:  # type: ignore[attr-defined]
+        cur.execute(
+            "SELECT s3_key FROM derived.documents "
+            "WHERE scraper_id = %s AND s3_key IS NOT NULL AND s3_key != '' "
+            "ORDER BY capture_timestamp DESC NULLS LAST "
+            "LIMIT %s",
+            (scraper_id, sample_size),
+        )
+        rows = cur.fetchall()
+    return [row[0] for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# S3 helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_envelope(s3: object, bucket: str, key: str) -> dict[str, Any] | None:
+    """GET a JSON envelope from S3 and return it parsed.
+
+    Returns None when the object is missing, the body is not valid
+    JSON, or the top-level payload is not a dict.  Raised exceptions
+    bubble out so the caller can decide between treating them as
+    "skip the sample" vs. "fail the audit".
+    """
+    try:
+        response = s3.get_object(Bucket=bucket, Key=key)  # type: ignore[attr-defined]
+        body = response["Body"].read()
+    except Exception as exc:
+        logger.warning("Failed to GET s3://%s/%s: %s", bucket, key, exc)
+        return None
+    try:
+        payload = json_mod.loads(body)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# Audit core
+# ---------------------------------------------------------------------------
+
+
+def audit_one_scraper(
+    conn: object,
+    s3: object,
+    bucket: str,
+    spec: ScraperFieldSpec,
+    *,
+    sample_size: int,
+    min_captures: int,
+    lookback_days: int,
+    now: datetime,
+) -> tuple[list[FieldResult], dict[str, Any] | None]:
+    """Audit a single scraper.  Returns (field_results, skip_reason).
+
+    If the scraper has fewer than *min_captures* in the lookback window,
+    returns ([], skip_reason).  Otherwise samples envelopes and resolves
+    each load-bearing field path against each sample.
+    """
+    since = now - timedelta(days=lookback_days)
+    capture_count = fetch_capture_count(conn, spec.scraper_id, since)
+    if capture_count < min_captures:
+        return [], {
+            "scraper_id": spec.scraper_id,
+            "reason": "insufficient_captures",
+            "capture_count": capture_count,
+            "min_captures": min_captures,
+            "lookback_days": lookback_days,
+        }
+
+    keys = fetch_sample_keys(conn, spec.scraper_id, sample_size)
+    if not keys:
+        return [], {
+            "scraper_id": spec.scraper_id,
+            "reason": "no_sample_keys",
+            "capture_count": capture_count,
+        }
+
+    # Resolve each field path against each sample envelope.
+    populated_counts: dict[str, int] = {p: 0 for p in spec.field_paths}
+    inspected = 0
+    for key in keys:
+        payload = fetch_envelope(s3, bucket, key)
+        if payload is None:
+            continue
+        inspected += 1
+        for path in spec.field_paths:
+            if is_populated(lookup_field(payload, path)):
+                populated_counts[path] += 1
+
+    results = [
+        FieldResult(
+            scraper_id=spec.scraper_id,
+            field_path=path,
+            populated=populated_counts[path],
+            sampled=inspected,
+            sample_keys=list(keys),
+        )
+        for path in spec.field_paths
+    ]
+    return results, None
+
+
+def run_audit(
+    conn: object,
+    s3: object,
+    bucket: str,
+    *,
+    sample_size: int = DEFAULT_SAMPLE_SIZE,
+    min_captures: int = DEFAULT_MIN_CAPTURES,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    scraper_filter: list[str] | None = None,
+    now: datetime | None = None,
+) -> AuditResult:
+    """Run the full audit and return an AuditResult."""
+    now = now or datetime.now(UTC)
+    result = AuditResult()
+
+    for spec in REGISTRY:
+        if scraper_filter and spec.scraper_id not in scraper_filter:
+            continue
+        field_results, skip = audit_one_scraper(
+            conn,
+            s3,
+            bucket,
+            spec,
+            sample_size=sample_size,
+            min_captures=min_captures,
+            lookback_days=lookback_days,
+            now=now,
+        )
+        if skip is not None:
+            result.skipped.append(skip)
+        result.field_results.extend(field_results)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Dry-run -- synthetic empty-field scenario for AC verification
+# ---------------------------------------------------------------------------
+
+
+def synthetic_drift_result() -> AuditResult:
+    """Return a synthetic AuditResult for --dry-run.
+
+    Simulates the bug class behind #4247: courtlistener's docket.court
+    empty in 10/10 samples.  Used for the AC verification step
+    "dry-run against a synthetic empty-field scenario produces a
+    generated issue body in tmp/" and for unit tests.
+    """
+    spec = get_spec("federal-courtlistener-opinions")
+    assert spec is not None, "registry must contain courtlistener"
+    drifted = FieldResult(
+        scraper_id=spec.scraper_id,
+        field_path="docket.court",
+        populated=0,
+        sampled=10,
+        sample_keys=[
+            f"federal/dc/dc_district/raw/{'a' * 64}.txt",
+            f"federal/dc/dc_district/raw/{'b' * 64}.txt",
+        ],
+    )
+    return AuditResult(field_results=[drifted])
+
+
+# ---------------------------------------------------------------------------
+# Issue body builder
+# ---------------------------------------------------------------------------
+
+
+def build_issue_body(result: AuditResult) -> str:
+    """Render the GitHub issue body for a drift-detected audit run."""
+    drifted = [r for r in result.field_results if r.drifted]
+    rows = [
+        "| Scraper | Field path | Populated / Sampled | Sample s3_key |",
+        "| --- | --- | --- | --- |",
+    ]
+    for r in drifted:
+        sample_key = r.sample_keys[0] if r.sample_keys else "(none)"
+        rows.append(
+            f"| `{r.scraper_id}` | `{r.field_path}` | "
+            f"{r.populated} / {r.sampled} | `{sample_key}` |"
+        )
+    table = "\n".join(rows)
+
+    return (
+        "## Scraper Field-Mapping Drift Alert\n\n"
+        "The daily field-population audit "
+        "(`scripts/audit_scraper_field_population.py`) detected at "
+        "least one load-bearing field that is empty in **every** sample "
+        "envelope.  This is the bug class behind #4247 and #3885 -- a "
+        "scraper reading a field documented as canonical that has "
+        "drifted to always-empty in production responses.\n\n"
+        "### Drifted fields\n\n"
+        f"{table}\n\n"
+        "### Context\n\n"
+        f"- **Audit run at:** {result.timestamp}\n"
+        "- **Audit script:** `scripts/audit_scraper_field_population.py`\n"
+        "- **Registry source:** `REGISTRY` constant in the audit script\n\n"
+        "### Next steps\n\n"
+        "1. Open one of the sample s3_keys with "
+        "`aws s3api get-object --bucket judgemind-document-archive-dev"
+        " --key <KEY> -` and confirm the field is empty in the raw "
+        "envelope.\n"
+        "2. Decide whether the source field has moved (update the "
+        "scraper's mapping) or whether the upstream API has stopped "
+        "populating it (file an upstream bug + add a fallback).\n"
+        "3. Update `REGISTRY` if the load-bearing field path itself "
+        "should change.\n\n"
+        "This issue was filed automatically.  It will not duplicate "
+        "while open."
+    )
+
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (urllib only, no extra deps)
+# ---------------------------------------------------------------------------
+
+
+def list_open_alert_issues(repo: str, token: str) -> list[dict[str, Any]]:
+    """Return open issues tagged with the field-drift alert label."""
+    import urllib.request
+
+    url = f"{GITHUB_API_BASE}/repos/{repo}/issues?labels={ALERT_LABEL}&state=open&per_page=10"
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json_mod.loads(resp.read().decode())
+
+
+def create_issue(repo: str, token: str, body: str) -> dict[str, Any]:
+    """Create a new GitHub issue and return the created issue object."""
+    import urllib.request
+
+    url = f"{GITHUB_API_BASE}/repos/{repo}/issues"
+    payload = {
+        "title": ISSUE_TITLE,
+        "body": body,
+        "labels": ISSUE_LABELS.split(","),
+    }
+    req = urllib.request.Request(
+        url, data=json_mod.dumps(payload).encode(), method="POST"
+    )
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json_mod.loads(resp.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON output")
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=DEFAULT_SAMPLE_SIZE,
+        help="envelopes to sample per scraper",
+    )
+    parser.add_argument(
+        "--min-captures",
+        type=int,
+        default=DEFAULT_MIN_CAPTURES,
+        help="skip scrapers with < N captures in lookback window",
+    )
+    parser.add_argument(
+        "--scraper",
+        action="append",
+        default=None,
+        help="audit only this scraper id (repeatable)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="emit a synthetic empty-field report; no DB or S3 calls",
+    )
+    parser.add_argument(
+        "--write-issue-body",
+        type=str,
+        default="",
+        help="write the rendered issue body to this path (used by AC tests)",
+    )
+    args = parser.parse_args(argv)
+
+    # --dry-run -- synthetic scenario, no I/O.
+    if args.dry_run:
+        result = synthetic_drift_result()
+        if args.write_issue_body:
+            os.makedirs(os.path.dirname(args.write_issue_body) or ".", exist_ok=True)
+            with open(args.write_issue_body, "w") as f:
+                f.write(build_issue_body(result))
+        if args.json:
+            print(json_mod.dumps(result.to_dict(), indent=2))
+        else:
+            _print_human(result)
+        return 1 if not result.healthy else 0
+
+    # Real run -- DB + S3.
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        logger.error(
+            "DATABASE_URL is not set. Run via scripts/ecs-run-task.sh "
+            "or scripts/with-secret.sh so the connection string is "
+            "injected."
+        )
+        return 2
+
+    import boto3
+    import psycopg
+
+    s3 = boto3.client("s3")
+    with psycopg.connect(database_url, autocommit=True) as conn:
+        result = run_audit(
+            conn,
+            s3,
+            BUCKET,
+            sample_size=args.sample_size,
+            min_captures=args.min_captures,
+            scraper_filter=args.scraper,
+        )
+
+    if args.json:
+        print(json_mod.dumps(result.to_dict(), indent=2))
+    else:
+        _print_human(result)
+
+    # When drift detected and runtime tokens are available, file/update
+    # the GitHub issue.  Best-effort -- a network failure here does not
+    # change the script's exit code.
+    if not result.healthy:
+        gh_token = os.environ.get("GITHUB_TOKEN", "").strip()
+        gh_repo = os.environ.get("GH_REPO", "judgemind/judgemind").strip()
+        if gh_token and gh_repo:
+            try:
+                open_issues = list_open_alert_issues(gh_repo, gh_token)
+                if not open_issues:
+                    body = build_issue_body(result)
+                    issue = create_issue(gh_repo, gh_token, body)
+                    logger.info(
+                        "Filed drift alert issue #%d: %s",
+                        issue.get("number"),
+                        issue.get("html_url"),
+                    )
+                else:
+                    logger.info(
+                        "Drift detected but issue #%d already open; not "
+                        "filing duplicate.",
+                        open_issues[0]["number"],
+                    )
+            except Exception as exc:
+                logger.warning("Issue filing failed (non-fatal): %s", exc)
+
+    return 0 if result.healthy else 1
+
+
+def _print_human(result: AuditResult) -> None:
+    print(f"Field-population audit at {result.timestamp}")
+    print(
+        f"  drift_count={result.drift_count}  "
+        f"field_results={len(result.field_results)}  "
+        f"skipped={len(result.skipped)}"
+    )
+    for r in result.field_results:
+        flag = "DRIFT" if r.drifted else "ok"
+        print(
+            f"  [{flag}] {r.scraper_id} :: {r.field_path} "
+            f"-> {r.populated}/{r.sampled} populated"
+        )
+    for skip in result.skipped:
+        print(
+            f"  [skip] {skip.get('scraper_id')} -- {skip.get('reason')} "
+            f"(captures={skip.get('capture_count')})"
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_audit_scraper_field_population.py
+++ b/scripts/tests/test_audit_scraper_field_population.py
@@ -1,0 +1,536 @@
+"""Tests for audit_scraper_field_population.
+
+Covers:
+- REGISTRY contains the 3 highest-volume JSON-envelope scrapers
+- lookup_field walks dotted paths and tolerates missing/non-dict segments
+- is_populated treats None / "" / [] / {} as not populated and 0 / False as populated
+- audit_one_scraper skips below min-captures, returns drift on 0/N, healthy on >0/N
+- run_audit scraper_filter limits which scrapers are inspected
+- synthetic_drift_result produces a non-healthy AuditResult
+- build_issue_body renders a markdown body with the drifted field
+- main() --dry-run --write-issue-body writes a non-empty file
+
+The script imports boto3 + psycopg lazily (only inside main's real run);
+tests can import the module without those deps.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import audit_scraper_field_population as _script  # noqa: E402
+
+REGISTRY = _script.REGISTRY
+get_spec = _script.get_spec
+lookup_field = _script.lookup_field
+is_populated = _script.is_populated
+FieldResult = _script.FieldResult
+AuditResult = _script.AuditResult
+audit_one_scraper = _script.audit_one_scraper
+run_audit = _script.run_audit
+synthetic_drift_result = _script.synthetic_drift_result
+build_issue_body = _script.build_issue_body
+fetch_capture_count = _script.fetch_capture_count
+fetch_sample_keys = _script.fetch_sample_keys
+fetch_envelope = _script.fetch_envelope
+
+
+# ---------------------------------------------------------------------------
+# Registry coverage (AC #1 + AC #4)
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """The registry must cover the 3 highest-volume JSON-envelope scrapers."""
+
+    def test_courtlistener_is_registered(self) -> None:
+        spec = get_spec("federal-courtlistener-opinions")
+        assert spec is not None
+        # Per #4247: docket.court is the canonical jurisdiction signal.
+        assert "docket.court" in spec.field_paths
+
+    def test_sf_civil_is_registered(self) -> None:
+        spec = get_spec("ca-sf-civil-tentatives")
+        assert spec is not None
+        assert "case_number" in spec.field_paths
+        assert "department" in spec.field_paths
+
+    def test_cc_portal_is_registered(self) -> None:
+        spec = get_spec("ca-cc-tentatives-portal")
+        assert spec is not None
+        assert "judge_id" in spec.field_paths
+        assert "judge_name_dropdown" in spec.field_paths
+
+    def test_at_least_three_scrapers_covered(self) -> None:
+        """AC #4: registry covers at least 3 highest-volume scrapers."""
+        assert len(REGISTRY) >= 3
+
+    def test_all_specs_are_json_envelope(self) -> None:
+        """Initial registry only inspects JSON envelopes -- PDF/HTML are out of scope."""
+        for spec in REGISTRY:
+            assert spec.envelope_format == "json", (
+                f"{spec.scraper_id}: only json envelopes are supported"
+            )
+
+    def test_unknown_scraper_returns_none(self) -> None:
+        assert get_spec("nonexistent-scraper") is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_field
+# ---------------------------------------------------------------------------
+
+
+class TestLookupField:
+    def test_flat_path(self) -> None:
+        assert lookup_field({"case_number": "ABC"}, "case_number") == "ABC"
+
+    def test_nested_path(self) -> None:
+        assert lookup_field({"docket": {"court": "ca9"}}, "docket.court") == "ca9"
+
+    def test_missing_top_level(self) -> None:
+        assert lookup_field({"other": 1}, "docket.court") is None
+
+    def test_missing_intermediate(self) -> None:
+        assert lookup_field({"docket": {}}, "docket.court") is None
+
+    def test_non_dict_intermediate(self) -> None:
+        # docket is a list -> path cannot resolve through it.
+        assert lookup_field({"docket": []}, "docket.court") is None
+
+    def test_explicit_none_returned(self) -> None:
+        # Caller distinguishes "missing" (None) from "present but None" via is_populated.
+        assert lookup_field({"docket": {"court": None}}, "docket.court") is None
+
+    def test_top_level_not_dict(self) -> None:
+        assert lookup_field([1, 2, 3], "foo") is None  # type: ignore[arg-type]
+
+    def test_empty_string_returned_as_is(self) -> None:
+        assert lookup_field({"case_number": ""}, "case_number") == ""
+
+
+# ---------------------------------------------------------------------------
+# is_populated
+# ---------------------------------------------------------------------------
+
+
+class TestIsPopulated:
+    @pytest.mark.parametrize(
+        "value",
+        [None, "", "   ", "\t\n", [], {}],
+    )
+    def test_falsy_or_empty(self, value: object) -> None:
+        assert not is_populated(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["foo", "ca9", " x ", [1], {"a": 1}, 0, 1, False, True, 0.0],
+    )
+    def test_populated(self, value: object) -> None:
+        # 0/False count as populated -- 0 is a valid judge_id in some courts.
+        assert is_populated(value)
+
+
+# ---------------------------------------------------------------------------
+# audit_one_scraper -- min-captures gate + drift detection
+# ---------------------------------------------------------------------------
+
+
+def _make_conn(
+    captures_by_scraper: dict[str, int], sample_keys: dict[str, list[str]]
+) -> object:
+    """Build a mock DB connection that answers fetch_capture_count and fetch_sample_keys.
+
+    The audit script issues two SELECTs per scraper: count, then top-N keys.
+    We dispatch on the SQL prefix.
+    """
+
+    class _Cursor:
+        def __init__(self) -> None:
+            self._rows: list = []
+
+        def execute(self, sql: str, params: tuple) -> None:
+            sql_lower = sql.lower()
+            if "count(*)" in sql_lower:
+                scraper_id = params[0]
+                self._rows = [(captures_by_scraper.get(scraper_id, 0),)]
+            elif "select s3_key" in sql_lower:
+                scraper_id = params[0]
+                limit = params[1]
+                keys = sample_keys.get(scraper_id, [])[:limit]
+                self._rows = [(k,) for k in keys]
+            else:
+                self._rows = []
+
+        def fetchone(self):
+            return self._rows[0] if self._rows else None
+
+        def fetchall(self):
+            return list(self._rows)
+
+        def __enter__(self) -> "_Cursor":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    class _Conn:
+        def cursor(self) -> _Cursor:
+            return _Cursor()
+
+    return _Conn()
+
+
+def _make_s3(envelopes_by_key: dict[str, dict | bytes | None]) -> object:
+    """Build a mock S3 client.  Values may be a dict (encoded as JSON), bytes (raw), or None (404)."""
+
+    def get_object(*, Bucket: str, Key: str) -> dict:
+        if Key not in envelopes_by_key:
+            raise KeyError(Key)
+        env = envelopes_by_key[Key]
+        if env is None:
+            raise KeyError(Key)
+        if isinstance(env, dict):
+            body_bytes = json.dumps(env).encode()
+        else:
+            body_bytes = env
+        return {"Body": MagicMock(read=lambda: body_bytes)}
+
+    s3 = MagicMock()
+    s3.get_object = get_object
+    return s3
+
+
+_NOW = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
+
+
+class TestAuditOneScraper:
+    def test_skip_when_below_min_captures(self) -> None:
+        conn = _make_conn({"federal-courtlistener-opinions": 10}, {})
+        s3 = _make_s3({})
+        spec = get_spec("federal-courtlistener-opinions")
+        assert spec is not None
+
+        results, skip = audit_one_scraper(
+            conn,
+            s3,
+            "bucket",
+            spec,
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            now=_NOW,
+        )
+        assert results == []
+        assert skip is not None
+        assert skip["reason"] == "insufficient_captures"
+        assert skip["capture_count"] == 10
+
+    def test_skip_when_no_sample_keys(self) -> None:
+        conn = _make_conn({"federal-courtlistener-opinions": 100}, {})
+        s3 = _make_s3({})
+        spec = get_spec("federal-courtlistener-opinions")
+        assert spec is not None
+
+        results, skip = audit_one_scraper(
+            conn,
+            s3,
+            "bucket",
+            spec,
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            now=_NOW,
+        )
+        assert results == []
+        assert skip is not None
+        assert skip["reason"] == "no_sample_keys"
+
+    def test_drift_when_field_empty_in_all_samples(self) -> None:
+        """The motivating bug class: docket.court empty in 10/10 samples."""
+        keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
+        # Simulates the #4247 scenario: cluster present, docket missing court.
+        envelopes = {
+            k: {
+                "cluster": {"id": i, "case_name": "X v. Y"},
+                "opinion": {"id": i, "plain_text": "text"},
+                "docket": {"id": i, "court": ""},  # empty -- the bug!
+            }
+            for i, k in enumerate(keys)
+        }
+        conn = _make_conn(
+            {"federal-courtlistener-opinions": 100},
+            {"federal-courtlistener-opinions": keys},
+        )
+        s3 = _make_s3(envelopes)  # type: ignore[arg-type]
+        spec = get_spec("federal-courtlistener-opinions")
+        assert spec is not None
+
+        results, skip = audit_one_scraper(
+            conn,
+            s3,
+            "bucket",
+            spec,
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            now=_NOW,
+        )
+        assert skip is None
+        assert len(results) == 1
+        assert results[0].scraper_id == "federal-courtlistener-opinions"
+        assert results[0].field_path == "docket.court"
+        assert results[0].populated == 0
+        assert results[0].sampled == 10
+        assert results[0].drifted is True
+
+    def test_healthy_when_field_populated_in_at_least_one(self) -> None:
+        """1/N populated is enough to clear -- the audit's floor is 'at least one'."""
+        keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
+        # Only one sample has docket.court populated; the audit clears.
+        envelopes = {}
+        for i, k in enumerate(keys):
+            court = "ca9" if i == 0 else ""
+            envelopes[k] = {
+                "cluster": {},
+                "opinion": {},
+                "docket": {"court": court},
+            }
+        conn = _make_conn(
+            {"federal-courtlistener-opinions": 100},
+            {"federal-courtlistener-opinions": keys},
+        )
+        s3 = _make_s3(envelopes)  # type: ignore[arg-type]
+        spec = get_spec("federal-courtlistener-opinions")
+        assert spec is not None
+
+        results, skip = audit_one_scraper(
+            conn,
+            s3,
+            "bucket",
+            spec,
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            now=_NOW,
+        )
+        assert skip is None
+        assert len(results) == 1
+        assert results[0].populated == 1
+        assert results[0].sampled == 10
+        assert results[0].drifted is False
+
+    def test_unparseable_envelope_skipped(self) -> None:
+        """Envelopes that aren't valid JSON or aren't dicts don't count toward sampled."""
+        keys = ["k1", "k2", "k3"]
+        envelopes = {
+            "k1": b"not json at all",  # parse fail
+            "k2": {"docket": {"court": "ca9"}},  # OK
+            "k3": b"[1, 2, 3]",  # JSON but not a dict
+        }
+        conn = _make_conn(
+            {"federal-courtlistener-opinions": 100},
+            {"federal-courtlistener-opinions": keys},
+        )
+        s3 = _make_s3(envelopes)  # type: ignore[arg-type]
+        spec = get_spec("federal-courtlistener-opinions")
+        assert spec is not None
+
+        results, skip = audit_one_scraper(
+            conn,
+            s3,
+            "bucket",
+            spec,
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            now=_NOW,
+        )
+        assert skip is None
+        assert len(results) == 1
+        # Only k2 was inspected; populated=1, sampled=1.
+        assert results[0].sampled == 1
+        assert results[0].populated == 1
+        assert results[0].drifted is False
+
+
+# ---------------------------------------------------------------------------
+# run_audit -- scraper_filter
+# ---------------------------------------------------------------------------
+
+
+class TestRunAudit:
+    def test_scraper_filter_limits_scope(self) -> None:
+        # Only courtlistener has captures; the others below threshold.
+        keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
+        envelopes = {k: {"docket": {"court": "ca9"}} for k in keys}
+        conn = _make_conn(
+            {
+                "federal-courtlistener-opinions": 100,
+                "ca-sf-civil-tentatives": 0,
+                "ca-cc-tentatives-portal": 0,
+            },
+            {"federal-courtlistener-opinions": keys},
+        )
+        s3 = _make_s3(envelopes)  # type: ignore[arg-type]
+
+        result = run_audit(
+            conn,
+            s3,
+            "bucket",
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            scraper_filter=["federal-courtlistener-opinions"],
+            now=_NOW,
+        )
+        # No skipped entries for the others -- they were filtered out.
+        assert len(result.field_results) == 1
+        assert result.field_results[0].scraper_id == "federal-courtlistener-opinions"
+        assert result.skipped == []
+
+    def test_full_run_records_skipped(self) -> None:
+        """Without --scraper, all REGISTRY entries are tried; below-threshold ones are skipped."""
+        conn = _make_conn(
+            {
+                "federal-courtlistener-opinions": 0,
+                "ca-sf-civil-tentatives": 0,
+                "ca-cc-tentatives-portal": 0,
+            },
+            {},
+        )
+        s3 = _make_s3({})
+        result = run_audit(
+            conn,
+            s3,
+            "bucket",
+            sample_size=10,
+            min_captures=50,
+            lookback_days=7,
+            now=_NOW,
+        )
+        assert len(result.skipped) == len(REGISTRY)
+        assert result.field_results == []
+        assert result.healthy is True
+
+
+# ---------------------------------------------------------------------------
+# Synthetic dry-run path (AC #3 verification)
+# ---------------------------------------------------------------------------
+
+
+class TestSyntheticDriftResult:
+    def test_synthetic_is_unhealthy(self) -> None:
+        """The synthetic scenario simulates the #4247 bug class."""
+        result = synthetic_drift_result()
+        assert result.healthy is False
+        assert result.drift_count == 1
+        assert result.field_results[0].field_path == "docket.court"
+        assert result.field_results[0].drifted is True
+
+
+# ---------------------------------------------------------------------------
+# Issue body (AC #3 verification)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIssueBody:
+    def test_body_contains_scraper_and_field(self) -> None:
+        result = synthetic_drift_result()
+        body = build_issue_body(result)
+        assert "federal-courtlistener-opinions" in body
+        assert "docket.court" in body
+        # Markdown table delimiter present.
+        assert "| Scraper |" in body
+
+    def test_body_includes_timestamp(self) -> None:
+        result = synthetic_drift_result()
+        body = build_issue_body(result)
+        assert result.timestamp in body
+
+
+# ---------------------------------------------------------------------------
+# Main entry -- dry-run path (AC #3 verification: tmp/ output)
+# ---------------------------------------------------------------------------
+
+
+class TestMainDryRun:
+    def test_dry_run_writes_issue_body(self, tmp_path) -> None:
+        """AC #3 verification: dry-run produces a generated issue body in tmp/."""
+        out = tmp_path / "drift_issue_body.md"
+        rc = _script.main(
+            [
+                "--dry-run",
+                "--json",
+                "--write-issue-body",
+                str(out),
+            ]
+        )
+        assert rc == 1
+        assert out.exists()
+        text = out.read_text()
+        assert "Scraper Field-Mapping Drift Alert" in text
+        assert "docket.court" in text
+
+    def test_dry_run_returns_1_when_unhealthy(self) -> None:
+        rc = _script.main(["--dry-run"])
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# DB fetch helpers -- exercise the SQL execute path
+# ---------------------------------------------------------------------------
+
+
+class TestDbHelpers:
+    def test_fetch_capture_count(self) -> None:
+        conn = _make_conn({"federal-courtlistener-opinions": 42}, {})
+        n = fetch_capture_count(
+            conn, "federal-courtlistener-opinions", _NOW - timedelta(days=7)
+        )
+        assert n == 42
+
+    def test_fetch_capture_count_unknown_returns_zero(self) -> None:
+        conn = _make_conn({}, {})
+        n = fetch_capture_count(conn, "unknown", _NOW - timedelta(days=7))
+        assert n == 0
+
+    def test_fetch_sample_keys_truncates_to_sample_size(self) -> None:
+        conn = _make_conn(
+            {},
+            {"federal-courtlistener-opinions": [f"k{i}" for i in range(20)]},
+        )
+        keys = fetch_sample_keys(conn, "federal-courtlistener-opinions", 5)
+        assert keys == [f"k{i}" for i in range(5)]
+
+
+# ---------------------------------------------------------------------------
+# fetch_envelope -- error handling
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEnvelope:
+    def test_missing_object_returns_none(self) -> None:
+        s3 = _make_s3({})
+        assert fetch_envelope(s3, "bucket", "missing/key") is None
+
+    def test_invalid_json_returns_none(self) -> None:
+        s3 = _make_s3({"k": b"not json"})
+        assert fetch_envelope(s3, "bucket", "k") is None
+
+    def test_top_level_not_dict_returns_none(self) -> None:
+        s3 = _make_s3({"k": b"[1, 2, 3]"})
+        assert fetch_envelope(s3, "bucket", "k") is None
+
+    def test_valid_envelope_returns_dict(self) -> None:
+        s3 = _make_s3({"k": {"docket": {"court": "ca9"}}})
+        env = fetch_envelope(s3, "bucket", "k")
+        assert env == {"docket": {"court": "ca9"}}


### PR DESCRIPTION
## Summary

Adds `scripts/audit_scraper_field_population.py` -- a daily probe that samples recent S3 envelopes per scraper and asserts that load-bearing JSON fields (e.g. CourtListener's `docket.court`) are populated. Wires a daily EventBridge schedule (15:00 UTC) via the new `infra/terraform/modules/scraper-field-population-audit` module. Closes the bug class behind #4247 / #3885 -- a documented JSON field that has drifted to empty in production responses without anyone noticing for weeks.

The initial registry covers the 3 JSON-envelope scrapers in the codebase (CourtListener, SF civil tentatives, CC tentatives portal). PDF-binary scrapers (OC, LA, etc.) are out of scope -- their S3 raw is binary PDF/HTML bytes which the audit cannot meaningfully introspect; their analogous failure mode (link-text parse failure) is already covered by capture-time validation. See the process summary on the issue for the full scope discussion.

Closes #4255

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (49 new tests in `scripts/tests/test_audit_scraper_field_population.py`)
- [x] CI green
- [x] Terraform validate green

### Post-deploy verification
- [x] After dev-apply lands, confirm the EventBridge Scheduler resource exists: `aws scheduler get-schedule --name judgemind-field-population-audit-dev --region us-west-2`
- [x] Run a one-shot of the audit task against dev and confirm it exits 0 (healthy) or 1 (drift detected) with valid JSON output (or a documented `skipped` reason). Verified via [task 0d8afdf5...](https://github.com/judgemind/judgemind/issues/4255#issuecomment-4391684584) -- exit 1 with valid drift JSON, alert issue #4268 auto-filed.
- [x] Verification evidence posted on issue (see [comment](https://github.com/judgemind/judgemind/issues/4255#issuecomment-4391684584))

Follow-up fixes that landed during verification: #4260 (entrypoint override), #4261 (Dockerfile script copy), #4264 (column name).
