### PR TITLE
fix(dispatcher): route operational verdict=blocked through diagnoser (#4272)

### DIFF
--- a/.claude/skills/task-v2-operational/SKILL.md
+++ b/.claude/skills/task-v2-operational/SKILL.md
@@ -84,8 +84,8 @@ Exit 0 regardless of verdict. The dispatcher reads the verdict from the JSON, no
 **Verdict rules:**
 
 - `succeeded` — task completed, evidence posted, issue closed (if the AC says to close it). The agent advances to `operational_done` with `status=succeeded`.
-- `blocked` — a bright line was hit, a required secret is missing, the environment is not ready, or any other condition that needs operator action before the task can proceed. Advances to `operational_failed` with `status=needs_review`.
-- `failed` — a genuine execution failure (script errored, DB unreachable, ECS task timed out, unexpected output). Routes to the diagnoser for retry/escalation.
+- `blocked` — a bright line was hit. Could be operator-only (a required secret is missing, the environment is not ready, an external account hit a hard limit) OR a fixable code bug (a script needs a flag the operator hasn't shipped yet, a script crashes on a code path you can identify). Either way the daemon routes this through the diagnoser (`/diagnose-failure`), which reads `block_reason` and either files an autonomous code-fix tracker (`Blocked by #N` + re-add `agent/ready`) when the block names a fixable bug, or marks `needs_review` for genuinely operator-only conditions. Set `block_reason` to a clear sentence that names the gap — the diagnoser uses it to pick the right branch (#4272).
+- `failed` — a genuine execution failure (script errored, DB unreachable, ECS task timed out, unexpected output). Same routing as `blocked` — through the diagnoser, which decides retry / escalation / tracker-filing.
 
 ---
 
@@ -169,8 +169,8 @@ condition and `evidence_md` containing the last validation output. Looping is
 the bug.
 
 **Why:** Repeating the same ECS run or DB query when the underlying data has
-not changed cannot produce a different result. A BLOCKED verdict routes to the
-operator / diagnoser so the root cause (data not populated, wrong script args,
+not changed cannot produce a different result. A BLOCKED verdict routes through
+the diagnoser so the root cause (data not populated, wrong script args,
 missing dependency) can be fixed — rather than burning the 60-min budget and
 having the supervisor catch the agent as stuck anyway.
 
@@ -204,7 +204,7 @@ Write `{worktree}/tmp/dispatcher-output/operational.json` with verdict + evidenc
 
 - **Does not write code.** No edits to source files, no commits, no PR.
 - **Does not deploy to production.** ECS writes are always against dev-tier clusters.
-- **Does not spawn recursive operational agents.** If the task requires a code change, emit `verdict=blocked` with `block_reason` explaining the gap so an operator can file a coding task.
+- **Does not spawn recursive operational agents.** If the task requires a code change, emit `verdict=blocked` with a `block_reason` that names the code-fix gap precisely. The daemon routes blocked verdicts through the diagnoser, which autonomously files a code-fix tracker (`Blocked by #N` + re-adds `agent/ready` on the operational issue) when `block_reason` describes a fixable bug — no operator hand-off needed (#4272).
 
 ## Worked example — Santa Clara county data restore
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2005,6 +2005,17 @@ TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
         # #3656 — ECS-mode silent-hang reaper. Diagnoser inspects the
         # last known phase + log tail to decide retry vs. escalate.
         FAILURE_CATEGORY_AGENT_SILENT_HANG,
+        # #4272 — operational verdict=blocked / verdict=failed. The
+        # diagnoser inspects the block_reason / evidence_md and either
+        # files an autonomous code-fix tracker (Blocked by #N + re-add
+        # agent/ready) when the block names a fixable code bug, or
+        # marks needs_review for genuinely operator-only blocks
+        # (missing secret, external account state). Pre-#4272 the
+        # blocked verdict short-circuited to operational_failed /
+        # needs_review without ever reaching the diagnoser, parking
+        # issues indefinitely (source incident: #3954 sat for 4 days
+        # until manual recovery; investigation #4248).
+        FAILURE_CATEGORY_OPERATIONAL_FAILED,
     }
 )
 
@@ -12218,15 +12229,25 @@ class DispatcherDaemon:
         a script / DB query / gh action directly, posts evidence to the
         issue, and closes the issue on success. No PR, no CI, no merge.
 
-        Mirrors the structure of :meth:`_run_plan_phase` with three
+        Mirrors the structure of :meth:`_run_plan_phase` with two
         possible outcomes:
 
         * ``succeeded`` — advance to ``operational_done`` with
           ``status='succeeded'``.
-        * ``blocked`` — advance to ``operational_failed`` with
-          ``status='needs_review'`` (operator must intervene).
-        * ``failed`` / missing / unrecognized — route through
-          ``_handle_agent_failure`` so the diagnoser picks it up.
+        * ``blocked`` / ``failed`` / missing / unrecognized — route
+          through :meth:`_handle_agent_failure` with
+          :data:`FAILURE_CATEGORY_OPERATIONAL_FAILED` (tier-2
+          first-occurrence) so the diagnoser picks it up. The
+          diagnoser inspects ``block_reason`` / ``evidence_md`` and
+          either files an autonomous code-fix tracker
+          (``Blocked by #N`` + re-add ``agent/ready``) when the block
+          names a fixable code bug, or marks ``needs_review`` for
+          genuinely operator-only conditions (missing secret, external
+          account state). #4272 unified this routing — pre-#4272 the
+          ``blocked`` arm short-circuited to ``operational_failed /
+          needs_review`` without ever reaching the diagnoser, parking
+          issues indefinitely (source incident #3954, investigation
+          #4248).
         """
         from scripts.dispatcher.phase_transitions import transition_from_operational
 

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -285,9 +285,14 @@ PHASE_OPERATIONAL = "operational"
 #: evidence, closed the issue, and completed without creating a PR.
 PHASE_OPERATIONAL_DONE = "operational_done"
 
-#: #3507 — Operational failed terminal. The operational skill returned
-#: ``verdict=blocked`` — the task needs operator review before it can
-#: proceed. Routed to ``needs_review`` status so the operator can see it.
+#: #3507 — Operational failed terminal. Reached when the diagnoser
+#: determines an operational ``verdict=blocked`` / ``verdict=failed`` is
+#: operator-only (missing secret, external account state) and applies
+#: Action 4 (``mark needs_review``). Pre-#4272 the daemon advanced here
+#: directly on every ``verdict=blocked`` regardless of cause, parking
+#: fixable-code-bug blocks indefinitely; that path now routes through
+#: the diagnoser, which only lands on this terminal when the block is
+#: genuinely operator-only.
 PHASE_OPERATIONAL_FAILED = "operational_failed"
 
 # ---------------------------------------------------------------------------
@@ -665,14 +670,18 @@ def transition_from_operational(output: Mapping[str, Any] | None) -> PhaseTransi
       ``operational_done`` with ``status='succeeded'``. No PR, no CI, no
       merge. The skill is expected to have already posted evidence and
       closed the issue before emitting this verdict.
-    * ``blocked`` — the task needs operator attention before it can
-      proceed (e.g. missing secret, environment not ready). Advance to
-      ``operational_failed`` with ``status='needs_review'`` so the
-      operator can see it in the cockpit.
-    * ``failed`` / missing / unrecognized — the skill encountered a
-      genuine failure (script errored, DB unreachable, etc.). Route to
-      the diagnoser with hint ``operational_failed`` so it can decide
-      whether to retry, escalate, or close the issue.
+    * ``blocked`` / ``failed`` / missing / unrecognized — the skill
+      determined it cannot complete the task on its own. Route to the
+      diagnoser with hint ``operational_failed`` so the empowered
+      diagnoser (``/diagnose-failure``) can decide what to do — file a
+      code-fix tracker (``Blocked by #N``) and re-add ``agent/ready``
+      when ``block_reason`` names a fixable code bug, mark
+      ``needs_review`` for operator-only escalations (missing secret,
+      external account state), or close the issue when the work is
+      already done. #4272 — pre-#4272 the ``blocked`` arm short-circuited
+      to ``operational_failed / needs_review`` here, parking issues
+      indefinitely instead of routing through the diagnoser; the source
+      incident #3954 → #4247 → #4248 motivated the unification.
     """
     verdict = _verdict(output)
     if verdict == "SUCCEEDED":
@@ -686,18 +695,11 @@ def transition_from_operational(output: Mapping[str, Any] | None) -> PhaseTransi
                 "action_taken": (output or {}).get("action_taken"),
             },
         )
-    if verdict == "BLOCKED":
-        return PhaseTransition(
-            action=TransitionAction.ADVANCE_WITH_STATUS,
-            next_phase=PHASE_OPERATIONAL_FAILED,
-            terminal_status=AgentStatus.NEEDS_REVIEW.value,
-            reason="operational blocked — needs operator review",
-            context={
-                "block_reason": (output or {}).get("block_reason"),
-                "evidence_md": (output or {}).get("evidence_md"),
-            },
-        )
-    # failed, missing, or unrecognized — route to diagnoser.
+    # blocked, failed, missing, or unrecognized — route to diagnoser
+    # (#4272). The diagnoser SKILL classifies operator-only blocks via
+    # Action 4 (mark needs_review), so the prior needs_review end-state
+    # is preserved for that subset; fixable-code-bug blocks now get an
+    # autonomously-filed tracker instead of parking indefinitely.
     return PhaseTransition(
         action=TransitionAction.ROUTE_TO_DIAGNOSER,
         failure_hint=FAILURE_HINT_OPERATIONAL_FAILED,

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -1151,3 +1151,162 @@ class TestFixCiRebaseOutcomeLogEvent:
         events = handler.events("fix_ci_rebase_outcome")
         assert len(events) == 1
         assert getattr(events[0], "rebase_outcome", "MISSING") is None
+
+
+# ==========================================================================
+# #4272 — operational verdict=blocked routes to the diagnoser
+# ==========================================================================
+
+
+class TestOperationalFailedTierRegistration:
+    """``operational_failed`` is the failure category written by
+    ``_run_operational_phase`` when ``transition_from_operational``
+    returns ``ROUTE_TO_DIAGNOSER`` (which #4272 now does for
+    ``verdict=blocked`` in addition to ``verdict=failed`` /
+    ``missing`` / ``unrecognized``).
+
+    Membership in :data:`TIER_2_FIRST_OCCURRENCE_CATEGORIES` is what
+    makes the supervisor's ``_find_diagnoser_candidates`` SQL filter
+    select these failure rows. Without this membership, the row is
+    written but never picked up — exactly the gap described in
+    #4248's investigation.
+    """
+
+    def test_operational_failed_is_tier_2_first_occurrence(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED
+            in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
+    def test_operational_failed_not_in_auto_retry(self) -> None:
+        """Operational failures are not mechanically retryable — the
+        diagnoser must triage them, not the auto-retry loop."""
+        assert (
+            daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED
+            not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+    def test_operational_failed_not_in_tier_3(self) -> None:
+        """Tier buckets must be disjoint — the candidate scanner's
+        tier assignment branches on exclusive membership."""
+        assert (
+            daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED not in daemon.TIER_3_CATEGORIES
+        )
+
+    def test_operational_failed_not_in_tier_2_recurrence(self) -> None:
+        """Operational failures diagnose on first occurrence (tier-2
+        first), not on recurrence (which would gate behind a prior
+        same-category row)."""
+        assert (
+            daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED
+            not in daemon.TIER_2_RECURRENCE_CATEGORIES
+        )
+
+
+class TestOperationalFailedCandidatePickup:
+    """End-to-end coverage of the routing chain (#4272 AC #3 + #4272 AC #5
+    structural-defense). A ``dispatcher.failures`` row with
+    ``category='operational_failed'`` must be selected by
+    ``_find_diagnoser_candidates`` and assigned tier 2.
+    """
+
+    def test_row_is_tier_2_candidate(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path, scope="operational_failed_scan")
+        row = _make_failure_row(
+            failure_id=9272,
+            agent_id="agent-op-blocked",
+            category=daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED,
+            details={
+                "issue_number": 4272,
+                "phase": "operational",
+                "verdict": "BLOCKED",
+                "block_reason": (
+                    "rebuild_db.py crashes on county=Riverside "
+                    "because DocumentRow is missing ruling_text_html"
+                ),
+                "evidence_md": "## Evidence\n\nAttributeError on .ruling_text_html",
+                "exit_code": 0,
+                "stderr_tail": "",
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["failure_id"] == 9272
+        assert cand["category"] == daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED
+        assert cand["tier"] == 2
+        assert cand["issue_number"] == 4272
+        # block_reason must be carried through so the diagnoser SKILL
+        # has the signal it needs to pick file_prerequisite_task vs
+        # mark needs_review.
+        assert "ruling_text_html" in cand["details"]["block_reason"]
+
+
+class TestOperationalBlockedEndToEndRouting:
+    """End-to-end coverage of the routing chain (#4272 AC #3 — the
+    investigation's structural defense). Asserts that the chain
+    ``transition_from_operational(verdict=blocked)`` →
+    ``_handle_agent_failure`` → ``dispatcher.failures`` row →
+    ``_find_diagnoser_candidates`` produces exactly one tier-2
+    candidate with the operational block context preserved.
+
+    Pre-#4272 this chain was severed at step 1 (the transition
+    advanced to ``operational_failed / needs_review`` without ever
+    routing to the diagnoser), so this test would have caught the
+    regression at the unit-test layer.
+    """
+
+    def test_full_routing_chain_produces_tier_2_candidate(self, tmp_path: Path) -> None:
+        from dispatcher.phase_transitions import (
+            FAILURE_HINT_OPERATIONAL_FAILED,
+            TransitionAction,
+            transition_from_operational,
+        )
+
+        # Step 1: phase_transitions returns ROUTE_TO_DIAGNOSER.
+        transition = transition_from_operational(
+            {
+                "verdict": "blocked",
+                "block_reason": (
+                    "rebuild_db.py needs --skip-cache flag the operator "
+                    "hasn't shipped yet"
+                ),
+                "evidence_md": "## Evidence\n\nargparse: unrecognized arg --skip-cache",
+            }
+        )
+        assert transition.action == TransitionAction.ROUTE_TO_DIAGNOSER
+        assert transition.failure_hint == FAILURE_HINT_OPERATIONAL_FAILED
+
+        # Step 2: simulate the daemon writing the dispatcher.failures
+        # row that ``_run_operational_phase`` would write via
+        # ``_handle_agent_failure``. We exercise the candidate scan
+        # against the row shape the daemon emits.
+        d, conn, _handler = _make_daemon(tmp_path, scope="operational_e2e")
+        row = _make_failure_row(
+            failure_id=9273,
+            agent_id="agent-e2e",
+            category=daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED,
+            details={
+                "issue_number": 4272,
+                "phase": "operational",
+                "verdict": transition.context.get("verdict"),
+                "block_reason": transition.context.get("block_reason"),
+                "evidence_md": transition.context.get("evidence_md"),
+                "exit_code": 0,
+                "stderr_tail": "",
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        # Step 3: candidate scan picks the row up at tier 2.
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["category"] == daemon.FAILURE_CATEGORY_OPERATIONAL_FAILED
+        assert cand["tier"] == 2
+        assert cand["issue_number"] == 4272
+        assert "--skip-cache" in cand["details"]["block_reason"]

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -1404,7 +1404,52 @@ class TestTransitionFromOperational:
         assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
         assert result.next_phase == pt.PHASE_OPERATIONAL_DONE
 
-    def test_blocked_advances_to_operational_failed_with_needs_review(self) -> None:
+    def test_blocked_routes_to_diagnoser(self) -> None:
+        """#4272 — ``verdict=blocked`` now routes to the diagnoser
+        (regardless of cause) so the diagnoser can pick between filing
+        an autonomous code-fix tracker and marking ``needs_review``.
+        Pre-#4272 every blocked verdict short-circuited to
+        ``operational_failed / needs_review``, which parked
+        fixable-code-bug blocks indefinitely (source incident #3954).
+        """
+        result = pt.transition_from_operational(
+            {
+                "verdict": "blocked",
+                "block_reason": (
+                    "rebuild_db.py crashes on county=Riverside because the "
+                    "DocumentRow type is missing the new ruling_text_html "
+                    "column added in #4123 — the script needs a code patch"
+                ),
+                "evidence_md": "## Evidence\n\nLast log: AttributeError on .ruling_text_html",
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+        assert result.next_phase is None
+        assert result.terminal_status is None
+        # Block context is forwarded so the diagnoser SKILL can read
+        # block_reason from the failure-row details payload.
+        assert result.context.get("verdict") == "BLOCKED"
+        assert "ruling_text_html" in result.context.get("block_reason", "")
+        assert "AttributeError" in result.context.get("evidence_md", "")
+
+    def test_blocked_uppercase_routes_to_diagnoser(self) -> None:
+        """Verdict matching is case-insensitive (#4272)."""
+        result = pt.transition_from_operational({"verdict": "BLOCKED"})
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+        assert result.context.get("verdict") == "BLOCKED"
+
+    def test_blocked_with_operator_only_reason_also_routes_to_diagnoser(
+        self,
+    ) -> None:
+        """#4272 — even operator-only blocks (missing secret, external
+        account state) route through the diagnoser. The diagnoser SKILL
+        applies Action 4 (``mark needs_review``) for those cases, so the
+        prior end-state is preserved for that subset; what changes is
+        that fixable-code-bug blocks are no longer trapped on the
+        old short-circuit path.
+        """
         result = pt.transition_from_operational(
             {
                 "verdict": "blocked",
@@ -1412,20 +1457,12 @@ class TestTransitionFromOperational:
                 "evidence_md": None,
             }
         )
-        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
-        assert result.next_phase == pt.PHASE_OPERATIONAL_FAILED
-        assert result.terminal_status == pt.AgentStatus.NEEDS_REVIEW.value
-        assert result.failure_hint is None
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
         assert (
             result.context.get("block_reason")
             == "JUDGEMIND_DB_URL secret not set in dev"
         )
-
-    def test_blocked_uppercase_still_matches(self) -> None:
-        result = pt.transition_from_operational({"verdict": "BLOCKED"})
-        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
-        assert result.next_phase == pt.PHASE_OPERATIONAL_FAILED
-        assert result.terminal_status == pt.AgentStatus.NEEDS_REVIEW.value
 
     def test_failed_routes_to_diagnoser(self) -> None:
         result = pt.transition_from_operational(
@@ -1534,7 +1571,8 @@ class TestModuleContractInvariants:
         advance_cases = [
             pt.transition_from_plan({}),
             pt.transition_from_operational({"verdict": "succeeded"}),
-            pt.transition_from_operational({"verdict": "blocked"}),
+            # #4272 — operational ``blocked`` now routes to the diagnoser
+            # (moved to ``diagnoser_cases`` below).
             pt.transition_from_ralph({"verdict": "SHIP"}),
             pt.transition_from_summary({}),
             pt.transition_from_push_and_pr({}),
@@ -1571,6 +1609,8 @@ class TestModuleContractInvariants:
             pt.transition_from_awaiting_deploy(deploy_succeeded=False),
             pt.transition_from_operational({"verdict": "failed"}),
             pt.transition_from_operational({}),
+            # #4272 — operational ``blocked`` joins the diagnoser cases.
+            pt.transition_from_operational({"verdict": "blocked"}),
         ]
         for t in diagnoser_cases:
             assert t.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER, (


### PR DESCRIPTION
## Summary

Routes operational `verdict=blocked` through the empowered diagnoser instead of short-circuiting to `operational_failed / needs_review`, so fixable-code-bug blocks no longer park dependent issues at `agent/ready + needs_review (active)` indefinitely. Two layers were broken — the `transition_from_operational` arm AND the `_find_diagnoser_candidates` tier-set membership — and both are fixed here.

Closes #4272

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deploy Dispatcher workflow run 25460285866 succeeded; merge SHA `9f8111d` confirmed in deployed image via `scripts/verify-pr-in-deployed-sha.sh 4275`.
- [x] Dispatcher healthy post-deploy — scheduler ticks running, supervisor tick fired, no Tracebacks or ERROR events in CloudWatch (`/ecs/judgemind-dispatcher-dev`).
- [x] Verification evidence posted on issue (#4272 comment 4392086026). AC #5 (live `verdict=blocked` event producing matching `dispatcher.failures` + `dispatcher.diagnoses` rows) is structurally covered by the `TestOperationalBlockedEndToEndRouting` end-to-end test and will be observable on the next operational blocked event.
