### PR TITLE
fix(dx): backfill_bare_vs_case_titles.py JOIN courts for county (#4277)

### DIFF
--- a/scripts/backfill_bare_vs_case_titles.py
+++ b/scripts/backfill_bare_vs_case_titles.py
@@ -45,18 +45,15 @@ logger = logging.getLogger(__name__)
 # then ends with whitespace + v/vs/vs. (case-insensitive).
 # Uses keyset pagination on (id) for efficient batching.
 #
-# NOTE: The `county` column does not exist on `derived.cases` (it lives on
-# `derived.courts`). This SELECT is broken and will fail at runtime; the
-# proper fix joins courts via court_id. Tracked separately so the new
-# unqualified-column check (#4271) can ship without bundling unrelated
-# bug fixes. See follow-up filed at PR-merge time.
-# sql-check:ignore
+# `county` lives on `derived.courts` (not `derived.cases`), so we JOIN courts
+# via `cases.court_id` to attach the per-county breakdown for logging.
 FETCH_QUERY = """
-    SELECT id, case_title, county
-    FROM derived.cases
-    WHERE case_title ~* '^[A-Z][^.]*\\s+v[s]?\\.?\\s*$'
-      AND id > %s
-    ORDER BY id
+    SELECT c.id, c.case_title, ct.county
+    FROM derived.cases c
+    JOIN derived.courts ct ON ct.id = c.court_id
+    WHERE c.case_title ~* '^[A-Z][^.]*\\s+v[s]?\\.?\\s*$'
+      AND c.id > %s
+    ORDER BY c.id
     LIMIT %s
 """
 


### PR DESCRIPTION
## Summary

`scripts/backfill_bare_vs_case_titles.py`'s `FETCH_QUERY` selected `county` directly from `derived.cases`, but that column lives on `derived.courts` (joined via `cases.court_id`). The query would fail at runtime with `psycopg.errors.UndefinedColumn`. This PR fixes the SELECT to JOIN courts and removes the `# sql-check:ignore` line so the unqualified-column check from #4271 / PR #4276 covers the script normally — the static check is itself the regression test for this bug class.

Closes #4277

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts/check-sql-columns.py` passes (locally verified — `All clean -- scanned 340 files, no invalid column references found.`)

### Post-deploy verification
- [x] Dispatched via `scripts/ecs-run-task.sh scripts/backfill_bare_vs_case_titles.py -- --dry-run` against dev — exit 0, 22 rows processed, no `UndefinedColumn`
- [x] Verification evidence posted on issue #4277
