### PR TITLE
docs(agent): distinguish observed symptoms from prescribed fix (#4262)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -377,6 +377,51 @@ Exit codes:
 - **Gap already satisfied (docs delta remains)** → post comment, pivot to reduced (docs-only) scope, continue as Path A with the reduced scope.
 - **Gap already satisfied (no docs delta — typical `fix(test)` and `test(...)`)** → post comment with the AC's `Verify:` command output as evidence, close issue with `--reason completed`, release `status/in-progress` label, run `scripts/unblock-dependents.sh <N>`. Skip Path A — there is no PR.
 
+### Step 4c — Verify the issue's hypothesis (5-minute probe)
+
+**Trigger condition:** Run this step when the issue is a bug-fix or investigation-style task that names a specific function, regex, layer, or code path the filer believes is broken — i.e. the issue body contains a *suspected root cause* and a *prescribed fix*. Skip when (a) the issue is purely additive and §4b's gap probe already covered it, (b) the symptom and the broken layer are visibly the same line (one-line typo/copy fix), or (c) the issue is `type/dx` workflow / docs / template work where there is no upstream "wrong return value" to verify.
+
+**Why this exists — the verify-the-hypothesis-first pattern.** Issue bodies that mix observed symptoms with a prescribed fix can lock the agent into the wrong-hypothesis path. If the hypothesis is wrong, extending the regex / patching the named function does nothing — the symptom stays unchanged and a full ralph cycle is wasted (or, worse, a no-op regex change merges and the real bug stays unfixed). The fix is to verify the hypothesis with a cheap probe before writing any implementation code. This is the agent-side complement to `docs/agent/issue-authoring.md` §"Hypothesis vs. evidence" — same lesson, applied at pickup time. Same shape as `docs/agent/investigation-patterns.md` §"Instrument before you guess" — don't anchor on an unconfirmed hypothesis.
+
+**Canonical worked example — #4251.** The prescribed fix was "extend `_HEARING_DATE_PROBATE_RE` to match the dept-38 PDF format." Investigation revealed the regex was already returning the correct date — the broken layer was `is_plausible_hearing_date` rejecting the correctly-extracted value because dept-38 master probate calendars publish 30+ days ahead, outside the civil ±14-day window the filter enforces. A 5-minute probe (run `_cc_hearing_date_from_pdf` on the sample PDF and inspect the return value) would have surfaced that immediately. An agent who blindly extended the regex would have found the symptom didn't move and burned the full iteration cap rediscovering the actual broken layer.
+
+**What to do:**
+
+1. **Read the issue body and identify the hypothesis explicitly.** State it back to yourself in one sentence: "The issue claims `<function/regex/layer>` is broken because `<reason>` and the fix is `<edit>`."
+
+2. **Run the issue's verification steps if it lists them.** When the issue body has a `## Hypothesis verification steps` section (or equivalent — `## Verify before fixing`, etc.), run those steps **verbatim** as the §4c probe. The filer already wrote the cheapest possible falsification check; running it first short-circuits the "what to probe for" decision and produces probe output that is also free verification evidence to cite in the A.2b process summary.
+
+3. **Otherwise, run a generic 5-minute probe.** Pick the pattern that matches the hypothesis shape:
+
+   - **"Function X returns wrong value"** — fetch the smallest reproducer mentioned in the issue (S3 key, sample input, DB row id), run X on it, compare the return value to the expected value. If X returns the expected value, the hypothesis is wrong — the symptom must come from a downstream caller or filter. Write the probe to `{worktree}/tmp/verify.py` and run it. Example shape, drawing on #4251:
+     ```python
+     # {worktree}/tmp/verify.py
+     from packages.scraper_framework.src.courts.ca.oc_tentatives import _cc_hearing_date_from_pdf
+     pdf_bytes = open("{worktree}/tmp/sample.pdf", "rb").read()
+     print(repr(_cc_hearing_date_from_pdf(pdf_bytes)))
+     # If this prints the expected date, the regex is fine; the bug is downstream.
+     ```
+   - **"Regex Y doesn't match format Z"** — extract the regex from the named module, run it against a sample of format Z, inspect the match groups. Same falsification pattern: if it matches, the hypothesis is wrong.
+   - **"Filter / validator F rejects valid input"** — run F on the input the issue says is being rejected. If F accepts it, the rejection is happening somewhere else.
+   - **"Query Q returns N rows but should return M"** — run Q against dev (`scripts/dev-db-query.sh`), inspect the actual rows. If the count matches expected, the symptom is in a downstream rendering / aggregation layer.
+
+4. **Trace from observed symptom through every layer to the named hypothesis.** Even if the named function does return the wrong value, ask: is there a SELECT / dispatch / filter upstream that controls whether this code path even runs on the affected rows? The trace-select-before-validating-fix lesson (an inner branch can be dead code if the SELECT/dispatch filters out the rows) applies here — verify the full call chain, not just the bottom layer the issue points at.
+
+**Decision tree:**
+
+- **Hypothesis confirmed** — the named function/regex/layer does in fact produce the wrong value, AND the trace-select check confirms the affected rows actually flow through that code path. Proceed with the prescribed fix as Path A normally.
+- **Hypothesis falsified** — the named function/regex/layer returns the expected value when probed directly. **Do NOT implement the prescribed fix.** Post a comment on the issue stating: (a) the hypothesis verification you ran, (b) the actual return value (with sample input cited), (c) the next layer to inspect (typically the immediate caller or a filter the value passes through). Then either:
+  - Continue investigating to root-cause from observed symptoms (treat the issue as Path B / investigation), OR
+  - Re-scope the issue: post a comment proposing the corrected hypothesis and prescribed fix, and proceed with Path A against the new scope.
+
+  Write the comment to `{worktree}/tmp/hypothesis_falsified_comment.txt` and post it:
+  ```
+  gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/hypothesis_falsified_comment.txt
+  ```
+- **Probe ambiguous** (the function returns something unexpected but not clearly right or wrong; the sample input may not be representative): instrument before guessing. Add a structured log to the suspected layer that captures the raw input/output it actually saw, ship that as an instrumentation-only PR (or local probe), and re-trigger. See `docs/agent/investigation-patterns.md` §"Instrument before you guess." Don't extend the prescribed fix on top of an ambiguous probe.
+
+**Cost / benefit.** A 5-minute probe is cheap relative to a 5-15 minute ralph iteration plus the PR / CI / merge round trip the wrong-fix path incurs. Even when the probe ratifies the hypothesis (the common case for well-written issues), the probe output is also free verification evidence to cite in the A.2b process summary and A.8 verification-evidence comment.
+
 ---
 
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -12,6 +12,28 @@ Why this task exists. Link to relevant specs, investigations, or parent tasks.
 
 Parent issue: (if applicable)
 
+<!--
+## Bug-fix framing (optional — use for bug-fix or investigation-style issues)
+
+When filing an issue that names a specific function/regex/layer as broken, separate the three pieces explicitly so an agent doesn't lock onto a wrong-hypothesis path. See `docs/agent/issue-authoring.md` §Hypothesis vs. evidence and `.claude/skills/task/SKILL.md` §4c. Uncomment and fill in the three sections below if applicable.
+
+### Observed Symptoms
+
+Facts you measured. NULL rate is X%, this query returns Y, sample input <S3 key> produces `field=NULL` after parse.
+
+### Suspected root cause
+
+Your best current theory of *why* the symptoms appear, framed as a hypothesis the agent should verify — NOT as a known-true premise. Example: "I suspect `_cc_hearing_date_from_pdf`'s regex doesn't match the dept-38 PDF format."
+
+### Hypothesis verification steps
+
+Cheap probes the agent should run BEFORE writing implementation code. Example:
+1. Download `<S3 key>` to {worktree}/tmp/sample.pdf.
+2. Run `_cc_hearing_date_from_pdf` on it directly (write a 5-line probe to {worktree}/tmp/verify.py).
+3. If it returns the expected date, the hypothesis is wrong — root-cause from the observed symptoms instead. Inspect `is_plausible_hearing_date` next.
+4. If it returns NULL, the hypothesis is confirmed — proceed with the prescribed fix.
+-->
+
 ## Objective
 
 One clear sentence: what does "done" look like?

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -123,6 +123,73 @@ Before filing a "does X" / "enable X" / "add X" issue, run a single command that
 
 **Decision after probing:** If the gap is genuinely absent (the feature/setting/doc does not yet exist), file the issue normally. If the gap is already satisfied, either close the draft, pivot scope to a doc-only update that confirms the current state (e.g., "document that Container Insights is enabled and cite the Terraform attribute"), or — for `fix(test)` issues whose ACs are exhausted by "the test passes" — skip filing and post the verification-only evidence elsewhere (a comment on the parent issue, or no action at all). If the probe is ambiguous, treat as real and file normally — agents can do their own probe at pickup time per Step 4b in `.claude/skills/task/SKILL.md`.
 
+## Hypothesis vs. evidence
+
+Bug-fix issues frequently mix three different things into a single body: what was *observed* (symptoms — the data the filer can actually see), what is *suspected* (root cause — the filer's best current theory), and what should *change* (prescribed fix — the code/config edit the filer expects). When all three are run together as "here's the bug, here's the fix," an agent that picks the issue up will mentally lock in on the prescribed fix path before doing any verification — and if the suspected root cause is wrong, the entire ralph cycle is wasted.
+
+This is the same shape as the "Instrument before you guess" principle in `docs/agent/investigation-patterns.md` — both rules say: *don't anchor on an unconfirmed hypothesis*. Issue authoring is the upstream mirror of agent-side investigation. The filer's hypothesis can be wrong for the same reasons an agent's first hypothesis can be wrong: the visible layer that produces the symptom is rarely the same layer where the bug lives, and trace-select-before-validating-fix (inner branches can be dead code if a downstream filter rejects the row) applies to issue authoring too.
+
+### The framing distinction
+
+When filing a bug-fix or investigation-style issue, separate the three pieces explicitly:
+
+- **Observed symptoms** — facts the filer measured. NULL rate is X%, this query returns Y, this PDF has `hearing_date=NULL`, the page renders the wrong number. Symptoms are reproducible and don't require trust in any theory of mechanism.
+- **Suspected root cause** — the filer's best current theory of *why* the symptoms appear. Frame this as a hypothesis the agent should verify, NOT as a known-true premise. "I suspect `_cc_hearing_date_from_pdf`'s regex doesn't match the dept-38 format" is a hypothesis; "extend `_HEARING_DATE_PROBATE_RE` to handle the dept-38 format" is a prescribed fix that assumes the hypothesis is correct.
+- **Hypothesis verification steps** — the cheap probes that confirm or falsify the suspected root cause before any code is written. Download a sample PDF, run the function on it, query the DB, capture the actual return value. These probes typically take 5 minutes and either ratify the prescribed fix or redirect the agent to the real broken layer.
+
+### Worked example — #4251
+
+The pattern in #4251 (the issue that motivated this section): the filer observed that several Orange County department-38 PDFs produced `hearing_date=NULL` and wrote the issue body around a single suspected root cause — `_cc_hearing_date_from_pdf`'s regex doesn't match the dept-38 format — with a prescribed fix to extend `_HEARING_DATE_PROBATE_RE`.
+
+What investigation actually found:
+
+1. The regex *did* match the dept-38 format correctly — the function returned the expected hearing date.
+2. The downstream `is_plausible_hearing_date` filter rejected the correctly-extracted date because dept-38 master probate calendars publish 30+ days ahead, outside the civil ±14-day window the filter enforces.
+3. An agent who blindly followed the prescribed fix would have extended the regex (no-op), found the symptom didn't move, and either hit the iteration cap or — worse — merged a regex change that did nothing because the layer below still rejects the date.
+
+The right framing would have been:
+
+```
+## Observed symptoms
+
+- N PDFs in Orange County department 38 produce `hearing_date=NULL` after parse.
+- Sample input: <S3 key>. Expected output: `hearing_date='2026-06-15'`. Actual: `NULL`.
+
+## Suspected root cause (hypothesis)
+
+`_cc_hearing_date_from_pdf`'s regex (`_HEARING_DATE_PROBATE_RE`) doesn't match the dept-38 PDF format.
+
+## Hypothesis verification steps
+
+Before writing code:
+1. Download `<S3 key>` to {worktree}/tmp/sample.pdf.
+2. Run `_cc_hearing_date_from_pdf` on it directly (write a 5-line probe to {worktree}/tmp/verify.py).
+3. If it returns the expected date, the hypothesis is wrong — root-cause from the observed symptoms instead. The next layer to inspect is `is_plausible_hearing_date`.
+4. If it returns NULL, the hypothesis is confirmed — proceed with the prescribed fix.
+```
+
+The verification-steps section is the thing that converts a wrong-hypothesis trap into at most a 5-minute redirect.
+
+### When this framing applies
+
+Use the explicit Observed / Suspected / Verification structure when:
+
+- The issue is a bug-fix or investigation-style task (`type/bug`, NLP/scraper extraction failures, data-quality regressions, "X returns wrong value").
+- The filer is naming a specific function, regex, or layer they believe is broken.
+- The fix path is more than a one-line edit, OR the failing layer is downstream of other layers that could be the actual root cause.
+
+It is less critical for:
+
+- Pure feature work where there is no existing wrong behaviour to root-cause (the "gap" framing in §Verify the gap exists before filing already covers this).
+- Trivial typo / copy fixes where the symptom and the broken layer are visibly the same line.
+
+When in doubt, including the framing is cheap and saves ralph cycles when the hypothesis turns out to be wrong.
+
+### Cross-references
+
+- `docs/agent/investigation-patterns.md` §"Instrument before you guess" — the agent-side mirror. When the filer's hypothesis is missing or known-thin, the agent ships an instrumentation-only PR first to make the next failure self-diagnosing.
+- `.claude/skills/task/SKILL.md` §4c — the agent-side complement to this section: when picking up a bug-fix issue, the agent runs the issue's hypothesis-verification probe **before** writing implementation code. If the issue body lists explicit verification steps, run those; otherwise run a generic 5-minute probe (download the smallest reproducer, run the function the issue claims is broken, compare to the expected value).
+
 ## Priority Framework
 
 Assign priority by urgency and workflow impact, not by user-visibility.


### PR DESCRIPTION
## Summary

Adds the observed-symptoms vs. suspected-root-cause vs. prescribed-fix framing at three points in the issue lifecycle: (1) `docs/agent/issue-authoring.md` gains a "Hypothesis vs. evidence" section with the #4251 worked example, (2) `.claude/skills/task/SKILL.md` gains a new §4c "Verify the issue's hypothesis (5-minute probe)" sub-step between §4b and Path A so agents falsify the named hypothesis before writing implementation code, and (3) `.github/ISSUE_TEMPLATE/task.md` gains an optional (HTML-commented) Observed Symptoms / Suspected root cause / Hypothesis verification steps block for filers of bug-fix-style issues.

The motivating incident is #4251: an issue filed with a specific implementation hypothesis ("`_cc_hearing_date_from_pdf` regex doesn't match dept-38 format") and a prescribed fix ("extend `_HEARING_DATE_PROBATE_RE`"), where investigation revealed the regex was correct and the bug lived in a downstream `is_plausible_hearing_date` filter. An agent who blindly followed the prescribed fix would have burned a full ralph cycle on a no-op regex change.

Closes #4262

## Test plan

### Automated checks
- [x] `scripts/check-markdown-links.sh` passes (no broken links — verified locally before push)
- [x] Pre-push hook (markdown-links + filename-collision checks) passed during `git push`
- [x] CI green (all 100 checks success on head SHA `2e280e74`; canonical merge gate green at 64s)

### Post-deploy verification
- [x] N/A — no deployed component (docs/SKILL/issue-template only). Verification evidence comment posted: https://github.com/judgemind/judgemind/issues/4262#issuecomment-4391612835
