### PR TITLE
fix(infra): override entryPoint on zero-record-check task def + add CI guard (#4270)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,6 +1161,21 @@ jobs:
         run: scripts/check-terraform-empty-resource-risk.sh
 
   # ---------------------------------------------------------------
+  # Terraform ECS entryPoint guard (#4270): detect aws_ecs_task_definition
+  # resources whose container command starts with an interpreter
+  # (python, python3, bash, sh, node) without an entryPoint override.
+  # The scraper image's Dockerfile ENTRYPOINT is ["python", "-m"] so an
+  # implicit interpreter prefix in command produces silent task failure
+  # (No module named python3). Same root cause class as #2840.
+  # ---------------------------------------------------------------
+  terraform-ecs-entrypoint-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate ECS task defs declare entryPoint when command begins with interpreter
+        run: scripts/check-terraform-ecs-entrypoint.sh
+
+  # ---------------------------------------------------------------
   # Placeholder gates guard: prevent stub security gates
   # ---------------------------------------------------------------
   placeholder-gates-check:
@@ -1827,7 +1842,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/infra/terraform/modules/scraper-zero-record-check/main.tf
+++ b/infra/terraform/modules/scraper-zero-record-check/main.tf
@@ -132,10 +132,19 @@ resource "aws_ecs_task_definition" "zero_record_check" {
 
   container_definitions = jsonencode([
     {
-      name      = "zero-record-check"
-      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
-      command   = ["python3", "scripts/check-scraper-zero-record-runner.py"]
-      essential = true
+      name  = "zero-record-check"
+      image = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      # Override the scraper image's ENTRYPOINT (["python", "-m"]).
+      # Without this override the rendered command becomes
+      # `python -m python3 scripts/...` -> "No module named python3"
+      # and the task silently exits 1 every fire (see #4270).
+      # Mirror of the fix landed in #4260 for the field-population-audit
+      # sibling module — the same root cause class. The CI guard
+      # `scripts/check-terraform-ecs-entrypoint.sh` (added in #4270)
+      # prevents this regression class going forward.
+      entryPoint = ["python3"]
+      command    = ["scripts/check-scraper-zero-record-runner.py"]
+      essential  = true
 
       environment = [
         { name = "AWS_REGION", value = data.aws_region.current.id },

--- a/scripts/check-terraform-ecs-entrypoint-allowlist.txt
+++ b/scripts/check-terraform-ecs-entrypoint-allowlist.txt
@@ -1,0 +1,29 @@
+# check-terraform-ecs-entrypoint-allowlist.txt
+#
+# Waivers for aws_ecs_task_definition resources whose container `command`
+# begins with an interpreter (python, python3, bash, sh, node) but
+# legitimately do not declare an `entryPoint` override -- because the
+# Dockerfile ENTRYPOINT is itself an argv-passthrough shim that exec's
+# the command verbatim.
+#
+# Each entry is:
+#
+#   <path>:<resource_name>:<container_name>  # issue #NNNN — justification
+#
+# The path is compared against the scanned file path (absolute or
+# relative-suffix match against the repo root).
+#
+# Add an entry here only when the image's Dockerfile ENTRYPOINT is a
+# transparent argv-passthrough (e.g. /bin/sh -c "exec \"$@\"" --) and the
+# `command` is therefore the actual argv exec'd inside the container.
+# Otherwise, FIX the task def by adding an explicit `entryPoint` override.
+
+# dispatcher-v3 task defs (#4270): the dispatcher-v3 image's Dockerfile
+# ENTRYPOINT is ["/bin/sh", "-c", "exec \"$@\"", "--"] -- a transparent
+# argv-passthrough shim. The container `command` IS the actual argv
+# exec'd inside the container, so an interpreter prefix here is correct.
+# See Dockerfile.dispatcher-v3 lines 286-309 for the design rationale.
+infra/terraform/modules/dispatcher-v3-task-defs/main.tf:launcher:launcher  # issue #4270 — dispatcher-v3 ENTRYPOINT is argv-passthrough sh -c exec
+infra/terraform/modules/dispatcher-v3-task-defs/main.tf:task_runner:task-runner  # issue #4270 — dispatcher-v3 ENTRYPOINT is argv-passthrough sh -c exec
+infra/terraform/modules/dispatcher-v3-task-defs/main.tf:diagnoser:diagnoser  # issue #4270 — dispatcher-v3 ENTRYPOINT is argv-passthrough sh -c exec
+infra/terraform/modules/dispatcher-v3-task-defs/main.tf:scheduled_skill:scheduled-skill  # issue #4270 — dispatcher-v3 ENTRYPOINT is argv-passthrough sh -c exec

--- a/scripts/check-terraform-ecs-entrypoint.sh
+++ b/scripts/check-terraform-ecs-entrypoint.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# check-terraform-ecs-entrypoint.sh -- Detect ECS task definitions whose
+# container `command` starts with an interpreter (python, python3, bash,
+# sh, node) but whose container does NOT specify an `entryPoint` override.
+#
+# Bug class (issue #4270, parent #4255):
+#
+#   The scraper image's Dockerfile sets
+#       ENTRYPOINT ["python", "-m"]
+#       CMD        ["framework"]
+#   so the actual argv exec'd inside the container is
+#       python -m <command...>
+#   If a Terraform aws_ecs_task_definition declares
+#       command = ["python3", "scripts/check-...py"]
+#   without overriding entryPoint, the runtime command becomes
+#       python -m python3 scripts/check-...py
+#       -> ModuleNotFoundError: No module named 'python3'
+#   and the task silently exits 1 every fire. Same root cause class as
+#   #2840 (silent task-def drift).
+#
+# Usage:
+#   scripts/check-terraform-ecs-entrypoint.sh            # scan infra/
+#   scripts/check-terraform-ecs-entrypoint.sh --list     # print scanned
+#                                                         files, exit 0
+#
+# Exit codes:
+#   0 -- No violations found (or --list mode).
+#   1 -- One or more unallowlisted violations found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ALLOWLIST="$REPO_ROOT/scripts/check-terraform-ecs-entrypoint-allowlist.txt"
+
+PYTHON="${PYTHON:-python3}"
+
+# Directories to skip
+EXCLUDE_DIRS=(
+    ".git"
+    ".terraform"
+    ".venv"
+    "node_modules"
+    "__pycache__"
+    "tests"
+)
+
+# Parse arguments
+LIST_MODE=false
+if [[ "${1:-}" == "--list" ]]; then
+    LIST_MODE=true
+fi
+
+# Collect .tf files to scan
+# Scan every main.tf under infra/terraform/modules/**/ and
+# infra/terraform/environments/**/. Skip module test fixtures (under
+# infra/terraform/modules/*/tests/) -- those are deliberately broken
+# fixtures that exercise postcondition/policy rules.
+TF_FILES=()
+
+while IFS= read -r -d '' f; do
+    skip=false
+    for excl_dir in "${EXCLUDE_DIRS[@]}"; do
+        if [[ "$f" == *"/$excl_dir/"* ]]; then
+            skip=true
+            break
+        fi
+    done
+    if ! "$skip"; then
+        TF_FILES+=("$f")
+    fi
+done < <(find "$REPO_ROOT/infra/terraform" -name "main.tf" -print0 2>/dev/null)
+
+if [[ "$LIST_MODE" == true ]]; then
+    for f in "${TF_FILES[@]}"; do
+        echo "$f"
+    done
+    exit 0
+fi
+
+# Run the check
+violations=0
+
+for f in "${TF_FILES[@]}"; do
+    if ! output=$("$PYTHON" "$REPO_ROOT/scripts/check_tf_ecs_entrypoint.py" "$f" "$ALLOWLIST" 2>&1); then
+        echo "$output"
+        violations=$((violations + 1))
+    elif [[ -n "$output" ]]; then
+        echo "$output"
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "ERROR: Found $violations file(s) with aws_ecs_task_definition resources"
+    echo "       whose container command starts with an interpreter (python,"
+    echo "       python3, bash, sh, node) without an entryPoint override."
+    echo ""
+    echo "       The scraper image's Dockerfile ENTRYPOINT is [\"python\", \"-m\"],"
+    echo "       so a command starting with another interpreter produces a"
+    echo "       silent runtime failure (e.g. python -m python3 scripts/foo.py"
+    echo "       -> No module named python3). See issue #4270."
+    echo ""
+    echo "  Fix: add an explicit entryPoint to the container definition. Example:"
+    echo ""
+    echo "      container_definitions = jsonencode(["
+    echo "        {"
+    echo "          name       = \"my-task\""
+    echo "          image      = \"...\""
+    echo "          entryPoint = [\"python3\"]"
+    echo "          command    = [\"scripts/foo.py\", \"--flag\"]"
+    echo "        }"
+    echo "      ])"
+    echo ""
+    echo "  Allowlist (only when the Dockerfile ENTRYPOINT is an argv-passthrough"
+    echo "  shim — e.g. dispatcher-v3's [\"/bin/sh\", \"-c\", \"exec \\\"\$@\\\"\", \"--\"])"
+    echo "  by adding a line to:"
+    echo "    scripts/check-terraform-ecs-entrypoint-allowlist.txt"
+    echo "  Format: <path>:<resource_name>:<container_name>  # issue #NNNN"
+    echo ""
+    exit 1
+fi
+
+echo "All clean -- no aws_ecs_task_definition resources are missing entryPoint overrides."
+exit 0

--- a/scripts/check_tf_ecs_entrypoint.py
+++ b/scripts/check_tf_ecs_entrypoint.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check_tf_ecs_entrypoint.py — Detect ECS task definitions whose container
+`command` starts with an interpreter (python, python3, bash, sh, node) but
+whose container does NOT specify an `entryPoint` override.
+
+The bug class this guards against (issue #4270, parent #4255):
+
+The scraper image's Dockerfile sets
+
+    ENTRYPOINT ["python", "-m"]
+    CMD        ["framework"]
+
+so the actual argv exec'd inside the container is
+
+    python -m <command...>
+
+If a Terraform `aws_ecs_task_definition` declares
+
+    command = ["python3", "scripts/check-...py"]
+
+without overriding `entryPoint`, the runtime command becomes
+
+    python -m python3 scripts/check-...py
+    -> ModuleNotFoundError: No module named 'python3'
+
+and the task silently exits 1 every fire. This was the root cause of the
+silent breakage of `judgemind-zero-record-check-dev` and the field-
+population-audit task def (fixed in #4260).
+
+The defensive rule enforced by this script: any container in
+`infra/terraform/modules/**/main.tf` whose `command` starts with an
+interpreter name (python, python3, bash, sh, node) MUST also declare an
+`entryPoint` override on the same container. Containers that legitimately
+rely on a Dockerfile ENTRYPOINT that is itself an argv-passthrough shim
+(e.g. dispatcher-v3's `["/bin/sh", "-c", "exec \"$@\"", "--"]`) can be
+allowlisted by adding a line to
+`scripts/check-terraform-ecs-entrypoint-allowlist.txt`.
+
+Called by check-terraform-ecs-entrypoint.sh for each .tf file.
+
+Usage:
+    python3 scripts/check_tf_ecs_entrypoint.py <path/to/file.tf> [<allowlist_file>]
+
+Exit codes:
+    0 — No violations found (or all violations are in the allowlist).
+    1 — One or more unallowlisted violations found.
+
+Output:
+    Lines of the form:
+        <path>:<line>: aws_ecs_task_definition "<name>" container "<container>"
+            command starts with interpreter "<interpreter>" without entryPoint override
+
+The allowlist format is:
+    <path>:<resource_name>:<container_name>  # issue #NNNN
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Interpreters that, if used as the first argv token, indicate the
+# container is implicitly relying on the Dockerfile ENTRYPOINT to provide
+# the actual interpreter — exactly the #4270 bug shape.
+INTERPRETERS = frozenset({"python", "python3", "bash", "sh", "node"})
+
+
+def load_allowlist(allowlist_path: str | None) -> set[str]:
+    """Load allowlist entries, stripping comments and blank lines.
+
+    Each entry is of the form: <path>:<resource_name>:<container_name>
+    Trailing comments (# ...) are stripped.
+    """
+    if not allowlist_path:
+        return set()
+    p = Path(allowlist_path)
+    if not p.is_file():
+        return set()
+    entries: set[str] = set()
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Strip inline comment
+        line = line.split("#")[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+# Regex to find the start of an aws_ecs_task_definition resource block.
+# Must match at the start of a line (HCL resource declarations are
+# top-level), so we use re.MULTILINE-style `^`.
+TASK_DEF_HEADER_RE = re.compile(
+    r'^resource\s+"aws_ecs_task_definition"\s+"([^"]+)"\s*\{', re.MULTILINE
+)
+
+# Regex to find the start of jsonencode([ -- the container_definitions encoder
+JSONENCODE_START_RE = re.compile(r'\bcontainer_definitions\s*=\s*jsonencode\(')
+
+
+def _extract_balanced_list(text: str, start: int) -> tuple[str, int] | None:
+    """Given text and a position pointing at '[', return (list_str, end_pos+1).
+
+    Walks the text, balancing [] and respecting "..." string boundaries.
+    Returns None if no balanced ] is found.
+    """
+    if start >= len(text) or text[start] != "[":
+        return None
+    depth = 0
+    in_string = False
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == '"' and (i == 0 or text[i - 1] != "\\"):
+            in_string = not in_string
+        elif not in_string:
+            if ch == "[":
+                depth += 1
+            elif ch == "]":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1], i + 1
+        i += 1
+    return None
+
+
+def _scan_containers(
+    body_text: str, body_start_line: int
+) -> list[tuple[int, str, str | None, list[str], list[str] | None]]:
+    """Walk a container_definitions body and yield container records.
+
+    Returns a list of (line_number, container_name, command_first_arg,
+    command_list, entrypoint_list) for each container block found inside
+    the body. line_number is 1-based, relative to the original file.
+    """
+    # Each container is a `{ ... }` block inside the surrounding `[...]`
+    # array. We walk top-level `{` boundaries.
+    results: list[tuple[int, str, str | None, list[str], list[str] | None]] = []
+
+    depth = 0
+    in_string = False
+    i = 0
+    block_start: int | None = None
+    while i < len(body_text):
+        ch = body_text[i]
+        if ch == '"' and (i == 0 or body_text[i - 1] != "\\"):
+            in_string = not in_string
+            i += 1
+            continue
+        if not in_string:
+            if ch == "{":
+                if depth == 0:
+                    block_start = i
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0 and block_start is not None:
+                    block_text = body_text[block_start : i + 1]
+                    record = _parse_container_block(
+                        block_text, body_text, body_start_line, block_start
+                    )
+                    if record is not None:
+                        results.append(record)
+                    block_start = None
+        i += 1
+    return results
+
+
+def _parse_container_block(
+    block_text: str, body_text: str, body_start_line: int, block_offset: int
+) -> tuple[int, str, str | None, list[str], list[str] | None] | None:
+    """Parse a single container `{...}` block.
+
+    Returns (line_number, container_name, command_first_arg, command_list,
+    entrypoint_list) or None if the block has no `command` key.
+
+    line_number is the 1-based line of the `command` assignment within the
+    original file.
+    """
+    # Find name = "..."
+    name_match = re.search(r'name\s*=\s*"([^"]+)"', block_text)
+    container_name = name_match.group(1) if name_match else "<unnamed>"
+
+    # Find command = [...]  -- balanced bracket walk.
+    command_list: list[str] | None = None
+    entrypoint_list: list[str] | None = None
+    command_offset_in_block: int | None = None
+
+    for key_re, target_attr in (
+        (re.compile(r"\bcommand\s*=\s*"), "command"),
+        (re.compile(r"\bentryPoint\s*=\s*"), "entryPoint"),
+    ):
+        for m in key_re.finditer(block_text):
+            after = m.end()
+            # Skip whitespace / newlines
+            j = after
+            while j < len(block_text) and block_text[j] in " \t\r\n":
+                j += 1
+            if j >= len(block_text) or block_text[j] != "[":
+                continue
+            extracted = _extract_balanced_list(block_text, j)
+            if extracted is None:
+                continue
+            list_str, _end = extracted
+            try:
+                parsed = json.loads(list_str)
+            except (json.JSONDecodeError, ValueError):
+                # Not a flat string literal list. We don't try to evaluate
+                # variable references — those legitimately can't be checked
+                # statically.
+                continue
+            if not isinstance(parsed, list) or not all(
+                isinstance(x, str) for x in parsed
+            ):
+                continue
+            if target_attr == "command":
+                command_list = parsed
+                command_offset_in_block = m.start()
+            elif target_attr == "entryPoint":
+                entrypoint_list = parsed
+            break  # First match within the block wins
+
+    if command_list is None:
+        return None
+
+    # Compute the 1-based line number of the `command =` assignment in the
+    # original file. body_start_line is the 1-based line where the body
+    # begins (inside jsonencode([). block_offset is the 0-based offset of
+    # this block's `{` within body_text. command_offset_in_block is the
+    # 0-based offset of the `command` keyword within the block.
+    if command_offset_in_block is not None:
+        absolute_offset = block_offset + command_offset_in_block
+    else:
+        absolute_offset = block_offset
+    line_in_body = body_text[:absolute_offset].count("\n") + 1
+    line_number = body_start_line + line_in_body - 1
+
+    first_arg = command_list[0] if command_list else None
+    return line_number, container_name, first_arg, command_list, entrypoint_list
+
+
+def check_file(
+    tf_path: str, allowlist: set[str]
+) -> list[tuple[int, str, str, str]]:
+    """Return a list of (line_number, resource_name, container_name, interpreter) violations."""
+    text = Path(tf_path).read_text(encoding="utf-8")
+
+    violations: list[tuple[int, str, str, str]] = []
+
+    # Walk the file, find each `resource "aws_ecs_task_definition"` block,
+    # and inspect its container_definitions = jsonencode([...]) body.
+    pos = 0
+    while pos < len(text):
+        m = TASK_DEF_HEADER_RE.search(text, pos)
+        if m is None:
+            break
+        resource_name = m.group(1)
+        # Find matching `}` for this resource block (balanced).
+        # Start tracking depth from the `{` after the header.
+        block_start = text.find("{", m.start())
+        if block_start == -1:
+            break
+        depth = 0
+        in_string = False
+        i = block_start
+        block_end = -1
+        while i < len(text):
+            ch = text[i]
+            if ch == '"' and (i == 0 or text[i - 1] != "\\"):
+                in_string = not in_string
+            elif not in_string:
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        block_end = i
+                        break
+            i += 1
+        if block_end == -1:
+            break
+        resource_block = text[block_start : block_end + 1]
+
+        # Find the `container_definitions = jsonencode([` in this block.
+        je_match = JSONENCODE_START_RE.search(resource_block)
+        if je_match is None:
+            pos = block_end + 1
+            continue
+
+        # Walk forward to the `[` after `jsonencode(`
+        bracket_pos = resource_block.find("[", je_match.end())
+        if bracket_pos == -1:
+            pos = block_end + 1
+            continue
+
+        extracted = _extract_balanced_list(resource_block, bracket_pos)
+        if extracted is None:
+            pos = block_end + 1
+            continue
+        body_with_brackets, _ = extracted
+        # Strip outer [ ... ]
+        body_text = body_with_brackets[1:-1]
+
+        # Compute the 1-based line in the original file where body_text begins
+        body_offset_in_resource = bracket_pos + 1
+        body_offset_in_file = block_start + body_offset_in_resource
+        body_start_line = text[:body_offset_in_file].count("\n") + 1
+
+        for record in _scan_containers(body_text, body_start_line):
+            line_no, container_name, first_arg, _command_list, entrypoint_list = (
+                record
+            )
+            if first_arg is None:
+                continue
+            if first_arg not in INTERPRETERS:
+                continue
+            if entrypoint_list is not None:
+                # Has an explicit entryPoint override — safe.
+                continue
+
+            # Check allowlist
+            tf_path_str = str(tf_path)
+            in_allowlist = False
+            for entry in allowlist:
+                parts = entry.split(":")
+                if len(parts) < 3:
+                    continue
+                entry_path = parts[0]
+                entry_resource = parts[1]
+                entry_container = parts[2]
+                if (
+                    entry_resource == resource_name
+                    and entry_container == container_name
+                    and (
+                        tf_path_str == entry_path
+                        or tf_path_str.endswith("/" + entry_path)
+                    )
+                ):
+                    in_allowlist = True
+                    break
+            if not in_allowlist:
+                violations.append(
+                    (line_no, resource_name, container_name, first_arg)
+                )
+
+        pos = block_end + 1
+
+    return violations
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file.tf> [allowlist_file]", file=sys.stderr)
+        return 2
+
+    tf_path = sys.argv[1]
+    allowlist_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    allowlist = load_allowlist(allowlist_path)
+    violations = check_file(tf_path, allowlist)
+
+    for lineno, resource_name, container_name, interpreter in violations:
+        print(
+            f'{tf_path}:{lineno}: aws_ecs_task_definition "{resource_name}" '
+            f'container "{container_name}" command starts with interpreter '
+            f'"{interpreter}" without entryPoint override'
+        )
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/tf-ecs-entrypoint-bad.tf
+++ b/scripts/tests/fixtures/tf-ecs-entrypoint-bad.tf
@@ -1,0 +1,24 @@
+# tf-ecs-entrypoint-bad.tf -- Fixture replicating the #4270 shape.
+#
+# An aws_ecs_task_definition whose container `command` begins with an
+# interpreter (python3) and does NOT declare an `entryPoint` override.
+# When the image's Dockerfile ENTRYPOINT is ["python", "-m"] (the scraper
+# image's pattern), the runtime command becomes `python -m python3 ...`
+# which fails with "No module named python3" -- silent task failure.
+
+resource "aws_ecs_task_definition" "bad_zero_record" {
+  family                   = "judgemind-bad-zero-record"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+
+  container_definitions = jsonencode([
+    {
+      name      = "bad-zero-record"
+      image     = "fake-ecr/scraper:latest"
+      command   = ["python3", "scripts/check-scraper-zero-record-runner.py"]
+      essential = true
+    }
+  ])
+}

--- a/scripts/tests/fixtures/tf-ecs-entrypoint-good.tf
+++ b/scripts/tests/fixtures/tf-ecs-entrypoint-good.tf
@@ -1,0 +1,24 @@
+# tf-ecs-entrypoint-good.tf -- The #4270 fix shape.
+#
+# An aws_ecs_task_definition with an explicit `entryPoint` override on
+# the container, so the runtime command is unambiguous regardless of the
+# image's Dockerfile ENTRYPOINT. Mirror of the fix landed in #4260 for
+# the field-population-audit module.
+
+resource "aws_ecs_task_definition" "good_zero_record" {
+  family                   = "judgemind-good-zero-record"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+
+  container_definitions = jsonencode([
+    {
+      name       = "good-zero-record"
+      image      = "fake-ecr/scraper:latest"
+      entryPoint = ["python3"]
+      command    = ["scripts/check-scraper-zero-record-runner.py"]
+      essential  = true
+    }
+  ])
+}

--- a/scripts/tests/test_check_terraform_ecs_entrypoint.sh
+++ b/scripts/tests/test_check_terraform_ecs_entrypoint.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# test_check_terraform_ecs_entrypoint.sh -- Tests for
+# check-terraform-ecs-entrypoint.sh / check_tf_ecs_entrypoint.py.
+#
+# Issue #4270 -- the silent zero-record-check task-def breakage caused
+# by `command = ["python3", "..."]` against a scraper image whose
+# Dockerfile ENTRYPOINT is ["python", "-m"].
+#
+# Usage:
+#   scripts/tests/test_check_terraform_ecs_entrypoint.sh
+#
+# Exit codes:
+#   0 -- All tests passed.
+#   1 -- One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-terraform-ecs-entrypoint.sh"
+PYTHON_HELPER="$SCRIPT_DIR/check_tf_ecs_entrypoint.py"
+FIXTURES_DIR="$SCRIPT_DIR/tests/fixtures"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Test-suite helpers required by _guard_self_match_helpers.sh
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"
+    TMPDIR_TEST=$(mktemp -d)
+}
+
+assert_py_fails() {
+    local desc="$1"
+    local tf_file="$2"
+    local allowlist="${3:-}"
+    TESTS=$((TESTS + 1))
+    local passed=false
+    if [[ -n "$allowlist" ]]; then
+        if python3 "$PYTHON_HELPER" "$tf_file" "$allowlist" > /dev/null 2>&1; then
+            passed=true
+        fi
+    else
+        if python3 "$PYTHON_HELPER" "$tf_file" > /dev/null 2>&1; then
+            passed=true
+        fi
+    fi
+    if "$passed"; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_py_passes() {
+    local desc="$1"
+    local tf_file="$2"
+    local allowlist="${3:-}"
+    TESTS=$((TESTS + 1))
+    local passed=false
+    if [[ -n "$allowlist" ]]; then
+        if python3 "$PYTHON_HELPER" "$tf_file" "$allowlist" > /dev/null 2>&1; then
+            passed=true
+        fi
+    else
+        if python3 "$PYTHON_HELPER" "$tf_file" > /dev/null 2>&1; then
+            passed=true
+        fi
+    fi
+    if "$passed"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_py_output_contains() {
+    local desc="$1"
+    local tf_file="$2"
+    local pattern="$3"
+    TESTS=$((TESTS + 1))
+    local out
+    out=$(python3 "$PYTHON_HELPER" "$tf_file" 2>&1 || true)
+    if echo "$out" | grep -qE "$pattern"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (pattern '$pattern' not found in output: $out)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Test 1: Bad fixture (the #4270 shape) is flagged
+assert_py_fails "bad fixture exits non-zero" "$FIXTURES_DIR/tf-ecs-entrypoint-bad.tf"
+
+# Test 2: Bad fixture output names the resource and the interpreter
+assert_py_output_contains \
+    "bad fixture output names resource and interpreter" \
+    "$FIXTURES_DIR/tf-ecs-entrypoint-bad.tf" \
+    'aws_ecs_task_definition "bad_zero_record".*"python3"'
+
+# Test 3: Bad fixture output includes line number
+assert_py_output_contains \
+    "bad fixture output contains :line: format" \
+    "$FIXTURES_DIR/tf-ecs-entrypoint-bad.tf" \
+    ":[0-9]+:"
+
+# Test 4: Good fixture (with entryPoint override) passes
+assert_py_passes "good fixture exits 0" "$FIXTURES_DIR/tf-ecs-entrypoint-good.tf"
+
+# Test 5: Inline fixture -- bash interpreter without entryPoint is flagged
+cat > "$TMPDIR_TEST/bash_no_entrypoint.tf" << 'TFEOF'
+resource "aws_ecs_task_definition" "bash_bad" {
+  family       = "judgemind-bash-bad"
+  cpu          = 256
+  memory       = 512
+  network_mode = "awsvpc"
+  container_definitions = jsonencode([
+    {
+      name      = "bash-bad"
+      image     = "fake/img:latest"
+      command   = ["bash", "-c", "echo hi"]
+      essential = true
+    }
+  ])
+}
+TFEOF
+assert_py_fails "bash interpreter without entryPoint is flagged" "$TMPDIR_TEST/bash_no_entrypoint.tf"
+
+# Test 6: Inline fixture -- node interpreter without entryPoint is flagged
+cat > "$TMPDIR_TEST/node_no_entrypoint.tf" << 'TFEOF'
+resource "aws_ecs_task_definition" "node_bad" {
+  family       = "judgemind-node-bad"
+  cpu          = 256
+  memory       = 512
+  network_mode = "awsvpc"
+  container_definitions = jsonencode([
+    {
+      name      = "node-bad"
+      image     = "fake/img:latest"
+      command   = ["node", "server.js"]
+      essential = true
+    }
+  ])
+}
+TFEOF
+assert_py_fails "node interpreter without entryPoint is flagged" "$TMPDIR_TEST/node_no_entrypoint.tf"
+
+# Test 7: Inline fixture -- non-interpreter command is NOT flagged
+# (e.g. an executable that takes its own argv directly).
+cat > "$TMPDIR_TEST/non_interpreter.tf" << 'TFEOF'
+resource "aws_ecs_task_definition" "non_interpreter" {
+  family       = "judgemind-non-interpreter"
+  cpu          = 256
+  memory       = 512
+  network_mode = "awsvpc"
+  container_definitions = jsonencode([
+    {
+      name      = "non-interpreter"
+      image     = "fake/img:latest"
+      command   = ["framework", "--args"]
+      essential = true
+    }
+  ])
+}
+TFEOF
+assert_py_passes "non-interpreter first arg is not flagged" "$TMPDIR_TEST/non_interpreter.tf"
+
+# Test 8: Inline fixture -- task def with entryPoint override passes even
+# when command starts with an interpreter.
+cat > "$TMPDIR_TEST/with_entrypoint.tf" << 'TFEOF'
+resource "aws_ecs_task_definition" "with_entrypoint" {
+  family       = "judgemind-with-entrypoint"
+  cpu          = 256
+  memory       = 512
+  network_mode = "awsvpc"
+  container_definitions = jsonencode([
+    {
+      name       = "with-entrypoint"
+      image      = "fake/img:latest"
+      entryPoint = ["python3"]
+      command    = ["python", "scripts/foo.py"]
+      essential  = true
+    }
+  ])
+}
+TFEOF
+assert_py_passes "task def with entryPoint passes" "$TMPDIR_TEST/with_entrypoint.tf"
+
+# Test 9: Allowlist suppression works
+ALLOWLIST_FILE="$TMPDIR_TEST/test_allowlist.txt"
+printf '%s\n' "$TMPDIR_TEST/bash_no_entrypoint.tf:bash_bad:bash-bad" > "$ALLOWLIST_FILE"
+assert_py_passes \
+    "allowlist suppression works" \
+    "$TMPDIR_TEST/bash_no_entrypoint.tf" \
+    "$ALLOWLIST_FILE"
+
+# Test 10: --list flag prints expected paths and exits 0
+TESTS=$((TESTS + 1))
+list_output=$("$CHECK_SCRIPT" --list 2>&1 || true)
+if echo "$list_output" | grep -q "main.tf"; then
+    echo "PASS: --list flag prints .tf files and exits 0"
+else
+    echo "FAIL: --list flag did not print any main.tf files (output: $list_output)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# Test 11: --list includes modules paths
+TESTS=$((TESTS + 1))
+if echo "$list_output" | grep -q "infra/terraform/modules"; then
+    echo "PASS: --list includes modules path"
+else
+    echo "FAIL: --list missing modules path"
+    echo "  Output was: $list_output"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# Test 12: Real repo scan exits 0 (zero-record-check fix landed,
+# dispatcher-v3 task defs are allowlisted)
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: real repo scan exits 0 (allowlist + fix complete)"
+else
+    echo "FAIL: real repo scan exits non-zero -- allowlist may be incomplete"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# Test 13: No self-match on ci.yml step name (per docs/agent/code-standards.md
+# § Hygiene-check CI steps -- the forbidden-string check must not match its
+# own ci.yml step name).
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-terraform-ecs-entrypoint.sh" "yml"
+
+# Summary
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes the silent breakage of the daily zero-record-check task and adds a CI guard preventing the same bug class from recurring. Same root cause class as #2840 / #4260: the scraper image's Dockerfile ENTRYPOINT is `["python", "-m"]`, so a TF task-def `command = ["python3", "scripts/foo.py"]` runs as `python -m python3 scripts/foo.py` -> `No module named python3` and the task silently exits 1 every fire.

- `infra/terraform/modules/scraper-zero-record-check/main.tf`: add `entryPoint = ["python3"]`, drop `"python3"` prefix from `command`. Mirror of #4260's fix in the field-population-audit sibling module.
- `scripts/check_tf_ecs_entrypoint.py` + `check-terraform-ecs-entrypoint.sh` + allowlist: statically detect `aws_ecs_task_definition` containers whose `command[0]` is in {python, python3, bash, sh, node} without an `entryPoint` override. Wired as `terraform-ecs-entrypoint-check` in `.github/workflows/ci.yml`. Test fixtures + 13-case test suite cover bad-shape detection, good-shape pass, every interpreter, allowlist suppression, and self-match guard.
- The four dispatcher-v3 task defs are allowlisted because their image's Dockerfile ENTRYPOINT is an argv-passthrough sh-c-exec shim (Dockerfile.dispatcher-v3 lines 286-309).

Closes #4270

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] New `terraform-ecs-entrypoint-check` job is green

### Post-deploy verification
- [x] After dev-apply lands the task-def revision, run a one-shot `aws ecs run-task --cluster judgemind-dev --task-definition judgemind-zero-record-check-dev --launch-type FARGATE ...` and confirm the runner produces structured Python output (zero-record streak query result OR a runner-level exception), NOT `No module named python3`.
- [x] Capture the `aws ecs describe-tasks` exit code + a CloudWatch `/ecs/judgemind-zero-record-check-dev` log excerpt in the verification evidence comment on #4270.
- [x] Verification evidence posted on issue #4270.
