### PR TITLE
fix(dx): override entryPoint on field-population-audit task def (#4255 follow-up)

### DIFF
--- a/infra/terraform/modules/scraper-field-population-audit/main.tf
+++ b/infra/terraform/modules/scraper-field-population-audit/main.tf
@@ -150,10 +150,16 @@ resource "aws_ecs_task_definition" "field_population_audit" {
 
   container_definitions = jsonencode([
     {
-      name      = "field-population-audit"
-      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
-      command   = ["python3", "scripts/audit_scraper_field_population.py", "--json"]
-      essential = true
+      name  = "field-population-audit"
+      image = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      # Override the scraper image's ENTRYPOINT (["python", "-m"]).
+      # Without this override the rendered command becomes
+      # `python -m python3 scripts/...` -> "No module named python3".
+      # The same bug pattern affects the zero-record-check sibling
+      # module today; that one is tracked separately (see /ecs/judgemind-zero-record-check-dev logs).
+      entryPoint = ["python3"]
+      command    = ["scripts/audit_scraper_field_population.py", "--json"]
+      essential  = true
 
       environment = [
         { name = "AWS_REGION", value = data.aws_region.current.id },


### PR DESCRIPTION
## Summary

Follow-up fix for #4255 (PR #4258). When verifying the deployed audit task ran correctly against dev, the on-demand `aws ecs run-task` invocation exited with `/usr/local/bin/python: No module named python3`. The scraper image's `ENTRYPOINT` is `["python", "-m"]`, so the original `command = ["python3", ...]` rendered as `python -m python3 scripts/...` -- broken.

Adds `entryPoint = ["python3"]` to the container definition so the runtime command is `python3 scripts/audit_scraper_field_population.py --json` as intended.

The same bug pattern affects `scripts-zero-record-check-dev` today (its logs show the same "No module named python3" error). That sibling module is tracked separately -- this PR fixes only the field-population audit task def.

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green
- [ ] Terraform validate green

### Post-deploy verification
- [ ] After dev-apply, run `aws ecs run-task --cluster judgemind-dev --task-definition judgemind-field-population-audit-dev --launch-type FARGATE --network-configuration awsvpcConfiguration={subnets=[subnet-013eb8c4981b56292,subnet-0f3aaf5503201dff4],securityGroups=[sg-0fe2683a541ae8f4a],assignPublicIp=DISABLED}` and confirm it exits 0 (healthy) or 1 (drift detected) with valid JSON output (NOT "No module named python3").
