### PR TITLE
feat(dx): add scripts/ecs-wait-task.sh for long-running oneshot tasks (#4252)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -408,14 +408,16 @@ This closes the race window observed in PR #2907 where a new resolver shipped on
 | `scripts/ecs-run-task.sh` | All data scripts (backfills, migrations, audits) | Reliable | Standalone Fargate task, CloudWatch logs, no session timeout |
 | `scripts/dev-db-query.sh` | Quick SQL queries | Good for short queries | Uses ECS Exec internally; may drop on long queries |
 | `scripts/ecs-run.sh` | Interactive debugging only | Unreliable | SSM sessions drop after seconds; never use for scripts |
+| `scripts/ecs-wait-task.sh` | Wait on a `--detach`'d oneshot until STOPPED | Reliable | 60s polling, no upper time limit, propagates container exitCode |
 
 ```
 # Run a script and wait for completion (default)
 scripts/ecs-run-task.sh scripts/backfill_llm_enrichment.py -- --dry-run
 
-# Long-running tasks: launch and detach, check logs later
+# Long-running tasks: launch and detach, then wait via the helper
 scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
-scripts/ecs-run-task.sh --logs <task-arn>
+scripts/ecs-wait-task.sh                    # reads tmp/last-ecs-task.arn auto-saved on detach
+scripts/ecs-run-task.sh --logs <task-arn>   # alternative: stream logs after the fact
 
 # Initial population of a county with S3 data but no DB records
 scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Orange"
@@ -427,6 +429,8 @@ scripts/ecs-task-logs.sh <task-id> --follow
 # Override CPU/memory (default: 1024 CPU / 4096 MB)
 scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/audit_field_completeness.py
 ```
+
+**Long oneshots: prefer `scripts/ecs-wait-task.sh` over `aws ecs wait tasks-stopped`.** The native `aws ecs wait tasks-stopped` polls 100 times at 6s intervals = 10 min hard cap, which is too short for typical reingests/rebuilds (30-180 min). `scripts/ecs-wait-task.sh` polls every 60s with no upper time limit, emits one-line liveness notes the agent transcript can use to verify progress, and propagates the container's `exitCode` as the script's exit code. It reads the ARN from `tmp/last-ecs-task.arn` (auto-written by `ecs-run-task.sh --detach`) when no positional ARN is passed. See #4252 and `scripts/ecs-wait-task.sh --help`.
 
 **Large-county rebuilds need memory override.** `rebuild_db.py --county <name>` holds per-worker OpenSearch/Postgres clients and LLM batch state for every document in the county. At the default 4096 MB, counties with thousands of documents (Los Angeles, Santa Clara, Orange) can exit 137 (OOM). Use `--cpu 2048 --memory 8192` for these rebuilds (see #2481):
 

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -765,6 +765,17 @@ echo "" >&2
 if [[ "$DETACH" == "true" ]]; then
     echo "Detach mode: task launched successfully." >&2
 
+    # Persist the ARN so `scripts/ecs-wait-task.sh` (and any other helper)
+    # can pick it up without copy-pasting.  The sentinel path is fixed at
+    # <repo>/tmp/last-ecs-task.arn — if a previous detach left a stale ARN
+    # there, it is overwritten.  Failures are non-fatal: the ARN is also
+    # printed to stdout below for callers that want to capture it directly.
+    if mkdir -p "${REPO_ROOT}/tmp" 2>/dev/null; then
+        if printf '%s\n' "${TASK_ARN}" > "${REPO_ROOT}/tmp/last-ecs-task.arn" 2>/dev/null; then
+            echo "Saved ARN to tmp/last-ecs-task.arn (run scripts/ecs-wait-task.sh to wait)." >&2
+        fi
+    fi
+
     # Print the task ARN to stdout (everything else goes to stderr)
     # so callers can capture it easily.
     echo "${TASK_ARN}"

--- a/scripts/ecs-wait-task.sh
+++ b/scripts/ecs-wait-task.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# ecs-wait-task.sh — Wait until a previously launched ECS oneshot task reaches STOPPED.
+#
+# # venv: none
+# # permanent: true
+#
+# ── Why this exists ─────────────────────────────────────────────────────────
+#
+# The native `aws ecs wait tasks-stopped` polls 100 times at 6s intervals,
+# capping at 10 minutes. That is too short for typical oneshot reingests,
+# rebuilds, or backfills, which routinely run 30-180 minutes (or longer).
+#
+# Long-running agents that launch a task with `scripts/ecs-run-task.sh
+# --detach` previously had to write throwaway shell scripts with their own
+# `until ...; do sleep 60; done` loop because the agent harness blocks the
+# `Monitor` tool and the inline `sleep N && next-cmd` shell pattern. This
+# script provides a single shared, well-tested wait helper.
+#
+# ── Usage ────────────────────────────────────────────────────────────────────
+#
+# Usage: scripts/ecs-wait-task.sh [<task-arn>] [options]
+#
+# When invoked from a Claude Code Bash tool call, set `timeout: 1200000`
+# (20 minutes) — typical reingests/rebuilds exceed the 2-minute default,
+# and you may need to extend further for very long jobs.
+#
+# Arguments:
+#   <task-arn>            ECS task ARN to wait on. If omitted, the script
+#                         reads the ARN from <repo>/tmp/last-ecs-task.arn,
+#                         which `scripts/ecs-run-task.sh --detach` writes
+#                         automatically.
+#
+# Options:
+#   --timeout <minutes>   Max minutes to wait before giving up. Default: 0
+#                         (unlimited — the harness's `timeout: 1200000`
+#                         Bash-tool flag bounds it from outside).
+#   --poll-interval <s>   Polling interval in seconds. Default: 60.
+#   --quiet               Suppress per-poll liveness notes (still prints
+#                         the final status + exit code on STOP).
+#   --region <name>       AWS region. Default: us-west-2.
+#   --help                Show this help and exit 0.
+#
+# Exit codes:
+#   The container's exitCode when the task reaches STOPPED. If the
+#   container died without an exitCode (OOM kill, agent failure), exits 1
+#   with `Container stopped without exit code: <reason>` on stderr.
+#   Exits 2 on timeout (task still RUNNING when --timeout expired).
+#   Exits 3 on usage error (bad arg, ARN parse failure, missing AWS CLI).
+#
+# Examples:
+#   # Launch a long oneshot, then wait on the auto-saved ARN.
+#   scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
+#   scripts/ecs-wait-task.sh
+#
+#   # Wait on a specific ARN with a 90-minute hard cap.
+#   scripts/ecs-wait-task.sh --timeout 90 \
+#       arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123
+#
+#   # Quieter polling (every 5 minutes, no per-poll line).
+#   scripts/ecs-wait-task.sh --poll-interval 300 --quiet
+
+set -euo pipefail
+# AWS CLI v1/v2 portability: suppress pager without --no-cli-pager (v2-only flag). See #3461.
+export AWS_PAGER=""
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+TASK_ARN=""
+TIMEOUT_MINUTES=0           # 0 = unlimited
+POLL_INTERVAL_SECS=60
+QUIET=false
+REGION="us-west-2"
+
+# ─── Parse options ───────────────────────────────────────────────────────────
+
+usage() {
+    sed -n '2,/^set -euo pipefail$/p' "$0" | sed 's/^# \{0,1\}//' | sed '$d'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --timeout)
+            TIMEOUT_MINUTES="${2:-}"
+            shift 2
+            ;;
+        --poll-interval)
+            POLL_INTERVAL_SECS="${2:-}"
+            shift 2
+            ;;
+        --quiet)
+            QUIET=true
+            shift
+            ;;
+        --region)
+            REGION="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*)
+            echo "Error: unknown option: $1" >&2
+            echo "Run: scripts/ecs-wait-task.sh --help" >&2
+            exit 3
+            ;;
+        *)
+            if [[ -n "$TASK_ARN" ]]; then
+                echo "Error: unexpected positional argument: $1" >&2
+                echo "Only one task ARN may be supplied." >&2
+                exit 3
+            fi
+            TASK_ARN="$1"
+            shift
+            ;;
+    esac
+done
+
+# ─── Validate inputs ────────────────────────────────────────────────────────
+
+# Validate numeric flags before any AWS calls.
+if ! [[ "$TIMEOUT_MINUTES" =~ ^[0-9]+$ ]]; then
+    echo "Error: --timeout must be a non-negative integer (minutes), got: '${TIMEOUT_MINUTES}'" >&2
+    exit 3
+fi
+if ! [[ "$POLL_INTERVAL_SECS" =~ ^[0-9]+$ ]] || [[ "$POLL_INTERVAL_SECS" -lt 1 ]]; then
+    echo "Error: --poll-interval must be a positive integer (seconds), got: '${POLL_INTERVAL_SECS}'" >&2
+    exit 3
+fi
+
+# ─── Resolve repo root + ARN sentinel file ──────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ARN_SENTINEL_FILE="${REPO_ROOT}/tmp/last-ecs-task.arn"
+
+# If no ARN was passed, fall back to the sentinel written by ecs-run-task.sh --detach.
+if [[ -z "$TASK_ARN" ]]; then
+    if [[ -f "$ARN_SENTINEL_FILE" ]]; then
+        TASK_ARN=$(tr -d '[:space:]' < "$ARN_SENTINEL_FILE")
+        if [[ -z "$TASK_ARN" ]]; then
+            echo "Error: ${ARN_SENTINEL_FILE} is empty." >&2
+            echo "Pass an ARN explicitly, or re-run scripts/ecs-run-task.sh --detach to populate it." >&2
+            exit 3
+        fi
+        echo "Using ARN from ${ARN_SENTINEL_FILE#"${REPO_ROOT}"/}: ${TASK_ARN}" >&2
+    else
+        echo "Error: no task ARN supplied and ${ARN_SENTINEL_FILE#"${REPO_ROOT}"/} is missing." >&2
+        echo "Usage: scripts/ecs-wait-task.sh <task-arn> [options]" >&2
+        echo "Or launch via: scripts/ecs-run-task.sh --detach <script>" >&2
+        exit 3
+    fi
+fi
+
+# Parse cluster name out of the ARN.
+# ARN format: arn:aws:ecs:<region>:<account>:task/<cluster>/<task-id>
+CLUSTER_FROM_ARN=$(echo "$TASK_ARN" | cut -d'/' -f2)
+TASK_ID_FROM_ARN=$(echo "$TASK_ARN" | rev | cut -d'/' -f1 | rev)
+if [[ -z "$CLUSTER_FROM_ARN" || -z "$TASK_ID_FROM_ARN" || "$TASK_ARN" != arn:aws:ecs:* ]]; then
+    echo "Error: could not parse task ARN: ${TASK_ARN}" >&2
+    echo "Expected format: arn:aws:ecs:<region>:<account>:task/<cluster>/<task-id>" >&2
+    exit 3
+fi
+
+if ! command -v aws >/dev/null 2>&1; then
+    echo "Error: aws CLI not found in PATH." >&2
+    exit 3
+fi
+
+# ─── Stage Python helper for JSON parsing ──────────────────────────────────
+#
+# We delegate JSON extraction to a one-shot Python script written to a temp
+# directory. This avoids the heredoc-stdin trap (`echo X | python3 << 'EOF'`
+# silently uses the heredoc as stdin instead of the piped echo) and keeps
+# the parsing logic in one place. The helper takes <json-file> <field> as
+# argv and prints exactly one line on stdout.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PARSER="${TMP_DIR}/parse_describe_tasks.py"
+cat > "$PARSER" << 'PY_PARSER'
+"""Parse one field out of an `aws ecs describe-tasks` JSON payload.
+
+Usage:
+    parse_describe_tasks.py <json-file> <field>
+
+Fields:
+    tasks_len       - number of tasks in the response (0 means ARN missing)
+    last_status     - tasks[0].lastStatus, or 'UNKNOWN'
+    stopped_reason  - tasks[0].stoppedReason (truncated to 120 chars), or ''
+    exit_code       - tasks[0].containers[0].exitCode, or '' if absent
+    container_reason- tasks[0].containers[0].reason, or ''
+    summary         - one machine-readable line:
+                      status=<S> exit_code=<N|''> stopped_reason=<R>
+"""
+import json
+import sys
+
+if len(sys.argv) != 3:
+    print(f"usage: {sys.argv[0]} <json-file> <field>", file=sys.stderr)
+    sys.exit(2)
+
+json_path, field = sys.argv[1], sys.argv[2]
+
+with open(json_path, encoding="utf-8") as fh:
+    data = json.load(fh)
+
+tasks = data.get("tasks", []) or []
+
+if field == "tasks_len":
+    print(len(tasks))
+    sys.exit(0)
+
+if not tasks:
+    # No task in payload — fields beyond tasks_len are undefined.
+    if field in {"last_status"}:
+        print("MISSING")
+    else:
+        print("")
+    sys.exit(0)
+
+task = tasks[0]
+status = task.get("lastStatus", "UNKNOWN")
+stopped_reason = (task.get("stoppedReason") or "")[:120]
+containers = task.get("containers", []) or []
+exit_code = ""
+container_reason = ""
+if containers:
+    ec = containers[0].get("exitCode")
+    if ec is not None:
+        exit_code = str(int(ec))
+    container_reason = containers[0].get("reason") or ""
+
+if field == "last_status":
+    print(status)
+elif field == "stopped_reason":
+    print(stopped_reason)
+elif field == "exit_code":
+    print(exit_code)
+elif field == "container_reason":
+    print(container_reason)
+elif field == "summary":
+    print(f"status={status} exit_code={exit_code} stopped_reason={stopped_reason}")
+else:
+    print(f"unknown field: {field}", file=sys.stderr)
+    sys.exit(2)
+PY_PARSER
+
+# Path used to stash each describe-tasks payload before parsing.
+DESCRIBE_PATH="${TMP_DIR}/describe.json"
+
+# parse_field <field> — read the cached describe-tasks JSON and emit one field.
+parse_field() {
+    python3 "$PARSER" "$DESCRIBE_PATH" "$1"
+}
+
+# ─── Poll loop ───────────────────────────────────────────────────────────────
+
+# Convert minutes-to-seconds budget. 0 = unlimited (we never compare against
+# DEADLINE_SECS in that case — see the loop guard below).
+TIMEOUT_SECS=$(( TIMEOUT_MINUTES * 60 ))
+ELAPSED_SECS=0
+
+if [[ "$QUIET" == "false" ]]; then
+    if [[ "$TIMEOUT_MINUTES" -gt 0 ]]; then
+        echo "Waiting for task ${TASK_ID_FROM_ARN} on cluster ${CLUSTER_FROM_ARN} (poll ${POLL_INTERVAL_SECS}s, timeout ${TIMEOUT_MINUTES}m)..." >&2
+    else
+        echo "Waiting for task ${TASK_ID_FROM_ARN} on cluster ${CLUSTER_FROM_ARN} (poll ${POLL_INTERVAL_SECS}s, no timeout)..." >&2
+    fi
+fi
+
+poll_once() {
+    if ! aws ecs describe-tasks \
+        --cluster "$CLUSTER_FROM_ARN" \
+        --tasks "$TASK_ARN" \
+        --region "$REGION" \
+        --output json > "$DESCRIBE_PATH" 2>/dev/null; then
+        echo "Error: aws ecs describe-tasks failed. Check the ARN and your AWS credentials." >&2
+        return 1
+    fi
+
+    local tasks_len
+    tasks_len=$(parse_field tasks_len)
+    if [[ "$tasks_len" == "0" ]]; then
+        echo "Error: ECS returned no task for ARN: ${TASK_ARN}" >&2
+        echo "The ARN may be wrong, the task may have been deleted (>1h after stop), or the cluster name is wrong." >&2
+        return 1
+    fi
+    return 0
+}
+
+# Print a single liveness note: timestamp + status (and any stop reason fragment).
+emit_progress() {
+    if [[ "$QUIET" == "true" ]]; then
+        return
+    fi
+
+    local status reason iso
+    status=$(parse_field last_status)
+    reason=$(parse_field stopped_reason)
+    iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    if [[ -n "$reason" ]]; then
+        echo "[${iso}] status=${status} elapsed=${ELAPSED_SECS}s reason=${reason}" >&2
+    else
+        echo "[${iso}] status=${status} elapsed=${ELAPSED_SECS}s" >&2
+    fi
+}
+
+# Main wait loop. We always poll at least once before the first sleep so a
+# task that is already STOPPED returns immediately.
+while true; do
+    poll_once || exit 3
+
+    emit_progress
+
+    LAST_STATUS=$(parse_field last_status)
+    if [[ "$LAST_STATUS" == "STOPPED" ]]; then
+        break
+    fi
+
+    # Timeout check (only when --timeout was set non-zero).
+    if [[ "$TIMEOUT_MINUTES" -gt 0 && "$ELAPSED_SECS" -ge "$TIMEOUT_SECS" ]]; then
+        echo "Error: timed out after ${TIMEOUT_MINUTES}m. Task is still RUNNING." >&2
+        echo "Task ARN: ${TASK_ARN}" >&2
+        echo "Re-run with a larger --timeout, or scripts/ecs-run-task.sh --logs ${TASK_ARN}" >&2
+        exit 2
+    fi
+
+    sleep "$POLL_INTERVAL_SECS"
+    ELAPSED_SECS=$(( ELAPSED_SECS + POLL_INTERVAL_SECS ))
+done
+
+# ─── Extract exit code + stop reason ───────────────────────────────────────
+
+FINAL_STATUS=$(parse_field last_status)
+FINAL_STOPPED_REASON=$(parse_field stopped_reason)
+FINAL_EXIT_CODE=$(parse_field exit_code)
+FINAL_CONTAINER_REASON=$(parse_field container_reason)
+
+# Echo a structured summary line on stdout for callers to capture.
+echo "status=${FINAL_STATUS} exit_code=${FINAL_EXIT_CODE} stopped_reason=${FINAL_STOPPED_REASON}"
+
+# Human-readable trailing summary on stderr (matches the --logs path style
+# used by ecs-run-task.sh).
+echo "Final status: ${FINAL_STATUS}" >&2
+if [[ -n "$FINAL_STOPPED_REASON" ]]; then
+    echo "Stop reason: ${FINAL_STOPPED_REASON}" >&2
+fi
+if [[ -n "$FINAL_EXIT_CODE" ]]; then
+    echo "Exit code: ${FINAL_EXIT_CODE}" >&2
+    exit "$FINAL_EXIT_CODE"
+fi
+
+# No exit code — surface the container reason and exit 1 so callers see a
+# non-zero exit even though the JSON didn't carry an exitCode (OOM kill,
+# agent crash, image pull failure, etc.).
+if [[ -n "$FINAL_CONTAINER_REASON" ]]; then
+    echo "Container stopped without exit code: ${FINAL_CONTAINER_REASON}" >&2
+elif [[ -n "$FINAL_STOPPED_REASON" ]]; then
+    echo "Container stopped without exit code: ${FINAL_STOPPED_REASON}" >&2
+else
+    echo "Container stopped without exit code (no reason in describe-tasks payload)." >&2
+fi
+exit 1

--- a/scripts/tests/test_ecs_wait_task.sh
+++ b/scripts/tests/test_ecs_wait_task.sh
@@ -1,0 +1,488 @@
+#!/usr/bin/env bash
+# test_ecs_wait_task.sh — Unit tests for scripts/ecs-wait-task.sh
+#
+# Exercises the polling loop against a mock `aws` CLI that emits a
+# pre-canned sequence of describe-tasks JSON responses, one per call.
+# Verifies:
+#   - --help exits 0 and includes the canonical usage line
+#   - Bad ARN format exits 3 with a clear error
+#   - Invalid --timeout exits 3 with a clear error
+#   - Sentinel-file fallback (no positional ARN) reads tmp/last-ecs-task.arn
+#   - Missing ARN + missing sentinel exits 3 with a clear error
+#   - A task that goes RUNNING -> RUNNING -> STOPPED returns the container
+#     exit code, prints a structured stdout line, and emits per-poll
+#     liveness notes on stderr
+#   - A task that STOPS with a non-zero exitCode propagates that code
+#   - A task that STOPS without an exitCode exits 1 with a clear stderr
+#     "Container stopped without exit code" line
+#   - --timeout fires when the task never reaches STOPPED (exit 2)
+#   - --quiet suppresses the per-poll status lines but keeps the final
+#     summary line on stdout
+#
+# Usage:
+#   scripts/tests/test_ecs_wait_task.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/ecs-wait-task.sh"
+
+if [ ! -x "$SCRIPT_UNDER_TEST" ]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [ -n "$d" ] && [ -d "$d" ]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    mkdir -p "$dir/responses"
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [ -n "${2:-}" ]; then
+        echo "  $2"
+    fi
+}
+
+# Create a mock `aws` CLI that reads describe-tasks responses from a
+# numbered sequence of JSON files in $RESPONSES_DIR. On each call it
+# bumps a counter and emits the matching response file (clamping to
+# the highest-numbered file once exhausted, so a "stopped" terminal
+# state can be repeated indefinitely).
+setup_mock_aws() {
+    local tmpdir="$1"
+    local mock="$tmpdir/aws"
+
+    cat > "$mock" << 'MOCK_AWS'
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESPONSES_DIR="${RESPONSES_DIR:?RESPONSES_DIR required}"
+CALL_COUNTER_FILE="${CALL_COUNTER_FILE:?CALL_COUNTER_FILE required}"
+
+# Only intercept `aws ecs describe-tasks` — the only AWS call the
+# script makes. Any other invocation is a test bug.
+ARGS="$*"
+case "$ARGS" in
+    *"ecs describe-tasks"*)
+        ;;
+    *)
+        echo "MOCK aws: unexpected call: $ARGS" >&2
+        exit 1
+        ;;
+esac
+
+# Read and increment call counter.
+if [ -f "$CALL_COUNTER_FILE" ]; then
+    COUNT=$(cat "$CALL_COUNTER_FILE")
+else
+    COUNT=0
+fi
+COUNT=$((COUNT + 1))
+printf '%s' "$COUNT" > "$CALL_COUNTER_FILE"
+
+# Pick response file; clamp to highest available so terminal-state
+# responses can repeat indefinitely if the loop polls past the end.
+RESPONSE_FILE=$(printf '%s/%02d.json' "$RESPONSES_DIR" "$COUNT")
+if [ ! -f "$RESPONSE_FILE" ]; then
+    RESPONSE_FILE=$(ls -1 "$RESPONSES_DIR"/*.json 2>/dev/null | sort | tail -n 1 || echo "")
+fi
+if [ -z "$RESPONSE_FILE" ] || [ ! -f "$RESPONSE_FILE" ]; then
+    echo "MOCK aws: no response file available for call $COUNT" >&2
+    exit 1
+fi
+
+cat "$RESPONSE_FILE"
+MOCK_AWS
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+# Run the script under test with the mock aws wired up via PATH.
+# Usage: run_script <tmpdir> [extra-args...]
+run_script() {
+    local tmpdir="$1"
+    shift
+    setup_mock_aws "$tmpdir" >/dev/null
+
+    PATH="$tmpdir:$PATH" \
+    RESPONSES_DIR="$tmpdir/responses" \
+    CALL_COUNTER_FILE="$tmpdir/counter" \
+        "$SCRIPT_UNDER_TEST" --poll-interval 1 "$@"
+}
+
+# Canned describe-tasks response builders.
+write_running_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "tasks": [
+    {
+      "taskArn": "arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123",
+      "lastStatus": "RUNNING",
+      "containers": [{"name": "worker"}]
+    }
+  ]
+}
+JSON
+}
+
+write_stopped_response_with_exit_code() {
+    local file="$1"
+    local exit_code="${2:-0}"
+    local stopped_reason="${3:-Essential container exited normally}"
+    cat > "$file" << JSON
+{
+  "tasks": [
+    {
+      "taskArn": "arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123",
+      "lastStatus": "STOPPED",
+      "stoppedReason": "$stopped_reason",
+      "containers": [{"name": "worker", "exitCode": $exit_code}]
+    }
+  ]
+}
+JSON
+}
+
+write_stopped_response_no_exit_code() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "tasks": [
+    {
+      "taskArn": "arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123",
+      "lastStatus": "STOPPED",
+      "stoppedReason": "OutOfMemoryError",
+      "containers": [{"name": "worker", "reason": "OutOfMemoryError: Container killed due to memory usage"}]
+    }
+  ]
+}
+JSON
+}
+
+ARN="arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/abc123"
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: --help exits 0 and contains the canonical usage line.
+test_help_documents_usage() {
+    local output
+    output=$("$SCRIPT_UNDER_TEST" --help 2>&1 || true)
+    if echo "$output" | grep -q "Usage: scripts/ecs-wait-task.sh"; then
+        pass "--help shows usage"
+    else
+        fail "--help shows usage" "got: $output"
+    fi
+    if echo "$output" | grep -q -- "--timeout"; then
+        pass "--help documents --timeout"
+    else
+        fail "--help documents --timeout" "got: $output"
+    fi
+}
+
+# Test 2: Bad ARN format exits 3.
+test_bad_arn_exits_3() {
+    local output exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" not-an-arn 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 3 ]; then
+        pass "bad ARN exits 3"
+    else
+        fail "bad ARN exits 3" "exit=$exit_code output=$output"
+    fi
+    if echo "$output" | grep -q "could not parse task ARN"; then
+        pass "bad ARN error message is clear"
+    else
+        fail "bad ARN error message is clear" "got: $output"
+    fi
+}
+
+# Test 3: Invalid --timeout exits 3.
+test_invalid_timeout_exits_3() {
+    local output exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" --timeout abc "$ARN" 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 3 ]; then
+        pass "non-numeric --timeout exits 3"
+    else
+        fail "non-numeric --timeout exits 3" "exit=$exit_code"
+    fi
+    if echo "$output" | grep -q "must be a non-negative integer"; then
+        pass "non-numeric --timeout produces clear error"
+    else
+        fail "non-numeric --timeout produces clear error" "got: $output"
+    fi
+}
+
+# Test 4: Missing ARN + missing sentinel exits 3.
+test_missing_arn_no_sentinel_exits_3() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    # Use a fake repo root with no tmp/last-ecs-task.arn.
+    local fake_repo="$tmpdir/repo"
+    mkdir -p "$fake_repo/scripts"
+    cp "$SCRIPT_UNDER_TEST" "$fake_repo/scripts/ecs-wait-task.sh"
+    chmod +x "$fake_repo/scripts/ecs-wait-task.sh"
+
+    local output exit_code=0
+    output=$("$fake_repo/scripts/ecs-wait-task.sh" 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 3 ]; then
+        pass "missing ARN + no sentinel exits 3"
+    else
+        fail "missing ARN + no sentinel exits 3" "exit=$exit_code"
+    fi
+    if echo "$output" | grep -q "no task ARN supplied"; then
+        pass "missing-ARN error message points at sentinel + --detach"
+    else
+        fail "missing-ARN error message points at sentinel + --detach" "got: $output"
+    fi
+}
+
+# Test 5: Sentinel fallback — when ARN is omitted, read tmp/last-ecs-task.arn.
+test_sentinel_fallback() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local fake_repo="$tmpdir/repo"
+    mkdir -p "$fake_repo/scripts" "$fake_repo/tmp"
+    cp "$SCRIPT_UNDER_TEST" "$fake_repo/scripts/ecs-wait-task.sh"
+    chmod +x "$fake_repo/scripts/ecs-wait-task.sh"
+
+    printf '%s\n' "$ARN" > "$fake_repo/tmp/last-ecs-task.arn"
+
+    write_stopped_response_with_exit_code "$tmpdir/responses/01.json" 0
+
+    setup_mock_aws "$tmpdir" >/dev/null
+
+    local output exit_code=0
+    output=$(
+        PATH="$tmpdir:$PATH" \
+        RESPONSES_DIR="$tmpdir/responses" \
+        CALL_COUNTER_FILE="$tmpdir/counter" \
+            "$fake_repo/scripts/ecs-wait-task.sh" --poll-interval 1 2>&1
+    ) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "sentinel fallback returns container exit code (0)"
+    else
+        fail "sentinel fallback returns container exit code (0)" "exit=$exit_code output=$output"
+    fi
+    if echo "$output" | grep -q "Using ARN from tmp/last-ecs-task.arn"; then
+        pass "sentinel fallback announces source"
+    else
+        fail "sentinel fallback announces source" "output=$output"
+    fi
+}
+
+# Test 6: Already-stopped task returns immediately with exitCode=0.
+test_already_stopped_exit_zero() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_stopped_response_with_exit_code "$tmpdir/responses/01.json" 0
+
+    local output exit_code=0
+    output=$(run_script "$tmpdir" "$ARN" 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 0 ]; then
+        pass "STOPPED+exit=0 yields shell exit 0"
+    else
+        fail "STOPPED+exit=0 yields shell exit 0" "exit=$exit_code output=$output"
+    fi
+    if echo "$output" | grep -q "status=STOPPED exit_code=0"; then
+        pass "structured stdout line shows status=STOPPED exit_code=0"
+    else
+        fail "structured stdout line shows status=STOPPED exit_code=0" "output=$output"
+    fi
+    if echo "$output" | grep -qE "status=STOPPED elapsed=0s"; then
+        pass "first-poll liveness note printed"
+    else
+        fail "first-poll liveness note printed" "output=$output"
+    fi
+}
+
+# Test 7: Non-zero exit code propagates as the shell exit code.
+test_nonzero_exit_propagates() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_stopped_response_with_exit_code "$tmpdir/responses/01.json" 137
+
+    local output exit_code=0
+    output=$(run_script "$tmpdir" "$ARN" 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 137 ]; then
+        pass "container exitCode=137 propagates as shell exit 137"
+    else
+        fail "container exitCode=137 propagates as shell exit 137" "exit=$exit_code"
+    fi
+    if echo "$output" | grep -q "exit_code=137"; then
+        pass "structured stdout includes exit_code=137"
+    else
+        fail "structured stdout includes exit_code=137" "output=$output"
+    fi
+}
+
+# Test 8: STOPPED with no exitCode (e.g. OOM kill) exits 1.
+test_stopped_no_exit_code() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_stopped_response_no_exit_code "$tmpdir/responses/01.json"
+
+    local output exit_code=0
+    output=$(run_script "$tmpdir" "$ARN" 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 1 ]; then
+        pass "STOPPED with no exitCode yields shell exit 1"
+    else
+        fail "STOPPED with no exitCode yields shell exit 1" "exit=$exit_code output=$output"
+    fi
+    if echo "$output" | grep -q "Container stopped without exit code"; then
+        pass "missing-exitCode message names the container reason"
+    else
+        fail "missing-exitCode message names the container reason" "output=$output"
+    fi
+}
+
+# Test 9: RUNNING -> STOPPED transition emits a per-poll liveness note then
+# returns the exit code.
+test_running_then_stopped() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_running_response "$tmpdir/responses/01.json"
+    write_running_response "$tmpdir/responses/02.json"
+    write_stopped_response_with_exit_code "$tmpdir/responses/03.json" 0
+
+    local output exit_code=0
+    output=$(run_script "$tmpdir" "$ARN" 2>&1) || exit_code=$?
+    if [ "$exit_code" -eq 0 ]; then
+        pass "RUNNING -> STOPPED returns 0"
+    else
+        fail "RUNNING -> STOPPED returns 0" "exit=$exit_code output=$output"
+    fi
+    # Should have at least 3 status= lines (one per poll).
+    local liveness_count
+    liveness_count=$(echo "$output" | grep -c "status=" || true)
+    if [ "$liveness_count" -ge 3 ]; then
+        pass "per-poll liveness notes printed (count=$liveness_count)"
+    else
+        fail "per-poll liveness notes printed" "count=$liveness_count, output=$output"
+    fi
+}
+
+# Test 10: --timeout fires when the task stays RUNNING.
+test_timeout_fires() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_running_response "$tmpdir/responses/01.json"
+    # All subsequent responses also RUNNING (clamp behavior).
+
+    # --timeout 0 means unlimited, so use 1 minute. Combined with
+    # --poll-interval 30s we need ~3 polls to exceed 60s elapsed.
+    local output exit_code=0
+    output=$(
+        setup_mock_aws "$tmpdir" >/dev/null
+        PATH="$tmpdir:$PATH" \
+        RESPONSES_DIR="$tmpdir/responses" \
+        CALL_COUNTER_FILE="$tmpdir/counter" \
+            "$SCRIPT_UNDER_TEST" --poll-interval 1 --timeout 1 "$ARN" 2>&1
+    ) || exit_code=$?
+
+    if [ "$exit_code" -eq 2 ]; then
+        pass "--timeout 1 fires with exit 2 when task stays RUNNING"
+    else
+        fail "--timeout 1 fires with exit 2 when task stays RUNNING" "exit=$exit_code output=$output"
+    fi
+    if echo "$output" | grep -q "timed out after 1m"; then
+        pass "timeout message names the budget"
+    else
+        fail "timeout message names the budget" "output=$output"
+    fi
+}
+
+# Test 11: --quiet suppresses per-poll lines but keeps stdout summary.
+test_quiet_suppresses_progress() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_stopped_response_with_exit_code "$tmpdir/responses/01.json" 0
+
+    local stdout stderr exit_code=0
+    # Capture stdout + stderr separately to verify channel separation.
+    # Place capture files inside our owned tmpdir so cleanup is bounded.
+    local stdout_file="$tmpdir/stdout.log"
+    local stderr_file="$tmpdir/stderr.log"
+
+    setup_mock_aws "$tmpdir" >/dev/null
+    PATH="$tmpdir:$PATH" \
+    RESPONSES_DIR="$tmpdir/responses" \
+    CALL_COUNTER_FILE="$tmpdir/counter" \
+        "$SCRIPT_UNDER_TEST" --poll-interval 1 --quiet "$ARN" \
+        > "$stdout_file" 2> "$stderr_file" || exit_code=$?
+
+    stdout=$(cat "$stdout_file")
+    stderr=$(cat "$stderr_file")
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "--quiet path returns container exit code"
+    else
+        fail "--quiet path returns container exit code" "exit=$exit_code stderr=$stderr"
+    fi
+    if echo "$stdout" | grep -q "status=STOPPED exit_code=0"; then
+        pass "--quiet keeps structured stdout summary"
+    else
+        fail "--quiet keeps structured stdout summary" "stdout=$stdout"
+    fi
+    if echo "$stderr" | grep -qE "^\[20[0-9]{2}-"; then
+        fail "--quiet suppresses per-poll [timestamp] lines" "stderr=$stderr"
+    else
+        pass "--quiet suppresses per-poll [timestamp] lines"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_help_documents_usage
+test_bad_arn_exits_3
+test_invalid_timeout_exits_3
+test_missing_arn_no_sentinel_exits_3
+test_sentinel_fallback
+test_already_stopped_exit_zero
+test_nonzero_exit_propagates
+test_stopped_no_exit_code
+test_running_then_stopped
+test_timeout_fires
+test_quiet_suppresses_progress
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [ "$FAILURES" -gt 0 ]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/ecs-wait-task.sh` — a long-running wait helper for `--detach`'d ECS oneshot tasks. Polls `aws ecs describe-tasks` every 60s with no upper time limit (versus the 10-minute hard cap of native `aws ecs wait tasks-stopped`), emits per-poll liveness notes so the agent transcript shows progress, and propagates the container's `exitCode` as the script's shell exit. `scripts/ecs-run-task.sh --detach` now auto-saves the launched ARN to `tmp/last-ecs-task.arn` so the wait helper can be invoked with no positional args.

Closes #4252

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new: `scripts/tests/test_ecs_wait_task.sh` — 11 tests / 24 assertions)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (developer tooling script + docs only)
- [x] Verification evidence posted on issue (skip-reason format — see CLAUDE.md §Verification evidence)
