### PR TITLE
refactor(ingestion): extract case_type fallback chain into shared resolver (#4295)

### DIFF
--- a/packages/scraper-framework/src/ingestion/case_type_resolver.py
+++ b/packages/scraper-framework/src/ingestion/case_type_resolver.py
@@ -1,0 +1,134 @@
+"""Shared ``case_type`` fallback resolver for ingestion + reingest paths.
+
+Two code paths produce a final ``case_type`` for ruling documents:
+
+* Live ingestion — ``packages/scraper-framework/src/ingestion/worker.py``
+  applies ``extract_case_type_from_*`` helpers as post-LLM fallbacks just
+  before the ``Field extraction summary`` log line.
+* Reparse — ``scripts/reingest_from_s3.py`` calls the same helpers inside
+  ``_apply_regex_fallbacks``.
+
+For four years the two paths each open-coded the same fallback chain in
+slightly different order/structure, and any time a new helper landed it
+had to be added to both — a footgun that has fired six times (#1731,
+#1749, #1763, #1836, #2062 surfacing as #4263, #2406).  The hygiene
+guard added in #4290 (``scripts/check-case-type-fallback-parity.py``)
+catches the divergence shape, but the duplication is still the root
+cause.
+
+This module exposes one function — :func:`resolve_case_type` — that
+encodes the canonical fallback chain.  Both paths import it instead of
+inlining the four ``extract_case_type_from_*`` helpers, so divergence
+becomes impossible by construction.
+
+The fallback order — case_number prefix → scraper_id → motion_type →
+case_title — is the order that ships in production.  See worker.py for
+the historical issue references on each step.
+
+Returns
+-------
+``(case_type, extraction_method)`` — ``extraction_method`` is one of
+``"regex"``, ``"scraper_id"``, ``"motion_type"``, ``"title"``, or
+``None`` (when no fallback matched).  When the caller passed a non-None
+``case_type`` in (i.e. a prior LLM/extraction step already populated
+it), this function returns ``(case_type, None)`` unchanged — callers
+distinguish between "we resolved a value" and "the value was already
+set by an upstream step" by inspecting the returned method.
+
+The method strings exactly match the keys ``worker.py`` and
+``_apply_regex_fallbacks`` historically wrote into
+``extraction_methods["case_type"]``, so swapping in this resolver is a
+behaviour-preserving refactor.
+"""
+
+from __future__ import annotations
+
+from .extract import (
+    extract_case_type_from_motion_type,
+    extract_case_type_from_number,
+    extract_case_type_from_scraper_id,
+    extract_case_type_from_title,
+)
+
+
+def resolve_case_type(
+    *,
+    case_type: str | None,
+    case_number: str | None,
+    scraper_id: str | None,
+    motion_type: str | None,
+    case_title: str | None,
+) -> tuple[str | None, str | None]:
+    """Apply the regex/heuristic ``case_type`` fallback chain.
+
+    Parameters
+    ----------
+    case_type : str | None
+        The current ``case_type`` value (e.g. as set by LLM extraction).
+        When non-None, the fallback chain is skipped and the returned
+        value matches the input — the second tuple element is ``None``
+        because no fallback ran.
+    case_number : str | None
+        Case number string.  When set and recognised by
+        :func:`extract_case_type_from_number`, the resolver returns
+        ``(case_type, "regex")``.
+    scraper_id : str | None
+        Scraper ID string.  Used when the case_number prefix doesn't
+        encode the type (e.g. OC North JC PDFs lack case numbers).
+        When set and recognised by
+        :func:`extract_case_type_from_scraper_id`, the resolver returns
+        ``(case_type, "scraper_id")``.
+    motion_type : str | None
+        Normalised motion type string (e.g. ``"motion_to_compel"``).
+        Used as a final fallback when the case number is generic and
+        the scraper_id is too (e.g. Ventura's all-digit case numbers).
+        When set and recognised by
+        :func:`extract_case_type_from_motion_type`, the resolver returns
+        ``(case_type, "motion_type")``.
+    case_title : str | None
+        Case title string.  Final fallback for unambiguous probate-style
+        titles (``"In the Matter of..."``, ``"Conservatorship of..."``,
+        etc.).  When set and recognised by
+        :func:`extract_case_type_from_title`, the resolver returns
+        ``(case_type, "title")``.
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        ``(case_type, extraction_method)``.  ``extraction_method`` is
+        ``None`` when no fallback ran — either because ``case_type`` was
+        already set, or because every fallback returned ``None``.
+
+    Notes
+    -----
+    The fallback order — number, scraper_id, motion_type, title —
+    encodes the production behaviour.  Earlier checks have higher
+    confidence (a case number prefix is a deterministic signal; a
+    case title heuristic is the weakest).  Do not reorder without
+    weighing the regression risk on the ``test_fallback_parity.py``
+    and ``test_worker_reingest_parity.py`` suites.
+    """
+    if case_type is not None:
+        return case_type, None
+
+    if case_number:
+        resolved = extract_case_type_from_number(case_number)
+        if resolved:
+            return resolved, "regex"
+
+    if scraper_id:
+        resolved = extract_case_type_from_scraper_id(scraper_id)
+        if resolved:
+            return resolved, "scraper_id"
+
+    if motion_type:
+        resolved = extract_case_type_from_motion_type(motion_type)
+        if resolved:
+            return resolved, "motion_type"
+
+    if case_title:
+        resolved = extract_case_type_from_title(case_title)
+        if resolved:
+            return resolved, "title"
+
+    return None, None

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -56,6 +56,7 @@ from validation.deterministic import (
 from validation.gate import ValidationResult, insert_validation_result, validate_document
 from validation.issue_filer import file_validation_issue
 
+from .case_type_resolver import resolve_case_type
 from .db import (
     batch_upsert_parties,
     delete_stale_split_children,
@@ -72,10 +73,6 @@ from .extract import (
     clean_case_title,
     dedupe_repeated_title,
     extract_case_number,
-    extract_case_type_from_motion_type,
-    extract_case_type_from_number,
-    extract_case_type_from_scraper_id,
-    extract_case_type_from_title,
     extract_hearing_date,
     extract_judge_name,
     has_bare_vs_suffix,
@@ -2269,10 +2266,23 @@ class IngestionWorker:
                         extraction_methods["judge_name"] = "regex_post_llm"
 
             # case_type from case number — does not require ruling_text.
+            # Uses the shared resolver (#4295) so this and the post-LLM
+            # block stay in lock-step with the reingest path; only the
+            # case_number signal is available here, so the resolver only
+            # exercises its first fallback step (returns method="regex"
+            # on a hit).
             if case_type is None and case_number:
-                case_type = extract_case_type_from_number(case_number)
-                if case_type:
-                    extraction_methods.setdefault("case_type", "regex")
+                resolved_ct, resolved_method = resolve_case_type(
+                    case_type=None,
+                    case_number=case_number,
+                    scraper_id=None,
+                    motion_type=None,
+                    case_title=None,
+                )
+                if resolved_ct:
+                    case_type = resolved_ct
+                    assert resolved_method is not None
+                    extraction_methods.setdefault("case_type", resolved_method)
 
             # Clean ruling text for display — the cleaned version is stored
             # in Postgres.
@@ -2453,41 +2463,24 @@ class IngestionWorker:
                     },
                 )
 
-        # Fallback case_type from case number prefix (#706).
-        if case_type is None and case_number:
-            case_type = extract_case_type_from_number(case_number)
-            if case_type:
-                extraction_methods.setdefault("case_type", "regex")
-
-        # Fallback case_type from scraper_id (#1524).
-        # When the case number is absent or doesn't encode a type prefix
-        # (e.g. OC North JC PDFs have no case numbers), infer from the
-        # scraper_id which encodes the case category in its suffix.
-        if case_type is None and scraper_id:
-            case_type = extract_case_type_from_scraper_id(scraper_id)
-            if case_type:
-                extraction_methods.setdefault("case_type", "scraper_id")
-
-        # Fallback case_type from motion_type (#1702).
-        # Final fallback for cases where the case number has no embedded
-        # type code and the scraper_id is generic (e.g. Ventura's
-        # all-digit case numbers like 202300574258).  Many civil motion
-        # types unambiguously identify the case type.
-        if case_type is None and motion_type:
-            case_type = extract_case_type_from_motion_type(motion_type)
-            if case_type:
-                extraction_methods.setdefault("case_type", "motion_type")
-
-        # Fallback case_type from case title (#2062).
-        # Final fallback for cases where no other signal determined the
-        # case type.  Probate-style titles ("In the Matter of...",
-        # "Conservatorship of...", "Guardianship of...") are unambiguous.
-        if case_type is None:
-            eff_title = case_title or event_data.get("case_title")
-            if eff_title:
-                case_type = extract_case_type_from_title(eff_title)
-                if case_type:
-                    extraction_methods.setdefault("case_type", "title")
+        # Post-LLM-enrichment case_type fallback chain — case_number
+        # prefix (#706) -> scraper_id (#1524) -> motion_type (#1702) ->
+        # case_title (#2062).  See ``ingestion.case_type_resolver`` for
+        # the canonical chain definition; the same resolver is invoked
+        # by ``_apply_regex_fallbacks`` in ``scripts/reingest_from_s3.py``
+        # so live ingestion and reparse cannot diverge by construction
+        # (#4295, follow-on to the #4290 hygiene guard).
+        eff_title = case_title or event_data.get("case_title")
+        resolved_ct, resolved_method = resolve_case_type(
+            case_type=case_type,
+            case_number=case_number,
+            scraper_id=scraper_id,
+            motion_type=motion_type,
+            case_title=eff_title,
+        )
+        if resolved_method is not None:
+            case_type = resolved_ct
+            extraction_methods.setdefault("case_type", resolved_method)
 
         if extraction_methods:
             logger.info(

--- a/packages/scraper-framework/tests/ingestion/test_case_type_resolver.py
+++ b/packages/scraper-framework/tests/ingestion/test_case_type_resolver.py
@@ -1,0 +1,265 @@
+"""Unit tests for ``ingestion.case_type_resolver.resolve_case_type``.
+
+The resolver replaces an open-coded fallback chain that previously lived
+both in ``packages/scraper-framework/src/ingestion/worker.py`` and in
+``_apply_regex_fallbacks`` inside ``scripts/reingest_from_s3.py``.  See
+issue #4295 (parent #4290).
+
+The tests below exercise every branch of the chain in the canonical
+order — case_number → scraper_id → motion_type → case_title — plus the
+``case_type already set`` early-return, the all-misses-returns-None
+case, and the priority interactions.
+"""
+
+from __future__ import annotations
+
+from ingestion.case_type_resolver import resolve_case_type
+
+
+class TestResolveCaseTypeAlreadySet:
+    """When ``case_type`` is already set, the resolver returns it verbatim."""
+
+    def test_returns_existing_case_type_unchanged(self) -> None:
+        result = resolve_case_type(
+            case_type="family",
+            case_number="CIVSB2501234",  # would otherwise resolve to civil
+            scraper_id="ca-oc-tentatives-probate",
+            motion_type="msj",
+            case_title="In the Matter of John Doe",
+        )
+        assert result == ("family", None), (
+            "Expected pre-set case_type to be returned with method=None — "
+            "the resolver must not re-run any fallback when case_type is "
+            "already populated."
+        )
+
+    def test_returns_existing_case_type_with_no_fallback_inputs(self) -> None:
+        result = resolve_case_type(
+            case_type="probate",
+            case_number=None,
+            scraper_id=None,
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("probate", None)
+
+
+class TestResolveCaseTypeFromCaseNumber:
+    """First fallback step — case_number prefix."""
+
+    def test_civil_case_number_resolves(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number="CIVSB2501234",
+            scraper_id=None,
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("civil", "regex")
+
+    def test_family_case_number_resolves(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number="FL2301234",
+            scraper_id=None,
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("family", "regex")
+
+    def test_probate_case_number_resolves(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number="PR2301234",
+            scraper_id=None,
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("probate", "regex")
+
+    def test_unrecognised_case_number_falls_through(self) -> None:
+        """Case number that doesn't match any prefix pattern moves on to
+        the next fallback step."""
+        result = resolve_case_type(
+            case_type=None,
+            case_number="UNKNOWN123",
+            scraper_id="ca-oc-tentatives-civil",
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("civil", "scraper_id")
+
+
+class TestResolveCaseTypeFromScraperId:
+    """Second fallback step — scraper_id suffix."""
+
+    def test_civil_scraper_id_resolves(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id="ca-oc-tentatives-civil",
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("civil", "scraper_id")
+
+    def test_probate_scraper_id_resolves(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id="ca-oc-tentatives-probate",
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("probate", "scraper_id")
+
+    def test_unrecognised_scraper_id_falls_through(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id="ca-mystery-scraper",
+            motion_type="msj",
+            case_title=None,
+        )
+        assert result == ("civil", "motion_type")
+
+
+class TestResolveCaseTypeFromMotionType:
+    """Third fallback step — motion_type."""
+
+    def test_msj_resolves_civil(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type="msj",
+            case_title=None,
+        )
+        assert result == ("civil", "motion_type")
+
+    def test_request_for_order_resolves_family(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type="request_for_order",
+            case_title=None,
+        )
+        assert result == ("family", "motion_type")
+
+    def test_unrecognised_motion_type_falls_through(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type="ex_parte_application",  # ambiguous, returns None
+            case_title="In the Matter of Jane Doe",
+        )
+        assert result == ("probate", "title")
+
+
+class TestResolveCaseTypeFromTitle:
+    """Fourth (final) fallback step — case_title."""
+
+    def test_in_the_matter_of_resolves_probate(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type=None,
+            case_title="In the Matter of John Smith",
+        )
+        assert result == ("probate", "title")
+
+    def test_conservatorship_of_resolves_probate(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type=None,
+            case_title="Conservatorship of Jane Doe",
+        )
+        assert result == ("probate", "title")
+
+    def test_estate_of_resolves_probate(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type=None,
+            case_title="Estate of Mary Roe",
+        )
+        assert result == ("probate", "title")
+
+
+class TestResolveCaseTypeAllMissesReturnsNone:
+    """When every signal misses, the resolver returns ``(None, None)``."""
+
+    def test_no_inputs_returns_none(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == (None, None)
+
+    def test_all_unrecognised_inputs_returns_none(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number="UNRECOGNIZED999",
+            scraper_id="generic-scraper-with-no-suffix",
+            motion_type="ex_parte_application",  # ambiguous
+            case_title="Smith v. Jones",  # generic civil title, no probate cue
+        )
+        assert result == (None, None)
+
+    def test_empty_strings_treated_as_missing(self) -> None:
+        """Empty / whitespace-only strings should be treated as missing
+        signals — falsy values short-circuit each step."""
+        result = resolve_case_type(
+            case_type=None,
+            case_number="",
+            scraper_id="",
+            motion_type="",
+            case_title="",
+        )
+        assert result == (None, None)
+
+
+class TestResolveCaseTypePriority:
+    """The fallback order encodes confidence — case_number wins over
+    scraper_id, scraper_id wins over motion_type, etc."""
+
+    def test_case_number_beats_scraper_id(self) -> None:
+        """``CIVSB`` -> civil, even when scraper_id encodes probate.
+        Mirrors ``test_fallback_parity.py::test_case_type_priority_number_over_scraper_id``."""
+        result = resolve_case_type(
+            case_type=None,
+            case_number="CIVSB2501234",
+            scraper_id="ca-oc-tentatives-probate",
+            motion_type=None,
+            case_title=None,
+        )
+        assert result == ("civil", "regex")
+
+    def test_scraper_id_beats_motion_type(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id="ca-oc-tentatives-probate",
+            motion_type="msj",  # would resolve civil
+            case_title=None,
+        )
+        assert result == ("probate", "scraper_id")
+
+    def test_motion_type_beats_title(self) -> None:
+        result = resolve_case_type(
+            case_type=None,
+            case_number=None,
+            scraper_id=None,
+            motion_type="msj",
+            case_title="In the Matter of John Doe",  # would resolve probate
+        )
+        assert result == ("civil", "motion_type")

--- a/packages/scraper-framework/tests/test_fallback_parity.py
+++ b/packages/scraper-framework/tests/test_fallback_parity.py
@@ -35,13 +35,16 @@ sys.path.insert(0, _SCRIPTS_DIR)
 reingest = importlib.import_module("reingest_from_s3")
 
 # ---------------------------------------------------------------------------
-# Import the same extract helpers used by both code paths
+# Import the same extract helpers used by both code paths.
+#
+# After #4295 the case_type fallback chain is encoded in
+# ``ingestion.case_type_resolver.resolve_case_type`` and both worker.py
+# and ``_apply_regex_fallbacks`` call it.  The simulator below uses the
+# same resolver so its case_type output continues to mirror production.
 # ---------------------------------------------------------------------------
+from ingestion.case_type_resolver import resolve_case_type  # noqa: E402
 from ingestion.extract import (  # noqa: E402
     extract_case_number,
-    extract_case_type_from_motion_type,
-    extract_case_type_from_number,
-    extract_case_type_from_scraper_id,
     extract_hearing_date,
     extract_judge_name,
 )
@@ -92,23 +95,20 @@ def _simulate_worker_fallbacks(
             extraction_methods.setdefault("case_number", "regex")
             case_number = extracted_cn
 
-    # Worker: case_type from case_number prefix
-    if case_type is None and case_number:
-        case_type = extract_case_type_from_number(case_number)
-        if case_type:
-            extraction_methods.setdefault("case_type", "regex")
-
-    # Worker: case_type from scraper_id
-    if case_type is None and scraper_id:
-        case_type = extract_case_type_from_scraper_id(scraper_id)
-        if case_type:
-            extraction_methods.setdefault("case_type", "scraper_id")
-
-    # Worker: case_type from motion_type
-    if case_type is None and motion_type:
-        case_type = extract_case_type_from_motion_type(motion_type)
-        if case_type:
-            extraction_methods.setdefault("case_type", "motion_type")
+    # Worker: full case_type fallback chain — delegated to the shared
+    # resolver since #4295 (number -> scraper_id -> motion_type ->
+    # case_title).  The simulator mirrors worker.py's call site so the
+    # parity assertion stays meaningful when the resolver evolves.
+    resolved_ct, resolved_method = resolve_case_type(
+        case_type=case_type,
+        case_number=case_number,
+        scraper_id=scraper_id or None,
+        motion_type=motion_type,
+        case_title=None,
+    )
+    if resolved_method is not None:
+        case_type = resolved_ct
+        extraction_methods.setdefault("case_type", resolved_method)
 
     return {
         "judge_name": judge_name,

--- a/scripts/check-case-type-fallback-parity.py
+++ b/scripts/check-case-type-fallback-parity.py
@@ -16,11 +16,24 @@ a reingest, which has caused multi-hour investigations and reingest re-runs
 six times over four years (#1731, #1749, #1763, #1836, #2062 surfaced as
 #4263, #2406).  This script is the cheap structural defense — see #4290.
 
+Defense-in-depth status (#4295):  As of #4295, both paths invoke
+``ingestion.case_type_resolver.resolve_case_type`` — a single shared
+helper that encodes the canonical fallback chain.  When that refactor
+holds, **both scanned sets are empty** ("(empty) == (empty)") and the
+guard reports ``All clean`` trivially.  The guard intentionally remains
+in place as defense-in-depth: if a future change re-inlines a call to
+``extract_case_type_from_<x>`` in either path without adding the same
+call to the other (the historical divergence shape), this guard fires
+again.  The shared resolver makes divergence impossible at the source
+level; this guard catches re-divergence.
+
 Usage:
     scripts/check-case-type-fallback-parity.py
 
 Exit codes:
-    0 — Both files reference the same set of helpers.
+    0 — Both files reference the same set of helpers (including the
+        post-#4295 case where both sets are empty because the chain is
+        delegated to ``case_type_resolver.resolve_case_type``).
     1 — Sets diverge (or a required file is missing).
 
 Test override:

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -207,13 +207,10 @@ from ingestion.db import (  # noqa: E402
     upsert_case_judge,
 )
 from ingestion.doc_timing import DocTiming, emit_via_structlog_logger  # noqa: E402
+from ingestion.case_type_resolver import resolve_case_type  # noqa: E402
 from ingestion.extract import (  # noqa: E402
     dedupe_repeated_title,
     extract_case_number,
-    extract_case_type_from_motion_type,
-    extract_case_type_from_number,
-    extract_case_type_from_scraper_id,
-    extract_case_type_from_title,
     extract_hearing_date,
     extract_judge_name,
     is_plausible_hearing_date,
@@ -834,50 +831,22 @@ def _apply_regex_fallbacks(extracted: dict, text: str, scraper_id: str = "") -> 
             extracted["hearing_date"] = val
             methods.setdefault("hearing_date", "regex")
 
-    # Fallback case_type from case number prefix (#706).
-    if not extracted["case_type"] and extracted["case_number"]:
-        val = extract_case_type_from_number(extracted["case_number"])
-        if val:
-            extracted["case_type"] = val
-            methods.setdefault("case_type", "regex")
-
-    # Fallback case_type from scraper_id (#1524 / #1836).
-    # When the case number is absent or doesn't encode a type prefix
-    # (e.g. OC North JC PDFs have no case numbers), infer from the
-    # scraper_id which encodes the case category in its suffix.
-    if not extracted["case_type"] and scraper_id:
-        val = extract_case_type_from_scraper_id(scraper_id)
-        if val:
-            extracted["case_type"] = val
-            methods.setdefault("case_type", "scraper_id")
-
-    # Fallback case_type from motion_type (#1731).
-    # Final fallback for cases where the case number has no embedded
-    # type code and the scraper_id is generic (e.g. Ventura's
-    # all-digit case numbers like 202300574258).  Many civil motion
-    # types unambiguously identify the case type.
-    if not extracted["case_type"] and extracted["motion_type"]:
-        val = extract_case_type_from_motion_type(extracted["motion_type"])
-        if val:
-            extracted["case_type"] = val
-            methods.setdefault("case_type", "motion_type")
-
-    # Fallback case_type from case title (#2062).  Mirrors
-    # ``packages/scraper-framework/src/ingestion/worker.py`` lines 2331-2336
-    # so reingest produces the same case_type as live ingestion.  Probate-
-    # style titles ("In the Matter of...", "Conservatorship of...",
-    # "Guardianship of...", "Estate of...") are unambiguous — without this
-    # fallback, the CC dept-38 ``MSP*`` and dept-NULL ``N*`` rulings whose
-    # case-number prefix doesn't match any pattern in
-    # ``_CASE_TYPE_PREFIX_PATTERNS`` fall into the civil ±14 day
-    # plausibility window in ``apply_post_extraction_guards`` and lose
-    # their correctly-extracted multi-week-master-calendar hearing dates
-    # (#4263, follow-up to #4256).
-    if not extracted["case_type"] and extracted.get("case_title"):
-        val = extract_case_type_from_title(extracted["case_title"])
-        if val:
-            extracted["case_type"] = val
-            methods.setdefault("case_type", "title")
+    # case_type fallback chain — case_number prefix (#706) -> scraper_id
+    # (#1524 / #1836) -> motion_type (#1731) -> case_title (#2062, surfaced
+    # via #4263 / #4256).  Delegated to the shared resolver in
+    # ``ingestion.case_type_resolver`` so this and the live ingestion
+    # path (worker.py) cannot diverge by construction (#4295, follow-on
+    # to the #4290 hygiene guard).
+    resolved_ct, resolved_method = resolve_case_type(
+        case_type=extracted["case_type"],
+        case_number=extracted["case_number"],
+        scraper_id=scraper_id,
+        motion_type=extracted["motion_type"],
+        case_title=extracted.get("case_title"),
+    )
+    if resolved_method is not None:
+        extracted["case_type"] = resolved_ct
+        methods.setdefault("case_type", resolved_method)
 
 
 def _extract_doc_level_judge_department(
@@ -2258,11 +2227,22 @@ def _reparse_document_multimodal(
             # extract case_type from case_number.  See #2270.
             # Party extraction from captions was removed in #2178 — LLM
             # enrichment handles party extraction.
-            if not extracted["case_type"] and extracted["case_number"]:
-                val = extract_case_type_from_number(extracted["case_number"])
-                if val:
-                    extracted["case_type"] = val
-                    extracted["extraction_methods"].setdefault("case_type", "regex")
+            #
+            # Uses the shared resolver (#4295) so this and the
+            # ``_apply_regex_fallbacks`` path stay in lock-step with the
+            # live worker.  Only the case_number signal is meaningful
+            # here — the resolver only exercises its first fallback
+            # step on a hit (returns method="regex").
+            resolved_ct, resolved_method = resolve_case_type(
+                case_type=extracted["case_type"],
+                case_number=extracted["case_number"],
+                scraper_id=None,
+                motion_type=None,
+                case_title=None,
+            )
+            if resolved_method is not None:
+                extracted["case_type"] = resolved_ct
+                extracted["extraction_methods"].setdefault("case_type", resolved_method)
         extracted["regex_fallback_ms"] = (time.perf_counter() - _regex_t0) * 1000.0
         # Multimodal does not invoke pdfplumber; ``parse_document_ms`` is
         # 0 for this path.  The multimodal LLM call itself is timed


### PR DESCRIPTION
## Summary

Replaces the duplicated case_type fallback chain in `worker.py` and `_apply_regex_fallbacks` (plus two early case_number-only call sites — one in each file) with a single shared `resolve_case_type(...)` helper in the new `packages/scraper-framework/src/ingestion/case_type_resolver.py` module. After the refactor, neither file directly references any `extract_case_type_from_*` helper — divergence is impossible by construction. The #4290 parity guard remains in place as defense-in-depth (and now reports `(empty) == (empty)` trivially).

Net production-code change: -14 LOC. The four-step inline chain compresses to one resolver call in each path.

Closes #4295

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] Reingest a small sample (5-10 documents per fallback type — case_number prefix, scraper_id-only, motion_type-only, case_title-only) on dev and confirm `case_type` is unchanged from pre-merge values via `scripts/dev-db-query.sh` (AC#4 from issue body).
- [ ] Verification evidence posted on issue (see A.8)
