### PR TITLE
fix(ci): exclude .claude/ from check-scraper-image-shipped.sh scan (#4300)

### DIFF
--- a/scripts/check-scraper-image-shipped.sh
+++ b/scripts/check-scraper-image-shipped.sh
@@ -42,6 +42,15 @@
 #        /app/scripts/ in headers and fixtures)
 #      - docs/  (descriptive, not invocation sites)
 #      - tmp/   (worktree-local scratch)
+#      - .claude/ (operator-managed agent state — worktrees, hooks,
+#                  skills; never an invocation site for /app/scripts/.
+#                  Some dispatcher tests under
+#                  scripts/dispatcher/tests/ create synthetic agent
+#                  worktrees beneath .claude/worktrees/, and those
+#                  fixtures may contain test heredocs that reference
+#                  /app/scripts/<X>.{py,sh}; without this exclusion
+#                  the check trips on those leftover fixtures during
+#                  CI's scripts-tests shard. See #4300.)
 #      - .git/, .venv/, node_modules/ (vendored / generated)
 # 3. For each unique <name>.<ext> token found, asserts that
 #    packages/scraper-framework/Dockerfile contains a matching
@@ -142,6 +151,7 @@ HITS=$(
         --exclude-dir='.next' \
         --exclude-dir='docs' \
         --exclude-dir='tmp' \
+        --exclude-dir='.claude' \
         2>/dev/null \
     | grep -v -F "$REPO_ROOT/$DOCKERFILE_REL:" \
     | grep -v -F "$REPO_ROOT/$SELF_REL:" \

--- a/scripts/tests/test_check_scraper_image_shipped.sh
+++ b/scripts/tests/test_check_scraper_image_shipped.sh
@@ -345,6 +345,21 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+# ─── Test 15b: References under .claude/ are excluded (#4300) ──────────
+# The dispatcher test suite creates synthetic agent worktrees under
+# .claude/worktrees/agent-<MagicMock id=...>/scripts/... when running
+# the scripts-tests pytest shard in CI. Those leftover fixtures may
+# contain test heredocs with literal `python /app/scripts/<X>.py`
+# strings, which would otherwise trip the check at the next CI step.
+# Reproduce the shape of that fixture and assert the check ignores it.
+reset_tmpdir
+synth_scraper_dockerfile  # no scripts COPY'd
+write_file "$TMPDIR_TEST/.claude/worktrees/agent-fake/scripts/tests/test_check_scraper_image_shipped.sh" \
+'#!/usr/bin/env bash
+# Synthetic leftover from dispatcher tests — must NOT trip the check.
+python /app/scripts/nonexistent.py --foo'
+assert_passes "References under .claude/ are excluded (#4300 regression)"
+
 # ─── Test 16: No self-match on ci.yml step name ────────────────────────
 # Per CLAUDE.md §Hygiene-check CI steps, every new string-forbidding
 # guard must not have a CI step name that itself contains a forbidden


### PR DESCRIPTION
## Summary

Add `--exclude-dir='.claude'` to the `grep -rEn` call in `scripts/check-scraper-image-shipped.sh` so the check no longer trips on synthetic agent-worktree directories left behind by the dispatcher pytest suite under `.claude/worktrees/agent-<MagicMock id=...>/scripts/...`. Adds a regression test (Test 15b) that recreates the failure shape and asserts the check exits 0. Verified the new test fails without the fix and passes with it.

This unblocks main CI — every PR (including #4299) was failing on the `scripts-tests (python)` shard with the same `FAIL: 11 script(s) referenced as /app/scripts/<X>...` error.

Closes #4300

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] CI on main is green after this PR merges (`.github/workflows/ci.yml` next post-merge run completes with `conclusion=success`) — run [25467982502](https://github.com/judgemind/judgemind/actions/runs/25467982502) succeeded
- [x] Verification evidence posted on issue (see A.8)
