### PR TITLE
ci(scraping): hygiene check that every /app/scripts reference has a Dockerfile COPY (#4294)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -725,6 +725,22 @@ jobs:
       - name: Verify dispatcher image installs every Python import used by the daemon
         if: matrix.shard == 'python'
         run: scripts/check-dispatcher-image-deps.sh
+      # Issue #4294 (retro from #4288): every operator-only script
+      # invoked at runtime via the scraper image's in-container scripts
+      # path must have a corresponding COPY directive in
+      # packages/scraper-framework/Dockerfile. Without this check, a new
+      # caller that references a script under that path but forgets to
+      # update the Dockerfile's COPY block fails silently — direct
+      # python invocation breaks at runtime, while the alternative
+      # scripts/ecs-run-task.sh path keeps working because it uploads
+      # scripts via S3 every run. #4288 was the fixing PR; this check
+      # is the recurrence preventer. NOTE: the literal in-container path
+      # prefix is intentionally not spelled here because the guard's
+      # own pattern would self-match on this comment (CLAUDE.md
+      # §Hygiene-check CI steps / #2542).
+      - name: Verify scraper image ships every script referenced from the in-container scripts path
+        if: matrix.shard == 'python'
+        run: scripts/check-scraper-image-shipped.sh
       # Issues #3062 (audit) + #3072 (this check): every
       # ``self._mark_agent_terminal`` call site in
       # ``scripts/dispatcher/daemon.py`` must carry a nearby

--- a/scripts/check-scraper-image-shipped.sh
+++ b/scripts/check-scraper-image-shipped.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# check-scraper-image-shipped.sh — assert every /app/scripts/<X>.{py,sh}
+# reference in the repo has a matching COPY directive in the
+# scraper-framework Dockerfile.
+#
+# Background — #4294 (retrospective from #4288 / PR #4292):
+#
+#   The scraper image (packages/scraper-framework/Dockerfile) bakes in a
+#   list of operator-only scripts via explicit COPY lines:
+#
+#       COPY scripts/<name> /app/scripts/<name>
+#
+#   Today that list is maintained by hand: when a new operator-only
+#   script is added that callers invoke via `python /app/scripts/<X>.py`
+#   (e.g. on an ECS task command override), an agent or human has to
+#   remember to add the COPY directive too. If they forget, the failure
+#   mode is silent — the script works through scripts/ecs-run-task.sh
+#   (which uploads a fresh copy via S3 every time) but does not work via
+#   direct `python /app/scripts/<X>.py` invocation. That's exactly the
+#   situation #4288 fixed for reingest_from_s3.py and rebuild_db.py.
+#
+#   This check is the hygiene gate that prevents recurrence: any new
+#   /app/scripts/<X>.{py,sh} reference added without the corresponding
+#   COPY in the scraper Dockerfile fails CI.
+#
+# What it checks
+# ──────────────
+# 1. Greps the repo for tokens of the form `/app/scripts/<name>.<ext>`
+#    where <name> is a single segment (no slash) and <ext> is `py` or
+#    `sh`. Subdirectory references (e.g. `/app/scripts/dispatcher/X.sh`)
+#    are out of scope — those live in different image Dockerfiles
+#    (Dockerfile.dispatcher*, Dockerfile.dispatcher-agent-runner) which
+#    manage their own COPY rules.
+# 2. Excludes paths the check should NOT scan:
+#      - the scraper-framework Dockerfile itself (it CONTAINS the COPY
+#        lines that satisfy references — counting them as references
+#        would produce a tautology)
+#      - all other Dockerfile* files in the repo (different images
+#        manage their own COPY rules; their /app/scripts references are
+#        their own concern, not the scraper image's)
+#      - this check script itself and its test suite (they reference
+#        /app/scripts/ in headers and fixtures)
+#      - docs/  (descriptive, not invocation sites)
+#      - tmp/   (worktree-local scratch)
+#      - .git/, .venv/, node_modules/ (vendored / generated)
+# 3. For each unique <name>.<ext> token found, asserts that
+#    packages/scraper-framework/Dockerfile contains a matching
+#    `COPY scripts/<name>.<ext> /app/scripts/<name>.<ext>` line.
+# 4. Exits non-zero with a clear error naming each missing script and
+#    the file:line where it was referenced.
+#
+# Usage:
+#   scripts/check-scraper-image-shipped.sh
+#
+# Exit codes:
+#   0 — all referenced scripts are COPY'd into the scraper image.
+#   1 — one or more referenced scripts are missing a COPY directive.
+#   2 — usage error or repo-structure assumption violated.
+#
+# Overrides (for the test harness; operators do not need these):
+#   --repo-root <path>   Repo root to scan (default: detect from this
+#                        script's location).
+#   --dockerfile <path>  Scraper Dockerfile to check against
+#                        (default: packages/scraper-framework/Dockerfile,
+#                        relative to --repo-root).
+#   --self-path <path>   Path of THIS check script relative to
+#                        --repo-root, used for self-exclusion. Defaults
+#                        to scripts/check-scraper-image-shipped.sh and
+#                        is overridable so the test harness can run a
+#                        copy of the check against a synthetic repo.
+
+set -uo pipefail
+
+# ── Defaults ───────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCKERFILE_REL="packages/scraper-framework/Dockerfile"
+SELF_REL="scripts/check-scraper-image-shipped.sh"
+TEST_REL="scripts/tests/test_check_scraper_image_shipped.sh"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo-root)
+            REPO_ROOT="$2"
+            shift 2
+            ;;
+        --dockerfile)
+            DOCKERFILE_REL="$2"
+            shift 2
+            ;;
+        --self-path)
+            SELF_REL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '2,/^set -uo pipefail$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+DOCKERFILE_ABS="$REPO_ROOT/$DOCKERFILE_REL"
+
+if [[ ! -f "$DOCKERFILE_ABS" ]]; then
+    echo "ERROR: scraper Dockerfile not found at $DOCKERFILE_ABS" >&2
+    exit 2
+fi
+
+# ── Step 1: find every /app/scripts/<name>.{py,sh} reference ──────────
+#
+# Use grep -rEn with --exclude/--exclude-dir flags. The regex
+# matches /app/scripts/<name>.py or /app/scripts/<name>.sh where
+# <name> has at least one [A-Za-z_], may contain alphanumeric, _, -,
+# and is followed immediately by .py or .sh and a non-word boundary.
+# The trailing word-boundary check rejects e.g. /app/scripts/X.python
+# and /app/scripts/X.shell.
+PATTERN='/app/scripts/[A-Za-z_][A-Za-z0-9_-]*\.(py|sh)([^A-Za-z0-9_]|$)'
+
+# Compute hits. Allow grep to exit 1 (no match) without tripping the
+# whole script (we have set -uo pipefail, no -e, so this is fine).
+HITS=$(
+    grep -rEn "$PATTERN" "$REPO_ROOT" \
+        --include='*.sh' \
+        --include='*.py' \
+        --include='*.tf' \
+        --include='*.yml' \
+        --include='*.yaml' \
+        --include='*.json' \
+        --include='*.md' \
+        --include='*.txt' \
+        --exclude-dir='.git' \
+        --exclude-dir='.venv' \
+        --exclude-dir='node_modules' \
+        --exclude-dir='__pycache__' \
+        --exclude-dir='dist' \
+        --exclude-dir='build' \
+        --exclude-dir='.next' \
+        --exclude-dir='docs' \
+        --exclude-dir='tmp' \
+        2>/dev/null \
+    | grep -v -F "$REPO_ROOT/$DOCKERFILE_REL:" \
+    | grep -v -F "$REPO_ROOT/$SELF_REL:" \
+    | grep -v -F "$REPO_ROOT/$TEST_REL:" \
+    | grep -vE "$REPO_ROOT/Dockerfile[^/]*:" \
+    | grep -vE "$REPO_ROOT/.+/Dockerfile[^/]*:"
+) || true
+
+# Note on the Dockerfile* exclusion: we drop hits in any Dockerfile in
+# the repo (root-level Dockerfile.dispatcher* and per-package
+# packages/<X>/Dockerfile, plus the .github/ecs-oneshot-test/Dockerfile
+# fixture). Each image has its own COPY rules; their /app/scripts/
+# references inside the image's own Dockerfile are not "callers
+# expecting the scraper image to ship them" — they're declarations of
+# what the OWN image ships. The Dockerfile-in-fixture-dir grep handles
+# the .github/ecs-oneshot-test/Dockerfile case.
+
+if [[ -z "$HITS" ]]; then
+    # No /app/scripts/X.{py,sh} references anywhere in the repo (other
+    # than the scraper Dockerfile itself and the self/test exclusions).
+    # Nothing to check.
+    echo "OK: no /app/scripts/<name>.{py,sh} references found outside the scraper Dockerfile"
+    exit 0
+fi
+
+# ── Step 2: extract unique script names from the hits ─────────────────
+#
+# Each hit line looks like:
+#   /repo/path/file.sh:42:    python /app/scripts/foo.py --bar
+#
+# We extract the basename token (foo.py) and dedupe. Keep the
+# first-seen file:line for each token so the error message can name a
+# concrete reference site.
+#
+# Bash 3.2 compat note (#3082): we cannot use associative arrays
+# (`declare -A`). Instead we use two parallel indexed arrays: SCRIPT_NAMES
+# holds the unique tokens in first-seen order, FIRST_REF_LINES holds the
+# file:line for the same index. Lookup is by linear scan, which is fine
+# because the count of unique tokens is tiny (≈10 at most in real-world
+# use).
+SCRIPT_NAMES=()
+FIRST_REF_LINES=()
+
+# Helper: 0 if $1 already in SCRIPT_NAMES, 1 otherwise.
+_already_seen() {
+    local needle="$1"
+    local existing
+    if [[ ${#SCRIPT_NAMES[@]} -eq 0 ]]; then
+        return 1
+    fi
+    for existing in "${SCRIPT_NAMES[@]}"; do
+        if [[ "$existing" == "$needle" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    file_part="${line%%:*}"
+    rest="${line#*:}"
+    line_num="${rest%%:*}"
+
+    # Extract every /app/scripts/<name>.<ext> token from this line.
+    # A single line may contain multiple tokens (rare but possible).
+    tokens=$(echo "$line" | grep -oE '/app/scripts/[A-Za-z_][A-Za-z0-9_-]*\.(py|sh)' | sort -u)
+    while IFS= read -r tok; do
+        [[ -z "$tok" ]] && continue
+        name_ext="${tok#/app/scripts/}"
+        if ! _already_seen "$name_ext"; then
+            SCRIPT_NAMES+=("$name_ext")
+            FIRST_REF_LINES+=("$file_part:$line_num")
+        fi
+    done <<< "$tokens"
+done <<< "$HITS"
+
+# Bash 3.2 + set -u: empty-array expansion is a fatal "unbound variable"
+# unless the array was assigned at least once. We assigned to SCRIPT_NAMES
+# above (even if no items were appended), so "${SCRIPT_NAMES[@]}" is safe
+# below — but a guard for the empty case is clearer.
+if [[ ${#SCRIPT_NAMES[@]} -eq 0 ]]; then
+    echo "OK: no /app/scripts/<name>.{py,sh} references found outside the scraper Dockerfile"
+    exit 0
+fi
+
+# ── Step 3: check each name has a matching COPY in the Dockerfile ─────
+#
+# A satisfying COPY line has the shape (whitespace-tolerant):
+#   COPY scripts/<name>.<ext> /app/scripts/<name>.<ext>
+#
+# We do not allow alternate destinations — the contract is that the
+# script is reachable at /app/scripts/<name>.<ext>.
+
+MISSING_NAMES=()
+MISSING_LINES=()
+i=0
+for name_ext in "${SCRIPT_NAMES[@]}"; do
+    expected="COPY scripts/${name_ext} /app/scripts/${name_ext}"
+    if ! grep -qF "$expected" "$DOCKERFILE_ABS"; then
+        MISSING_NAMES+=("$name_ext")
+        MISSING_LINES+=("${FIRST_REF_LINES[$i]}")
+    fi
+    i=$((i + 1))
+done
+
+if [[ ${#MISSING_NAMES[@]} -eq 0 ]]; then
+    echo "OK: all ${#SCRIPT_NAMES[@]} /app/scripts/<name>.{py,sh} references are COPY'd into the scraper image"
+    exit 0
+fi
+
+# ── Step 4: report missing scripts and exit non-zero ──────────────────
+
+echo "FAIL: ${#MISSING_NAMES[@]} script(s) referenced as /app/scripts/<X>.{py,sh} but missing from $DOCKERFILE_REL:" >&2
+i=0
+for name_ext in "${MISSING_NAMES[@]}"; do
+    echo "  - $name_ext (referenced at ${MISSING_LINES[$i]})" >&2
+    i=$((i + 1))
+done
+echo "" >&2
+echo "Fix: add a COPY line to $DOCKERFILE_REL alongside the existing scripts/* COPY block:" >&2
+for name_ext in "${MISSING_NAMES[@]}"; do
+    echo "  COPY scripts/${name_ext} /app/scripts/${name_ext}" >&2
+done
+echo "" >&2
+echo "Why this matters: callers that invoke 'python /app/scripts/<X>.py' against the" >&2
+echo "scraper image (e.g. via an ECS task command override) will fail at runtime if the" >&2
+echo "script is not COPY'd in. The failure mode is silent under scripts/ecs-run-task.sh," >&2
+echo "which uploads scripts via S3 every run — direct /app/scripts/ exec is the broken path." >&2
+echo "See #4288 (the bug this check prevents recurring) and #4294 (the check itself)." >&2
+
+exit 1

--- a/scripts/tests/test_check_scraper_image_shipped.sh
+++ b/scripts/tests/test_check_scraper_image_shipped.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# test_check_scraper_image_shipped.sh — Tests for check-scraper-image-shipped.sh
+#
+# Builds synthetic (repo, Dockerfile) pairs in a temp directory and
+# verifies the checker's exit code matches expectations. Covers the
+# four behaviors the issue (#4294) calls out explicitly:
+#
+#   (a) Current main passes (smoke test against the real repo).
+#   (b) A reference to /app/scripts/<X>.py with a matching COPY in the
+#       scraper Dockerfile passes.
+#   (c) A reference to /app/scripts/<X>.py without a matching COPY
+#       fails with stderr naming X.py.
+#   (d) A reference to /app/scripts/<X>.sh without a matching COPY
+#       fails with stderr naming X.sh.
+#
+# Plus extras:
+#   - Subdirectory references (/app/scripts/dispatcher/X.sh) are out of
+#     scope.
+#   - References inside other Dockerfiles (Dockerfile.dispatcher, etc.)
+#     are excluded — those images manage their own COPYs.
+#   - References in docs/ are excluded.
+#   - References in tmp/ are excluded.
+#   - The check script's own header is excluded (no self-match).
+#   - Multiple missing scripts in a single run are all reported.
+#
+# Usage:
+#   scripts/tests/test_check_scraper_image_shipped.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-scraper-image-shipped.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Helper: clear tmpdir between tests so unrelated fixtures do not leak.
+# The "${TMPDIR_TEST:?}" guard ensures the variable is non-empty before
+# the rm — without it shellcheck (SC2115) flags the rm as a foot-gun
+# because an unset TMPDIR_TEST would expand to `/*` and wipe the disk.
+reset_tmpdir() {
+    rm -rf "${TMPDIR_TEST:?}"/*
+    rm -rf "${TMPDIR_TEST:?}"/.[!.]* 2>/dev/null || true
+}
+
+# Helper: write content to a path, creating parent dirs as needed.
+write_file() {
+    local path="$1"
+    local content="$2"
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+}
+
+# Run the check against the synthetic repo at $TMPDIR_TEST.
+# The synthetic repo always has its scraper Dockerfile at
+# packages/scraper-framework/Dockerfile and the check is invoked with
+# --repo-root pointing at TMPDIR_TEST.
+#
+# We pass --self-path pointing to a path that does not exist inside the
+# synthetic repo so the self-exclusion grep never matches anything in
+# the fixtures (the real check script lives outside TMPDIR_TEST). Same
+# for --repo-root: the real script gets invoked but scans only the
+# synthetic tree.
+#
+# shellcheck disable=SC2120  # "$@" passthrough is intentional for future
+# tests that want to add a flag-shape — current callers happen to pass none.
+run_check_on_tmp() {
+    "$CHECK_SCRIPT" \
+        --repo-root "$TMPDIR_TEST" \
+        --self-path "scripts/check-scraper-image-shipped.sh" \
+        "$@"
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    local output
+    output=$(run_check_on_tmp 2>&1) && status=0 || status=$?
+    if [[ $status -eq 0 ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got exit $status)"
+        echo "--- output ---"
+        echo "$output"
+        echo "--------------"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local expected_token="${2:-}"
+    TESTS=$((TESTS + 1))
+    local output
+    output=$(run_check_on_tmp 2>&1) && status=0 || status=$?
+    if [[ $status -eq 0 ]]; then
+        echo "FAIL: $desc (expected failure, got success)"
+        echo "--- output ---"
+        echo "$output"
+        echo "--------------"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    if [[ -n "$expected_token" ]] && ! echo "$output" | grep -qF "$expected_token"; then
+        echo "FAIL: $desc (exit $status was non-zero but stderr did not mention '$expected_token')"
+        echo "--- output ---"
+        echo "$output"
+        echo "--------------"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "PASS: $desc"
+}
+
+# Scaffold helper: create a synthetic scraper Dockerfile under TMPDIR_TEST.
+# Pass extra COPY targets as varargs (e.g. "rebuild_db.py" "reingest_from_s3.py").
+synth_scraper_dockerfile() {
+    local out="$TMPDIR_TEST/packages/scraper-framework/Dockerfile"
+    mkdir -p "$(dirname "$out")"
+    {
+        echo 'FROM python:3.12-slim'
+        echo 'WORKDIR /app'
+        for name in "$@"; do
+            echo "COPY scripts/$name /app/scripts/$name"
+        done
+        echo 'ENTRYPOINT ["python", "-m"]'
+    } > "$out"
+}
+
+# ─── Test 1: AC #1 — check script exists and is executable ─────────────
+TESTS=$((TESTS + 1))
+if [[ -x "$CHECK_SCRIPT" ]]; then
+    echo "PASS: $CHECK_SCRIPT exists and is executable"
+else
+    echo "FAIL: $CHECK_SCRIPT exists and is executable"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 2: AC #2 — current main passes ───────────────────────────────
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: Current main passes (real repo, default args)"
+else
+    echo "FAIL: Current main passes (real repo, default args)"
+    "$CHECK_SCRIPT" 2>&1 | head -20
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 3: AC #3 — synthetic missing script fails with clear stderr ──
+# This is the AC's exact scenario: a tmp/fake_caller.sh containing
+# `python /app/scripts/nonexistent.py` causes the check to fail with
+# stderr naming nonexistent.py.
+#
+# Note: AC says tmp/fake_caller.sh, but the real check excludes tmp/
+# (worktree-local scratch). For the test we put the fake caller under
+# scripts/ instead, which is the same idea — a non-Dockerfile, non-docs,
+# non-tmp file referencing a script that the Dockerfile does not COPY.
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/scripts/fake_caller.sh" \
+'#!/usr/bin/env bash
+# Synthetic caller used only by the test harness.
+python /app/scripts/nonexistent.py --foo'
+assert_fails \
+    "Reference to missing /app/scripts/nonexistent.py is detected" \
+    "nonexistent.py"
+
+# ─── Test 4: Reference with matching COPY passes ───────────────────────
+reset_tmpdir
+synth_scraper_dockerfile "rebuild_db.py"
+write_file "$TMPDIR_TEST/scripts/some_caller.sh" \
+'#!/usr/bin/env bash
+python /app/scripts/rebuild_db.py --county la'
+assert_passes "Reference to /app/scripts/rebuild_db.py with matching COPY passes"
+
+# ─── Test 5: Reference to .sh script with matching COPY passes ─────────
+reset_tmpdir
+synth_scraper_dockerfile "notify-telegram.sh"
+write_file "$TMPDIR_TEST/scripts/some_caller.sh" \
+'#!/usr/bin/env bash
+/app/scripts/notify-telegram.sh "alert text"'
+assert_passes "Reference to /app/scripts/notify-telegram.sh with matching COPY passes"
+
+# ─── Test 6: Missing .sh script is detected ────────────────────────────
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/scripts/some_caller.sh" \
+'#!/usr/bin/env bash
+/app/scripts/missing-helper.sh "alert text"'
+assert_fails "Reference to missing /app/scripts/missing-helper.sh is detected" \
+    "missing-helper.sh"
+
+# ─── Test 7: Subdirectory references are out of scope ──────────────────
+# /app/scripts/dispatcher/agent-runner-entrypoint.sh is in a different
+# image's COPY hierarchy (Dockerfile.dispatcher-agent-runner). The
+# check's regex does not match subdir references — only single-segment
+# basenames after /app/scripts/.
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/scripts/some_caller.sh" \
+'#!/usr/bin/env bash
+PHASE_TRANSITIONS_DIR="${PHASE_TRANSITIONS_DIR:-/app/scripts/dispatcher}"
+exec /app/scripts/dispatcher/agent-runner-entrypoint.sh'
+assert_passes "Subdirectory references (/app/scripts/dispatcher/...) are out of scope"
+
+# ─── Test 8: References inside other Dockerfile* are excluded ──────────
+# Dockerfile.dispatcher-* manage their own COPY rules. The check only
+# enforces against packages/scraper-framework/Dockerfile, so references
+# inside any Dockerfile* are excluded.
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/Dockerfile.dispatcher-agent-runner" \
+'FROM python:3.12-slim
+COPY scripts/check-issue-author.sh /app/scripts/check-issue-author.sh
+RUN chmod +x /app/scripts/check-issue-author.sh
+ENTRYPOINT ["/app/scripts/dispatcher/agent-runner-entrypoint.sh"]'
+assert_passes "References inside Dockerfile.dispatcher-agent-runner are excluded"
+
+# ─── Test 9: References under docs/ are excluded ───────────────────────
+# Documentation is descriptive, not invocation-site.
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/docs/agent/infrastructure-reference.md" \
+'# Some doc
+
+The script is at `/app/scripts/example_only.py` inside the image.'
+assert_passes "References under docs/ are excluded"
+
+# ─── Test 10: References under tmp/ are excluded ───────────────────────
+# Worktree-local scratch never ships and should never trip the check.
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/tmp/scratch.sh" \
+'#!/usr/bin/env bash
+python /app/scripts/scratch_caller.py'
+assert_passes "References under tmp/ are excluded"
+
+# ─── Test 11: Multiple missing scripts are all reported ────────────────
+reset_tmpdir
+synth_scraper_dockerfile "rebuild_db.py"
+write_file "$TMPDIR_TEST/scripts/caller_a.sh" 'python /app/scripts/missing_a.py'
+write_file "$TMPDIR_TEST/scripts/caller_b.sh" 'python /app/scripts/missing_b.py'
+write_file "$TMPDIR_TEST/scripts/caller_c.sh" 'python /app/scripts/rebuild_db.py'
+
+TESTS=$((TESTS + 1))
+output=$(run_check_on_tmp 2>&1) && status=0 || status=$?
+if [[ $status -eq 0 ]]; then
+    echo "FAIL: Multiple missing scripts are all reported (expected failure, got success)"
+    FAILURES=$((FAILURES + 1))
+elif echo "$output" | grep -qF "missing_a.py" && echo "$output" | grep -qF "missing_b.py"; then
+    if echo "$output" | grep -qF "rebuild_db.py" && ! echo "$output" | grep -qE "rebuild_db\.py.*\(referenced at"; then
+        # rebuild_db.py SHOULD appear in the recovery hint suggestion list ONLY
+        # if listed as missing — but it's NOT missing here. Check it's not
+        # listed as missing.
+        echo "PASS: Multiple missing scripts are all reported"
+    elif echo "$output" | grep -qE "rebuild_db\.py.*\(referenced at"; then
+        echo "FAIL: rebuild_db.py wrongly reported as missing"
+        echo "--- output ---"
+        echo "$output"
+        echo "--------------"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: Multiple missing scripts are all reported"
+    fi
+else
+    echo "FAIL: Multiple missing scripts are all reported (output did not mention both missing names)"
+    echo "--- output ---"
+    echo "$output"
+    echo "--------------"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 12: Same script referenced from multiple files is deduped ────
+# The error message names the script once, and the file:line points to
+# the FIRST reference site (deterministic ordering by grep -r).
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/scripts/caller_a.sh" 'python /app/scripts/dup.py'
+write_file "$TMPDIR_TEST/scripts/caller_b.sh" 'python /app/scripts/dup.py'
+
+TESTS=$((TESTS + 1))
+output=$(run_check_on_tmp 2>&1) && status=0 || status=$?
+dup_count=$(echo "$output" | grep -cE "^\s+- dup\.py " || true)
+if [[ $status -ne 0 && "$dup_count" == "1" ]]; then
+    echo "PASS: Same script referenced from multiple files is deduped"
+else
+    echo "FAIL: Same script referenced from multiple files is deduped (status=$status, dup_count=$dup_count)"
+    echo "--- output ---"
+    echo "$output"
+    echo "--------------"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 13: Word-boundary check rejects /app/scripts/X.python ────────
+# A reference like /app/scripts/foo.python should NOT match (it's a
+# bogus extension, not .py followed by a non-word character).
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/scripts/some_caller.sh" \
+'#!/usr/bin/env bash
+# This string contains /app/scripts/foo.python which is NOT a real
+# python invocation — the regex must not match it.
+echo "/app/scripts/foo.python is not a real reference"'
+assert_passes "Word-boundary check rejects /app/scripts/X.python (not .py)"
+
+# ─── Test 14: COPY directive with different destination does not satisfy ─
+# The check requires exact "COPY scripts/X /app/scripts/X" — a COPY to
+# a different path does not satisfy the contract that the script is
+# reachable at /app/scripts/X.
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/packages/scraper-framework"
+{
+    echo 'FROM python:3.12-slim'
+    echo 'WORKDIR /app'
+    echo 'COPY scripts/wrong_dest.py /app/elsewhere/wrong_dest.py'  # wrong dest
+} > "$TMPDIR_TEST/packages/scraper-framework/Dockerfile"
+write_file "$TMPDIR_TEST/scripts/some_caller.sh" \
+'python /app/scripts/wrong_dest.py'
+assert_fails \
+    "COPY to a different destination does not satisfy /app/scripts/X.py" \
+    "wrong_dest.py"
+
+# ─── Test 15: Self-match guard — check's own header references /app/scripts ─
+# The check script's header text mentions /app/scripts/<X>.py several
+# times in prose. Running the check on the real repo (Test 2) already
+# covers this — if the self-exclusion broke, Test 2 would fail. This
+# test makes the assertion explicit.
+TESTS=$((TESTS + 1))
+header_hits=$(grep -cE '/app/scripts/[A-Za-z_][A-Za-z0-9_-]*\.(py|sh)' "$CHECK_SCRIPT" || true)
+if [[ "$header_hits" -gt 0 ]] && "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: Check's own header contains /app/scripts/<X>.{py,sh} prose ($header_hits hits) but does not self-trip"
+else
+    echo "FAIL: Self-match guard (header_hits=$header_hits, status=$?)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 16: No self-match on ci.yml step name ────────────────────────
+# Per CLAUDE.md §Hygiene-check CI steps, every new string-forbidding
+# guard must not have a CI step name that itself contains a forbidden
+# pattern. Our pattern is /app/scripts/<X>.{py,sh} — no CI step name
+# should literally contain that prose, since the check would trip on
+# its own step name during the workflow run.
+TESTS=$((TESTS + 1))
+ci_yml="$REPO_ROOT/.github/workflows/ci.yml"
+if [[ -f "$ci_yml" ]]; then
+    if grep -qE '/app/scripts/[A-Za-z_][A-Za-z0-9_-]*\.(py|sh)' "$ci_yml"; then
+        echo "FAIL: ci.yml contains /app/scripts/<X>.{py,sh} prose — guard would self-match"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: No self-match on ci.yml — no /app/scripts/<X>.{py,sh} prose in workflow"
+    fi
+else
+    echo "PASS: No self-match on ci.yml step name (ci.yml missing — skipped)"
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI hygiene check (`scripts/check-scraper-image-shipped.sh`) that asserts every in-container `/app/scripts/<name>.{py,sh}` reference in the repo has a matching `COPY scripts/<name> /app/scripts/<name>` directive in `packages/scraper-framework/Dockerfile`. Wired into `.github/workflows/ci.yml` alongside the existing `check-dispatcher-image-deps.sh` step. Prevents recurrence of the silent failure mode #4288 fixed (operator-only script added with a direct in-container call-site but no Dockerfile COPY — works via `scripts/ecs-run-task.sh`, breaks on direct exec).

Closes #4294

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_scraper_image_shipped.sh` — 16 scenarios, all passing locally)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check + workflow wiring only)
- [x] Verification evidence posted on issue (see #4294)
