### PR TITLE
fix(dx): bake oneshot scripts into scraper image (#4255 follow-up)

### DIFF
--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -30,6 +30,14 @@ on:
       # Same shared-script convention — a regression there silently breaks
       # every scraper deploy's task-def render. See #4073.
       - "scripts/ecs-render-task-def.sh"
+      # Oneshot scripts baked into the scraper image (#4255 Dockerfile
+      # change). Without these on the path-filter, an edit to one of
+      # these scripts ships as code-only without rebuilding the image
+      # the EventBridge-scheduled tasks actually run.
+      - "scripts/audit_scraper_field_population.py"
+      - "scripts/check-scraper-zero-record-runner.py"
+      - "scripts/check-scraper-zero-record-streak.py"
+      - "scripts/notify-telegram.sh"
   workflow_dispatch:
     inputs:
       image_tag:

--- a/packages/scraper-framework/Dockerfile
+++ b/packages/scraper-framework/Dockerfile
@@ -65,6 +65,18 @@ RUN ! pip show google-generativeai >/dev/null 2>&1
 # context is the repo root, so this file is accessible.  See #2323.
 COPY data-quality-baselines.json /app/data-quality-baselines.json
 
+# Embed the EventBridge-driven oneshot scripts that share this image as
+# their runtime.  These are the scripts referenced from ECS task
+# definitions wired by `infra/terraform/modules/scraper-*-check` and
+# `infra/terraform/modules/scraper-field-population-audit`.  Without
+# this COPY, the ECS task fails with "No such file or directory" --
+# the existing zero-record-check task hits exactly that error today.
+# See #4255 (this audit) and the predecessor zero-record bug.
+COPY scripts/audit_scraper_field_population.py /app/scripts/audit_scraper_field_population.py
+COPY scripts/check-scraper-zero-record-runner.py /app/scripts/check-scraper-zero-record-runner.py
+COPY scripts/check-scraper-zero-record-streak.py /app/scripts/check-scraper-zero-record-streak.py
+COPY scripts/notify-telegram.sh /app/scripts/notify-telegram.sh
+
 # Own everything by the non-root user
 RUN chown -R scraper:scraper /app
 


### PR DESCRIPTION
## Summary

Second follow-up for #4255 (after #4258 + #4260). When verifying the deployed audit task ran end-to-end on dev, the on-demand `aws ecs run-task` invocation hit `python3: can't open file '/app/scripts/audit_scraper_field_population.py': [Errno 2] No such file or directory`. The scraper Dockerfile only copies `packages/scraper-framework/src/` -- it never embeds the `scripts/*.py` oneshot entrypoints that the EventBridge-scheduled tasks reference.

This was silently broken for the existing `zero-record-check` runner too -- its dev logs show the same "No module named python3" / "No such file or directory" failure today. #4255's audit was the third oneshot to hit it.

Fix:
- `packages/scraper-framework/Dockerfile`: `COPY scripts/audit_scraper_field_population.py` plus the zero-record-check trio (runner, streak, notify-telegram) into `/app/scripts/`.
- `.github/workflows/deploy-scraper.yml`: add the same script paths to the workflow's `paths:` filter so future edits to these scripts trigger a rebuild + redeploy automatically.

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] CI green
- [ ] Tests pass

### Post-deploy verification
- [ ] After `deploy-scraper.yml` rebuilds + rolls out, run `aws ecs run-task --cluster judgemind-dev --launch-type FARGATE --task-definition judgemind-field-population-audit-dev --network-configuration 'awsvpcConfiguration={subnets=[subnet-013eb8c4981b56292,subnet-0f3aaf5503201dff4],securityGroups=[sg-0fe2683a541ae8f4a],assignPublicIp=DISABLED}' --region us-west-2`, then `aws ecs describe-tasks --cluster judgemind-dev --tasks <task-id>` and confirm the container exits 0 (healthy) or 1 (drift detected) with the expected JSON in CloudWatch -- NOT exit 1 with "No such file or directory".
