### PR TITLE
feat(scraping): ship reingest_from_s3.py + rebuild_db.py in scraper image (#4288)

### DIFF
--- a/packages/scraper-framework/Dockerfile
+++ b/packages/scraper-framework/Dockerfile
@@ -77,6 +77,18 @@ COPY scripts/check-scraper-zero-record-runner.py /app/scripts/check-scraper-zero
 COPY scripts/check-scraper-zero-record-streak.py /app/scripts/check-scraper-zero-record-streak.py
 COPY scripts/notify-telegram.sh /app/scripts/notify-telegram.sh
 
+# Embed the operator-only reingest/rebuild scripts that target the
+# ingestion-worker image via `scripts/ecs-run-task.sh`.  These are run
+# frequently for backfills, carry-forward sweeps, cache-bust reingest,
+# and county-scoped rebuilds, and the ecs-run-task.sh path uploads them
+# via S3 every time -- baking them into the image lets operators invoke
+# them directly as `python /app/scripts/<name>.py` without the runtime
+# download dance, and pins the executed code to the image build SHA
+# instead of whatever happens to be at HEAD when the task fires.  The
+# combined ~280 KB image-size impact is negligible.  See #4288.
+COPY scripts/reingest_from_s3.py /app/scripts/reingest_from_s3.py
+COPY scripts/rebuild_db.py /app/scripts/rebuild_db.py
+
 # Own everything by the non-root user
 RUN chown -R scraper:scraper /app
 


### PR DESCRIPTION
## Summary

Add COPY directives to `packages/scraper-framework/Dockerfile` so `scripts/reingest_from_s3.py` and `scripts/rebuild_db.py` ship at `/app/scripts/` in the deployed `judgemind/scraper:*` image. Until now, every operator reingest task had to download the script at runtime via `urllib.request` from raw.githubusercontent.com (~5 min friction per task, plus a dependency on `main` being clean post-merge). With the script baked in, operators can `exec python /app/scripts/reingest_from_s3.py ...` from a custom shell command, and the executed code is pinned to the image build SHA. Combined image-size impact ~280 KB.

Closes #4288

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] After deploy-scraper.yml runs, launch a one-shot ECS task that execs `python /app/scripts/reingest_from_s3.py --help`. Exit code 0 and stdout contains `usage: reingest_from_s3.py`.
- [x] Same probe for `python /app/scripts/rebuild_db.py --help`. Exit code 0 and stdout contains `usage: rebuild_db.py`.
- [x] Verification evidence posted on issue (see A.8).
