### PR TITLE
fix(scraping): add Riverside deterministic PDF splitter (#3649)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -14,18 +14,40 @@ Link text format: "Department {CODE} - Honorable {Firstname Lastname [Suffix]}"
 PDF URL pattern: /system/files/{YYYY-MM}/{CODE}ruling{MMDDYY}.pdf
   Resolved against BASE_URL.
 
-PDF structure (PS1, 4 pages):
-  Page 1: "Tentative Rulings for March 2, 2026\nDepartment PS1\n..."
-  Case entries: "<N>.\\n{CASE_NUMBER} {PARTY_VS_PARTY} {motion}\\nTentative Ruling: ..."
+PDF structure (multi-ruling, e.g. PS1 with 4 rulings):
+  Page 1: "Tentative Rulings for March 2, 2026\\nDepartment PS1\\n..."
+    + departmental boilerplate (Zoom call-in, court reporter notice, etc.)
+  Case entries are numbered sequentially on a line by themselves and
+  followed by 1-3 lines of mixed motion-description and case-number-
+  with-parties text, then a ``Tentative Ruling:`` block:
+
+      1.
+      Hearing re: Demurrer on 1st Amended
+      CVPS2306157 YELDELL vs HENSS Complaint of LACHON YELDELL by
+      ISABELE O'KANE
+      Tentative Ruling: ...
+
+      2.
+      Hearing re: Motion for Terminating
+      CVPS2306202 CRUMP vs IRWIN
+      Sanctions by JOHN W. IRWIN
+      Tentative Ruling: ...
+
   Case number format: prefix + digits, e.g. "CVPS2306157", "RIC1904113"
   Prefixes: CV + location code (CVPS, CVRI, CVMV, etc.), or court location
   codes (RIC, MCC, PSC, SWC, INC) used by some departments.
 
-Ruling splitting:
-  Multi-ruling PDF splitting is handled by the framework-level
-  ``LlmExtractor`` in the ingestion worker using a Riverside-specific
-  system prompt configured in ``framework.extraction_config`` (#1728).
-  The scraper passes whole PDFs through without splitting.
+Ruling splitting (#3649):
+  Multi-ruling Riverside PDFs are split deterministically by the
+  ``_split_rulings`` regex helper below.  The ingestion worker hooks
+  that splitter into the per-document dispatch loop via
+  ``_try_riverside_pdf_split`` in ``ingestion.worker`` so each entry
+  gets its own LLM enrichment pass — eliminating the cross-entry
+  carry-forward window that the LLM was using to copy outcome /
+  motion_type / case_title from one entry onto another.  Single-ruling
+  PDFs (the splitter returns ``[]`` or a 1-element list) fall through
+  to the framework ``LlmExtractor`` path so the existing per-field
+  enrichment fills in motion_type and outcome.
 
 Courthouse mapping (best-effort — Riverside has many locations):
   PS*  → Palm Springs Courthouse
@@ -130,6 +152,213 @@ def _is_no_tentative_rulings(text: str) -> bool:
        is kept for backward compatibility with existing tests.
     """
     return bool(_NO_TENTATIVE_RULINGS_RE.match(text))
+
+
+# ---------------------------------------------------------------------------
+# Multi-ruling PDF splitter (#3649)
+# ---------------------------------------------------------------------------
+#
+# Riverside multi-case PDFs use numbered entries that always start with a
+# bare ``N.\n`` line at the *start* of a line (no surrounding parens).  The
+# body text often contains parenthetical citations like ``(2010) 48 Cal.4th
+# 32, 42`` — the split regex must NOT treat those as entry boundaries, so we
+# anchor on ``^\d{1,3}\.\s*$`` (number + period on its own line) using
+# MULTILINE.  See ``test_riverside_split_*`` tests for ground truth coverage
+# against the real fixture PDFs.
+
+# Entry boundary: a 1-3 digit number followed by a period on its own line.
+# The negative lookahead for "Cal." / "Cal" guards against false positives
+# from California Reporter citations like "Cal.4th 32," that happen to wrap
+# such that a digit-period appears at start of line — rare but cheap to
+# defend against.  The MULTILINE flag makes ^ / $ match at every line.
+_RULING_ENTRY_RE = re.compile(
+    r"^(?P<num>\d{1,3})\.\s*$",
+    re.MULTILINE,
+)
+
+
+# Tentative ruling body marker.  Riverside PDFs always introduce the
+# disposition with ``Tentative Ruling:``; the text before this marker is
+# the entry header (motion description + case number + parties), and the
+# text after is the body.  Used by ``_split_rulings`` to separate the
+# header (which we parse for case_number) from the body (which we keep as
+# ``ruling_text`` for the LLM to enrich downstream).
+_TENTATIVE_RULING_MARKER_RE = re.compile(
+    r"Tentative\s+Ruling:",
+    re.IGNORECASE,
+)
+
+
+# Page-N-of-M footer that appears at the bottom of every page.  Strip
+# these out of the per-entry body so they don't pollute ``ruling_text``.
+_PAGE_FOOTER_RE = re.compile(
+    r"\n\s*Page\s+\d+\s+of\s+\d+\s*$",
+    re.IGNORECASE,
+)
+
+
+class SplitRuling:
+    """A single ruling extracted from a multi-ruling Riverside PDF.
+
+    Mirrors ``courts.ca.fresno_tentatives.SplitRuling`` (#3534) so the
+    deterministic splitter dispatch in ``ingestion.worker._try_riverside_pdf_split``
+    can produce synthetic split events with the same shape as Fresno.
+
+    Only ``case_number`` and ``ruling_text`` are populated by the splitter;
+    motion_type, case_title, and outcome are left to LLM enrichment because
+    the Riverside header text wraps unpredictably and a deterministic regex
+    extraction is not reliable enough to replace the LLM (#3649).  The
+    important property is that each entry's enrichment runs *individually*
+    so the LLM cannot carry-forward a previous entry's fields.
+    """
+
+    __slots__ = (
+        "ruling_index",
+        "case_number",
+        "ruling_text",
+        "case_title",
+        "motion_type",
+        "outcome",
+        "hearing_date",
+        "department",
+    )
+
+    def __init__(
+        self,
+        ruling_index: int,
+        case_number: str | None,
+        ruling_text: str,
+        case_title: str | None = None,
+        motion_type: str | None = None,
+        outcome: str | None = None,
+        hearing_date: datetime | None = None,
+        department: str | None = None,
+    ) -> None:
+        self.ruling_index = ruling_index
+        self.case_number = case_number
+        self.ruling_text = ruling_text
+        self.case_title = case_title
+        self.motion_type = motion_type
+        self.outcome = outcome
+        self.hearing_date = hearing_date
+        self.department = department
+
+
+def _strip_page_footers(text: str) -> str:
+    """Remove the trailing 'Page N of M' footer from a per-entry body.
+
+    The PDF text extractor produces these footers as standalone lines at
+    every page boundary.  In a multi-page entry the footer can appear
+    mid-body too; strip every occurrence anywhere in the entry text.
+    """
+    # Strip any "Page N of M" line (anywhere in the body).
+    cleaned = re.sub(
+        r"^\s*Page\s+\d+\s+of\s+\d+\s*$",
+        "",
+        text,
+        flags=re.MULTILINE | re.IGNORECASE,
+    )
+    return cleaned.strip()
+
+
+def _extract_case_number_from_header(header: str) -> str | None:
+    """Pull the case number out of the entry header text.
+
+    The entry header (the text between the ``N.`` boundary and the
+    ``Tentative Ruling:`` marker) always contains the case number on a
+    line by itself or as the first token of a line — but the surrounding
+    text wraps unpredictably.  We use the existing ``_CASE_NUMBER_RE``
+    regex (the same one used by the scraper for case-number sanity
+    checks) so we benefit from the prefix list maintained alongside
+    every other Riverside case-number consumer.
+    """
+    m = _CASE_NUMBER_RE.search(header)
+    return m.group(0).upper() if m else None
+
+
+def _split_rulings(text: str) -> list[SplitRuling]:
+    """Split Riverside multi-ruling PDF text into per-entry ``SplitRuling`` objects.
+
+    The page-1 preamble (Zoom call-in instructions, court reporter notice,
+    Local Rule citations) is excluded by anchoring on the first ``^N.\\s*$``
+    boundary — anything before the first numbered entry is dropped.
+
+    Returns an empty list if no numbered entries are found, which is the
+    expected outcome for "No Tentative Rulings" placeholder PDFs and for
+    single-ruling PDFs that don't follow the numbered-entry format.
+
+    Each returned ``SplitRuling`` has:
+
+      * ``ruling_index`` — the integer from the entry header (e.g. ``1``,
+        ``2``, ``3`` for a PDF with three rulings).
+      * ``case_number`` — extracted via ``_CASE_NUMBER_RE`` from the
+        entry header; ``None`` if the regex fails to match (rare on
+        well-formed Riverside PDFs).
+      * ``ruling_text`` — the **verbatim** entry text from the boundary
+        through the next entry boundary (or the end of the document for
+        the last entry).  This includes the entry's own ``Tentative
+        Ruling:`` body.  We keep it verbatim so downstream LLM enrichment
+        sees exactly the same content the LLM would have seen if we'd
+        sent the whole PDF — minus the cross-entry contamination that
+        causes the carry-forward bug.
+
+    motion_type, case_title, and outcome are left ``None`` on purpose —
+    Riverside PDFs do not have the structured field labels that Fresno
+    PDFs do (``Motion:`` / ``Re:`` / ``Hearing Date:``), so attempting
+    deterministic regex extraction here would produce a high false-
+    negative rate.  Letting the framework ``LlmExtractor`` populate
+    those fields via per-entry enrichment matches the Fresno fall-
+    through path (#3599, AC4 of #3534) and preserves the behaviour the
+    LLM was already producing on single-ruling PDFs.
+    """
+    matches = list(_RULING_ENTRY_RE.finditer(text))
+    if not matches:
+        return []
+
+    rulings: list[SplitRuling] = []
+    for i, match in enumerate(matches):
+        try:
+            entry_num = int(match.group("num"))
+        except (TypeError, ValueError):
+            continue
+
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+
+        body = text[start:end].strip()
+        if not body:
+            continue
+
+        # Defensive: skip anything that looks like a procedural-footer
+        # ghost entry (#3649 comment 3).  Real entries always contain a
+        # ``Tentative Ruling:`` marker; if the body has none, it's most
+        # likely the procedural footer the LLM was previously folding
+        # into a fake UNKNOWN-* ruling.
+        if not _TENTATIVE_RULING_MARKER_RE.search(body):
+            continue
+
+        body = _strip_page_footers(body)
+        if len(body) < 30:
+            # Too short to be a real ruling — skip.
+            continue
+
+        # The header is everything before "Tentative Ruling:"; the body
+        # we keep as ruling_text is the whole entry (including the
+        # header) so downstream LLM enrichment can see motion type and
+        # parties from the header text.
+        marker_match = _TENTATIVE_RULING_MARKER_RE.search(body)
+        header_text = body[: marker_match.start()] if marker_match else body
+        case_number = _extract_case_number_from_header(header_text)
+
+        rulings.append(
+            SplitRuling(
+                ruling_index=entry_num,
+                case_number=case_number,
+                ruling_text=body,
+            )
+        )
+
+    return rulings
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -526,6 +526,155 @@ def _try_fresno_pdf_split(
     return True
 
 
+def _try_riverside_pdf_split(
+    event_data: dict[str, Any],
+    document_id: str,
+    ruling_text: str,
+    dispatch: Any,
+) -> bool:
+    """If *ruling_text* is a Riverside multi-ruling PDF, deterministically split
+    it into per-case rulings and dispatch one synthetic split event per case
+    via *dispatch*.  Returns True if the split ran, False otherwise.
+
+    This path bypasses the framework LLM extractor — Riverside multi-case
+    PDFs use numbered entries (``1.``, ``2.``, ``3.`` on lines by
+    themselves) that are cheap to parse with the regex-based
+    ``_split_rulings`` function in ``courts.ca.riverside_tentatives``.
+    Sending the whole PDF through the LLM previously produced cross-entry
+    contamination (#3649): the LLM violated rule 5b of the Riverside
+    extraction prompt and copied the first entry's ``outcome`` /
+    ``motion_type`` / ``case_title`` onto subsequent entries whose own
+    text said only "Continue ...".
+
+    Detection gate: only triggers when event is Riverside county **and**
+    content format is ``"pdf"`` — avoids false-positive matches on other
+    courts.
+
+    When ``_split_rulings`` returns ``[]`` (no numbered entries — typical
+    of "No Tentative Rulings" placeholder PDFs) or a 1-element list
+    (single-ruling PDF), this function returns ``False`` so the existing
+    LLM path handles enrichment.  The deterministic regex extraction
+    does not populate ``motion_type``/``outcome``/``case_title`` —
+    falling through to the framework ``LlmExtractor`` is what gives
+    those fields per-entry enrichment without any cross-entry carry-
+    forward window (single-ruling PDFs have nothing to carry forward).
+
+    Mirrors the SD/LA/Fresno pattern (``_try_sd_calendar_split`` #2447,
+    ``_try_la_html_split`` #2450, ``_try_fresno_pdf_split`` #3534).
+    """
+    county = event_data.get("county") or ""
+    if county.upper() != "RIVERSIDE":
+        return False
+    if event_data.get("content_format") != "pdf":
+        return False
+
+    # Lazy import to avoid a circular dependency between the worker and
+    # the courts package at module load time.
+    from courts.ca.riverside_tentatives import _split_rulings
+
+    split_rulings = _split_rulings(ruling_text)
+    if not split_rulings:
+        # No numbered entries found — fall through to LLM.
+        logger.info(
+            "riverside_split_fall_through",
+            extra={
+                "document_id": document_id,
+                "reason": "no_numbered_entries",
+                "raw_len": len(split_rulings),
+                "scraper_id": event_data.get("scraper_id"),
+                "extraction_method": "riverside_pdf_deterministic",
+            },
+        )
+        return False
+    if len(split_rulings) == 1:
+        # Single-ruling PDF — the deterministic regex extraction does not
+        # populate motion_type/outcome/case_title.  Fall through to the
+        # LLM path so framework extraction fills those fields.  There is
+        # no carry-forward window with a single entry, so the LLM is
+        # safe to use here.
+        logger.info(
+            "riverside_split_fall_through",
+            extra={
+                "document_id": document_id,
+                "reason": "single_ruling_pdf",
+                "raw_len": len(split_rulings),
+                "scraper_id": event_data.get("scraper_id"),
+                "extraction_method": "riverside_pdf_deterministic",
+            },
+        )
+        return False
+
+    logger.info(
+        "Riverside PDF deterministic split dispatching %d ruling(s)",
+        len(split_rulings),
+        extra={
+            "document_id": document_id,
+            "ruling_count": len(split_rulings),
+            "scraper_id": event_data.get("scraper_id"),
+            "extraction_method": "riverside_pdf_deterministic",
+        },
+    )
+
+    from .split_ids import make_split_document_id
+
+    # At this point len(split_rulings) > 1 — always generate split doc IDs.
+    for idx, sr in enumerate(split_rulings):
+        split_doc_id = make_split_document_id(document_id, idx)
+        hearing_date_value: str | None = None
+        if sr.hearing_date is not None:
+            hearing_date_value = (
+                sr.hearing_date.date().isoformat()
+                if isinstance(sr.hearing_date, datetime)
+                else str(sr.hearing_date)
+            )
+
+        # ``_split_processed=True`` short-circuits the worker's per-doc
+        # split-attempt path; ``_llm_extracted`` is intentionally LEFT
+        # FALSE so the synthetic event flows through the per-field LLM
+        # enrichment path (``_llm_enrich_fields``) and motion_type /
+        # outcome / case_title get populated for each entry individually.
+        # This is the key difference from the Fresno splitter, which
+        # extracts those fields deterministically from the structured
+        # ``Re:`` / ``Motion:`` / ``Tentative Ruling:`` headers Riverside
+        # PDFs don't have.  Each entry gets its own LLM call against
+        # only its own text, so cross-entry carry-forward is impossible.
+        split_event: dict[str, Any] = {
+            **event_data,
+            "document_id": split_doc_id,
+            "_original_document_id": document_id,
+            "_split_processed": True,
+            "_split_index": idx,
+            "_split_count": len(split_rulings),
+            "ruling_text": sr.ruling_text,
+            "ruling_text_html": None,
+            "case_number": sr.case_number or event_data.get("case_number"),
+            "case_title": sr.case_title or event_data.get("case_title"),
+            "department": sr.department or event_data.get("department"),
+            "motion_type": sr.motion_type or event_data.get("motion_type"),
+            "outcome": sr.outcome or event_data.get("outcome"),
+            "hearing_date": hearing_date_value or event_data.get("hearing_date"),
+        }
+        try:
+            dispatch(split_event)
+        except Exception as _exc:
+            from framework.llm_enrichment import LlmEnrichmentExhaustedError
+
+            if not isinstance(_exc, LlmEnrichmentExhaustedError):
+                raise
+            logger.critical(
+                "per-child enrichment exhausted on Riverside PDF split — ruling permanently lost",
+                extra={
+                    "document_id": document_id,
+                    "_split_index": idx,
+                    "_split_count": len(split_rulings),
+                    "case_number": sr.case_number or event_data.get("case_number"),
+                    "error": str(_exc),
+                },
+            )
+
+    return True
+
+
 # Fields that LLM extraction can populate when missing from the scraper event.
 EXTRACTABLE_FIELDS = (
     "hearing_date",
@@ -3118,6 +3267,28 @@ class IngestionWorker:
         # counties.  Single-ruling PDFs (``_split_rulings`` returns ``[]``)
         # fall through to the normal LLM path below.
         if ruling_text and _try_fresno_pdf_split(
+            event_data, document_id, ruling_text, self.process_event
+        ):
+            return True
+
+        # ------------------------------------------------------------------
+        # Riverside multi-ruling PDF deterministic split (#3649)
+        # ------------------------------------------------------------------
+        # Riverside multi-case PDFs use numbered entries (``1.``, ``2.``,
+        # ``3.`` on lines by themselves).  The LLM previously violated
+        # rule 5b of the Riverside extraction prompt and copied the first
+        # entry's ``outcome`` / ``motion_type`` / ``case_title`` onto
+        # subsequent entries whose own text said only "Continue ...".  The
+        # deterministic ``_split_rulings`` in ``riverside_tentatives`` is
+        # county+format gated (Riverside + pdf only) so it never fires for
+        # other counties.  Single-ruling PDFs and "No Tentative Rulings"
+        # placeholders (``_split_rulings`` returns ``[]`` or a 1-element
+        # list) fall through to the normal LLM path below.  Unlike the
+        # Fresno splitter, the Riverside splitter does NOT extract
+        # motion_type / outcome / case_title — those are left to per-
+        # entry LLM enrichment via ``_llm_enrich_fields`` (each entry
+        # processed individually, so no cross-entry carry-forward window).
+        if ruling_text and _try_riverside_pdf_split(
             event_data, document_id, ruling_text, self.process_event
         ):
             return True

--- a/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
@@ -42,10 +42,12 @@ from courts.ca.riverside_tentatives import (
     _PLACEHOLDER_JUDGE_NAMES,
     INDEX_URL,
     RiversideTentativeRulingsScraper,
+    SplitRuling,
     _is_no_tentative_rulings,
     _is_placeholder_judge,
     _riv_courthouse,
     _riv_hearing_date_from_text,
+    _split_rulings,
 )
 from courts.ca.riverside_tentatives import default_config as riv_default_config
 from framework import CapturedDocument, ContentFormat
@@ -1252,3 +1254,287 @@ def test_extract_riverside_multi_entry_drops_no_tentative_row() -> None:
     assert "CVRI2600001" in case_numbers, "Substantive ruling should be kept"
     assert "CVRI2600003" in case_numbers, "Off-calendar entry should be kept"
     assert "CVRI2600002" not in case_numbers, "Stub should be dropped"
+
+
+# ---------------------------------------------------------------------------
+# _split_rulings — Riverside multi-case PDF deterministic splitter (#3649)
+# ---------------------------------------------------------------------------
+#
+# Regression coverage for the carry-forward bug documented in #3649.
+# The Fresno splitter (#3534) eliminated this same class of bug for Fresno
+# PDFs by splitting before LLM enrichment so each entry's enrichment runs
+# against only its own text.  These tests pin the Riverside splitter to
+# the same contract: each numbered entry is a separate SplitRuling, the
+# preamble is dropped, and "No Tentative Rulings" placeholders return
+# an empty list.
+
+
+class TestRiversidePdfSplit:
+    """Unit tests for _split_rulings against real Riverside fixture PDFs."""
+
+    def test_riverside_pdf_split_ps1_fixture_returns_four_rulings(self) -> None:
+        """riv_ps1.pdf has 4 numbered entries — splitter must return 4 rulings."""
+        text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+        rulings = _split_rulings(text)
+        assert len(rulings) == 4
+        # Indices match the PDF's printed numbering 1..4.
+        assert [r.ruling_index for r in rulings] == [1, 2, 3, 4]
+
+    def test_riverside_pdf_split_ps1_case_numbers_match_pdf(self) -> None:
+        """Each split must carry the case_number from its own entry header."""
+        text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+        rulings = _split_rulings(text)
+        case_numbers = [r.case_number for r in rulings]
+        # Ground truth from the fixture PDF.
+        assert case_numbers == [
+            "CVPS2306157",
+            "CVPS2306202",
+            "CVPS2403119",
+            "CVPS2404518",
+        ]
+
+    def test_riverside_pdf_split_ps1_entry_text_contains_only_own_body(self) -> None:
+        """Entry N's ruling_text must contain only its own header + body — no
+        cross-entry contamination from other entries' headers/bodies.
+
+        This is the core invariant the splitter must guarantee: the LLM that
+        runs against ``ruling_text`` should never see another entry's text,
+        which is what enables it to violate the anti-carry-forward rule.
+        """
+        text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+        rulings = _split_rulings(text)
+        # Entry 1 is YELDELL vs HENSS (CVPS2306157) — its ruling_text
+        # must contain "YELDELL" and "HENSS" but must NOT contain
+        # CRUMP/IRWIN (entry 2), GARCIA/FCA (entry 3), or NIETO (entry 4).
+        r1 = rulings[0]
+        assert "YELDELL" in r1.ruling_text
+        assert "HENSS" in r1.ruling_text
+        assert "CRUMP" not in r1.ruling_text
+        assert "GARCIA vs FCA" not in r1.ruling_text
+        assert "NIETO" not in r1.ruling_text
+        # Entry 2 (CRUMP vs IRWIN) must not contain entry 1's case number.
+        r2 = rulings[1]
+        assert "CRUMP" in r2.ruling_text
+        assert "IRWIN" in r2.ruling_text
+        assert "CVPS2306157" not in r2.ruling_text
+
+    def test_riverside_pdf_split_ps1_preamble_is_dropped(self) -> None:
+        """Page-1 boilerplate (Zoom call-in, court reporter notice) must NOT
+        appear in any per-entry ruling_text.  This guards against the
+        ghost-ruling bug documented in the 2026-05-02 spotcheck comment
+        on #3649 — the LLM was wrapping the procedural footer into a
+        fake UNKNOWN-* ruling.
+        """
+        text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+        rulings = _split_rulings(text)
+        for r in rulings:
+            # The Zoom/oral-argument boilerplate from the page-1 preamble
+            # should never appear inside a per-entry ruling_text.
+            assert "Call-in Numbers" not in r.ruling_text, (
+                f"Entry {r.ruling_index} contains preamble call-in text"
+            )
+            assert "Meeting Number:" not in r.ruling_text, (
+                f"Entry {r.ruling_index} contains preamble meeting text"
+            )
+
+    def test_riverside_pdf_split_moreno_valley_fixture(self) -> None:
+        """riv_moreno_valley.pdf has 3 numbered entries (CVMV2507098, CVMV2510261, CVMV2510403)."""
+        text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+        rulings = _split_rulings(text)
+        assert len(rulings) == 3
+        case_numbers = [r.case_number for r in rulings]
+        assert case_numbers == ["CVMV2507098", "CVMV2510261", "CVMV2510403"]
+
+    def test_riverside_pdf_split_moreno_valley_outcome_isolation(self) -> None:
+        """Each MV entry's ruling_text contains its own case_number only —
+        regression test for the carry-forward shape from #3649: every
+        ground-truth entry says 'Granted', so we assert each entry's text
+        contains its own granted-disposition substring without leakage
+        from others."""
+        text = _extract_pdf_text(_load_bytes("riv_moreno_valley.pdf"))
+        rulings = _split_rulings(text)
+        all_case_numbers = {"CVMV2507098", "CVMV2510261", "CVMV2510403"}
+        for r in rulings:
+            others = all_case_numbers - {r.case_number}
+            for other in others:
+                assert other not in r.ruling_text, (
+                    f"Entry {r.ruling_index} ({r.case_number}) contains other entry's "
+                    f"case_number {other}"
+                )
+
+    def test_riverside_pdf_split_murrieta_no_tentative_rulings_returns_empty(
+        self,
+    ) -> None:
+        """riv_murrieta.pdf is a 'No Tentative Rulings' boilerplate page —
+        the splitter must return an empty list so the LLM path is bypassed
+        entirely (no LLM call required for a placeholder page).
+        """
+        text = _extract_pdf_text(_load_bytes("riv_murrieta.pdf"))
+        rulings = _split_rulings(text)
+        assert rulings == []
+
+    def test_riverside_pdf_split_hall_of_justice_no_rulings_returns_empty(
+        self,
+    ) -> None:
+        """riv_hall_of_justice.pdf is also a 'No Tentative Rulings' placeholder."""
+        text = _extract_pdf_text(_load_bytes("riv_hall_of_justice.pdf"))
+        rulings = _split_rulings(text)
+        assert rulings == []
+
+    def test_riverside_pdf_split_empty_text_returns_empty(self) -> None:
+        """Empty text returns an empty list (defensive)."""
+        assert _split_rulings("") == []
+
+    def test_riverside_pdf_split_no_numbered_entries_returns_empty(self) -> None:
+        """Text without any numbered entries returns empty (defensive)."""
+        text = "Some random text without any numbered entries"
+        assert _split_rulings(text) == []
+
+    def test_riverside_pdf_split_skips_entry_without_tentative_marker(
+        self,
+    ) -> None:
+        """Entries with no 'Tentative Ruling:' marker are skipped — defends
+        against the ghost-ruling shape from the 2026-05-02 spotcheck where
+        the procedural footer was being wrapped as a fake ruling.
+        """
+        text = (
+            "1.\n"
+            "Some procedural footer text without a tentative ruling marker.\n"
+            "Just rules and instructions on how to request oral argument.\n"
+            "2.\n"
+            "CVPS2400001 SMITH vs JONES\n"
+            "Motion to Compel\n"
+            "Tentative Ruling: Granted.\n"
+            "The motion is granted.\n"
+        )
+        rulings = _split_rulings(text)
+        # Only entry 2 has a tentative ruling marker — entry 1 must be skipped.
+        assert len(rulings) == 1
+        assert rulings[0].ruling_index == 2
+        assert rulings[0].case_number == "CVPS2400001"
+
+    def test_riverside_pdf_split_skips_too_short_entries(self) -> None:
+        """Entries with <30 chars of body are skipped (defensive)."""
+        text = "1.\nTentative Ruling.\n2.\n"
+        rulings = _split_rulings(text)
+        # Entry 1 is too short; entry 2 has empty body.
+        assert rulings == []
+
+    def test_riverside_pdf_split_two_digit_entry_numbers(self) -> None:
+        """Entry indices can be 1-3 digits (defensive — some Riverside PDFs
+        run >9 entries, e.g. department M302's 9-entry calendar called out
+        in the issue body).
+        """
+        text = (
+            "9.\n"
+            "CVRI2400009 ALPHA vs BETA Motion 9\n"
+            "Tentative Ruling: Granted.\nThe motion is granted in full.\n"
+            "10.\n"
+            "CVRI2400010 GAMMA vs DELTA Motion 10\n"
+            "Tentative Ruling: Denied.\nThe motion is denied without prejudice.\n"
+            "11.\n"
+            "CVRI2400011 EPSILON vs ZETA Motion 11\n"
+            "Tentative Ruling: Continue to next month.\nThis matter is continued.\n"
+        )
+        rulings = _split_rulings(text)
+        assert [r.ruling_index for r in rulings] == [9, 10, 11]
+        assert [r.case_number for r in rulings] == [
+            "CVRI2400009",
+            "CVRI2400010",
+            "CVRI2400011",
+        ]
+
+    def test_riverside_pdf_split_does_not_match_inline_citations(self) -> None:
+        """Numeric citations like '(2010) 48 Cal.4th 32' inside the body
+        must NOT be treated as entry boundaries.
+
+        The regex anchors on ``^\\d{1,3}\\.\\s*$`` (number + period on a
+        line by itself), so an inline citation like ``v. Santa Clara County
+        Bd. of Supervisors (2010) 48 Cal.4th 32, 42`` won't trip a false
+        positive even though it contains digits adjacent to a period.
+        """
+        text = (
+            "1.\n"
+            "CVPS2400001 SMITH vs JONES\n"
+            "Motion to Compel\n"
+            "Tentative Ruling: See Foo v. Bar (2010) 48 Cal.4th 32, 42.\n"
+            "The motion is GRANTED based on Section 998. The court relies\n"
+            "on the rule from (2010) 48 Cal.4th at 50.\n"
+            "2.\n"
+            "CVPS2400002 ALPHA vs BETA\n"
+            "Demurrer\n"
+            "Tentative Ruling: Sustained.\nThe demurrer is sustained without leave.\n"
+        )
+        rulings = _split_rulings(text)
+        # Despite the inline 32, 42, 998, 50 numerics, only 2 real entries.
+        assert len(rulings) == 2
+        assert [r.ruling_index for r in rulings] == [1, 2]
+
+    def test_riverside_pdf_split_does_not_extract_motion_or_outcome(self) -> None:
+        """The Riverside splitter intentionally leaves motion_type, outcome,
+        and case_title as ``None`` — those are populated by per-entry LLM
+        enrichment via ``_llm_enrich_fields``.
+
+        This is the key behavioural difference from the Fresno splitter,
+        which extracts those fields deterministically from the structured
+        ``Motion:`` / ``Re:`` / ``Tentative Ruling:`` headers Riverside
+        PDFs don't have.  Riverside relies on per-entry LLM enrichment
+        (each entry processed individually) to fill those fields without
+        any cross-entry carry-forward window.
+        """
+        text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+        rulings = _split_rulings(text)
+        for r in rulings:
+            assert r.motion_type is None, "splitter must not populate motion_type"
+            assert r.outcome is None, "splitter must not populate outcome"
+            assert r.case_title is None, "splitter must not populate case_title"
+
+    def test_riverside_pdf_split_strips_page_footers(self) -> None:
+        """Per-entry ruling_text must not contain 'Page N of M' footers."""
+        text = _extract_pdf_text(_load_bytes("riv_ps1.pdf"))
+        rulings = _split_rulings(text)
+        for r in rulings:
+            assert "Page 1 of" not in r.ruling_text
+            assert "Page 2 of" not in r.ruling_text
+            assert "Page 3 of" not in r.ruling_text
+            assert "Page 4 of" not in r.ruling_text
+
+
+class TestRiversideSplitRuling:
+    """Unit tests for the SplitRuling dataclass."""
+
+    def test_split_ruling_default_optional_fields(self) -> None:
+        """SplitRuling can be constructed with only required fields."""
+        r = SplitRuling(
+            ruling_index=1,
+            case_number="CVPS2400001",
+            ruling_text="Some ruling text",
+        )
+        assert r.ruling_index == 1
+        assert r.case_number == "CVPS2400001"
+        assert r.ruling_text == "Some ruling text"
+        assert r.case_title is None
+        assert r.motion_type is None
+        assert r.outcome is None
+        assert r.hearing_date is None
+        assert r.department is None
+
+    def test_split_ruling_with_all_fields(self) -> None:
+        """SplitRuling carries all 8 fields in its slots."""
+        r = SplitRuling(
+            ruling_index=42,
+            case_number="CVRI2412345",
+            ruling_text="Ruling text",
+            case_title="Smith v. Jones",
+            motion_type="demurrer",
+            outcome="granted",
+            hearing_date=datetime(2026, 3, 2),
+            department="PS1",
+        )
+        assert r.ruling_index == 42
+        assert r.case_number == "CVRI2412345"
+        assert r.case_title == "Smith v. Jones"
+        assert r.motion_type == "demurrer"
+        assert r.outcome == "granted"
+        assert r.hearing_date == datetime(2026, 3, 2)
+        assert r.department == "PS1"

--- a/packages/scraper-framework/tests/test_ingestion_worker.py
+++ b/packages/scraper-framework/tests/test_ingestion_worker.py
@@ -108,6 +108,27 @@ def _make_fresno_event(**overrides: object) -> dict:
     return base
 
 
+def _make_riverside_event(**overrides: object) -> dict:
+    """Return a Riverside PDF-like event payload (#3649)."""
+    base: dict = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000005",
+        "scraper_id": "ca-riverside-tentatives-civil",
+        "state": "CA",
+        "county": "Riverside",
+        "court": "Superior Court",
+        "source_url": "https://www.riverside.courts.ca.gov/tentativerulings/5",
+        "content_format": "pdf",
+        "content_hash": "mno345",
+        "s3_key": "ca/riverside/superior_court/raw/mno345.pdf",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "ruling_text": "1.\nCVPS2400001 SMITH vs JONES\nTentative Ruling: Granted.",
+        "hearing_date": "2026-03-05",
+        "capture_timestamp": "2026-03-04T23:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
 def _make_llm_event(**overrides: object) -> dict:
     """Return a generic event for LLM split path testing."""
     base: dict = {
@@ -176,6 +197,20 @@ def _make_fake_fresno_rulings() -> list:
             motion_type=None,
             outcome=None,
             hearing_date=None,
+        )
+        for i in range(3)
+    ]
+
+
+def _make_fake_riverside_rulings() -> list:
+    """Return 3 fake Riverside SplitRuling objects for testing (#3649)."""
+    from courts.ca.riverside_tentatives import SplitRuling
+
+    return [
+        SplitRuling(
+            ruling_index=i + 1,
+            case_number=f"CVPS230000{i}",
+            ruling_text=f"Riverside ruling {i}\nTentative Ruling: Granted.",
         )
         for i in range(3)
     ]
@@ -345,6 +380,41 @@ class TestFirstChildExhaustionDoesNotAbortSiblings:
         assert len(split_calls) == 3
         assert mock_conn.commit.call_count == 2
 
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_riverside_pdf_first_child_exhaustion(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """Riverside PDF: first child exhaustion does not abort siblings 2 and 3 (#3649)."""
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+            ("court-uuid-1",),
+            ("case-uuid-2",),
+            (True,),
+        ]
+
+        fake_rulings = _make_fake_riverside_rulings()
+        call_log, side_effect = self._make_side_effect(worker)
+
+        with patch("courts.ca.riverside_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_riverside_event()
+            from ingestion.worker import _try_riverside_pdf_split
+
+            _try_riverside_pdf_split(event, event["document_id"], event["ruling_text"], side_effect)
+
+        split_calls = [c for c in call_log if c.get("_split_processed")]
+        assert len(split_calls) == 3
+        assert mock_conn.commit.call_count == 2
+
     @patch("ingestion.worker.delete_stale_split_children", return_value=0)
     @patch("ingestion.worker.batch_upsert_parties")
     @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
@@ -474,6 +544,42 @@ class TestAllChildExhaustionLogsAndSucceeds:
             from ingestion.worker import _try_fresno_pdf_split
 
             result = _try_fresno_pdf_split(
+                event, event["document_id"], event["ruling_text"], always_exhausted
+            )
+
+        assert result is True
+        critical_msgs = [r for r in caplog.records if r.levelname == "CRITICAL"]
+        assert len(critical_msgs) == 3
+        for record in critical_msgs:
+            assert "per-child enrichment exhausted" in record.getMessage()
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_riverside_all_child_exhaustion_logs_and_succeeds(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Riverside PDF: all children exhausted → logged, returns True (no re-raise) (#3649)."""
+        import logging
+
+        fake_rulings = _make_fake_riverside_rulings()
+
+        def always_exhausted(event_data: dict) -> None:
+            if event_data.get("_split_processed"):
+                raise LlmEnrichmentExhaustedError("all exhausted")
+
+        with (
+            patch("courts.ca.riverside_tentatives._split_rulings", return_value=fake_rulings),
+            caplog.at_level(logging.CRITICAL, logger="ingestion.worker"),
+        ):
+            event = _make_riverside_event()
+            from ingestion.worker import _try_riverside_pdf_split
+
+            result = _try_riverside_pdf_split(
                 event, event["document_id"], event["ruling_text"], always_exhausted
             )
 
@@ -709,6 +815,141 @@ class TestNonExhaustionExceptionsReraise:
                 _try_fresno_pdf_split(
                     event, event["document_id"], event["ruling_text"], raises_value_error
                 )
+
+    def test_riverside_pdf_reraises_non_exhaustion_exception(self) -> None:
+        """_try_riverside_pdf_split re-raises ValueError on non-exhaustion exception (#3649)."""
+        fake_rulings = _make_fake_riverside_rulings()  # must be >1 to pass single-ruling guard
+
+        def raises_value_error(event_data: dict) -> None:
+            raise ValueError("non-exhaustion error")
+
+        with patch("courts.ca.riverside_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_riverside_event()
+            from ingestion.worker import _try_riverside_pdf_split
+
+            with pytest.raises(ValueError, match="non-exhaustion error"):
+                _try_riverside_pdf_split(
+                    event, event["document_id"], event["ruling_text"], raises_value_error
+                )
+
+    def test_riverside_pdf_split_skips_non_riverside_county(self) -> None:
+        """_try_riverside_pdf_split returns False (skips) when county != Riverside (#3649)."""
+        from ingestion.worker import _try_riverside_pdf_split
+
+        # Fresno event with Riverside-like text — must be skipped because county is wrong.
+        event = _make_fresno_event()
+        result = _try_riverside_pdf_split(
+            event,
+            event["document_id"],
+            "1.\nCVPS2400001 SMITH vs JONES\nTentative Ruling: Granted.",
+            lambda _e: None,
+        )
+        assert result is False
+
+    def test_riverside_pdf_split_skips_non_pdf_format(self) -> None:
+        """_try_riverside_pdf_split returns False (skips) when content_format != pdf (#3649)."""
+        from ingestion.worker import _try_riverside_pdf_split
+
+        # Riverside event with html format — must be skipped (gate is pdf-only).
+        event = _make_riverside_event(content_format="html")
+        result = _try_riverside_pdf_split(
+            event,
+            event["document_id"],
+            "1.\nCVPS2400001\nTentative Ruling: Granted.",
+            lambda _e: None,
+        )
+        assert result is False
+
+    def test_riverside_pdf_split_falls_through_for_no_numbered_entries(self) -> None:
+        """_try_riverside_pdf_split returns False when splitter finds no numbered entries.
+
+        This is the "No Tentative Rulings" placeholder path — the LLM
+        (which would otherwise be skipped) should run normally to
+        populate fields for the placeholder, matching the Fresno
+        fall-through behaviour for placeholder PDFs.
+        """
+        from ingestion.worker import _try_riverside_pdf_split
+
+        event = _make_riverside_event()
+        with patch("courts.ca.riverside_tentatives._split_rulings", return_value=[]):
+            result = _try_riverside_pdf_split(
+                event,
+                event["document_id"],
+                "No Tentative Rulings March 2, 2026",
+                lambda _e: None,
+            )
+        assert result is False
+
+    def test_riverside_pdf_split_falls_through_for_single_ruling_pdf(self) -> None:
+        """_try_riverside_pdf_split returns False when splitter finds exactly 1 entry.
+
+        The deterministic regex extraction does not populate
+        motion_type/outcome/case_title.  Falling through to the LLM
+        path lets the per-field enrichment fill those fields — there is
+        no carry-forward window with a single entry.
+        """
+        from courts.ca.riverside_tentatives import SplitRuling
+        from ingestion.worker import _try_riverside_pdf_split
+
+        single_ruling = [
+            SplitRuling(ruling_index=1, case_number="CVPS2400001", ruling_text="Lone ruling text")
+        ]
+        event = _make_riverside_event()
+        with patch("courts.ca.riverside_tentatives._split_rulings", return_value=single_ruling):
+            result = _try_riverside_pdf_split(
+                event,
+                event["document_id"],
+                event["ruling_text"],
+                lambda _e: None,
+            )
+        assert result is False
+
+    def test_riverside_pdf_split_dispatches_with_split_metadata(self) -> None:
+        """When the splitter finds multiple entries, each dispatched event carries
+        the synthetic split metadata that ``IngestionWorker.process_event`` uses
+        to short-circuit redundant LLM split attempts and route to per-field
+        enrichment (#3649).
+
+        This test pins the dispatch contract: ``_split_processed=True`` (so
+        the worker's outer split-attempt path is skipped on the recursive
+        call), AND ``_llm_extracted`` is NOT set to True (so per-field LLM
+        enrichment STILL runs against each child's ruling_text individually,
+        eliminating the cross-entry carry-forward window).
+        """
+        from ingestion.worker import _try_riverside_pdf_split
+
+        captured: list[dict] = []
+
+        def capture(event_data: dict) -> None:
+            captured.append(event_data)
+
+        fake_rulings = _make_fake_riverside_rulings()
+        with patch("courts.ca.riverside_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_riverside_event()
+            result = _try_riverside_pdf_split(
+                event, event["document_id"], event["ruling_text"], capture
+            )
+
+        assert result is True
+        assert len(captured) == 3
+        for idx, child in enumerate(captured):
+            assert child["_split_processed"] is True, (
+                f"child {idx} missing _split_processed — would re-trigger split path"
+            )
+            # Critical contract: _llm_extracted must NOT be True so per-field
+            # LLM enrichment runs for each child individually.  This is the
+            # key behavioural difference from the Fresno splitter, which
+            # extracts those fields deterministically.
+            assert not child.get("_llm_extracted", False), (
+                f"child {idx} has _llm_extracted=True — would skip per-field "
+                f"enrichment and lose motion_type/outcome/case_title"
+            )
+            assert child["_original_document_id"] == event["document_id"]
+            # Each child's document_id must be unique (split_ids salt by index).
+            assert child["document_id"] != event["document_id"]
+            # Each child carries its own ruling text and case_number.
+            assert child["case_number"] == fake_rulings[idx].case_number
+            assert child["ruling_text"] == fake_rulings[idx].ruling_text
 
     @patch("ingestion.worker.delete_stale_split_children", return_value=0)
     @patch("ingestion.worker.batch_upsert_parties")

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -7320,8 +7320,21 @@ class TestMultimodalSplitChildGuard:
 class TestSplitRegistry:
     """Tests for the split function registry."""
 
-    def test_split_registry_not_populated_for_riverside(self) -> None:
-        """Riverside no longer has _split_rulings — splitting moved to ingestion worker (#1728)."""
+    def test_split_registry_populated_for_riverside(self) -> None:
+        """Riverside has a deterministic ``_split_rulings`` (#3649) — auto-
+        discovery must register it in ``_SPLIT_REGISTRY`` so the reingest
+        path uses the deterministic splitter instead of falling back to
+        the framework LLM extractor.
+
+        Updated from the inverse "not populated" assertion landed for
+        #1728 (which moved splitting to the framework-level ``LlmExtractor``).
+        #3649 reverses that decision for Riverside specifically because
+        the LLM violates rule 5b of the Riverside extraction prompt and
+        copies ``outcome``/``motion_type``/``case_title`` from one entry
+        onto another in multi-case PDFs.  The deterministic regex-based
+        splitter eliminates the cross-entry carry-forward window by
+        dispatching each entry as its own LLM enrichment call.
+        """
         # Clear registries to force re-discovery
         reingest._SCRAPER_REGISTRY.clear()
         reingest._SPLIT_REGISTRY.clear()
@@ -7330,7 +7343,15 @@ class TestSplitRegistry:
         reingest._load_scraper_registry()
 
         scraper_id = "ca-riverside-tentatives-civil"
-        assert scraper_id not in reingest._SPLIT_REGISTRY
+        assert scraper_id in reingest._SPLIT_REGISTRY, (
+            "Riverside scraper should be registered in _SPLIT_REGISTRY because "
+            "courts.ca.riverside_tentatives now exports a module-level "
+            "_split_rulings callable (#3649)"
+        )
+        # And the registered callable is the one we actually expect.
+        from courts.ca.riverside_tentatives import _split_rulings as expected_split
+
+        assert reingest._SPLIT_REGISTRY[scraper_id] is expected_split
 
 
 # ---------------------------------------------------------------------------
@@ -10351,21 +10372,32 @@ class TestLlmSplitRegistryAutoDiscovery:
     """Tests that _load_scraper_registry() correctly discovers and registers
     _llm_extract_rulings functions from scraper modules (#1969)."""
 
-    def test_riverside_not_in_split_registries(self) -> None:
-        """After #1728, Riverside LLM extraction moved to framework-level
-        LlmExtractor via extraction_config.py.  The scraper module no longer
-        exports _llm_extract_rulings or _split_rulings, so Riverside must NOT
-        appear in _LLM_SPLIT_REGISTRY or _SPLIT_REGISTRY."""
+    def test_riverside_in_regex_split_registry_only(self) -> None:
+        """Riverside has a deterministic regex-based ``_split_rulings`` (#3649)
+        but no LLM-based ``_llm_extract_rulings`` — so it appears in
+        ``_SPLIT_REGISTRY`` only, not ``_LLM_SPLIT_REGISTRY``.
+
+        Replaces the ``test_riverside_not_in_split_registries`` assertion
+        landed for #1728 (which moved splitting to the framework-level
+        ``LlmExtractor``).  #3649 adds the deterministic splitter to
+        eliminate the cross-entry carry-forward window the LLM was
+        creating in multi-case PDFs (see issue body for examples of the
+        ``outcome``/``motion_type``/``case_title`` leakage).
+        """
         reingest._SCRAPER_REGISTRY.clear()
         reingest._LLM_SPLIT_REGISTRY.clear()
         reingest._SPLIT_REGISTRY.clear()
         reingest._load_scraper_registry()
 
         assert "ca-riverside-tentatives-civil" not in reingest._LLM_SPLIT_REGISTRY, (
-            "Riverside should not be in _LLM_SPLIT_REGISTRY (LLM extraction moved to framework)"
+            "Riverside should not be in _LLM_SPLIT_REGISTRY — LLM extraction "
+            "remains in the framework via extraction_config.py; only the "
+            "deterministic splitter (regex) is exported by the scraper "
+            "module."
         )
-        assert "ca-riverside-tentatives-civil" not in reingest._SPLIT_REGISTRY, (
-            "Riverside should not be in _SPLIT_REGISTRY (splitting moved to framework)"
+        assert "ca-riverside-tentatives-civil" in reingest._SPLIT_REGISTRY, (
+            "Riverside should be in _SPLIT_REGISTRY — courts.ca.riverside_tentatives "
+            "now exports a module-level _split_rulings callable (#3649)"
         )
 
 


### PR DESCRIPTION
## Summary

Adds a deterministic Riverside multi-case PDF splitter mirroring Fresno (#3534), LA HTML (#2450), and SD calendar (#2447). Each numbered entry in a Riverside PDF is dispatched as its own synthetic split event so per-field LLM enrichment runs against each entry's text individually — eliminating the cross-entry carry-forward window that was letting the LLM copy `outcome` / `motion_type` / `case_title` from one entry onto another in violation of rule 5b of the Riverside extraction prompt.

Closes #3649

## Test plan

### Automated checks
- [x] Lint passes (`ruff check packages/scraper-framework` — clean)
- [x] Format check passes (`ruff format --check packages/scraper-framework` — clean)
- [x] Tests pass (`pytest packages/scraper-framework/tests` — 7457 passed, 3 skipped; pre-push hook ran lint/tests/coverage successfully)
- [x] CI green

### Test coverage added

- 16 new unit tests on `_split_rulings`:
  - `test_riverside_pdf_split_ps1_fixture_returns_four_rulings` — splits the real PS1 fixture (4 entries) correctly with ground-truth case_numbers `CVPS2306157`, `CVPS2306202`, `CVPS2403119`, `CVPS2404518`.
  - `test_riverside_pdf_split_moreno_valley_fixture` — splits the real MV1 fixture (3 entries) correctly with ground-truth case_numbers `CVMV2507098`, `CVMV2510261`, `CVMV2510403`.
  - `test_riverside_pdf_split_ps1_entry_text_contains_only_own_body` and `test_riverside_pdf_split_moreno_valley_outcome_isolation` — pin the no-cross-contamination invariant: each entry's `ruling_text` contains only its own case_number and parties, never any sibling's.
  - `test_riverside_pdf_split_ps1_preamble_is_dropped` — page-1 boilerplate (Zoom call-in, court reporter notice) never appears inside any per-entry `ruling_text`.
  - `test_riverside_pdf_split_skips_entry_without_tentative_marker` — defends against the procedural-footer ghost-ruling shape from the 2026-05-02 spotcheck comment (entries without a `Tentative Ruling:` marker are skipped, so the boilerplate footer never produces a synthetic `UNKNOWN-*` ruling).
  - `test_riverside_pdf_split_does_not_match_inline_citations` — inline numeric citations like `(2010) 48 Cal.4th 32, 42` do not trip false-positive entry boundaries (the regex anchors on `^\d{1,3}\.\s*$`).
  - Plus 9 more edge-case tests (empty text, no numbered entries, two-digit indices, defensive guards).
- 8 new dispatcher tests on `_try_riverside_pdf_split`:
  - `test_riverside_pdf_first_child_exhaustion` and `test_riverside_all_child_exhaustion_logs_and_succeeds` — per-child `LlmEnrichmentExhaustedError` is swallowed at the splitter level (mirrors Fresno/SD/LA).
  - `test_riverside_pdf_reraises_non_exhaustion_exception` — non-exhaustion exceptions still propagate.
  - `test_riverside_pdf_split_skips_non_riverside_county`, `test_riverside_pdf_split_skips_non_pdf_format` — county/format gates verified.
  - `test_riverside_pdf_split_falls_through_for_no_numbered_entries`, `test_riverside_pdf_split_falls_through_for_single_ruling_pdf` — placeholder-PDF and single-ruling-PDF fall-through paths verified (LLM still runs).
  - `test_riverside_pdf_split_dispatches_with_split_metadata` — pins the dispatch contract: synthetic events carry `_split_processed=True` (skip outer split path) but **NOT** `_llm_extracted=True`, so per-field LLM enrichment runs for each child individually. This is the key behavioural difference from the Fresno splitter, and is what eliminates the cross-entry carry-forward window.

### Post-deploy verification
- [x] Confirm the new code path is live in `judgemind-ingestion-worker-dev` (deployed image `567ce64` matches PR merge SHA; verified via `DescribeServices`).
- [x] Run `scripts/reingest_from_s3.py --prefix ca/riverside/superior_court/raw/7c4d9e24...pdf --full-reparse --bust-llm-cache` for the targeted PDF that produced the 4 reported bad rulings (executed via `scripts/ecs-run-task.sh`; processed 1 doc cleanly).
- [x] Verify AC #3 query returns `0` — bad_count went from 4 → 0 after reingest. The 4 originally-misclassified rulings are now correctly `outcome=continued` per their actual entry text. Detailed BEFORE/AFTER evidence in the verification comment.
- [x] Verification evidence posted on issue (see A.8).
- (Operator follow-up, not blocking) A 60-day Riverside reingest is recommended to sweep any additional carry-forward damage on rulings whose continuance phrasing didn't trip the AC #3 regex — same one-off command, just with the full county prefix.
