### PR TITLE
fix(dx): use captured_at column in audit query (#4255 follow-up)

### DIFF
--- a/scripts/audit_scraper_field_population.py
+++ b/scripts/audit_scraper_field_population.py
@@ -298,7 +298,7 @@ def fetch_capture_count(conn: object, scraper_id: str, since: datetime) -> int:
     with conn.cursor() as cur:  # type: ignore[attr-defined]
         cur.execute(
             "SELECT COUNT(*) FROM derived.documents "
-            "WHERE scraper_id = %s AND capture_timestamp >= %s",
+            "WHERE scraper_id = %s AND captured_at >= %s",
             (scraper_id, since),
         )
         row = cur.fetchone()
@@ -308,7 +308,7 @@ def fetch_capture_count(conn: object, scraper_id: str, since: datetime) -> int:
 def fetch_sample_keys(conn: object, scraper_id: str, sample_size: int) -> list[str]:
     """Return up to *sample_size* recent s3_key values for *scraper_id*.
 
-    Ordered by capture_timestamp DESC so the audit always inspects the
+    Ordered by captured_at DESC so the audit always inspects the
     freshest envelopes -- field drift is most visible at the leading
     edge of capture.  Empty s3_key rows are excluded.
     """
@@ -316,7 +316,7 @@ def fetch_sample_keys(conn: object, scraper_id: str, sample_size: int) -> list[s
         cur.execute(
             "SELECT s3_key FROM derived.documents "
             "WHERE scraper_id = %s AND s3_key IS NOT NULL AND s3_key != '' "
-            "ORDER BY capture_timestamp DESC NULLS LAST "
+            "ORDER BY captured_at DESC NULLS LAST "
             "LIMIT %s",
             (scraper_id, sample_size),
         )


### PR DESCRIPTION
## Summary

Third follow-up for #4255 (after #4258, #4260, #4261). When the audit task finally ran end-to-end on dev (after #4261 baked the script into the image), psycopg raised `UndefinedColumn: column "capture_timestamp" does not exist` -- the SQL referred to `capture_timestamp` but the actual column on `derived.documents` is `captured_at` (see `packages/api/migrations/1_initial-schema.sql:181`).

Mocked unit tests didn't catch this -- they only matched on SQL prefixes (`COUNT(*)`, `SELECT s3_key`), not column names. Live ECS run was the first signal.

Changes: `capture_timestamp -> captured_at` in `fetch_capture_count` and `fetch_sample_keys`. No test changes needed (existing 49 tests still pass; the SQL path is exercised by the live audit task on dev).

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (49 existing tests; no new ones — the bug class is "SQL column name drift" which doesn't admit a meaningful unit test against a mocked cursor)
- [ ] CI green

### Post-deploy verification
- [ ] After deploy-scraper rebuilds + rolls out, run the audit task on-demand: `aws ecs run-task --cluster judgemind-dev --task-definition judgemind-field-population-audit-dev --launch-type FARGATE --network-configuration 'awsvpcConfiguration={subnets=[subnet-013eb8c4981b56292,subnet-0f3aaf5503201dff4],securityGroups=[sg-0fe2683a541ae8f4a],assignPublicIp=DISABLED}' --region us-west-2`
- [ ] Confirm container exits 0 (healthy) or 1 (legitimate drift / skipped) with valid JSON output containing the `field_results` and `skipped` keys.
