### PR TITLE
docs(architecture): document dual LLM extraction paths + CI symmetry guard (#4254)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1237,6 +1237,20 @@ jobs:
         run: scripts/check-llm-json-loads.sh
 
   # ---------------------------------------------------------------
+  # Dual LLM extraction paths symmetry guard: both
+  # framework/llm_extractor.py and ingestion/llm_extract.py must emit
+  # their canonical chunk-failure event with document_id= in kwargs
+  # (the recurring instrumentation footgun behind #4246/#4249, see
+  # docs/specs/architecture-spec-v1.md §3.3.2.1 and #4254).
+  # ---------------------------------------------------------------
+  llm-paths-symmetry-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce dual LLM extraction path symmetry
+        run: scripts/check-llm-paths-symmetry.sh
+
+  # ---------------------------------------------------------------
   # Test DATABASE_URL fallback guard: api tests must read
   # TEST_DATABASE_URL, not the operational DATABASE_URL (#3006)
   # ---------------------------------------------------------------
@@ -1813,7 +1827,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/specs/architecture-spec-v1.md
+++ b/docs/specs/architecture-spec-v1.md
@@ -231,6 +231,26 @@ The transcription LLM prompt describes **visual structure, not text heuristics**
 
 **Reingestion.** Historical documents already in S3 can be reprocessed through the full pipeline using `scripts/reingest_from_s3.py`. Operates on **existing database records only** — it queries `documents` to find S3 keys to reprocess. For initial population of a county that has S3 data but no DB records, use `scripts/rebuild_db.py --county <name>`, which discovers documents directly from S3 keys.
 
+#### 3.3.2.1 Dual LLM extraction paths
+
+Two distinct LLM extraction modules cohabit in `packages/scraper-framework/src/`. **They are not interchangeable** — each owns a different stage of the pipeline, with different retry/cache/chunking strategies. Knowing which path a given document flows through is required for any work that touches LLM extraction (instrumentation, prompt changes, cache invalidation, error-class handling).
+
+| Path | Module | Used by | Purpose |
+|---|---|---|---|
+| **A — Splitting / multimodal** | `framework/llm_extractor.py` (`LlmExtractor.extract()` / `.extract_from_pdf()`) | `ingestion/worker.py::_llm_split_document` | Splits multi-case documents into one `ExtractedRuling` per case; multimodal per-page extraction for image-based PDFs (e.g. OC); recursive sub-chunk retry on partial failure. |
+| **B — Per-document field fill** | `ingestion/llm_extract.py` (`extract_fields_llm()`) | `ingestion/worker.py::process_event` (line ~1906); `scripts/reingest_from_s3.py` (line ~1266) | Populates remaining scalar fields on already-split rulings; fans chunks out via `ThreadPoolExecutor` for per-document parallelism. |
+
+**Failure-event log shape (#4246, #4249).** Each path emits its own structured log event when an LLM API call fails on a chunk:
+
+- Path A: `llm_extractor.google_api_failure` — `framework/llm_extractor.py:3126`
+- Path B: `llm_extract.chunk_api_failure` — `ingestion/llm_extract.py:961`
+
+Both call sites include `document_id=` in the structured log payload. `scripts/check-llm-paths-symmetry.sh` enforces this rule in CI.
+
+**Canonical change rule.** When an issue mentions "instrument the LLM extraction path," "the LLM extraction failure event," or any single-path framing, **check both modules**. The duplication is intentional today (different retry strategies, different cache layouts, different chunking) but the names `llm_extractor` vs `llm_extract` are deliberately confusable — instrumentation, log-shape changes, and field-coverage audits that touch only one path will silently miss the other. The recurring failure mode that this rule prevents is shipping an instrumentation PR for path A based on a hypothesis check, then discovering post-deploy that the actually-failing documents flow through path B (the #4246 → #4249 sequence).
+
+If you are considering consolidating the two paths, file a `type/decision` issue first. Long-term consolidation is desirable, but the existing strategies differ enough that a naive merge regresses today's behavior.
+
 ### 3.3.3 Scraper Development Constraints
 
 Rules every scraper author and reviewer must follow. These apply to new scrapers and changes to existing ones.

--- a/scripts/check-llm-paths-symmetry.sh
+++ b/scripts/check-llm-paths-symmetry.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# check-llm-paths-symmetry.sh — Assert dual-LLM-extraction-path instrumentation
+# parity between framework/llm_extractor.py and ingestion/llm_extract.py.
+#
+# Two distinct LLM extraction modules cohabit in
+# packages/scraper-framework/src/ — a recurring shape that produced #4246 (path
+# A only) immediately followed by #4249 (path B follow-up) when the agent
+# instrumented one path on a hypothesis check, then discovered post-deploy that
+# the actually-failing documents flowed through the other path.
+#
+# This guard codifies the invariant that BOTH paths emit a chunk-failure
+# structured log event AND that both call sites carry ``document_id`` in their
+# kwargs.  The guard does not (and should not) replace the docs subsection in
+# docs/specs/architecture-spec-v1.md §3.3.2.1 — it just enforces the one
+# instrumentation property that #4246/#4249 surfaced as the recurring footgun.
+#
+# Rules enforced (a violation in any rule produces a non-zero exit):
+#
+#   1. ingestion/llm_extract.py emits at least one ``llm_extract.chunk_api_failure``
+#      logger.warning call.
+#   2. framework/llm_extractor.py emits at least one
+#      ``llm_extractor.google_api_failure`` logger.warning call.
+#   3. Every emission of those two events includes ``document_id=`` in the
+#      structured payload (the multiline kwarg block that immediately follows
+#      the opening ``logger.warning(`` line).
+#
+# Rules 1 and 2 are stricter than #4233's hypothesis frame — they don't just
+# assert "the event exists in the instrumented set"; they assert each path
+# CARRIES its own event under its own canonical name.  If either module
+# replaces its event with a different name (e.g. consolidation per H3), this
+# script must be updated atomically with the rename.
+#
+# Usage:
+#   scripts/check-llm-paths-symmetry.sh          # exits 0 if clean, 1 if violations
+#
+# Exit codes:
+#   0 — Both paths are instrumented; both call sites include document_id=.
+#   1 — One or more rules violated (details on stderr).
+#
+# Test override:
+#   Set LLM_PATHS_SYMMETRY_ROOT to a directory containing alternate
+#   ``packages/scraper-framework/src/{framework/llm_extractor.py,
+#   ingestion/llm_extract.py}`` files.  Used by
+#   scripts/tests/test_check_llm_paths_symmetry.sh to drive failure-mode
+#   coverage without mutating the real source tree.
+
+set -euo pipefail
+
+REPO_ROOT="${LLM_PATHS_SYMMETRY_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+PATH_A="$REPO_ROOT/packages/scraper-framework/src/framework/llm_extractor.py"
+PATH_B="$REPO_ROOT/packages/scraper-framework/src/ingestion/llm_extract.py"
+
+EVENT_A="llm_extractor.google_api_failure"
+EVENT_B="llm_extract.chunk_api_failure"
+
+violations=0
+
+check_event_present() {
+    local file="$1"
+    local event="$2"
+
+    if [[ ! -f "$file" ]]; then
+        echo "ERROR: Expected LLM-extraction module is missing: $file" >&2
+        violations=$((violations + 1))
+        return
+    fi
+
+    # Match the log-call form ``"<event>",`` inside a logger.warning(...) call.
+    # The trailing comma rules out doc-comment mentions of the event name.
+    if ! grep -qE "\"$event\"," "$file"; then
+        echo "ERROR: $file does not emit a ``$event`` structured log event." >&2
+        echo "       Both LLM extraction paths must emit a chunk-failure event" >&2
+        echo "       under their canonical name — see" >&2
+        echo "       docs/specs/architecture-spec-v1.md §3.3.2.1." >&2
+        violations=$((violations + 1))
+    fi
+}
+
+# Rule 1 + 2: each path emits its canonical event.
+check_event_present "$PATH_A" "$EVENT_A"
+check_event_present "$PATH_B" "$EVENT_B"
+
+# Rule 3: each emission includes ``document_id=`` in its kwargs.  The kwargs
+# follow the event name on subsequent lines until the closing ``)`` of the
+# logger.warning(...) call.  We use a small Python helper because awk-style
+# multiline scanning is fragile across editors that mix tabs/spaces and
+# wrap kwargs differently.
+check_event_carries_document_id() {
+    local file="$1"
+    local event="$2"
+
+    [[ -f "$file" ]] || return
+
+    python3 - "$file" "$event" <<'PY' || violations=$((violations + 1))
+import re
+import sys
+
+path, event = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as fh:
+    src = fh.read()
+
+# Find every ``logger.warning(`` that is followed by ``"<event>",`` and capture
+# the kwargs block up to the matching closing paren.  We approximate "matching
+# closing paren" by scanning forward until paren depth returns to zero — good
+# enough for the call shape used in both modules today.
+needle = f'"{event}",'
+errors = []
+search_start = 0
+while True:
+    idx = src.find(needle, search_start)
+    if idx == -1:
+        break
+    # Walk backwards to find the enclosing logger.warning( opening.
+    open_idx = src.rfind("logger.warning(", 0, idx)
+    if open_idx == -1:
+        search_start = idx + len(needle)
+        continue
+    # Walk forward from open_idx to find the matching close paren.
+    depth = 0
+    end = None
+    for i in range(open_idx, len(src)):
+        ch = src[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    if end is None:
+        errors.append(f"unterminated logger.warning(... call at offset {open_idx}")
+        search_start = idx + len(needle)
+        continue
+    block = src[open_idx:end + 1]
+    # The structured-log kwargs block is everything after the event-name comma.
+    after_event = block[block.find(needle) + len(needle):]
+    if not re.search(r"\bdocument_id\s*=", after_event):
+        line_no = src.count("\n", 0, open_idx) + 1
+        errors.append(f"{path}:{line_no}: logger.warning({event!r}, ...) missing document_id= kwarg")
+    search_start = end + 1
+
+if errors:
+    for e in errors:
+        print(f"ERROR: {e}", file=sys.stderr)
+    print(
+        "       The chunk-failure event MUST include document_id= so the "
+        "log line is\n"
+        "       self-diagnosing — see docs/specs/architecture-spec-v1.md "
+        "§3.3.2.1.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+}
+
+check_event_carries_document_id "$PATH_A" "$EVENT_A"
+check_event_carries_document_id "$PATH_B" "$EVENT_B"
+
+if [[ $violations -gt 0 ]]; then
+    echo "" >&2
+    echo "  Found $violations dual-LLM-path symmetry violation(s)." >&2
+    echo "  See docs/specs/architecture-spec-v1.md §3.3.2.1 and #4254." >&2
+    exit 1
+fi
+
+echo "All clean — both LLM extraction paths emit their chunk-failure event with document_id=."
+exit 0

--- a/scripts/tests/test_check_llm_paths_symmetry.sh
+++ b/scripts/tests/test_check_llm_paths_symmetry.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# test_check_llm_paths_symmetry.sh — Tests for check-llm-paths-symmetry.sh
+#
+# Exercises the dual-LLM-path symmetry guard against synthetic source trees
+# under a temp directory.  The check script honors LLM_PATHS_SYMMETRY_ROOT to
+# enable this without mutating the real repo.
+#
+# Usage:
+#   scripts/tests/test_check_llm_paths_symmetry.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-llm-paths-symmetry.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_module() {
+    local rel="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$rel"
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+}
+
+PATH_A_REL="packages/scraper-framework/src/framework/llm_extractor.py"
+PATH_B_REL="packages/scraper-framework/src/ingestion/llm_extract.py"
+
+# Canonical "both paths good" content — both events present, both carry
+# document_id=.  Each test case overlays one or both files with a variant.
+GOOD_A='import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk():
+    logger.warning(
+        "llm_extractor.google_api_failure",
+        chunk_index=0,
+        document_id="abc123",
+        provider="google",
+    )
+'
+
+GOOD_B='import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk():
+    logger.warning(
+        "llm_extract.chunk_api_failure",
+        chunk_index=0,
+        document_id="abc123",
+        provider="anthropic",
+    )
+'
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if LLM_PATHS_SYMMETRY_ROOT="$TMPDIR_TEST" "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if LLM_PATHS_SYMMETRY_ROOT="$TMPDIR_TEST" "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: both paths good — script passes ──────────────────────────
+write_module "$PATH_A_REL" "$GOOD_A"
+write_module "$PATH_B_REL" "$GOOD_B"
+assert_passes "both paths emit canonical event with document_id="
+reset_tmpdir
+
+# ─── Test 2: path A missing the event entirely — script fails ─────────
+write_module "$PATH_A_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk():
+    logger.warning("some_other_event", document_id="abc")
+'
+write_module "$PATH_B_REL" "$GOOD_B"
+assert_fails "missing google_api_failure in framework/llm_extractor.py is detected"
+reset_tmpdir
+
+# ─── Test 3: path B missing the event entirely — script fails ─────────
+write_module "$PATH_A_REL" "$GOOD_A"
+write_module "$PATH_B_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk():
+    logger.warning("some_other_event", document_id="abc")
+'
+assert_fails "missing chunk_api_failure in ingestion/llm_extract.py is detected"
+reset_tmpdir
+
+# ─── Test 4: path A emits event but missing document_id — script fails ─
+write_module "$PATH_A_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk():
+    logger.warning(
+        "llm_extractor.google_api_failure",
+        chunk_index=0,
+        provider="google",
+    )
+'
+write_module "$PATH_B_REL" "$GOOD_B"
+assert_fails "google_api_failure without document_id= is detected"
+reset_tmpdir
+
+# ─── Test 5: path B emits event but missing document_id — script fails ─
+write_module "$PATH_A_REL" "$GOOD_A"
+write_module "$PATH_B_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk():
+    logger.warning(
+        "llm_extract.chunk_api_failure",
+        chunk_index=0,
+        provider="anthropic",
+    )
+'
+assert_fails "chunk_api_failure without document_id= is detected"
+reset_tmpdir
+
+# ─── Test 6: both files missing — script fails ────────────────────────
+mkdir -p "$TMPDIR_TEST/packages/scraper-framework/src/framework"
+mkdir -p "$TMPDIR_TEST/packages/scraper-framework/src/ingestion"
+assert_fails "missing module files are detected"
+reset_tmpdir
+
+# ─── Test 7: docstring/comment mention of the event name does NOT  ────
+# count as an emission — the check requires the trailing comma form
+# that occurs only inside the logger.warning() call.
+write_module "$PATH_A_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+# This file used to emit llm_extractor.google_api_failure but no longer does.
+def extract_chunk():
+    pass
+'
+write_module "$PATH_B_REL" "$GOOD_B"
+assert_fails "comment mention of event name is not counted as an emission"
+reset_tmpdir
+
+# ─── Test 8: multiple emissions, one missing document_id — fails ──────
+write_module "$PATH_A_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk_a():
+    logger.warning(
+        "llm_extractor.google_api_failure",
+        chunk_index=0,
+        document_id="abc123",
+    )
+
+def extract_chunk_b():
+    logger.warning(
+        "llm_extractor.google_api_failure",
+        chunk_index=1,
+        provider="google",
+    )
+'
+write_module "$PATH_B_REL" "$GOOD_B"
+assert_fails "second emission missing document_id= is detected"
+reset_tmpdir
+
+# ─── Test 9: multiple emissions, all carrying document_id — passes ────
+write_module "$PATH_A_REL" 'import logging
+logger = logging.getLogger(__name__)
+
+def extract_chunk_a():
+    logger.warning(
+        "llm_extractor.google_api_failure",
+        chunk_index=0,
+        document_id="abc123",
+    )
+
+def extract_chunk_b():
+    logger.warning(
+        "llm_extractor.google_api_failure",
+        chunk_index=1,
+        document_id="def456",
+    )
+'
+write_module "$PATH_B_REL" "$GOOD_B"
+assert_passes "multiple emissions all carrying document_id= is allowed"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Document the dual LLM extraction path shape (the recurring #4246/#4249 footgun) and add a CI guard that asserts both paths emit a chunk-failure event with `document_id=` in kwargs. Both H1 and H2 from the issue's "Proposed fix shape" — H3 (consolidation) deferred to a future `type/decision` issue.

Closes #4254

## What changed

- **`docs/specs/architecture-spec-v1.md` §3.3.2.1** — new "Dual LLM extraction paths" subsection naming `framework/llm_extractor.py` and `ingestion/llm_extract.py`, their entry-point file:line refs, the canonical chunk-failure event for each, and the "if you change one, check the other" rule.
- **`scripts/check-llm-paths-symmetry.sh`** — bash + embedded python3 helper that asserts (a) both modules emit their canonical chunk-failure event, (b) every emission carries `document_id=` in kwargs.
- **`scripts/tests/test_check_llm_paths_symmetry.sh`** — 9 unit tests covering canonical-good, missing-event-A, missing-event-B, missing-document_id-A, missing-document_id-B, missing-modules, comment-only mention, multi-emission with one bad, multi-emission all-good.
- **`.github/workflows/ci.yml`** — wires the new `llm-paths-symmetry-check` job, registered in `ci-passed.needs:`.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green (including the new `llm-paths-symmetry-check` job)

### Post-deploy verification
- [x] N/A — no deployed component (docs + CI hygiene script only)
- [x] Verification evidence posted on issue (see A.8)
