### PR TITLE
feat(scripts): add hygiene check for python3-heredoc-shadowing-pipe-stdin pattern (#4267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,6 +686,14 @@ jobs:
       - name: Check docs describe the actual rebuild_db.py CLI
         if: matrix.shard == 'python'
         run: scripts/check-no-rebuild-db-skip-reset.sh
+      # Issue #4267: detect the silent-miscompile pattern where a
+      # piped python3 invocation also has a heredoc — bash gives the
+      # heredoc precedence as stdin, so json.load(sys.stdin) parses
+      # the Python source as JSON and raises "Expecting value: line 1
+      # column 1" at runtime.  Surfaced by #4252 (scripts/ecs-wait-task.sh).
+      - name: Check shell scripts pipe data into python3 without heredoc shadowing
+        if: matrix.shard == 'python'
+        run: scripts/check-no-heredoc-pipe-shadow.sh
       # Issue #4119: every aws_cloudwatch_metric_alarm in
       # infra/terraform/modules/ must have a row in docs/agent/infrastructure-reference.md
       # (§"CloudWatch Alarms"). Drift accumulates silently otherwise — the

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -426,6 +426,8 @@ When wiring a `scripts/check-no-*.sh`, `scripts/check-forbidden-*.sh`, or `scrip
 
 The peer guard tests under `scripts/tests/test_check_*.sh` include a self-match assertion (see `scripts/tests/_guard_self_match_helpers.sh`) that catches this at test time. When adding a new string-forbidding guard, add an `assert_no_self_match_on_ci_step_name` call to its test.
 
+**`scripts/check-no-heredoc-pipe-shadow.sh`** — flags the silent-miscompile pattern `... | python3 << TAG` whose body reads stdin via `json.load(sys.stdin)` / `sys.stdin.read()`. Bash gives the heredoc precedence as Python's stdin, so the piped data is silently discarded and JSON parsing raises `Expecting value: line 1 column 1` at runtime. See #4267 (the guard) and #4252 (the `scripts/ecs-wait-task.sh` PR that surfaced the footgun).
+
 ### Test profiling — find the long pole in a shell test
 
 When a `scripts/tests/test_*.sh` shell test gets slow and the cost is unclear ("which `# Test N:` section is dominant?"), run `scripts/profile-shell-test.sh` against it:

--- a/scripts/check-no-heredoc-pipe-shadow.sh
+++ b/scripts/check-no-heredoc-pipe-shadow.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# check-no-heredoc-pipe-shadow.sh — Forbid the silent-miscompile pattern
+# `... | python3 << TAG` whose Python body reads stdin via
+# `json.load(sys.stdin)` / `sys.stdin.read()` / `sys.stdin.readlines()`.
+#
+# The bug: when bash sees both a pipe predecessor AND a heredoc on the
+# same `python3` invocation, the heredoc wins as the process's stdin
+# and the piped data is silently discarded. A `json.load(sys.stdin)`
+# body then attempts to parse the Python source itself as JSON and
+# raises `JSONDecodeError: Expecting value: line 1 column 1`. The
+# error is runtime-only — no syntax warning, no shellcheck rule, no
+# failing test until the script runs against a real input.
+#
+# The fix is one of:
+#   1. Pipe via stdin **without** a heredoc:
+#        echo "$X" | python3 -c '<single-line code>'
+#   2. Heredoc **without** a pipe (Python reads the heredoc as code,
+#      not data); pass data via argv or env var.
+#   3. Heredoc + tmpfile — write the payload to a tmp file, pass path
+#      as argv. See scripts/ecs-wait-task.sh for the canonical worked
+#      example (the script that surfaced this footgun — issue #4267).
+#
+# Usage:
+#   scripts/check-no-heredoc-pipe-shadow.sh          # scan repo root
+#   scripts/check-no-heredoc-pipe-shadow.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more tracked files contain the bad pattern.
+#
+# See issue #4267 for the original report and #4252 for the
+# scripts/ecs-wait-task.sh PR that surfaced the failure mode.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".vite"
+    "tmp"
+)
+
+# ─── Files that legitimately mention the pattern as context ──────────────
+EXCLUDE_FILES=(
+    "scripts/check-no-heredoc-pipe-shadow.sh"
+    "scripts/tests/test_check_no_heredoc_pipe_shadow.sh"
+)
+
+# ─── Build find arguments ───────────────────────────────────────────────
+
+prune_args=()
+first=true
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    if $first; then
+        prune_args+=("(" "-name" "$dir")
+        first=false
+    else
+        prune_args+=("-o" "-name" "$dir")
+    fi
+done
+prune_args+=(")" "-prune" "-o")
+
+# Limit to shell-ish files. Markdown/YAML excluded — those cannot
+# literally execute, so any heredoc pattern there is documentation.
+SCAN_TARGETS=()
+while IFS= read -r f; do
+    SCAN_TARGETS+=("$f")
+done < <(
+    find "$SCAN_DIR" \
+        "${prune_args[@]}" \
+        -type f \
+        \( -name "*.sh" -o -name "*.bash" \) \
+        -print
+)
+
+# ─── Per-file scanner (pure bash, portable to bash 3.2 / macOS) ─────────
+#
+# State machine:
+#   in_heredoc == 0: look for `... | python3 [-flags]* <<[-]['"]?TAG['"]?`
+#                    on the same logical line. If matched: capture TAG,
+#                    record start lineno + start line.
+#   in_heredoc == 1: look for terminator (line == TAG, with leading
+#                    whitespace allowed iff `<<-` was used).  In the
+#                    body, look for `json.load(sys.stdin)` /
+#                    `sys.stdin.read()` / `sys.stdin.readlines()`.
+#                    On terminator: if dirty, print start line.
+#
+# Returns:
+#   0 — file clean (or no heredoc-pipe pattern)
+#   1 — at least one violation; violation lines emitted on stdout.
+#
+# The regex matches python3 invocations that have BOTH a pipe
+# predecessor (`|`) and a heredoc redirection (`<<`). We deliberately
+# do not match `python3 <<...` without a leading pipe — that form
+# is safe (Python reads the heredoc as source code; stdin is unset).
+HEREDOC_START_RE='\|[[:space:]]*python3([[:space:]]+-[A-Za-z]+)*[[:space:]]*<<-?[[:space:]]*'\''?"?([A-Za-z_][A-Za-z0-9_]*)"?'\''?'
+
+scan_file() {
+    local path="$1"
+    local in_heredoc=0
+    local dirty=0
+    local tag=""
+    local start_lineno=0
+    local start_line=""
+    local dash_form=0
+    local lineno=0
+    local line
+    local file_violations=0
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        lineno=$((lineno + 1))
+        if [[ $in_heredoc -eq 0 ]]; then
+            if [[ "$line" =~ $HEREDOC_START_RE ]]; then
+                tag="${BASH_REMATCH[2]}"
+                if [[ "$line" == *"<<-"* ]]; then
+                    dash_form=1
+                else
+                    dash_form=0
+                fi
+                in_heredoc=1
+                dirty=0
+                start_lineno=$lineno
+                start_line="$line"
+            fi
+            continue
+        fi
+        # in_heredoc — check terminator first.
+        if [[ $dash_form -eq 1 ]]; then
+            # POSIX <<- allows leading TABs (and we accept any whitespace).
+            local stripped="${line#"${line%%[! 	]*}"}"
+            if [[ "$stripped" == "$tag" ]]; then
+                if [[ $dirty -eq 1 ]]; then
+                    printf '%s:%d: %s\n' "$path" "$start_lineno" "$start_line"
+                    file_violations=$((file_violations + 1))
+                fi
+                in_heredoc=0
+                dirty=0
+                tag=""
+                start_lineno=0
+                start_line=""
+                dash_form=0
+                continue
+            fi
+        else
+            if [[ "$line" == "$tag" ]]; then
+                if [[ $dirty -eq 1 ]]; then
+                    printf '%s:%d: %s\n' "$path" "$start_lineno" "$start_line"
+                    file_violations=$((file_violations + 1))
+                fi
+                in_heredoc=0
+                dirty=0
+                tag=""
+                start_lineno=0
+                start_line=""
+                dash_form=0
+                continue
+            fi
+        fi
+        # Body line — check for stdin reads.
+        if [[ "$line" == *"json.load(sys.stdin)"* \
+            || "$line" == *"sys.stdin.read()"* \
+            || "$line" == *"sys.stdin.readlines()"* ]]; then
+            dirty=1
+        fi
+    done < "$path"
+
+    # Unterminated heredoc with a dirty body — also flag.
+    if [[ $in_heredoc -eq 1 && $dirty -eq 1 ]]; then
+        printf '%s:%d: %s\n' "$path" "$start_lineno" "$start_line"
+        file_violations=$((file_violations + 1))
+    fi
+
+    if [[ $file_violations -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+violations=0
+violation_lines=""
+
+if [[ ${#SCAN_TARGETS[@]} -gt 0 ]]; then
+    for f in "${SCAN_TARGETS[@]}"; do
+        # Skip explicitly-excluded files.
+        skip=false
+        for excl in "${EXCLUDE_FILES[@]}"; do
+            if [[ "$f" == *"$excl" ]]; then
+                skip=true
+                break
+            fi
+        done
+        if "$skip"; then
+            continue
+        fi
+
+        # Skip docs/investigations/* — post-mortems may reference the
+        # pattern as historical context.
+        if [[ "$f" == *"docs/investigations/"* ]]; then
+            continue
+        fi
+
+        out=$(scan_file "$f" || true)
+        if [[ -n "$out" ]]; then
+            violation_lines+="$out"$'\n'
+            count=$(printf '%s' "$out" | grep -c '^' || true)
+            violations=$((violations + count))
+        fi
+    done
+fi
+
+if [[ $violations -gt 0 ]]; then
+    echo "ERROR: Found forbidden 'pipe + python3 <<HEREDOC + stdin-read' pattern."
+    echo ""
+    echo "  When a 'python3' invocation has BOTH a pipe predecessor AND a"
+    echo "  heredoc, bash gives the heredoc precedence as Python's stdin."
+    echo "  The piped data is silently discarded, so 'json.load(sys.stdin)'"
+    echo "  parses the Python source itself as JSON and raises"
+    echo "  'JSONDecodeError: Expecting value: line 1 column 1'."
+    echo ""
+    echo "  See issue #4267 for the original report. See"
+    echo "  scripts/ecs-wait-task.sh for the canonical fix recipe (heredoc"
+    echo "  + tmpfile + argv) that surfaced this footgun (issue #4252)."
+    echo ""
+    printf '%s' "$violation_lines"
+    echo ""
+    echo "  Fix recipes:"
+    echo "    1. Pipe + python3 -c (no heredoc):"
+    echo "       echo \"\$X\" | python3 -c '<single-line code>'"
+    echo "    2. Heredoc + argv / env (no pipe)."
+    echo "    3. Heredoc + tmpfile + argv (most flexible) — see"
+    echo "       scripts/ecs-wait-task.sh for the worked example."
+    echo ""
+    echo "  Found $violations occurrence(s)."
+    exit 1
+fi
+
+echo "All clean — no 'pipe + python3 <<HEREDOC + stdin-read' usage detected."
+exit 0

--- a/scripts/tests/test_check_no_heredoc_pipe_shadow.sh
+++ b/scripts/tests/test_check_no_heredoc_pipe_shadow.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# test_check_no_heredoc_pipe_shadow.sh — Tests for
+# check-no-heredoc-pipe-shadow.sh.
+#
+# Creates temporary shell-script fixtures to verify the checker
+# detects the forbidden `... | python3 << HEREDOC` + stdin-read
+# pattern while allowing the safe alternatives (heredoc-without-pipe,
+# pipe-without-heredoc, comment lines).
+#
+# Usage:
+#   scripts/tests/test_check_no_heredoc_pipe_shadow.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-heredoc-pipe-shadow.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp dir outside the repo's `tmp/` (which the check excludes).
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: The canonical bad pattern is detected ────────────────────────
+# This is the exact shape that bit issue #4252 / motivated #4267:
+#   $(echo "$JSON" | python3 << 'PY'
+#     import sys, json
+#     data = json.load(sys.stdin)  # <-- bug
+#     print(data["foo"])
+#   PY
+#   )
+create_test_file "bad_canonical.sh" '#!/usr/bin/env bash
+JSON='\''{"foo": 1}'\''
+RESULT=$(echo "$JSON" | python3 << '\''PY'\''
+import sys, json
+data = json.load(sys.stdin)
+print(data["foo"])
+PY
+)
+echo "$RESULT"'
+assert_fails "Canonical bad pattern (echo \$JSON | python3 << 'PY' ... json.load(sys.stdin) ... PY) is detected"
+reset_tmpdir
+
+# ─── Test 2: Bad pattern with double-quoted tag ──────────────────────────
+create_test_file "bad_dquote_tag.sh" '#!/usr/bin/env bash
+echo "$X" | python3 <<"PY"
+import sys, json
+print(json.load(sys.stdin))
+PY'
+assert_fails "Bad pattern with double-quoted heredoc tag is detected"
+reset_tmpdir
+
+# ─── Test 3: Bad pattern with bare (unquoted) tag ────────────────────────
+create_test_file "bad_bare_tag.sh" '#!/usr/bin/env bash
+echo "$X" | python3 << EOF
+import sys
+data = sys.stdin.read()
+print(data)
+EOF'
+assert_fails "Bad pattern with bare unquoted tag is detected"
+reset_tmpdir
+
+# ─── Test 4: Bad pattern with sys.stdin.read() ───────────────────────────
+create_test_file "bad_stdin_read.sh" '#!/usr/bin/env bash
+echo "data" | python3 << '\''PY'\''
+import sys
+content = sys.stdin.read()
+print(len(content))
+PY'
+assert_fails "Bad pattern using sys.stdin.read() is detected"
+reset_tmpdir
+
+# ─── Test 5: Bad pattern with sys.stdin.readlines() ──────────────────────
+create_test_file "bad_stdin_readlines.sh" '#!/usr/bin/env bash
+cat foo.txt | python3 << '\''PY'\''
+import sys
+for line in sys.stdin.readlines():
+    print(line.strip())
+PY'
+assert_fails "Bad pattern using sys.stdin.readlines() is detected"
+reset_tmpdir
+
+# ─── Test 6: Bad pattern using <<- (dash form, allows tab-indented terminator) ─
+# Note: bash <<- only strips leading TABs, not arbitrary whitespace. We
+# write a literal tab before the terminator.
+printf '%s\n' '#!/usr/bin/env bash' \
+    'echo "$X" | python3 <<- '\''PY'\''' \
+    '	import sys, json' \
+    '	data = json.load(sys.stdin)' \
+    '	print(data)' \
+    '	PY' > "$TMPDIR_TEST/bad_dash_form.sh"
+assert_fails "Bad pattern using <<- dash form is detected"
+reset_tmpdir
+
+# ─── Test 7: Bad pattern with -u flag between python3 and << ─────────────
+create_test_file "bad_with_flag.sh" '#!/usr/bin/env bash
+echo "$X" | python3 -u <<'\''PY'\''
+import sys, json
+print(json.load(sys.stdin))
+PY'
+assert_fails "Bad pattern with python3 -u flag is detected"
+reset_tmpdir
+
+# ─── Test 8: Heredoc WITHOUT a pipe is allowed ───────────────────────────
+# Python reads the heredoc as source code; stdin is unset. This is the
+# safe pattern (recipe #2 from the docstring).
+create_test_file "good_no_pipe.sh" '#!/usr/bin/env bash
+python3 << '\''PY'\''
+import sys, json
+# json.load would fail here too, but stdin is /dev/tty, not a heredoc.
+print("hello")
+PY'
+assert_passes "Heredoc without pipe predecessor is allowed"
+reset_tmpdir
+
+# ─── Test 9: Pipe + python3 -c (no heredoc) is allowed ───────────────────
+# Recipe #1 from the docstring — the canonical safe form.
+create_test_file "good_pipe_dash_c.sh" '#!/usr/bin/env bash
+echo "$X" | python3 -c "import sys, json; print(json.load(sys.stdin))"'
+assert_passes "Pipe + python3 -c (no heredoc) is allowed"
+reset_tmpdir
+
+# ─── Test 10: Heredoc + pipe but Python body does NOT read stdin ─────────
+# This is technically an unusual but legal shape: the pipe data goes
+# unused, but the Python code does not call json.load/stdin.read, so
+# there is no silent miscompile of JSON parsing. Don't flag it — too
+# many false positives. The check is precise to the json.load /
+# sys.stdin.read shape that produces the "Expecting value" footgun.
+create_test_file "good_pipe_no_stdin_read.sh" '#!/usr/bin/env bash
+echo "ignored" | python3 << '\''PY'\''
+import sys
+print("hello world")
+PY'
+assert_passes "Pipe + heredoc but no stdin-read in body is allowed"
+reset_tmpdir
+
+# ─── Test 11: Heredoc + tmpfile + argv (recipe #3) is allowed ────────────
+create_test_file "good_tmpfile_argv.sh" '#!/usr/bin/env bash
+TMP=$(mktemp -d)
+printf '\''%s'\'' "$JSON" > "$TMP/payload.json"
+python3 << '\''PY'\'' "$TMP/payload.json"
+import json, sys
+with open(sys.argv[1]) as fh:
+    data = json.load(fh)
+print(data)
+PY'
+assert_passes "Heredoc + tmpfile + argv pattern (recipe #3) is allowed"
+reset_tmpdir
+
+# ─── Test 12: Comment line documenting the pattern is allowed ────────────
+# A shell comment that mentions the bad pattern as cautionary context
+# should not trigger the check (the comment is not executable).
+create_test_file "good_comment.sh" '#!/usr/bin/env bash
+# Beware: "echo X | python3 << '\''PY'\''" with json.load(sys.stdin)
+# silently parses the heredoc as JSON. Use the tmpfile pattern instead.
+echo "$X" | python3 -c "print(input())"'
+assert_passes "Comment lines describing the pattern are allowed"
+reset_tmpdir
+
+# ─── Test 13: Markdown files are not scanned ─────────────────────────────
+# Documentation that shows the bad pattern as a teaching example must
+# not trigger the check. The check only scans *.sh and *.bash.
+create_test_file "docs/teaching.md" '
+Bad pattern:
+```bash
+echo "$X" | python3 << '\''PY'\''
+import sys, json
+data = json.load(sys.stdin)
+PY
+```'
+assert_passes "Markdown documentation showing the pattern is allowed (not scanned)"
+reset_tmpdir
+
+# ─── Test 14: docs/investigations/*.sh are still excluded ────────────────
+# Post-mortem .sh repros under docs/investigations/ are allowed to
+# contain the pattern as historical context.
+create_test_file "docs/investigations/repro_2026_05.sh" '#!/usr/bin/env bash
+echo "$X" | python3 << '\''PY'\''
+import sys, json
+data = json.load(sys.stdin)
+PY'
+assert_passes "docs/investigations/*.sh repros are allowed to reference the pattern"
+reset_tmpdir
+
+# ─── Test 15: Empty directory passes ─────────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 16: .git directory is excluded ─────────────────────────────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf '%s\n' '#!/usr/bin/env bash' \
+    'echo "$X" | python3 << '\''PY'\''' \
+    'import sys, json' \
+    'json.load(sys.stdin)' \
+    'PY' > "$TMPDIR_TEST/.git/objects/badfile.sh"
+assert_passes ".git directory contents are excluded"
+reset_tmpdir
+
+# ─── Test 17: node_modules is excluded ───────────────────────────────────
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf '%s\n' '#!/usr/bin/env bash' \
+    'echo "$X" | python3 << '\''PY'\''' \
+    'import sys, json' \
+    'json.load(sys.stdin)' \
+    'PY' > "$TMPDIR_TEST/node_modules/some-pkg/install.sh"
+assert_passes "node_modules directory is excluded"
+reset_tmpdir
+
+# ─── Test 18: tmp/ is excluded ───────────────────────────────────────────
+mkdir -p "$TMPDIR_TEST/tmp"
+printf '%s\n' '#!/usr/bin/env bash' \
+    'echo "$X" | python3 << '\''PY'\''' \
+    'json.load(sys.stdin)' \
+    'PY' > "$TMPDIR_TEST/tmp/scratch.sh"
+assert_passes "tmp/ directory is excluded"
+reset_tmpdir
+
+# ─── Test 19: Multiple violations in one file are detected ───────────────
+create_test_file "multi.sh" '#!/usr/bin/env bash
+echo "$A" | python3 << '\''PY'\''
+import sys, json
+print(json.load(sys.stdin))
+PY
+echo "---"
+echo "$B" | python3 << '\''QY'\''
+import sys
+print(sys.stdin.read())
+QY'
+assert_fails "Multiple violations in one file are detected"
+reset_tmpdir
+
+# ─── Test 20: Bad block followed by clean block does not falsely silence ─
+# State machine must reset cleanly: a clean second block should NOT
+# mask a violation in the first block.
+create_test_file "bad_then_good.sh" '#!/usr/bin/env bash
+echo "$A" | python3 << '\''PY'\''
+import sys, json
+print(json.load(sys.stdin))
+PY
+
+python3 << '\''QY'\''
+print("safe heredoc, no pipe")
+QY'
+assert_fails "Bad block followed by safe block still flags the bad block"
+reset_tmpdir
+
+# ─── Test 21: tag must match exactly (substring of TAG inside body OK) ──
+# A line containing `PY` as part of a longer token in the body must
+# NOT be mistaken for the heredoc terminator (terminator is a whole
+# line equal to the tag).
+create_test_file "tag_substring.sh" '#!/usr/bin/env bash
+echo "$X" | python3 << '\''PY'\''
+import sys, json
+# This line mentions PYTHON but is not the terminator.
+data = json.load(sys.stdin)
+print(data)
+PY'
+assert_fails "Substring of tag in body does not falsely terminate the heredoc"
+reset_tmpdir
+
+# ─── Test 22: Different tags (PY vs EOF) don't interfere ─────────────────
+create_test_file "different_tags.sh" '#!/usr/bin/env bash
+echo "$X" | python3 << EOF
+import sys
+print(sys.stdin.read())
+EOF
+echo "---"
+python3 << PY
+print("safe block")
+PY'
+assert_fails "Bad EOF-tagged block is detected even when followed by a clean PY block"
+reset_tmpdir
+
+# ─── Test 23: Self-match assertion on ci.yml step name ───────────────────
+# The CI step name that runs this guard must not itself contain the
+# forbidden pattern. See #2541/#2542 for the class of bug.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-heredoc-pipe-shadow.sh" "sh"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-no-heredoc-pipe-shadow.sh` — a hygiene check that flags the silent-miscompile pattern `... | python3 << TAG` whose Python body reads stdin via `json.load(sys.stdin)` / `sys.stdin.read()` / `sys.stdin.readlines()`. When bash sees both a pipe predecessor AND a heredoc on the same `python3` invocation, the heredoc wins as stdin and the piped data is discarded — `json.load` then parses the Python source itself as JSON and raises `Expecting value: line 1 column 1` at runtime only, with no syntax warning, shellcheck rule, or test-time signal. Surfaced by `/task #4252` (`scripts/ecs-wait-task.sh`).

Wired into the `infra-validate` job in `.github/workflows/ci.yml` next to peer `check-no-rebuild-db-skip-reset`. Added a 23-test fixture suite covering all three fix recipes plus the `<<-` dash form, varied tag quoting, multi-block files, and the standard self-match assertion. Updated `docs/agent/code-standards.md` §Hygiene-check CI steps with a one-line rationale and pointer to this issue.

Closes #4267

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts-tests` shell shard auto-discovers the new test)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check only; lives in `scripts/` and runs inside `infra-validate`).
- [x] Verification evidence posted on issue (see A.8)
