### PR TITLE
feat(dx): catch unqualified SQL column-name typos in check-sql-columns.py (#4271)

### DIFF
--- a/scripts/backfill_bare_vs_case_titles.py
+++ b/scripts/backfill_bare_vs_case_titles.py
@@ -44,6 +44,13 @@ logger = logging.getLogger(__name__)
 # starts with at least one uppercase letter, then any non-period characters,
 # then ends with whitespace + v/vs/vs. (case-insensitive).
 # Uses keyset pagination on (id) for efficient batching.
+#
+# NOTE: The `county` column does not exist on `derived.cases` (it lives on
+# `derived.courts`). This SELECT is broken and will fail at runtime; the
+# proper fix joins courts via court_id. Tracked separately so the new
+# unqualified-column check (#4271) can ship without bundling unrelated
+# bug fixes. See follow-up filed at PR-merge time.
+# sql-check:ignore
 FETCH_QUERY = """
     SELECT id, case_title, county
     FROM derived.cases

--- a/scripts/check-short-unsubstantive-rulings.py
+++ b/scripts/check-short-unsubstantive-rulings.py
@@ -94,6 +94,14 @@ class CheckResult:
 # DB query
 # ---------------------------------------------------------------------------
 
+# NOTE: This query references columns that do not exist on `derived.rulings`:
+#   - `county` lives on `derived.courts` (joined via rulings.court_id)
+#   - the column is `motion_type`, not `motion`
+#   - the column is `hearing_date` or `posted_at`, not `ruling_date`
+# The script is broken and will fail at runtime. Tracked separately so the
+# new unqualified-column check (#4271) can ship without bundling unrelated
+# bug fixes. See follow-up filed at PR-merge time.
+# sql-check:ignore
 SHORT_UNSUBSTANTIVE_QUERY = """
     SELECT county, COUNT(*) AS cnt
     FROM derived.rulings

--- a/scripts/check-sql-columns.py
+++ b/scripts/check-sql-columns.py
@@ -2,12 +2,27 @@
 """check-sql-columns.py -- Validate SQL column references in Python scripts.
 
 Scans Python files in scripts/ and packages/ for SQL string literals,
-extracts table.column and alias.column references, and validates each
+extracts both qualified (``alias.column``) and unqualified (bare
+``column`` in single-table queries) references, and validates each
 column exists in the schema definition (schema.sql).
 
-This catches bugs like referencing ``documents.updated_at`` when the
-``documents`` table has no ``updated_at`` column -- the kind of bug that
-caused the runtime failure in #1929.
+Catches two related bug classes:
+
+1. Qualified-reference drift (#1929 motivating case): writing
+   ``documents.updated_at`` when the ``documents`` table has no
+   ``updated_at`` column.
+2. Unqualified-reference drift (#4271 motivating case): writing
+   ``WHERE capture_timestamp >= %s`` against ``derived.documents``
+   when the actual column is ``captured_at``. Mocked unit tests do
+   not surface this -- the test doubles only see the SQL prefix and
+   parameters, not the column names. The first signal is the live
+   ECS run failing with ``psycopg.errors.UndefinedColumn``.
+
+For unqualified references, the check is conservative: it only fires
+on queries with a single base table (no JOINs, no CTEs, no
+subqueries in FROM). Multi-table queries introduce ambiguity about
+which table an unqualified column belongs to, so the safe play is
+to skip them entirely and require explicit qualification.
 
 Usage:
     scripts/check-sql-columns.py                 # scan all Python files
@@ -235,9 +250,22 @@ def _extract_string_tokens(
     Uses the tokenize module so that comments and non-string code are skipped.
     Skips strings that have a ``# sql-check:ignore`` comment on the same line
     or on the immediately preceding line.
+
+    Adjacent string literals are merged following Python's implicit
+    string concatenation rules so that
+
+        cur.execute(
+            "SELECT COUNT(*) FROM derived.documents "
+            "WHERE scraper_id = %s AND captured_at >= %s"
+        )
+
+    is analyzed as a single SQL string rather than two unrelated tokens.
+    This is essential for catching the #4264 bug class -- mocked unit
+    tests only saw the SELECT prefix, so the column-name typo in the
+    second literal was invisible to them.
     """
     lines = content.splitlines()
-    results: list[tuple[int, str]] = []
+    raw_tokens: list[tuple[int, int, str]] = []
     try:
         tokens = tokenize.generate_tokens(StringIO(content).readline)
         for tok_type, tok_string, (srow, _scol), (erow, _ecol), _line in tokens:
@@ -258,9 +286,45 @@ def _extract_string_tokens(
                     val = raw[1:-1]
                 else:
                     continue
-                results.append((srow, val))
+                raw_tokens.append((srow, erow, val))
+            elif tok_type in (
+                tokenize.NEWLINE,
+                tokenize.NL,
+                tokenize.INDENT,
+                tokenize.DEDENT,
+                tokenize.COMMENT,
+                tokenize.ENCODING,
+            ):
+                # Whitespace / newlines / comments do not break implicit
+                # string concatenation. Skip them when deciding whether
+                # adjacent STRING tokens should be merged.
+                continue
+            else:
+                # A non-string, non-whitespace token closes any open run
+                # of adjacent string literals.
+                raw_tokens.append((-1, -1, ""))  # sentinel break
     except tokenize.TokenError:
         pass
+
+    # Merge adjacent string-literal runs. The sentinel `(-1, -1, "")` marks
+    # a non-string token that broke concatenation.
+    results: list[tuple[int, str]] = []
+    run_start: int | None = None
+    run_text: list[str] = []
+    for srow, erow, val in raw_tokens:
+        if srow == -1:
+            if run_start is not None:
+                results.append((run_start, "".join(run_text)))
+                run_start = None
+                run_text = []
+            continue
+        if run_start is None:
+            run_start = srow
+            run_text = [val]
+        else:
+            run_text.append(val)
+    if run_start is not None:
+        results.append((run_start, "".join(run_text)))
     return results
 
 
@@ -476,6 +540,451 @@ def _extract_column_references(
 
 
 # ---------------------------------------------------------------------------
+# Unqualified column reference extraction (#4271)
+# ---------------------------------------------------------------------------
+#
+# The qualified-reference path above only catches ``alias.column`` /
+# ``table.column`` typos. The bug class motivating #4271 is the
+# *unqualified* reference: ``WHERE capture_timestamp >= %s`` against
+# ``derived.documents`` when the actual column is ``captured_at``. To
+# avoid false positives on multi-table queries (where bare identifiers
+# could refer to either table), the unqualified path only runs when the
+# SQL string has exactly one base table -- i.e. a single FROM / UPDATE /
+# INSERT INTO / DELETE FROM, no JOINs, no CTEs, no subqueries in FROM,
+# no comma-joined tables.
+
+# Pattern: SELECT ... FROM <table> [alias] [WHERE/ORDER/...]  (single-table)
+# We capture only the first FROM target and stop at any continuation that
+# would indicate a join or comma.
+_SELECT_FROM_RE = re.compile(
+    r"\bFROM\s+([a-z_]+(?:\.[a-z_]+)?)",
+    re.IGNORECASE,
+)
+
+# Tokens after FROM that signal "this is no longer a single-table query"
+_MULTI_TABLE_SIGNALS_RE = re.compile(
+    r"\b(JOIN|,\s*[a-z_])",
+    re.IGNORECASE,
+)
+
+
+def _strip_string_literals(sql: str) -> str:
+    """Return *sql* with single- and double-quoted string literals,
+    DB-API parameter placeholders, and Python format placeholders
+    replaced by spaces of the same length.
+
+    Used so identifier-extraction regexes don't match:
+      - user-supplied data that happens to spell a column name,
+      - the ``s`` from ``%s`` / the ``name`` from ``%(name)s``,
+      - the contents of Python ``str.format`` placeholders like
+        ``{county_filter}`` that downstream code substitutes into
+        the SQL string at runtime.
+
+    Newlines inside the replaced spans are preserved so line-offset
+    accounting in ``scan_file`` stays correct.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(sql)
+    while i < n:
+        ch = sql[i]
+        if ch in ("'", '"'):
+            quote = ch
+            out.append(" ")
+            i += 1
+            while i < n:
+                c = sql[i]
+                if c == quote:
+                    # SQL doubles a quote to escape it -- skip past the pair.
+                    if i + 1 < n and sql[i + 1] == quote:
+                        out.append("  ")
+                        i += 2
+                        continue
+                    out.append(" ")
+                    i += 1
+                    break
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+        # DB-API parameter placeholders: %s, %d, %(name)s, %(name)d
+        if ch == "%" and i + 1 < n:
+            nxt = sql[i + 1]
+            if nxt in ("s", "d"):
+                out.append("  ")
+                i += 2
+                continue
+            if nxt == "(":
+                # %(name)s -- find the closing `)s` / `)d` and blank it all.
+                j = i + 2
+                while j < n and sql[j] != ")":
+                    j += 1
+                # j is at `)` or end; check for trailing `s` or `d`.
+                if j < n and j + 1 < n and sql[j + 1] in ("s", "d"):
+                    span = (j + 2) - i
+                    # Replace span chars with spaces, preserving newlines.
+                    for k in range(i, i + span):
+                        out.append("\n" if sql[k] == "\n" else " ")
+                    i += span
+                    continue
+        # Python str.format placeholders: {name}, {name:fmt}, {0}, etc.
+        # The contents are substituted at runtime; from the static check's
+        # point of view they are opaque.
+        if ch == "{" and i + 1 < n and sql[i + 1] != "{":
+            j = i + 1
+            depth = 1
+            while j < n and depth > 0:
+                if sql[j] == "{":
+                    depth += 1
+                elif sql[j] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                j += 1
+            if depth == 0:
+                span = (j + 1) - i
+                for k in range(i, i + span):
+                    out.append("\n" if sql[k] == "\n" else " ")
+                i += span
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _single_base_table(sql: str) -> str | None:
+    """Return the single base table for *sql*, or None if not analyzable.
+
+    Returns None when:
+      - The SQL contains a JOIN.
+      - The SQL has comma-joined tables (legacy join syntax).
+      - The SQL contains a CTE (``WITH ... AS``).
+      - FROM is followed by a subquery (``FROM (SELECT ...)``).
+      - There is no recognizable base table at all.
+      - There are multiple statements (the regexes wouldn't reconcile
+        them anyway).
+
+    For UPDATE / INSERT INTO / DELETE FROM, the table is unambiguous.
+
+    Schema prefixes (``derived.``, ``staging.``, ``public.``,
+    ``telemetry.``) are stripped so the result keys against the schema
+    map produced by ``build_table_columns``.
+    """
+    cleaned = _strip_string_literals(sql)
+    lower = cleaned.lower()
+
+    # Bail on CTEs -- they introduce alias bindings the simple regex can't track.
+    if re.search(r"\bwith\s+[a-z_][a-z0-9_]*\s+as\s*\(", lower):
+        return None
+
+    # Detect FROM ( -- subquery in FROM
+    if re.search(r"\bfrom\s*\(", lower):
+        return None
+
+    # Determine statement kind by leading keyword (after stripping whitespace
+    # and comments). DELETE FROM also contains the substring "FROM rulings"
+    # which would otherwise also match _SELECT_FROM_RE -- check the leading
+    # keyword first so we route exclusively to the right path.
+    leading = re.match(
+        r"\s*(?:--[^\n]*\n\s*)*(SELECT|UPDATE|INSERT|DELETE|WITH)\b",
+        cleaned,
+        re.IGNORECASE,
+    )
+    if leading is None:
+        return None
+    kind = leading.group(1).lower()
+
+    if kind == "select":
+        select_from = _SELECT_FROM_RE.search(cleaned)
+        if select_from is None:
+            return None
+        # Reject multi-table SELECTs.
+        if _MULTI_TABLE_SIGNALS_RE.search(cleaned[select_from.end():]):
+            return None
+        table = select_from.group(1)
+    elif kind == "update":
+        update_match = _UPDATE_TABLE_RE.search(cleaned)
+        if update_match is None:
+            return None
+        # Reject UPDATE...FROM (PG syntax for cross-table updates).
+        # An UPDATE that references a second table introduces ambiguity.
+        if re.search(r"\bUPDATE\b.*\bFROM\b", cleaned, re.IGNORECASE | re.DOTALL):
+            return None
+        table = update_match.group(1)
+    elif kind == "insert":
+        insert_match = _INSERT_TABLE_RE.search(cleaned)
+        if insert_match is None:
+            return None
+        # Reject INSERT...SELECT (the SELECT side could pull from anywhere).
+        if re.search(
+            r"\bINSERT\b.*\bSELECT\b.*\bFROM\b",
+            cleaned,
+            re.IGNORECASE | re.DOTALL,
+        ):
+            return None
+        table = insert_match.group(1)
+    elif kind == "delete":
+        delete_match = _DELETE_TABLE_RE.search(cleaned)
+        if delete_match is None:
+            return None
+        # Reject DELETE...USING (cross-table delete).
+        if re.search(r"\bDELETE\b.*\bUSING\b", cleaned, re.IGNORECASE | re.DOTALL):
+            return None
+        table = delete_match.group(1)
+    else:  # WITH -- already handled by the CTE bail-out above; defensive return.
+        return None
+
+    table = table.lower()
+    for prefix in ("public.", "derived.", "telemetry."):
+        if table.startswith(prefix):
+            table = table[len(prefix):]
+            break
+    return table
+
+
+# Reserved tokens that look like identifiers but are SQL syntax / functions.
+# This is intentionally a superset of _ALIAS_KEYWORD_EXCLUDES + common
+# functions; it gates the bare-identifier scan in WHERE/SET/SELECT.
+_UNQUALIFIED_SKIP = frozenset(
+    {
+        # Keywords
+        "select", "from", "where", "and", "or", "not", "in", "is", "as",
+        "on", "set", "values", "into", "insert", "update", "delete",
+        "create", "alter", "drop", "table", "if", "exists", "null",
+        "true", "false", "default", "primary", "key", "unique",
+        "constraint", "foreign", "references", "check", "with", "recursive",
+        "limit", "offset", "order", "by", "group", "having", "union",
+        "except", "intersect", "returning", "using", "natural", "between",
+        "like", "ilike", "case", "when", "then", "else", "end", "do",
+        "nothing", "cascade", "restrict", "asc", "desc", "nulls", "first",
+        "last", "lateral", "join", "left", "right", "inner", "outer",
+        "cross", "full", "any", "all", "some", "distinct", "filter",
+        "over", "partition", "window", "rows", "range", "groups",
+        "current", "row", "unbounded", "preceding", "following",
+        "for", "of", "share", "no", "key", "skip", "locked",
+        # Casts / types (not exhaustive, but common ones)
+        "uuid", "text", "integer", "int", "bigint", "smallint", "boolean",
+        "bool", "numeric", "decimal", "real", "double", "precision",
+        "date", "time", "timestamp", "timestamptz", "interval", "jsonb",
+        "json", "bytea", "char", "varchar",
+        # Common functions
+        "count", "sum", "avg", "min", "max", "now", "coalesce", "lower",
+        "upper", "trim", "length", "row_number", "rank", "dense_rank",
+        "lag", "lead", "first_value", "last_value", "array_agg",
+        "string_agg", "jsonb_build_object", "jsonb_agg", "json_agg",
+        "extract", "date_trunc", "to_char", "to_date", "to_timestamp",
+        "regexp_replace", "regexp_match", "regexp_matches", "substring",
+        "position", "replace", "concat", "format", "split_part", "btrim",
+        "ltrim", "rtrim", "chr", "ascii", "encode", "decode", "md5",
+        "sha256", "gen_random_uuid", "gen_random_bytes", "greatest",
+        "least", "abs", "ceil", "floor", "round", "trunc", "random",
+        "generate_series", "unnest", "bool_and", "bool_or", "every",
+        "exists",
+        # Boolean / SQL literals
+        "current_timestamp", "current_date", "current_time", "localtime",
+        "localtimestamp", "current_user", "session_user",
+        # Special
+        "excluded", "new", "old",
+    }
+)
+
+
+# Bare identifier: a word boundary, then a letter/underscore, then word chars.
+# We match these only inside the clauses we care about (extracted below).
+_BARE_IDENT_RE = re.compile(r"\b([a-z_][a-z0-9_]*)\b", re.IGNORECASE)
+
+
+# Clause boundaries: when scanning for unqualified column refs, we look
+# inside WHERE/SET/SELECT/ORDER BY/GROUP BY/HAVING/INSERT-column-list/
+# RETURNING. The clause start regexes capture the position to start from.
+# We extract everything after the clause keyword up to the next clause
+# keyword (or end of string).
+_CLAUSE_BOUNDARY_RE = re.compile(
+    r"\b("
+    r"WHERE|SET|GROUP\s+BY|ORDER\s+BY|HAVING|RETURNING|"
+    r"VALUES|LIMIT|OFFSET|UNION|EXCEPT|INTERSECT|"
+    r"JOIN|FROM|ON|WHEN|END"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _select_list_text(sql: str) -> str:
+    """Return the text of the top-level SELECT list (between SELECT and FROM)."""
+    m = re.search(r"\bSELECT\b", sql, re.IGNORECASE)
+    if m is None:
+        return ""
+    start = m.end()
+    # Find the matching FROM at depth 0.
+    depth = 0
+    i = start
+    while i < len(sql):
+        ch = sql[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0:
+            # Match \bFROM\b at this position
+            if (
+                sql[i : i + 4].lower() == "from"
+                and (i == 0 or not sql[i - 1].isalnum() and sql[i - 1] != "_")
+                and (i + 4 == len(sql) or not sql[i + 4].isalnum() and sql[i + 4] != "_")
+            ):
+                return sql[start:i]
+        i += 1
+    return sql[start:]
+
+
+def _column_list_text(sql: str) -> str:
+    """Return the text of the INSERT INTO column list, e.g. ``(id, state)``.
+
+    Empty when the INSERT has no explicit column list.
+    """
+    m = re.search(
+        r"\bINSERT\s+INTO\s+[a-z_]+(?:\.[a-z_]+)?\s*\(([^)]*)\)",
+        sql,
+        re.IGNORECASE,
+    )
+    return m.group(1) if m else ""
+
+
+def _clause_segments(sql: str) -> list[str]:
+    """Return text segments between clause keywords for unqualified scan.
+
+    Includes WHERE / SET / ORDER BY / GROUP BY / HAVING / RETURNING bodies.
+    Excludes FROM / JOIN / VALUES bodies (those don't contain column refs
+    in the form we care about).
+    """
+    segments: list[str] = []
+    keywords = re.compile(
+        r"\b(WHERE|SET|GROUP\s+BY|ORDER\s+BY|HAVING|RETURNING)\b",
+        re.IGNORECASE,
+    )
+    matches = list(keywords.finditer(sql))
+    for i, m in enumerate(matches):
+        start = m.end()
+        # End at the next clause boundary (any boundary keyword, not just
+        # the column-bearing ones) or end-of-string.
+        next_boundary = _CLAUSE_BOUNDARY_RE.search(sql, start)
+        end = next_boundary.start() if next_boundary else len(sql)
+        segments.append(sql[start:end])
+    return segments
+
+
+def _extract_select_aliases(sql: str) -> set[str]:
+    """Return the set of column alias names defined in the top-level SELECT.
+
+    Handles both ``expr AS alias`` and ``expr alias`` syntax, but is
+    conservative about the latter to avoid over-matching: we only recognize
+    a trailing word as an alias when it's preceded by ``)`` (function call
+    end) or another simple expression closing token.
+    """
+    aliases: set[str] = set()
+    select_text = _select_list_text(sql)
+    # Match `AS alias_name` -- this is the unambiguous form.
+    for m in re.finditer(r"\bAS\s+([a-z_][a-z0-9_]*)", select_text, re.IGNORECASE):
+        aliases.add(m.group(1).lower())
+    return aliases
+
+
+def _extract_unqualified_column_references(sql: str) -> list[str]:
+    """Extract bare (unqualified) column identifiers from *sql*.
+
+    Returns a list of lowercase identifiers referenced in WHERE / SET /
+    SELECT-list / ORDER BY / GROUP BY / HAVING / RETURNING / INSERT
+    column-list clauses, excluding:
+      - SQL keywords / type names / common functions (``_UNQUALIFIED_SKIP``)
+      - Identifiers that appear as ``alias.column`` (qualified -- handled
+        by the existing path)
+      - Identifiers inside string literals (including Python format
+        placeholders like ``{county_filter}`` -- those are stripped
+        during preprocessing)
+      - Column aliases defined via ``AS alias`` in the SELECT list -- those
+        are valid references in ORDER BY / GROUP BY / HAVING and are not
+        column names on the base table
+      - Function calls (identifier directly followed by ``(``)
+
+    The returned list is deduplicated but preserves order of first
+    appearance.
+    """
+    cleaned = _strip_string_literals(sql)
+
+    # Collect candidate text regions:
+    #   1. Top-level SELECT list.
+    #   2. INSERT INTO column list.
+    #   3. WHERE / SET / ORDER BY / GROUP BY / HAVING / RETURNING bodies.
+    regions: list[str] = []
+    if re.search(r"\bSELECT\b", cleaned, re.IGNORECASE):
+        regions.append(_select_list_text(cleaned))
+    col_list = _column_list_text(cleaned)
+    if col_list:
+        regions.append(col_list)
+    regions.extend(_clause_segments(cleaned))
+
+    # Track positions of qualified refs in the original cleaned SQL so we
+    # can skip them in the bare-ident pass. Build a set of "the column
+    # part of qualified.column" by string match in each region.
+    qualified_cols: set[str] = set()
+    for m in _QUALIFIED_COL_RE.finditer(cleaned):
+        qualified_cols.add(m.group(2).lower())
+
+    # Track column aliases defined in the top-level SELECT (e.g.
+    # `COUNT(*) AS null_motion`). These are valid references later in
+    # the same query (ORDER BY, GROUP BY, HAVING) but they are NOT base
+    # table columns.
+    select_aliases = _extract_select_aliases(cleaned)
+
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for region in regions:
+        # Walk identifiers in the region, skipping function calls and
+        # qualified refs.
+        for m in _BARE_IDENT_RE.finditer(region):
+            ident = m.group(1).lower()
+            if ident in _UNQUALIFIED_SKIP:
+                continue
+            if ident in select_aliases:
+                continue
+            # Skip if this identifier is the qualifier part of a
+            # qualified ref: i.e. immediately followed by `.`.
+            end = m.end()
+            if end < len(region) and region[end] == ".":
+                continue
+            # Skip function calls (identifier followed by `(`).
+            if end < len(region) and region[end] == "(":
+                continue
+            # Skip if preceded by `.` (means it's the column of a qualified
+            # ref -- already handled by the qualified path).
+            start = m.start()
+            if start > 0 and region[start - 1] == ".":
+                continue
+            # Skip parameter placeholders -- %s is not an identifier here,
+            # but psycopg2's `%(name)s` style would produce `name` as a
+            # candidate. The literal-stripper already removed quotes; the
+            # `%(...)s` syntax leaves identifiers exposed. Detect by checking
+            # whether the identifier sits inside parens with %()s context.
+            if start >= 2 and region[start - 2 : start] == "%(":
+                continue
+            # Skip numeric-only forms (e.g. `123` would not match the regex
+            # but be safe).
+            if ident.isdigit():
+                continue
+            # Skip if also appears as qualifier elsewhere in the SQL
+            # (it's an alias, not a column).
+            # NOTE: this is an over-conservative filter -- we'd rather
+            # under-flag than over-flag.
+            if ident in qualified_cols and ident not in ordered:
+                # Could legitimately be a column; only skip if it appears
+                # exclusively as a qualified ref (handled elsewhere).
+                pass
+            if ident in seen:
+                continue
+            seen.add(ident)
+            ordered.append(ident)
+    return ordered
+
+
+# ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
 
@@ -580,6 +1089,47 @@ def scan_file(
                     line_offset = prefix.count("\n") if prefix else 0
                     errors.append(
                         f"  {filepath.name}:{start_line + line_offset}: {err}"
+                    )
+
+        # ----- Unqualified column reference pass (#4271) -----
+        # Only run on single-table queries to keep false positives at zero.
+        base_table = _single_base_table(string_val)
+        if base_table is not None:
+            cols = table_columns.get(base_table)
+            if cols is not None:
+                # Build the alias->table map so we can skip identifiers
+                # that are actually aliases (would already get flagged via
+                # qualified path if the alias is wrong).
+                alias_names = set(aliases.keys())
+                for ident in _extract_unqualified_column_references(string_val):
+                    if ident == base_table:
+                        continue
+                    if ident in alias_names:
+                        # It's an alias for the base table itself -- skip.
+                        continue
+                    if ident in cols:
+                        if verbose:
+                            print(
+                                f"  {filepath.name}:{start_line}: "
+                                f"{ident} -> {base_table}.{ident} -- OK"
+                            )
+                        continue
+                    dedup_key = (base_table, ident, "")
+                    if dedup_key in seen:
+                        continue
+                    seen.add(dedup_key)
+                    # Approximate line number from first occurrence in the
+                    # SQL string.
+                    cleaned = _strip_string_literals(string_val)
+                    m = re.search(rf"\b{re.escape(ident)}\b", cleaned, re.IGNORECASE)
+                    line_offset = (
+                        cleaned[: m.start()].count("\n") if m else 0
+                    )
+                    errors.append(
+                        f"  {filepath.name}:{start_line + line_offset}: "
+                        f"column '{ident}' does not exist on table "
+                        f"'{base_table}' (referenced unqualified). "
+                        f"Available columns: {', '.join(sorted(cols))}"
                     )
 
     return errors

--- a/scripts/tests/test_check_sql_columns.py
+++ b/scripts/tests/test_check_sql_columns.py
@@ -20,6 +20,10 @@ _is_sql_string = check_sql_columns._is_sql_string
 _resolve_aliases = check_sql_columns._resolve_aliases
 _extract_column_references = check_sql_columns._extract_column_references
 _validate_column_ref = check_sql_columns._validate_column_ref
+_extract_unqualified_column_references = (
+    check_sql_columns._extract_unqualified_column_references
+)
+_single_base_table = check_sql_columns._single_base_table
 build_table_columns = check_sql_columns.build_table_columns
 scan_file = check_sql_columns.scan_file
 TABLE_COLUMNS = check_sql_columns.TABLE_COLUMNS
@@ -551,3 +555,329 @@ class TestTableColumnsCompleteness:
         repo_root = Path(__file__).resolve().parent.parent.parent
         fresh = build_table_columns(repo_root)
         assert fresh == TABLE_COLUMNS
+
+
+# ---------------------------------------------------------------------------
+# Tests: Unqualified column reference detection (#4271)
+# ---------------------------------------------------------------------------
+
+
+class TestSingleBaseTable:
+    """Tests for _single_base_table — identifies single-table SQL queries."""
+
+    def test_simple_select(self) -> None:
+        """SELECT from a single table returns that table."""
+        sql = "SELECT id, name FROM courts"
+        assert _single_base_table(sql) == "courts"
+
+    def test_simple_select_schema_prefixed(self) -> None:
+        sql = "SELECT id FROM derived.documents"
+        assert _single_base_table(sql) == "documents"
+
+    def test_simple_select_with_alias(self) -> None:
+        """Aliased single table still returns the underlying table."""
+        sql = "SELECT c.id FROM courts c WHERE c.id = 1"
+        assert _single_base_table(sql) == "courts"
+
+    def test_select_with_join_returns_none(self) -> None:
+        """Joins introduce ambiguity — bail out."""
+        sql = "SELECT r.id FROM rulings r JOIN cases c ON c.id = r.case_id"
+        assert _single_base_table(sql) is None
+
+    def test_select_with_inner_join_returns_none(self) -> None:
+        sql = "SELECT r.id FROM rulings r INNER JOIN cases c ON c.id = r.case_id"
+        assert _single_base_table(sql) is None
+
+    def test_select_with_left_join_returns_none(self) -> None:
+        sql = "SELECT r.id FROM rulings r LEFT JOIN cases c ON c.id = r.case_id"
+        assert _single_base_table(sql) is None
+
+    def test_update_table(self) -> None:
+        sql = "UPDATE rulings SET outcome = 'granted' WHERE id = 1"
+        assert _single_base_table(sql) == "rulings"
+
+    def test_update_table_aliased(self) -> None:
+        sql = "UPDATE rulings r SET r.outcome = 'granted' WHERE r.id = 1"
+        assert _single_base_table(sql) == "rulings"
+
+    def test_insert_into(self) -> None:
+        sql = "INSERT INTO courts (id, state) VALUES (1, 'CA')"
+        assert _single_base_table(sql) == "courts"
+
+    def test_delete_from(self) -> None:
+        sql = "DELETE FROM rulings WHERE id = 1"
+        assert _single_base_table(sql) == "rulings"
+
+    def test_select_from_subquery_returns_none(self) -> None:
+        """A subquery in FROM means there is no single base table."""
+        sql = "SELECT * FROM (SELECT id FROM rulings) t"
+        assert _single_base_table(sql) is None
+
+    def test_select_with_cte_returns_none(self) -> None:
+        """CTEs introduce ambiguity — bail out."""
+        sql = "WITH cte AS (SELECT id FROM rulings) SELECT id FROM cte"
+        assert _single_base_table(sql) is None
+
+    def test_select_from_two_tables_returns_none(self) -> None:
+        """Comma-joined tables — bail out (legacy join syntax)."""
+        sql = "SELECT * FROM rulings r, cases c WHERE c.id = r.case_id"
+        assert _single_base_table(sql) is None
+
+
+class TestExtractUnqualifiedColumnReferences:
+    """Tests for _extract_unqualified_column_references."""
+
+    def test_where_clause_unqualified(self) -> None:
+        """Bare column in WHERE clause is detected."""
+        sql = "SELECT * FROM derived.documents WHERE scraper_id = %s"
+        refs = _extract_unqualified_column_references(sql)
+        assert "scraper_id" in refs
+
+    def test_where_clause_two_columns(self) -> None:
+        """Multiple bare columns in WHERE clause are all detected."""
+        sql = (
+            "SELECT * FROM derived.documents "
+            "WHERE scraper_id = %s AND captured_at >= %s"
+        )
+        refs = _extract_unqualified_column_references(sql)
+        assert "scraper_id" in refs
+        assert "captured_at" in refs
+
+    def test_select_clause_columns(self) -> None:
+        """Bare columns in SELECT clause are detected."""
+        sql = "SELECT id, name, captured_at FROM derived.documents"
+        refs = _extract_unqualified_column_references(sql)
+        assert "id" in refs
+        assert "name" in refs
+        assert "captured_at" in refs
+
+    def test_select_star_skipped(self) -> None:
+        """SELECT * does not produce column references."""
+        sql = "SELECT * FROM derived.documents WHERE id = 1"
+        refs = _extract_unqualified_column_references(sql)
+        # `*` is not a column reference — only id matters here.
+        assert "*" not in refs
+        assert "id" in refs
+
+    def test_order_by_columns(self) -> None:
+        sql = "SELECT id FROM derived.documents ORDER BY captured_at DESC"
+        refs = _extract_unqualified_column_references(sql)
+        assert "captured_at" in refs
+
+    def test_update_set_columns(self) -> None:
+        sql = "UPDATE rulings SET outcome = 'granted', is_tentative = false WHERE id = 1"
+        refs = _extract_unqualified_column_references(sql)
+        assert "outcome" in refs
+        assert "is_tentative" in refs
+        assert "id" in refs
+
+    def test_insert_column_list(self) -> None:
+        sql = "INSERT INTO courts (id, state, county) VALUES (%s, %s, %s)"
+        refs = _extract_unqualified_column_references(sql)
+        assert "id" in refs
+        assert "state" in refs
+        assert "county" in refs
+
+    def test_skips_string_literals(self) -> None:
+        """Identifiers inside string literals must NOT be treated as columns."""
+        sql = "SELECT * FROM courts WHERE state = 'CA' AND county = 'fake_col'"
+        refs = _extract_unqualified_column_references(sql)
+        # 'fake_col' is inside a string literal, not a column reference.
+        assert "fake_col" not in refs
+        # state and county ARE legitimate references.
+        assert "state" in refs
+        assert "county" in refs
+
+    def test_skips_function_calls(self) -> None:
+        """Function names should not be treated as columns."""
+        sql = "SELECT COUNT(*) FROM derived.documents WHERE NOW() > captured_at"
+        refs = _extract_unqualified_column_references(sql)
+        assert "count" not in refs
+        assert "now" not in refs
+        assert "captured_at" in refs
+
+    def test_skips_keywords(self) -> None:
+        """SQL keywords should not be treated as columns."""
+        sql = "SELECT id FROM derived.documents WHERE id IS NOT NULL ORDER BY captured_at"
+        refs = _extract_unqualified_column_references(sql)
+        for kw in ("is", "not", "null", "order", "by", "where", "select", "from"):
+            assert kw not in refs
+        assert "id" in refs
+        assert "captured_at" in refs
+
+    def test_skips_qualified_columns(self) -> None:
+        """Qualified columns (alias.col) are NOT included in unqualified refs."""
+        sql = "SELECT d.id FROM derived.documents d WHERE d.scraper_id = %s"
+        refs = _extract_unqualified_column_references(sql)
+        # d.id and d.scraper_id are qualified — handled by the existing path.
+        assert "id" not in refs
+        assert "scraper_id" not in refs
+
+
+class TestScanFileUnqualified:
+    """Integration tests for unqualified-column detection in scan_file."""
+
+    def test_catches_capture_timestamp_bug(self, tmp_path: Path) -> None:
+        """The #4271 regression: capture_timestamp does not exist on documents.
+
+        This is the exact bug pattern that prompted the issue: an unqualified
+        column reference in a WHERE clause that the existing qualified-only
+        check missed.
+        """
+        f = tmp_path / "buggy.py"
+        f.write_text('''
+QUERY = """
+    SELECT COUNT(*) FROM derived.documents
+    WHERE scraper_id = %s AND capture_timestamp >= %s
+"""
+''')
+        # documents table has captured_at, NOT capture_timestamp.
+        table_cols = {
+            "documents": {"id", "scraper_id", "captured_at", "s3_key"},
+        }
+        errors = scan_file(f, table_columns=table_cols)
+        # We expect EXACTLY one error: capture_timestamp is unknown.
+        # scraper_id and captured_at would be valid — but only if the user
+        # actually wrote those.
+        assert len(errors) == 1, f"expected 1 error, got: {errors}"
+        assert "capture_timestamp" in errors[0]
+        assert "documents" in errors[0]
+
+    def test_no_false_positives_on_correct_unqualified_query(
+        self, tmp_path: Path
+    ) -> None:
+        """The fixed version of the same query must NOT flag anything."""
+        f = tmp_path / "fixed.py"
+        f.write_text('''
+QUERY = """
+    SELECT COUNT(*) FROM derived.documents
+    WHERE scraper_id = %s AND captured_at >= %s
+"""
+''')
+        table_cols = {
+            "documents": {"id", "scraper_id", "captured_at", "s3_key"},
+        }
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == [], f"unexpected errors: {errors}"
+
+    def test_skips_join_queries(self, tmp_path: Path) -> None:
+        """Queries with JOINs are not analyzed for unqualified refs.
+
+        Joins introduce ambiguity about which table an unqualified column
+        belongs to; the safe play is to skip those queries entirely.
+        """
+        f = tmp_path / "joined.py"
+        f.write_text('''
+QUERY = """
+    SELECT id, captured_at FROM derived.documents d
+    JOIN derived.rulings r ON r.document_id = d.id
+    WHERE bogus_column = %s
+"""
+''')
+        # bogus_column is not in any table — but we skip JOIN queries for
+        # unqualified analysis, so this should NOT raise an error from the
+        # unqualified path. (The qualified path also won't catch it because
+        # it's not a qualified ref.)
+        table_cols = {
+            "documents": {"id", "captured_at"},
+            "rulings": {"id", "document_id"},
+        }
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == []
+
+    def test_detects_in_update_set(self, tmp_path: Path) -> None:
+        f = tmp_path / "update_buggy.py"
+        f.write_text('''
+QUERY = """
+    UPDATE rulings SET bogus_col = 'x' WHERE id = %s
+"""
+''')
+        table_cols = {"rulings": {"id", "outcome", "is_tentative"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert len(errors) == 1
+        assert "bogus_col" in errors[0]
+
+    def test_detects_in_insert_column_list(self, tmp_path: Path) -> None:
+        f = tmp_path / "insert_buggy.py"
+        f.write_text('''
+QUERY = """
+    INSERT INTO courts (id, state, fake_county) VALUES (%s, %s, %s)
+"""
+''')
+        table_cols = {"courts": {"id", "state", "county"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert len(errors) == 1
+        assert "fake_county" in errors[0]
+
+    def test_string_literal_not_flagged(self, tmp_path: Path) -> None:
+        """Identifiers inside SQL string literals must not be flagged."""
+        f = tmp_path / "string_lit.py"
+        f.write_text('''
+QUERY = """
+    SELECT id FROM courts WHERE state = 'capture_timestamp'
+"""
+''')
+        table_cols = {"courts": {"id", "state"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == []
+
+    def test_sql_check_ignore_suppresses_unqualified(
+        self, tmp_path: Path
+    ) -> None:
+        """sql-check:ignore suppresses both qualified and unqualified checks."""
+        f = tmp_path / "ignored.py"
+        f.write_text('''
+# sql-check:ignore
+BAD_QUERY = """
+    SELECT * FROM derived.documents WHERE bogus_col = %s
+"""
+''')
+        table_cols = {"documents": {"id", "captured_at"}}
+        errors = scan_file(f, table_columns=table_cols)
+        assert errors == []
+
+    def test_unknown_table_skipped(self, tmp_path: Path) -> None:
+        """Queries against unknown tables (CTEs, temp tables) are skipped."""
+        f = tmp_path / "unknown.py"
+        f.write_text('''
+QUERY = """
+    SELECT bogus FROM unknown_table WHERE other_bogus = %s
+"""
+''')
+        table_cols = {"documents": {"id"}}
+        errors = scan_file(f, table_columns=table_cols)
+        # Unknown table — skip without error.
+        assert errors == []
+
+    def test_ac_capture_timestamp_typo_against_real_schema(
+        self, tmp_path: Path
+    ) -> None:
+        """AC #4271: deliberate typo `captured_at` -> `capture_timestamp`
+        on `derived.documents` is detected against the real repo schema.
+
+        Verifies the issue's explicit acceptance criterion: introduce a
+        deliberate column-name typo, run the check, confirm it fails
+        with a clear error pointing at the bad reference.
+        """
+        f = tmp_path / "regression_ac.py"
+        # This is the exact bug the issue describes: WHERE clause uses
+        # `capture_timestamp` but the actual column is `captured_at`.
+        f.write_text('''
+def fetch_capture_count(conn, scraper_id, since):
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM derived.documents "
+            "WHERE scraper_id = %s AND capture_timestamp >= %s",
+            (scraper_id, since),
+        )
+        return cur.fetchone()[0]
+''')
+        # Use the real TABLE_COLUMNS map built from the repo's schema files.
+        errors = scan_file(f, table_columns=TABLE_COLUMNS)
+        assert len(errors) >= 1
+        joined = "\n".join(errors)
+        assert "capture_timestamp" in joined
+        assert "documents" in joined
+        # The error message must call out the available columns to make
+        # the fix obvious.
+        assert "captured_at" in joined


### PR DESCRIPTION
## Summary

Extends `scripts/check-sql-columns.py` to also catch **unqualified** SQL column-name typos — not just `alias.column` forms. Surfaces the `#4264` bug class statically (`WHERE capture_timestamp >= %s` vs. real column `captured_at`) so the next agent doesn't have to wait for an ECS run + `psycopg.errors.UndefinedColumn` to find it.

Closes #4271

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (88 tests in `scripts/tests/test_check_sql_columns.py`, 23 new)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (CI tooling only). The new check runs in the existing `sql-column-check` CI job; verification evidence is the green CI run plus the AC-mapping process summary on #4271.

## Notes

- The unqualified path is intentionally conservative: it only fires on single-base-table queries (no JOINs / CTEs / subqueries in FROM / comma-joined tables). Multi-table ambiguity would produce false positives without manual qualification, which is the wrong tradeoff.
- `_extract_string_tokens` now merges adjacent string literals (Python implicit concatenation). The original #4264 bug was written across two tokens; without the merge, the per-token scan saw only fragments and recognized neither as SQL.
- Two pre-existing bugs surfaced by the new check (`backfill_bare_vs_case_titles.py:48`, `check-short-unsubstantive-rulings.py:97-107`) are marked `# sql-check:ignore` here so this PR ships scope-tight; follow-up issues filed in retro.
