### PR TITLE
fix(scraper): extract per-ruling judge_name in LA _split_rulings (#4282)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -340,6 +340,13 @@ class LASplitRuling:
     hearing_date: datetime | None = None
     department: str | None = None
     parties: list[dict[str, str]] = dataclass_field(default_factory=list)
+    # In-document judge name extracted from the per-case HTML (#4282).  Captures
+    # both the "JUDGE/DEPT: <Surname>/<dept>" form-layout header (Dept-25
+    # Mkrtchyan pattern, #2578) and the "<Name> Judge of the Superior Court"
+    # signature line.  When non-None, downstream worker / reingest paths must
+    # prefer this value over the dept-to-judge directory fallback so day-of-
+    # bench judge attributions match the document text.
+    judge_name: str | None = None
 
 
 LA_SYSTEM_PROMPT = (
@@ -708,13 +715,19 @@ def _replace_ruling_text_from_html(
 
     Modifies ``rulings`` in-place.  If chunking fails or produces no
     results, leaves the LLM-generated text unchanged.
+
+    Also populates ``LASplitRuling.judge_name`` from the matched chunk
+    when the chunk's HTML carries a deterministic JUDGE/DEPT or
+    "Judge of the Superior Court" line (#4282).  Keeps the LLM and regex
+    split paths in sync — both produce ``LASplitRuling`` objects with the
+    same in-document precedence for judge attribution.
     """
     case_htmls = _split_cases_html(ruling_html)
     if not case_htmls:
         return
 
-    # Build a map from case number to (plain_text, sanitized_html).
-    chunk_data: list[tuple[str | None, str, str | None]] = []
+    # Build a map from case number to (plain_text, sanitized_html, judge_name).
+    chunk_data: list[tuple[str | None, str, str | None, str | None]] = []
     for html_chunk in case_htmls:
         soup = BeautifulSoup(html_chunk, "lxml")
         content = soup.find("div", id="speechSynthesis")
@@ -728,19 +741,29 @@ def _replace_ruling_text_from_html(
         # Extract case number from this chunk for matching.
         case_num_match = _CASE_NUMBER_RE.search(text)
         case_num = case_num_match.group(1) if case_num_match else None
-        chunk_data.append((case_num, text, sanitized))
+        # Extract per-chunk judge_name (#4282) — propagated to the LLM
+        # ruling at match time below.
+        chunk_judge = _extract_judge_name_from_case_section(content, text)
+        chunk_data.append((case_num, text, sanitized, chunk_judge))
 
     # Match each ruling to its HTML chunk.
     for ruling in rulings:
         matched_text: str | None = None
         matched_html: str | None = None
+        matched_judge: str | None = None
 
         if ruling.case_number:
             # Try case-number match.
-            for chunk_case_num, chunk_text, chunk_html in chunk_data:
+            for (
+                chunk_case_num,
+                chunk_text,
+                chunk_html,
+                chunk_judge,
+            ) in chunk_data:
                 if chunk_case_num and chunk_case_num == ruling.case_number:
                     matched_text = chunk_text
                     matched_html = chunk_html
+                    matched_judge = chunk_judge
                     break
             # If case_number was present but didn't match any chunk, do NOT
             # fall back to positional matching — that risks assigning text
@@ -758,11 +781,67 @@ def _replace_ruling_text_from_html(
             if 0 <= idx < len(chunk_data):
                 matched_text = chunk_data[idx][1]
                 matched_html = chunk_data[idx][2]
+                matched_judge = chunk_data[idx][3]
 
         if matched_text and len(matched_text) > 100:
             ruling.ruling_text = matched_text
         if matched_html:
             ruling.ruling_text_html = matched_html
+        # Only overwrite judge_name when the regex actually matched in the
+        # chunk — never clobber a non-None LLM-extracted judge_name with
+        # ``None`` from a chunk that lacked a JUDGE/DEPT or signature line.
+        if matched_judge and not ruling.judge_name:
+            ruling.judge_name = matched_judge
+
+
+def _extract_judge_name_from_case_section(
+    content: BeautifulSoup | None,
+    full_text: str,
+) -> str | None:
+    """Extract a judge name from a single LA per-case HTML section (#4282).
+
+    Mirrors the strategy used by :func:`_extract_ruling_fields` (lines
+    1820-1835) so that the deterministic, non-LLM split path
+    (:func:`_split_rulings`) populates ``LASplitRuling.judge_name`` with the
+    same in-document precedence order as the live-capture / single-doc
+    parse path.
+
+    Strategies, in order:
+
+    1. **JUDGE/DEPT form-layout header** (``JUDGE/DEPT: <Surname>/<dept>``):
+       LA Dept-25 Mkrtchyan pattern (#2578).  Some LA dept pages print the
+       presiding judge as a surname followed by ``/`` and the department
+       identifier in a header row.  The classic
+       "<Name> Judge of the Superior Court" signature regex never matches
+       these pages.
+    2. **Signature line** (``<Name> Judge of the Superior Court``):
+       The traditional LA judge signature appearing on its own ``<div>``
+       at the foot of the ruling.
+
+    Returns the matched name with whitespace collapsed, or ``None`` when
+    neither pattern matches.  Callers that want the broader cross-court
+    regex fallback (LA ALL-CAPS, SB / SF / Riverside / OC patterns from
+    :data:`ingestion.extract._JUDGE_NAME_PATTERNS`) should run that
+    fallback at the worker / reingest layer to keep this helper free of
+    cross-package imports.
+    """
+    # Strategy 1: JUDGE/DEPT form-layout header.
+    judge_dept_match = _JUDGE_DEPT_RE.search(full_text)
+    if judge_dept_match:
+        return " ".join(judge_dept_match.group("name").split())
+
+    # Strategy 2: <X> Judge of the Superior Court signature div.  Only
+    # walked when content is a real BeautifulSoup element — the soup-less
+    # branch falls back to ``None`` since the regex requires HTML structure
+    # and the strategy-1 search above already covered the plain-text case.
+    if content is not None:
+        for div in content.find_all("div"):
+            div_text = div.get_text(separator=" ", strip=True)
+            m = _JUDGE_DIV_RE.match(div_text)
+            if m:
+                return " ".join(m.group(1).split())
+
+    return None
 
 
 def _split_rulings(text: str) -> list[LASplitRuling]:
@@ -775,8 +854,12 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
     The ``text`` parameter is the raw HTML content (for HTML documents,
     ``_extract_text_from_content()`` returns the decoded HTML string).
 
-    Uses ``_split_cases_html()`` for splitting and ``_extract_ruling_fields()``
-    for per-case field extraction via BeautifulSoup.
+    Uses ``_split_cases_html()`` for splitting and per-case BeautifulSoup
+    extraction for header fields, case title, parties, and judge name.
+    The ``judge_name`` field captures the in-document presiding judge so
+    downstream worker / reingest paths can attribute the ruling to the
+    day-of-bench judge instead of the directory's primary-assignment
+    fallback (#4282).
 
     Returns an empty list if no case sections are found.
     """
@@ -821,6 +904,13 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
                 if isinstance(p, dict) and p.get("name") and p.get("role"):
                     parties.append({"name": str(p["name"]), "role": str(p["role"])})
 
+        # Extract in-document judge name (#4282).  Critical for LA pages whose
+        # HTML uses the JUDGE/DEPT form-layout header — without this, the
+        # downstream regex fallback in worker.py / reingest_from_s3.py never
+        # finds the day-of-bench judge and falls through to the directory's
+        # primary-assignment fallback for the department.
+        judge_name = _extract_judge_name_from_case_section(content, ruling_text)
+
         rulings.append(
             LASplitRuling(
                 ruling_index=idx + 1,
@@ -833,6 +923,7 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
                 hearing_date=header.hearing_date,
                 department=header.department,
                 parties=parties,
+                judge_name=judge_name,
             )
         )
 

--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -839,6 +839,28 @@ def normalize_motion_type(motion_type: str) -> str | None:
 # names from ruling text that was already stored in the database.
 
 _JUDGE_NAME_PATTERNS: list[re.Pattern[str]] = [
+    # LA: "JUDGE/DEPT: <Surname>/<dept>" form-layout header (Dept-25
+    # Mkrtchyan pattern, #2578 / #4282).  Some LA dept pages print the
+    # presiding judge as a surname followed by a slash and the
+    # department identifier in a header row.  This must come BEFORE the
+    # signature-line pattern below: when both are present, JUDGE/DEPT
+    # carries the day-of-bench judge for the dept whereas the signature
+    # line is sometimes from a different judge who issued an earlier
+    # related order.  The surname may be a single word (Mkrtchyan) or a
+    # compound (Van Der Berg, O'Connor, etc.).  The character class
+    # mirrors ``courts/ca/la_tentatives._JUDGE_DEPT_RE``: letters plus
+    # ``-`` ``'`` ``.`` and space.  We stop at the first ``/`` followed
+    # by a short dept token (alphanumeric, <=8 chars) so trailing
+    # caption text never gets swallowed.  This pattern is the
+    # defense-in-depth fallback — the la_tentatives split path
+    # (``_split_rulings``) populates ``LASplitRuling.judge_name`` with
+    # the same regex earlier in the pipeline (#4282).
+    re.compile(
+        r"JUDGE\s*/\s*DEPT\s*:\s*"
+        r"(?P<judge_name>[A-Za-z][A-Za-z\-\'\. ]*?)"
+        r"\s*/\s*[A-Za-z0-9]{1,8}\b",
+        re.IGNORECASE,
+    ),
     # LA: "William A. Crowfoot Judge of the Superior Court" (now case-insensitive
     # to also match "JARED D. MOSES JUDGE OF THE SUPERIOR COURT").
     #

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -351,9 +351,13 @@ def _try_la_html_split(
                 else str(sr.hearing_date)
             )
 
-        # LASplitRuling has no judge_name field — preserve whatever the scraper
-        # provided in the original event (LA judge_name is resolved from the
-        # dept-to-judge directory snapshot).
+        # ``LASplitRuling.judge_name`` carries the in-document presiding judge
+        # extracted from the per-case HTML (JUDGE/DEPT form-layout header or
+        # "<Name> Judge of the Superior Court" signature line, #4282).  When
+        # present it must take precedence over both the original event's
+        # judge_name and the downstream dept-to-judge directory fallback —
+        # otherwise dept-25 Mkrtchyan rulings get misattributed to the
+        # directory's primary-assignment judge (Latrice A. G. Byrdsong).
         split_event: dict[str, Any] = {
             **event_data,
             "document_id": split_doc_id,
@@ -371,6 +375,7 @@ def _try_la_html_split(
             "outcome": sr.outcome or event_data.get("outcome"),
             "hearing_date": hearing_date_value or event_data.get("hearing_date"),
             "parties": sr.parties if sr.parties else event_data.get("parties", []),
+            "judge_name": sr.judge_name or event_data.get("judge_name"),
         }
         try:
             dispatch(split_event)

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -2380,6 +2380,121 @@ class TestSplitRulings:
 
 
 # ---------------------------------------------------------------------------
+# _split_rulings — judge_name extraction from per-case HTML (#4282)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitRulingsJudgeName:
+    """Tests for _split_rulings() populating LASplitRuling.judge_name (#4282).
+
+    Without per-ruling judge_name extraction, LA dept-25 (and other depts
+    using the JUDGE/DEPT form-layout header) fall through to the
+    derived.court_directory_snapshots dept→judge directory fallback,
+    which produces the wrong judge when the directory's primary
+    assignment differs from the day-of-bench judge.
+    """
+
+    def test_la_split_ruling_has_judge_name_field(self) -> None:
+        """LASplitRuling exposes a judge_name attribute (AC1)."""
+        ruling = LASplitRuling(ruling_index=1, case_number="X", ruling_text="Y")
+        # Default value when not provided is None.
+        assert ruling.judge_name is None
+        # Explicit value is preserved.
+        ruling.judge_name = "Mkrtchyan"
+        assert ruling.judge_name == "Mkrtchyan"
+
+    def test_split_rulings_populates_judge_name_dept25_fixture(self) -> None:
+        """Dept-25 fixture (JUDGE/DEPT: Mkrtchyan/25) yields judge_name='Mkrtchyan' (AC2)."""
+        html = _load("la_ruling_dept25_judge_dept_format.html")
+        rulings = _split_rulings(html)
+        assert len(rulings) >= 1
+        # The fixture's HTML carries the JUDGE/DEPT form-layout header but no
+        # signature line — _split_rulings must extract Mkrtchyan from the
+        # JUDGE/DEPT line, not fall through to None.
+        assert rulings[0].judge_name == "Mkrtchyan"
+
+    def test_split_rulings_populates_judge_name_signature_line(self) -> None:
+        """Signature-line fixture yields judge_name from '<X> Judge of the Superior Court'."""
+        html = _load("la_ruling_response.html")
+        rulings = _split_rulings(html)
+        assert len(rulings) == 2
+        # Both Alhambra Dept 3 cases share the same Crowfoot signature line.
+        for ruling in rulings:
+            assert ruling.judge_name is not None
+            assert "Crowfoot" in ruling.judge_name
+
+    def test_split_rulings_judge_name_inline_judge_dept_only(self) -> None:
+        """Synthetic JUDGE/DEPT-only HTML (no signature line) yields judge_name (AC6).
+
+        Mirrors the Highlakes failure mode in #4282: a per-case fragment
+        whose HTML carries only the JUDGE/DEPT header — without this fix,
+        _split_rulings produces LASplitRuling(judge_name=None) and the
+        downstream worker / reingest path falls through to the directory
+        primary-assignment judge.
+        """
+        # Use a long ruling_text so _split_rulings's 50-char minimum passes.
+        html = (
+            "<html><body><div id='speechSynthesis'>"
+            "<b>Case Number: </b> 25STLC05162"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Hearing Date: </b> March 26, 2026"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Dept: </b> 25"
+            "<p>HEARING DATE: Tues., April 7, 2026 "
+            "JUDGE/DEPT: Mkrtchyan/25 "
+            "CASE NAME: Highlakes Towing v. Acme Corp</p>"
+            "<p>The motion is GRANTED. The court finds that the moving party "
+            "has carried its burden under Code of Civil Procedure section 2031.310 "
+            "to compel further responses to requests for production.</p>"
+            "</div></body></html>"
+        )
+        rulings = _split_rulings(html)
+        assert len(rulings) == 1
+        assert rulings[0].judge_name == "Mkrtchyan"
+        # Department comes from the deterministic <b>-tag header.
+        assert rulings[0].department == "25"
+
+    def test_split_rulings_judge_name_compound_surname(self) -> None:
+        """JUDGE/DEPT regex accepts compound surnames with internal whitespace."""
+        html = (
+            "<html><body><div id='speechSynthesis'>"
+            "<b>Case Number: </b> 25STLC99999"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Hearing Date: </b> March 26, 2026"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Dept: </b> F46"
+            "<p>HEARING DATE: Tues., April 7, 2026 "
+            "JUDGE/DEPT: Van Der Berg/F46 "
+            "CASE NAME: Foo v. Bar</p>"
+            "<p>The motion is DENIED.  The court finds that the moving party "
+            "has not carried its burden under Code of Civil Procedure section "
+            "2031.310 to compel further responses to requests for production.</p>"
+            "</div></body></html>"
+        )
+        rulings = _split_rulings(html)
+        assert len(rulings) == 1
+        assert rulings[0].judge_name == "Van Der Berg"
+
+    def test_split_rulings_judge_name_none_when_no_judge_signal(self) -> None:
+        """Pages with no JUDGE/DEPT or signature line yield judge_name=None."""
+        html = (
+            "<html><body><div id='speechSynthesis'>"
+            "<b>Case Number: </b> 25STLC99999"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Hearing Date: </b> March 26, 2026"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Dept: </b> 1"
+            "<p>The motion is DENIED.  The court finds that the moving party "
+            "has not carried its burden under Code of Civil Procedure section "
+            "2031.310 to compel further responses to requests for production.</p>"
+            "</div></body></html>"
+        )
+        rulings = _split_rulings(html)
+        assert len(rulings) == 1
+        assert rulings[0].judge_name is None
+
+
+# ---------------------------------------------------------------------------
 # _replace_ruling_text_from_html — LLM text replacement (#2007)
 # ---------------------------------------------------------------------------
 
@@ -2481,6 +2596,63 @@ class TestReplaceRulingTextFromHtml:
         rulings = [LASplitRuling(ruling_index=1, case_number="X", ruling_text=original)]
         _replace_ruling_text_from_html(no_cases_html, rulings)
         assert rulings[0].ruling_text == original
+
+    def test_populates_judge_name_from_chunk_judge_dept(self) -> None:
+        """LLM-path replace populates judge_name from chunk JUDGE/DEPT (#4282)."""
+        html = (
+            "<html><body><div id='speechSynthesis'>"
+            "<b>Case Number: </b> 25STLC05162"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Hearing Date: </b> March 26, 2026"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Dept: </b> 25"
+            "<p>HEARING DATE: Tues., April 7, 2026 "
+            "JUDGE/DEPT: Mkrtchyan/25 "
+            "CASE NAME: Highlakes v. Acme</p>"
+            "<p>The motion is GRANTED. The court finds that the moving party "
+            "has carried its burden under Code of Civil Procedure section 2031.310 "
+            "to compel further responses to requests for production.</p>"
+            "</div></body></html>"
+        )
+        rulings = [
+            LASplitRuling(
+                ruling_index=1,
+                case_number="25STLC05162",
+                ruling_text="LLM truncated text" * 10,
+            ),
+        ]
+        _replace_ruling_text_from_html(html, rulings)
+        assert rulings[0].judge_name == "Mkrtchyan"
+
+    def test_does_not_clobber_existing_llm_judge_name(self) -> None:
+        """LLM-extracted judge_name is preserved when the chunk also has a value (#4282)."""
+        html = (
+            "<html><body><div id='speechSynthesis'>"
+            "<b>Case Number: </b> 25STLC05162"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Hearing Date: </b> March 26, 2026"
+            "&nbsp;&nbsp;&nbsp;"
+            "<b>Dept: </b> 25"
+            "<p>HEARING DATE: Tues., April 7, 2026 "
+            "JUDGE/DEPT: Mkrtchyan/25 "
+            "CASE NAME: Highlakes v. Acme</p>"
+            "<p>The motion is GRANTED. The court finds that the moving party "
+            "has carried its burden under Code of Civil Procedure section 2031.310 "
+            "to compel further responses to requests for production.</p>"
+            "</div></body></html>"
+        )
+        rulings = [
+            LASplitRuling(
+                ruling_index=1,
+                case_number="25STLC05162",
+                ruling_text="LLM truncated text" * 10,
+                judge_name="LLM Provided Judge",
+            ),
+        ]
+        _replace_ruling_text_from_html(html, rulings)
+        # LLM-provided judge_name takes precedence — the chunk match must
+        # not clobber a non-None value.
+        assert rulings[0].judge_name == "LLM Provided Judge"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -575,6 +575,54 @@ class TestExtractJudgeName:
         text = "Judge Sarah Wu"
         assert extract_judge_name(text) == "Sarah Wu"
 
+    # --- LA JUDGE/DEPT form-layout pattern (#4282) ---
+
+    def test_la_judge_dept_form_layout_simple(self) -> None:
+        """LA JUDGE/DEPT: <surname>/<dept> form-layout header (#4282).
+
+        Defense-in-depth fallback for the case where the la_tentatives
+        split path was bypassed.  The pattern lives at index 0 of
+        _JUDGE_NAME_PATTERNS so it fires before the broader
+        signature-line pattern.
+        """
+        text = "HEARING DATE: April 7, 2026 JUDGE/DEPT: Mkrtchyan/25 CASE NAME: Foo v. Bar"
+        assert extract_judge_name(text) == "Mkrtchyan"
+
+    def test_la_judge_dept_form_layout_compound_surname(self) -> None:
+        """JUDGE/DEPT pattern accepts compound surnames with internal spaces."""
+        text = "JUDGE/DEPT: Van Der Berg/F46 CASE NAME: Acme v. Beta"
+        assert extract_judge_name(text) == "Van Der Berg"
+
+    def test_la_judge_dept_form_layout_apostrophe_surname(self) -> None:
+        """JUDGE/DEPT pattern accepts apostrophe-bearing surnames (O'Connor)."""
+        text = "JUDGE/DEPT: O'Connor/12 CASE NAME: Acme v. Beta"
+        assert extract_judge_name(text) == "O'Connor"
+
+    def test_la_judge_dept_form_layout_alphanumeric_dept(self) -> None:
+        """Department token may be alphanumeric (P, F46, etc.)."""
+        text = "JUDGE/DEPT: Smith/F46 CASE NAME: Foo v. Bar"
+        assert extract_judge_name(text) == "Smith"
+
+    def test_la_judge_dept_takes_precedence_over_signature_line(self) -> None:
+        """When both patterns are present, JUDGE/DEPT wins (#4282).
+
+        The JUDGE/DEPT line carries the day-of-bench judge for the dept;
+        the signature line is sometimes from a different judge who
+        signed an earlier related order.  The pattern ordering in
+        _JUDGE_NAME_PATTERNS encodes this precedence.
+        """
+        text = (
+            "HEARING DATE: April 7, 2026 JUDGE/DEPT: Mkrtchyan/25\n"
+            "Some case ruling text here.\n"
+            "William A. Crowfoot Judge of the Superior Court"
+        )
+        assert extract_judge_name(text) == "Mkrtchyan"
+
+    def test_la_judge_dept_lowercase_label(self) -> None:
+        """Pattern is case-insensitive (handles 'judge/dept:' too)."""
+        text = "judge/dept: Mkrtchyan/25 case name: Foo v. Bar"
+        assert extract_judge_name(text) == "Mkrtchyan"
+
 
 # ---------------------------------------------------------------------------
 # _looks_like_person_name validation

--- a/packages/scraper-framework/tests/test_ingestion_worker.py
+++ b/packages/scraper-framework/tests/test_ingestion_worker.py
@@ -348,6 +348,115 @@ class TestFirstChildExhaustionDoesNotAbortSiblings:
     @patch("ingestion.worker.batch_upsert_parties")
     @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
     @patch("ingestion.worker.psycopg")
+    def test_la_html_split_passes_judge_name_through(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """LA HTML: split_event carries LASplitRuling.judge_name through to dispatch (AC3, #4282).
+
+        Without this pass-through, dept-25 rulings whose HTML uses the
+        JUDGE/DEPT form-layout header fall through to the directory's
+        primary-assignment judge (Latrice A. G. Byrdsong) instead of the
+        day-of-bench judge (Mkrtchyan) named in the document text.
+        """
+        from courts.ca.la_tentatives import LASplitRuling
+
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        # One LASplitRuling with a non-None judge_name.  The worker should
+        # surface that value in the dispatched split_event so downstream
+        # process_event sees a populated judge_name and skips the
+        # dept-to-judge directory fallback.
+        fake_rulings = [
+            LASplitRuling(
+                ruling_index=0,
+                case_number="25STLC05162",
+                ruling_text="LA ruling for dept-25 — Mkrtchyan presiding.",
+                department="25",
+                judge_name="Mkrtchyan",
+            )
+        ]
+        call_log, side_effect = self._make_side_effect(worker)
+
+        with (
+            patch("courts.ca.la_tentatives.is_la_html", return_value=True),
+            patch("courts.ca.la_tentatives._split_rulings", return_value=fake_rulings),
+        ):
+            event = _make_la_event()
+            from ingestion.worker import _try_la_html_split
+
+            _try_la_html_split(event, event["document_id"], event["ruling_text"], side_effect)
+
+        split_calls = [c for c in call_log if c.get("_split_processed")]
+        assert len(split_calls) == 1
+        # AC3 verification: the split_event passed to dispatch carries
+        # judge_name=Mkrtchyan.
+        assert split_calls[0]["judge_name"] == "Mkrtchyan"
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
+    def test_la_html_split_falls_back_to_event_judge_name(
+        self,
+        mock_psycopg: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_batch_upsert: MagicMock,
+    ) -> None:
+        """LA HTML: when sr.judge_name is None, fall back to event_data['judge_name'] (#4282).
+
+        Preserves the pre-fix behaviour for split rulings whose HTML
+        carries no JUDGE/DEPT or signature line — the original event's
+        judge_name (e.g. seeded from the DB on a reingest) flows through
+        instead of being clobbered to None.
+        """
+        from courts.ca.la_tentatives import LASplitRuling
+
+        worker, _ = _make_worker()
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur.fetchone.side_effect = [
+            ("court-uuid-1",),
+            ("case-uuid-1",),
+            (True,),
+        ]
+
+        fake_rulings = [
+            LASplitRuling(
+                ruling_index=0,
+                case_number="25STLC05162",
+                ruling_text="LA ruling with no JUDGE/DEPT or signature line.",
+                department="25",
+                judge_name=None,
+            )
+        ]
+        call_log, side_effect = self._make_side_effect(worker)
+
+        with (
+            patch("courts.ca.la_tentatives.is_la_html", return_value=True),
+            patch("courts.ca.la_tentatives._split_rulings", return_value=fake_rulings),
+        ):
+            event = _make_la_event(judge_name="DB Seeded Judge")
+            from ingestion.worker import _try_la_html_split
+
+            _try_la_html_split(event, event["document_id"], event["ruling_text"], side_effect)
+
+        split_calls = [c for c in call_log if c.get("_split_processed")]
+        assert len(split_calls) == 1
+        # Fallback: when sr.judge_name is None, use event_data['judge_name'].
+        assert split_calls[0]["judge_name"] == "DB Seeded Judge"
+
+    @patch("ingestion.worker.batch_upsert_parties")
+    @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+    @patch("ingestion.worker.psycopg")
     def test_fresno_pdf_first_child_exhaustion(
         self,
         mock_psycopg: MagicMock,

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -1012,6 +1012,157 @@ class TestFullReparseDocumentMergeAsymmetry:
 
 
 # ---------------------------------------------------------------------------
+# _full_reparse_document — per-ruling judge_name preference (#4282)
+# ---------------------------------------------------------------------------
+
+
+class TestFullReparsePerRulingJudgeName:
+    """Regression coverage for #4282.
+
+    LA HTMLs whose per-case section uses the ``JUDGE/DEPT: <surname>/<dept>``
+    form-layout header carry the day-of-bench judge in
+    ``LASplitRuling.judge_name``.  ``_full_reparse_document`` must prefer
+    that per-ruling value over the doc-level ``doc_judge_name`` so the
+    DB write attributes the ruling to the in-document judge instead of
+    the directory's primary-assignment fallback.
+    """
+
+    def _doc_meta(self) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Los Angeles",
+            "court_name": "Los Angeles Superior Court",
+            "source_url": "https://www.lacourt.ca.gov/...",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "html",
+            "case_number": "25STLC05162",
+            "case_title": "Highlakes v. Acme",
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-la-tentatives-civil",
+            "s3_key": "ca/los_angeles/superior_court/raw/abc.html",
+            "s3_bucket": "test-bucket",
+            "judge_name": None,
+            "department": None,
+        }
+
+    def _make_la_split_rulings(
+        self,
+        *,
+        per_ruling_judge: str | None,
+    ) -> list:
+        from courts.ca.la_tentatives import LASplitRuling
+
+        return [
+            LASplitRuling(
+                ruling_index=1,
+                case_number="25STLC05162",
+                ruling_text="Ruling text for Mkrtchyan.",
+                department="25",
+                judge_name=per_ruling_judge,
+            ),
+            LASplitRuling(
+                ruling_index=2,
+                case_number="25STLC05163",
+                ruling_text="Ruling text for the second case.",
+                department="25",
+                judge_name=per_ruling_judge,
+            ),
+        ]
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_per_ruling_judge_name_overrides_doc_level(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """LASplitRuling.judge_name takes precedence over doc-level judge (#4282)."""
+        mock_extract.return_value = "<html>la text</html>"
+        # Live-only no-op parse_document so doc_judge_name comes from
+        # the DB seed below.
+        parsed = MagicMock()
+        parsed.case_number = None
+        parsed.case_title = None
+        parsed.judge_name = None
+        parsed.department = None
+        parsed.hearing_date = None
+        mock_scraper_cls = MagicMock()
+        mock_scraper_cls.return_value.parse_document.return_value = parsed
+
+        reingest._SCRAPER_REGISTRY["test-la-per-ruling-judge"] = mock_scraper_cls
+        reingest._SPLIT_REGISTRY["test-la-per-ruling-judge"] = MagicMock(
+            return_value=self._make_la_split_rulings(per_ruling_judge="Mkrtchyan")
+        )
+
+        try:
+            doc_meta = self._doc_meta()
+            doc_meta["judge_name"] = "Latrice A. G. Byrdsong"  # DB seed (wrong)
+            doc_meta["scraper_id"] = "test-la-per-ruling-judge"
+            results = reingest._full_reparse_document(
+                b"<html>raw</html>",
+                "test-la-per-ruling-judge",
+                doc_meta,
+            )
+            assert len(results) == 2
+            for ruling in results:
+                # Per-ruling Mkrtchyan wins over the DB-seeded Byrdsong.
+                assert ruling["judge_name"] == "Mkrtchyan"
+                assert ruling["extraction_methods"]["judge_name"] == "split"
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("test-la-per-ruling-judge", None)
+            reingest._SPLIT_REGISTRY.pop("test-la-per-ruling-judge", None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_per_ruling_judge_name_none_falls_back_to_doc_level(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """When LASplitRuling.judge_name is None, doc-level judge survives.
+
+        Preserves the pre-fix behaviour for split rulings whose HTML
+        carries no JUDGE/DEPT or signature line — the doc-level
+        ``doc_judge_name`` (parsed.judge_name or DB seed) flows through
+        unchanged.
+        """
+        mock_extract.return_value = "<html>la text</html>"
+        parsed = MagicMock()
+        parsed.case_number = None
+        parsed.case_title = None
+        parsed.judge_name = "Hon. Doc Level Judge"
+        parsed.department = None
+        parsed.hearing_date = None
+        mock_scraper_cls = MagicMock()
+        mock_scraper_cls.return_value.parse_document.return_value = parsed
+
+        reingest._SCRAPER_REGISTRY["test-la-no-per-ruling-judge"] = mock_scraper_cls
+        reingest._SPLIT_REGISTRY["test-la-no-per-ruling-judge"] = MagicMock(
+            return_value=self._make_la_split_rulings(per_ruling_judge=None)
+        )
+
+        try:
+            doc_meta = self._doc_meta()
+            doc_meta["scraper_id"] = "test-la-no-per-ruling-judge"
+            results = reingest._full_reparse_document(
+                b"<html>raw</html>",
+                "test-la-no-per-ruling-judge",
+                doc_meta,
+            )
+            assert len(results) == 2
+            for ruling in results:
+                # Falls through to the doc-level judge from parsed.
+                assert ruling["judge_name"] == "Hon. Doc Level Judge"
+                assert ruling["extraction_methods"]["judge_name"] == "scraper"
+        finally:
+            reingest._SCRAPER_REGISTRY.pop("test-la-no-per-ruling-judge", None)
+            reingest._SPLIT_REGISTRY.pop("test-la-no-per-ruling-judge", None)
+
+
+# ---------------------------------------------------------------------------
 # _reparse_document_multimodal merge-asymmetry tests (#4150)
 # ---------------------------------------------------------------------------
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1649,6 +1649,14 @@ def _full_reparse_document(
         # header).  Fall back to the doc-level department otherwise.
         ruling_department = getattr(ruling, "department", None) or doc_department
 
+        # Prefer per-ruling judge_name when the split provides one
+        # (#4282: LASplitRuling.judge_name carries the in-document
+        # JUDGE/DEPT or signature-line judge).  Fall back to the
+        # doc-level judge name otherwise.  This mirrors the worker.py
+        # path in _try_la_html_split which now passes sr.judge_name
+        # through the split_event.
+        ruling_judge_name = getattr(ruling, "judge_name", None) or doc_judge_name
+
         extracted: dict = {
             "ruling_text": ruling_text_cleaned,
             # ``case_number`` keeps its ``doc_meta`` fallback because it is
@@ -1691,7 +1699,7 @@ def _full_reparse_document(
             "case_type": (
                 getattr(ruling, "case_type", None) or doc_meta.get("case_type")
             ),
-            "judge_name": doc_judge_name,
+            "judge_name": ruling_judge_name,
             "outcome": normalize_outcome(ruling.outcome),
             # Normalize split-provided motion_type to snake_case (#1849).
             "motion_type": (
@@ -1720,8 +1728,10 @@ def _full_reparse_document(
             extracted["extraction_methods"]["case_type"] = (
                 "split" if getattr(ruling, "case_type", None) else "db_seed"
             )
-        if doc_judge_name:
-            extracted["extraction_methods"]["judge_name"] = "scraper"
+        if ruling_judge_name:
+            extracted["extraction_methods"]["judge_name"] = (
+                "split" if getattr(ruling, "judge_name", None) else "scraper"
+            )
         if doc_hearing_date:
             extracted["extraction_methods"]["hearing_date"] = "scraper"
         if ruling_department:


### PR DESCRIPTION
## Summary

LA dept-25 rulings whose HTML uses the `JUDGE/DEPT: <Surname>/<dept>` form-layout header (Mkrtchyan/25, Van Der Berg/F46, etc.) were misattributed to the directory's primary-assignment judge (Latrice A. G. Byrdsong) instead of the day-of-bench judge named in the document. Root cause: `LASplitRuling` had no `judge_name` field, so `_split_rulings` dropped the in-document judge entirely; the worker's regex fallback (`_JUDGE_NAME_PATTERNS`) had no JUDGE/DEPT pattern either, so the directory fallback won. Adds `judge_name` to `LASplitRuling`, populates it from the per-case `JUDGE/DEPT` header (and signature line), threads it through `_try_la_html_split` and `_full_reparse_document`, and adds the JUDGE/DEPT regex to `_JUDGE_NAME_PATTERNS` as defense-in-depth.

Closes #4282

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] After this PR merges and the new image is deployed, run `scripts/ecs-run-task.sh scripts/rebuild_db.py --county "Los Angeles" --reset` against dev.
- [x] Verify `Latrice A. G. Byrdsong`-on-dept-25 ruling count drops from 123 (verified — partial rebuild shows 3 Byrdsong, 36 NULL judge; 97% reduction on the rebuilt subset).
- [ ] Highlakes ruling attributed to `Karine Mkrtchyan` — **partial: surfaced follow-up #4297 because `db.resolve_judge` rejects single-word surnames; needs surname expansion via court directory.**
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/4282#issuecomment-4392920878).
