### PR TITLE
ci(hygiene): enforce case_type fallback chain parity (#4290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1274,6 +1274,21 @@ jobs:
         run: scripts/check-llm-paths-symmetry.sh
 
   # ---------------------------------------------------------------
+  # case_type fallback chain parity: worker.py (live ingestion) and
+  # _apply_regex_fallbacks in reingest_from_s3.py (reparse) must
+  # reference the same set of extract_case_type_from_* helpers.  The
+  # pattern of one path adding a helper that never lands in the other
+  # has recurred 6 times over four years (#1731, #1749, #1763, #1836,
+  # #2062 surfaced as #4263, #2406) — see #4290.
+  # ---------------------------------------------------------------
+  case-type-fallback-parity-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce case_type fallback chain parity
+        run: scripts/check-case-type-fallback-parity.sh
+
+  # ---------------------------------------------------------------
   # Test DATABASE_URL fallback guard: api tests must read
   # TEST_DATABASE_URL, not the operational DATABASE_URL (#3006)
   # ---------------------------------------------------------------
@@ -1850,7 +1865,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-case-type-fallback-parity.py
+++ b/scripts/check-case-type-fallback-parity.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Enforce case_type fallback chain parity between worker.py and reingest_from_s3.py.
+
+Two code paths produce a final ``case_type`` for ruling documents:
+
+* Live ingestion — ``packages/scraper-framework/src/ingestion/worker.py``
+  applies ``extract_case_type_from_*`` helpers as post-LLM fallbacks just
+  before the ``Field extraction summary`` log line.
+* Reparse — ``scripts/reingest_from_s3.py`` calls the same helpers inside
+  ``_apply_regex_fallbacks``.
+
+The two paths must reference the **same set** of ``extract_case_type_from_*``
+helpers.  When they diverge (a helper is added to one path but not the
+other) the same document gets different case_type during live ingestion vs.
+a reingest, which has caused multi-hour investigations and reingest re-runs
+six times over four years (#1731, #1749, #1763, #1836, #2062 surfaced as
+#4263, #2406).  This script is the cheap structural defense — see #4290.
+
+Usage:
+    scripts/check-case-type-fallback-parity.py
+
+Exit codes:
+    0 — Both files reference the same set of helpers.
+    1 — Sets diverge (or a required file is missing).
+
+Test override:
+    Set ``CASE_TYPE_PARITY_ROOT`` to point at an alternate source tree.
+    The script then reads
+    ``$CASE_TYPE_PARITY_ROOT/packages/scraper-framework/src/ingestion/worker.py``
+    and ``$CASE_TYPE_PARITY_ROOT/scripts/reingest_from_s3.py``.
+"""
+
+# permanent: true
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+WORKER_REL = "packages/scraper-framework/src/ingestion/worker.py"
+REINGEST_REL = "scripts/reingest_from_s3.py"
+REINGEST_FN = "_apply_regex_fallbacks"
+
+
+def _repo_root() -> Path:
+    override = os.environ.get("CASE_TYPE_PARITY_ROOT")
+    if override:
+        return Path(override).resolve()
+    # This script lives at scripts/ in the repo root.
+    return Path(__file__).resolve().parent.parent
+
+
+def _scan_worker(text: str) -> set[str]:
+    """Return the set of ``extract_case_type_from_*`` identifiers actually
+    USED (referenced as expressions) in worker.py.
+
+    The check intentionally scans the entire file rather than the post-LLM
+    block alone — the reingest equivalent is a single helper function, but
+    worker.py has multiple call sites for case_type fallbacks (the
+    ``regex_fallback_ms`` timing block at ~line 2268 plus the post-LLM
+    block at ~2451–2485) and a future refactor could legitimately move
+    calls around.  The invariant we care about is "the set of helpers
+    actually invoked is identical" — not "the helpers appear in a
+    specific block of the file."
+
+    Imports are not counted: ``from x import extract_case_type_from_title``
+    appears as an ``ast.alias`` node, not ``ast.Name``, so a helper that
+    is imported but never called will NOT appear in the returned set.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as exc:  # pragma: no cover — parse failure surfaces immediately.
+        print(
+            f"ERROR: failed to parse worker.py as Python: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Collect identifiers actually USED (Name nodes in expression contexts —
+    # i.e. function calls, attribute reads, etc.).  We do not require the
+    # name to appear in a Call node specifically; an assignment like
+    # ``fn = extract_case_type_from_X`` is also a usage.
+    used: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id.startswith("extract_case_type_from_"):
+            used.add(node.id)
+    return used
+
+
+def _scan_reingest(text: str) -> set[str]:
+    """Return the set of ``extract_case_type_from_*`` identifiers called
+    inside the ``_apply_regex_fallbacks`` function in
+    ``scripts/reingest_from_s3.py``.
+
+    We restrict to the function body — not the whole file — because the
+    reingest module imports the helpers at module scope, and a stray
+    reference outside ``_apply_regex_fallbacks`` (a comment, a docstring
+    citation, an unrelated helper) would be a false positive.  The
+    invariant the spec articulates is specifically "_apply_regex_fallbacks
+    must call all worker.py helpers" — see issue #4290.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as exc:  # pragma: no cover.
+        print(
+            f"ERROR: failed to parse reingest_from_s3.py as Python: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    target_fn: ast.FunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == REINGEST_FN:
+            target_fn = node
+            break
+
+    if target_fn is None:
+        print(
+            f"ERROR: function ``{REINGEST_FN}`` not found in {REINGEST_REL}.\n"
+            "       The parity guard relies on this function as the canonical\n"
+            "       reingest fallback chain — if it has been renamed or\n"
+            "       removed, update both check-case-type-fallback-parity.py\n"
+            "       and the issue-#4290 documentation accordingly.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    used: set[str] = set()
+    for node in ast.walk(target_fn):
+        if isinstance(node, ast.Name) and node.id.startswith("extract_case_type_from_"):
+            used.add(node.id)
+    return used
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        print(
+            f"ERROR: required source file is missing: {path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    root = _repo_root()
+    worker_path = root / WORKER_REL
+    reingest_path = root / REINGEST_REL
+
+    worker_text = _read(worker_path)
+    reingest_text = _read(reingest_path)
+
+    worker_set = _scan_worker(worker_text)
+    reingest_set = _scan_reingest(reingest_text)
+
+    if worker_set == reingest_set:
+        joined = ", ".join(sorted(worker_set)) if worker_set else "(empty)"
+        print(
+            f"All clean — both paths reference the same case_type fallback "
+            f"helpers: {joined}."
+        )
+        return 0
+
+    only_worker = worker_set - reingest_set
+    only_reingest = reingest_set - worker_set
+
+    print(
+        "ERROR: case_type fallback chain has diverged between worker.py and "
+        "_apply_regex_fallbacks in reingest_from_s3.py.",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    if only_worker:
+        print(
+            f"  Helpers called in {WORKER_REL}\n"
+            f"  but missing from {REINGEST_FN} in {REINGEST_REL}:",
+            file=sys.stderr,
+        )
+        for name in sorted(only_worker):
+            print(f"    - {name}", file=sys.stderr)
+        print("", file=sys.stderr)
+    if only_reingest:
+        print(
+            f"  Helpers called in {REINGEST_FN} ({REINGEST_REL})\n"
+            f"  but missing from {WORKER_REL}:",
+            file=sys.stderr,
+        )
+        for name in sorted(only_reingest):
+            print(f"    - {name}", file=sys.stderr)
+        print("", file=sys.stderr)
+
+    print(
+        "  Add the missing call(s) so both paths produce the same case_type\n"
+        "  for the same document.  See #4290 for context and the recurrence\n"
+        "  history (#1731, #1749, #1763, #1836, #2062 -> #4263, #2406).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-case-type-fallback-parity.sh
+++ b/scripts/check-case-type-fallback-parity.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# check-case-type-fallback-parity.sh — Assert the case_type fallback chain
+# stays in sync between live ingestion (worker.py) and reingest
+# (_apply_regex_fallbacks in reingest_from_s3.py).
+#
+# Why this guard exists
+# ---------------------
+# The regex/heuristic fallback chain that fills ``case_type`` when LLM
+# extraction returns NULL has historically diverged between
+# ``packages/scraper-framework/src/ingestion/worker.py`` (live ingestion path)
+# and ``scripts/reingest_from_s3.py`` (reparse path).  Each new
+# ``extract_case_type_from_*`` helper added to worker.py must also land in
+# ``_apply_regex_fallbacks`` to keep the two paths producing identical
+# case_type for the same document.
+#
+# The pattern has recurred at least six times over four years (#1731, #1749,
+# #1763, #1836, #2062 / surfaced as #4263, #2406).  Each gap was a single
+# missing call site in one of the two files; each cost multi-hour
+# investigations + reingest re-runs on dev.  This check is the cheap
+# structural defense — see #4290.
+#
+# Rule
+# ----
+# The set of distinct ``extract_case_type_from_<suffix>`` call names in
+# ``worker.py`` (excluding the ``from ... import`` statement) MUST equal the
+# set in ``_apply_regex_fallbacks`` of ``reingest_from_s3.py``.  Any
+# asymmetry — fallback added to one file but not the other — fails the
+# check.
+#
+# Usage
+# -----
+#   scripts/check-case-type-fallback-parity.sh   # exits 0 if in sync, 1 otherwise
+#
+# Exit codes
+# ----------
+#   0 — Both paths reference the same set of case_type fallback helpers.
+#   1 — The two sets diverge (details on stderr).
+#
+# Test override
+# -------------
+# Set ``CASE_TYPE_PARITY_ROOT`` to a directory containing alternate
+# ``packages/scraper-framework/src/ingestion/worker.py`` and
+# ``scripts/reingest_from_s3.py`` files.  Used by
+# ``scripts/tests/test_check_case_type_fallback_parity.sh`` to drive
+# regression coverage without mutating the real source tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-case-type-fallback-parity.py" "$@"

--- a/scripts/tests/test_check_case_type_fallback_parity.sh
+++ b/scripts/tests/test_check_case_type_fallback_parity.sh
@@ -1,0 +1,361 @@
+#!/usr/bin/env bash
+# test_check_case_type_fallback_parity.sh — Tests for
+# check-case-type-fallback-parity.sh.
+#
+# Exercises the case_type fallback parity guard against synthetic source
+# trees under a temp directory.  The check script honors
+# ``CASE_TYPE_PARITY_ROOT`` to enable this without mutating the real repo.
+#
+# Usage:
+#   scripts/tests/test_check_case_type_fallback_parity.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-case-type-fallback-parity.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_module() {
+    local rel="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$rel"
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+}
+
+WORKER_REL="packages/scraper-framework/src/ingestion/worker.py"
+REINGEST_REL="scripts/reingest_from_s3.py"
+
+# Canonical "both paths in sync" fixture — the four helpers that ship in
+# main today (number, scraper_id, motion_type, title).  Each test case
+# overlays one or both files with a variant that mutates this fixture.
+GOOD_WORKER='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def enrich(case_number, scraper_id, motion_type, title):
+    case_type = None
+    if case_number:
+        case_type = extract_case_type_from_number(case_number)
+    if case_type is None and scraper_id:
+        case_type = extract_case_type_from_scraper_id(scraper_id)
+    if case_type is None and motion_type:
+        case_type = extract_case_type_from_motion_type(motion_type)
+    if case_type is None and title:
+        case_type = extract_case_type_from_title(title)
+    return case_type
+'
+
+GOOD_REINGEST='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def _apply_regex_fallbacks(extracted, text, scraper_id=""):
+    if not extracted["case_type"] and extracted["case_number"]:
+        val = extract_case_type_from_number(extracted["case_number"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and scraper_id:
+        val = extract_case_type_from_scraper_id(scraper_id)
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and extracted["motion_type"]:
+        val = extract_case_type_from_motion_type(extracted["motion_type"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and extracted.get("case_title"):
+        val = extract_case_type_from_title(extracted["case_title"])
+        if val:
+            extracted["case_type"] = val
+'
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if CASE_TYPE_PARITY_ROOT="$TMPDIR_TEST" "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if CASE_TYPE_PARITY_ROOT="$TMPDIR_TEST" "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: both paths in sync — script passes ────────────────────────
+write_module "$WORKER_REL" "$GOOD_WORKER"
+write_module "$REINGEST_REL" "$GOOD_REINGEST"
+assert_passes "matched fallback chain in worker.py and _apply_regex_fallbacks"
+reset_tmpdir
+
+# ─── Test 2: worker.py has a fallback that reingest is missing ─────────
+# This is the #4263 / #2062 shape — extract_case_type_from_title was
+# added to worker.py but the corresponding call never landed in
+# _apply_regex_fallbacks.  Reingest is missing extract_case_type_from_title.
+WORKER_WITH_TITLE='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def enrich(case_number, scraper_id, motion_type, title):
+    case_type = None
+    if case_number:
+        case_type = extract_case_type_from_number(case_number)
+    if case_type is None and scraper_id:
+        case_type = extract_case_type_from_scraper_id(scraper_id)
+    if case_type is None and motion_type:
+        case_type = extract_case_type_from_motion_type(motion_type)
+    if case_type is None and title:
+        case_type = extract_case_type_from_title(title)
+    return case_type
+'
+
+REINGEST_WITHOUT_TITLE='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def _apply_regex_fallbacks(extracted, text, scraper_id=""):
+    if not extracted["case_type"] and extracted["case_number"]:
+        val = extract_case_type_from_number(extracted["case_number"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and scraper_id:
+        val = extract_case_type_from_scraper_id(scraper_id)
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and extracted["motion_type"]:
+        val = extract_case_type_from_motion_type(extracted["motion_type"])
+        if val:
+            extracted["case_type"] = val
+'
+write_module "$WORKER_REL" "$WORKER_WITH_TITLE"
+write_module "$REINGEST_REL" "$REINGEST_WITHOUT_TITLE"
+assert_fails "worker has extract_case_type_from_title but reingest does not (#4263 shape)"
+reset_tmpdir
+
+# ─── Test 3: reingest has a fallback that worker.py is missing ─────────
+# Symmetric case — someone adds a new fallback to reingest but forgets
+# to add it to worker.py.
+WORKER_WITHOUT_PARTY='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def enrich(case_number, scraper_id, motion_type, title):
+    case_type = None
+    if case_number:
+        case_type = extract_case_type_from_number(case_number)
+    if case_type is None and scraper_id:
+        case_type = extract_case_type_from_scraper_id(scraper_id)
+    if case_type is None and motion_type:
+        case_type = extract_case_type_from_motion_type(motion_type)
+    if case_type is None and title:
+        case_type = extract_case_type_from_title(title)
+    return case_type
+'
+
+REINGEST_WITH_PARTY='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_party,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def _apply_regex_fallbacks(extracted, text, scraper_id=""):
+    if not extracted["case_type"] and extracted["case_number"]:
+        val = extract_case_type_from_number(extracted["case_number"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and scraper_id:
+        val = extract_case_type_from_scraper_id(scraper_id)
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and extracted["motion_type"]:
+        val = extract_case_type_from_motion_type(extracted["motion_type"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and extracted.get("case_title"):
+        val = extract_case_type_from_title(extracted["case_title"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"]:
+        val = extract_case_type_from_party(extracted.get("party_name"))
+        if val:
+            extracted["case_type"] = val
+'
+write_module "$WORKER_REL" "$WORKER_WITHOUT_PARTY"
+write_module "$REINGEST_REL" "$REINGEST_WITH_PARTY"
+assert_fails "reingest has extract_case_type_from_party but worker does not"
+reset_tmpdir
+
+# ─── Test 4: both paths add the new fallback symmetrically — passes ────
+WORKER_WITH_PARTY='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_party,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def enrich(case_number, scraper_id, motion_type, title, party):
+    case_type = None
+    if case_number:
+        case_type = extract_case_type_from_number(case_number)
+    if case_type is None and scraper_id:
+        case_type = extract_case_type_from_scraper_id(scraper_id)
+    if case_type is None and motion_type:
+        case_type = extract_case_type_from_motion_type(motion_type)
+    if case_type is None and title:
+        case_type = extract_case_type_from_title(title)
+    if case_type is None and party:
+        case_type = extract_case_type_from_party(party)
+    return case_type
+'
+write_module "$WORKER_REL" "$WORKER_WITH_PARTY"
+write_module "$REINGEST_REL" "$REINGEST_WITH_PARTY"
+assert_passes "new fallback added to both paths symmetrically"
+reset_tmpdir
+
+# ─── Test 5: import-only reference does NOT count as a usage ───────────
+# A helper that is imported but never CALLED is still a divergence — the
+# fallback chain isn't actually wiring it.  This test asserts that the
+# guard counts USES, not imports.
+WORKER_IMPORTS_BUT_DOES_NOT_CALL_TITLE='from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def enrich(case_number, scraper_id, motion_type, title):
+    case_type = None
+    if case_number:
+        case_type = extract_case_type_from_number(case_number)
+    if case_type is None and scraper_id:
+        case_type = extract_case_type_from_scraper_id(scraper_id)
+    if case_type is None and motion_type:
+        case_type = extract_case_type_from_motion_type(motion_type)
+    # extract_case_type_from_title is imported but never called below.
+    return case_type
+'
+write_module "$WORKER_REL" "$WORKER_IMPORTS_BUT_DOES_NOT_CALL_TITLE"
+write_module "$REINGEST_REL" "$GOOD_REINGEST"
+assert_fails "worker imports extract_case_type_from_title but never calls it"
+reset_tmpdir
+
+# ─── Test 6: missing _apply_regex_fallbacks function — script fails ────
+write_module "$WORKER_REL" "$GOOD_WORKER"
+write_module "$REINGEST_REL" 'from extractors import extract_case_type_from_number
+
+
+def some_other_function():
+    return extract_case_type_from_number("ABC123")
+'
+assert_fails "missing _apply_regex_fallbacks function in reingest_from_s3.py"
+reset_tmpdir
+
+# ─── Test 7: missing source files — script fails ──────────────────────
+mkdir -p "$TMPDIR_TEST/packages/scraper-framework/src/ingestion"
+mkdir -p "$TMPDIR_TEST/scripts"
+assert_fails "missing source files are detected"
+reset_tmpdir
+
+# ─── Test 8: helper called only OUTSIDE _apply_regex_fallbacks fails ───
+# The reingest module has many other functions (_reparse_document, etc.)
+# that may reference the helpers.  When worker.py uses a helper that is
+# referenced ONLY outside _apply_regex_fallbacks (e.g. in a stale doc
+# path or unrelated helper), the parity check MUST still fail — the
+# fallback chain inside _apply_regex_fallbacks is what makes reingest
+# produce the same case_type as worker.py.  This is the inverse of test
+# 5 for the reingest side.
+write_module "$WORKER_REL" "$GOOD_WORKER"
+write_module "$REINGEST_REL" 'from extractors import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def _apply_regex_fallbacks(extracted, text, scraper_id=""):
+    # NOTE: extract_case_type_from_title intentionally absent here —
+    # it is referenced only in some_unrelated_helper below, which is
+    # NOT called from the reingest fallback chain.
+    if not extracted["case_type"] and extracted["case_number"]:
+        val = extract_case_type_from_number(extracted["case_number"])
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and scraper_id:
+        val = extract_case_type_from_scraper_id(scraper_id)
+        if val:
+            extracted["case_type"] = val
+    if not extracted["case_type"] and extracted["motion_type"]:
+        val = extract_case_type_from_motion_type(extracted["motion_type"])
+        if val:
+            extracted["case_type"] = val
+
+
+def some_unrelated_helper(case_title):
+    # A reference to extract_case_type_from_title here MUST NOT make the
+    # parity check pass — only the call set inside
+    # _apply_regex_fallbacks counts.
+    return extract_case_type_from_title(case_title)
+'
+assert_fails "helper called only outside _apply_regex_fallbacks does not satisfy parity"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a structural CI hygiene guard that asserts the set of `extract_case_type_from_*` helpers used in `packages/scraper-framework/src/ingestion/worker.py` (live ingestion) equals the set used inside `_apply_regex_fallbacks` in `scripts/reingest_from_s3.py` (reparse). When a new fallback is added to one path but not the other — the recurring footgun behind #1731, #1749, #1763, #1836, #2062 (surfaced as #4263), and #2406 — CI fails red with a diff of which helpers are missing on which side.

The guard uses Python's `ast` module rather than line-range greps so it survives refactors that move the post-LLM fallback block within `worker.py`.

Closes #4290

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check only). Verification is the new `case-type-fallback-parity-check` job appearing green in this PR's checks.
- [x] Verification evidence posted on issue (see A.8)
