### PR TITLE
feat(scraping): add --s3-key-list flag to reingest_from_s3.py (#3659)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3234,6 +3234,43 @@ class TestRunReingest:
         assert "AND EXISTS" in filters_arg
         assert "r.outcome IS NULL" in filters_arg
 
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.reingest_batch")
+    def test_s3_key_list_filter_passed_through(
+        self,
+        mock_batch: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """``run_reingest(s3_key_list=...)`` plumbs the list through to
+        ``_build_filters`` and the resulting ``ANY(%s)`` clause + param show
+        up on the ``reingest_batch`` call."""
+        mock_conn = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_psycopg.connect.return_value = mock_conn
+
+        mock_batch.return_value = _make_batch_result()
+
+        keys = [
+            "ca/santa_clara/superior_court/raw/aaa.pdf",
+            "ca/santa_clara/superior_court/raw/bbb.pdf",
+        ]
+        reingest.run_reingest(
+            "postgresql://test",
+            county="Santa Clara",
+            s3_key_list=keys,
+        )
+
+        call_args = mock_batch.call_args_list[0]
+        filters_arg = call_args[0][4]
+        filter_params_arg = call_args[0][5]
+        assert "AND ct.county = %s" in filters_arg
+        assert "AND d.s3_key = ANY(%s)" in filters_arg
+        assert "Santa Clara" in filter_params_arg
+        assert keys in filter_params_arg
+
 
 # ---------------------------------------------------------------------------
 # _build_filters
@@ -3471,6 +3508,129 @@ class TestBuildFilters:
         assert "AND c.case_number LIKE %s" in clauses
         assert "r.department = ANY(%s)" in clauses
         assert params == ["Orange", pattern, depts]
+
+    def test_s3_key_list_adds_any_clause(self) -> None:
+        """A non-empty s3_key_list emits ``AND d.s3_key = ANY(%s)`` and
+        appends the list verbatim as the corresponding param."""
+        keys = [
+            "ca/santa_clara/superior_court/raw/aaa.pdf",
+            "ca/santa_clara/superior_court/raw/bbb.pdf",
+        ]
+        clauses, params = reingest._build_filters(None, None, None, s3_key_list=keys)
+        assert "AND d.s3_key = ANY(%s)" in clauses
+        assert params == [keys]
+
+    def test_s3_key_list_none_no_clause(self) -> None:
+        """Passing s3_key_list=None emits no clause."""
+        clauses, params = reingest._build_filters(None, None, None, s3_key_list=None)
+        assert "s3_key" not in clauses
+        assert params == []
+
+    def test_s3_key_list_empty_no_clause(self) -> None:
+        """Passing an empty s3_key_list emits no clause (degenerate input
+        guarded at the CLI layer, but the SQL builder must not emit
+        ``= ANY('{}'::text[])`` which matches no rows accidentally)."""
+        clauses, params = reingest._build_filters(None, None, None, s3_key_list=[])
+        assert "s3_key" not in clauses
+        assert params == []
+
+    def test_s3_key_list_with_county(self) -> None:
+        """Combined county + s3_key_list; both clauses present and params
+        ordered [county, key_list]."""
+        keys = ["ca/santa_clara/superior_court/raw/abc.pdf"]
+        clauses, params = reingest._build_filters("Santa Clara", None, None, s3_key_list=keys)
+        assert "AND ct.county = %s" in clauses
+        assert "AND d.s3_key = ANY(%s)" in clauses
+        assert params == ["Santa Clara", keys]
+
+
+# ---------------------------------------------------------------------------
+# _read_s3_key_list_file
+# ---------------------------------------------------------------------------
+
+
+class TestReadS3KeyListFile:
+    """Unit tests for the ``_read_s3_key_list_file`` helper."""
+
+    def test_reads_keys_one_per_line(self, tmp_path: object) -> None:
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "keys.txt"  # type: ignore[operator]
+        path.write_text(
+            "ca/santa_clara/superior_court/raw/aaa.pdf\n"
+            "ca/santa_clara/superior_court/raw/bbb.pdf\n",
+            encoding="utf-8",
+        )
+        keys = reingest._read_s3_key_list_file(str(path))
+        assert keys == [
+            "ca/santa_clara/superior_court/raw/aaa.pdf",
+            "ca/santa_clara/superior_court/raw/bbb.pdf",
+        ]
+
+    def test_strips_whitespace_and_skips_blank_lines(self, tmp_path: object) -> None:
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "keys.txt"  # type: ignore[operator]
+        path.write_text(
+            "\n  ca/foo.pdf  \n\n  ca/bar.pdf\n\n",
+            encoding="utf-8",
+        )
+        keys = reingest._read_s3_key_list_file(str(path))
+        assert keys == ["ca/foo.pdf", "ca/bar.pdf"]
+
+    def test_skips_comment_lines(self, tmp_path: object) -> None:
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "keys.txt"  # type: ignore[operator]
+        path.write_text(
+            "# this list was extracted from #3659 spotcheck\n"
+            "ca/foo.pdf\n"
+            "  # indented comments are stripped too\n"
+            "ca/bar.pdf\n",
+            encoding="utf-8",
+        )
+        keys = reingest._read_s3_key_list_file(str(path))
+        assert keys == ["ca/foo.pdf", "ca/bar.pdf"]
+
+    def test_deduplicates_preserving_first_order(self, tmp_path: object) -> None:
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "keys.txt"  # type: ignore[operator]
+        path.write_text(
+            "ca/foo.pdf\nca/bar.pdf\nca/foo.pdf\n",
+            encoding="utf-8",
+        )
+        keys = reingest._read_s3_key_list_file(str(path))
+        assert keys == ["ca/foo.pdf", "ca/bar.pdf"]
+
+    def test_empty_file_raises_value_error(self, tmp_path: object) -> None:
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "empty.txt"  # type: ignore[operator]
+        path.write_text("", encoding="utf-8")
+        with pytest.raises(ValueError, match="empty"):
+            reingest._read_s3_key_list_file(str(path))
+
+    def test_only_comments_and_blanks_raises_value_error(self, tmp_path: object) -> None:
+        """An all-comments / all-blank file is the same defect class as an
+        empty file: silently matching every document is dangerous, so fail
+        loud."""
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "comments.txt"  # type: ignore[operator]
+        path.write_text(
+            "# only comments\n\n# and blanks\n   \n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="empty"):
+            reingest._read_s3_key_list_file(str(path))
+
+    def test_missing_file_raises_filenotfound(self, tmp_path: object) -> None:
+        from pathlib import Path as _Path
+
+        path: _Path = tmp_path / "does_not_exist.txt"  # type: ignore[operator]
+        with pytest.raises(FileNotFoundError):
+            reingest._read_s3_key_list_file(str(path))
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -152,6 +152,11 @@ Options:
                         Useful when the LLM prompt has been updated and the
                         existing cache entries store stale outputs keyed by
                         the old prompt hash.  See #2424.
+    --s3-key-list PATH  Path to a file listing S3 keys (one per line, blank
+                        lines and ``#`` comments ignored) to restrict the
+                        reingest to.  Surgical scope for hand-picked SHAs
+                        where county / date / regex filters all over- or
+                        under-match.  See #3659.
 """
 
 from __future__ import annotations
@@ -500,6 +505,7 @@ def _build_filters(
     case_number_like: str | None = None,
     filter_null_outcome: bool = False,
     department_in: list[str] | None = None,
+    s3_key_list: list[str] | None = None,
 ) -> tuple[str, list]:
     """Build WHERE clause fragments and params for the document query."""
     clauses = []
@@ -539,7 +545,46 @@ def _build_filters(
             " WHERE r.document_id = d.id AND r.department = ANY(%s))"
         )
         params.append(department_in)
+    if s3_key_list:
+        # Surgical scoping: limit reingest to a hand-picked set of S3 keys.
+        # Useful for targeted backfills (e.g. #3659 — re-resolve a small set
+        # of pre-#3655 cached SC PDFs) where county-wide rescope would
+        # over-shoot 10-100x and broader date filters lack sub-day granularity.
+        clauses.append("AND d.s3_key = ANY(%s)")
+        params.append(list(s3_key_list))
     return " ".join(clauses), params
+
+
+def _read_s3_key_list_file(path: str) -> list[str]:
+    """Read a list of S3 keys from a file, one per line.
+
+    Blank lines and lines starting with ``#`` are skipped, leading/trailing
+    whitespace on each entry is stripped, and duplicates are de-duplicated
+    while preserving first-occurrence order.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* does not exist.
+    ValueError
+        If the file produces an empty key list (every line was blank or a
+        comment) — fail loud rather than silently match every document.
+    """
+    raw = Path(path).read_text(encoding="utf-8")
+    seen: set[str] = set()
+    keys: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped in seen:
+            continue
+        seen.add(stripped)
+        keys.append(stripped)
+    if not keys:
+        msg = f"--s3-key-list file is empty after stripping blanks/comments: {path}"
+        raise ValueError(msg)
+    return keys
 
 
 def _is_real_case_number(case_number: str | None) -> bool:
@@ -3742,6 +3787,7 @@ def run_reingest(
     filter_null_outcome: bool = False,
     bust_llm_cache: bool = False,
     department_in: list[str] | None = None,
+    s3_key_list: list[str] | None = None,
 ) -> dict[str, Any]:
     """Run the full reingest. Returns summary stats including cost.
 
@@ -3759,6 +3805,14 @@ def run_reingest(
         When *True*, only re-ingest documents that have at least one ruling
         with a NULL outcome.  Useful for targeted reprocessing when only a
         subset of documents need outcome extraction.
+    s3_key_list:
+        Optional list of S3 keys (``ct.county``-relative or full prefix) to
+        restrict the reingest to.  When provided, the document query adds an
+        ``AND d.s3_key = ANY(%s)`` clause and only documents whose ``s3_key``
+        exactly matches one of these values are re-ingested.  Useful for
+        surgical backfills targeting a hand-picked set of SHAs (#3659) where
+        county-wide rescope would over-shoot and date filters lack sub-day
+        granularity.
     """
     filters, filter_params = _build_filters(
         county,
@@ -3770,6 +3824,7 @@ def run_reingest(
         case_number_like=case_number_like,
         filter_null_outcome=filter_null_outcome,
         department_in=department_in,
+        s3_key_list=s3_key_list,
     )
 
     s3_client = boto3.client("s3")
@@ -4235,6 +4290,23 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--s3-key-list",
+        type=str,
+        default=None,
+        dest="s3_key_list",
+        help=(
+            "Path to a file listing S3 keys (one per line) to restrict the "
+            "reingest to.  Blank lines and lines starting with '#' are "
+            "ignored.  Adds an AND d.s3_key = ANY(...) clause to the document "
+            "query.  Useful for surgical backfills against a hand-picked set "
+            "of SHAs — e.g. #3659 (re-resolve cross-references on the 13 SC "
+            "PDFs whose cached LLM payload predates #3655) — where county-wide "
+            "rescope would over-shoot 10-100x and --date-from/--date-to clamp "
+            "to whole days only.  Combine with --bust-llm-cache to force "
+            "fresh LLM extraction on those keys."
+        ),
+    )
+    parser.add_argument(
         "--force-retranscribe",
         action="store_true",
         help=(
@@ -4253,6 +4325,23 @@ def main() -> None:
 
     if args.resume and not args.checkpoint_file:
         parser.error("--resume requires --checkpoint-file to be specified.")
+
+    # Resolve --s3-key-list path → list of keys (or None when not provided).
+    # Loaded eagerly so a missing file or empty list fails fast, before any
+    # DB connect or S3 client setup.
+    s3_key_list_values: list[str] | None = None
+    if args.s3_key_list:
+        try:
+            s3_key_list_values = _read_s3_key_list_file(args.s3_key_list)
+        except FileNotFoundError:
+            parser.error(f"--s3-key-list file not found: {args.s3_key_list}")
+        except ValueError as err:
+            parser.error(str(err))
+        logger.info(
+            "Loaded --s3-key-list",
+            path=args.s3_key_list,
+            count=len(s3_key_list_values),
+        )
 
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
@@ -4309,6 +4398,7 @@ def main() -> None:
         filter_null_outcome=args.filter_null_outcome,
         bust_llm_cache=args.bust_llm_cache,
         department_in=args.department_in,
+        s3_key_list=s3_key_list_values,
     )
 
     logger.info(


### PR DESCRIPTION
## Summary

Adds a `--s3-key-list <path>` flag to `scripts/reingest_from_s3.py` so reingests can be scoped to a hand-picked set of S3 keys via an `AND d.s3_key = ANY(%s)` clause. This is the enabler the prior operational agent recommended for #3659 (their 2026-04-28 [diagnostic comment](https://github.com/judgemind/judgemind/issues/3659#issuecomment-4332307344) §"Recommended next steps" path #1) — `--bust-llm-cache` is mandatory for the 13 affected SC SHAs because their cached LLM payloads predate `entry_number` (added in #3655), but the existing CLI has no way to scope to just those SHAs (`--filter-null-outcome` matches 0 of the 32 stubs; `--date-from`/`--date-to` clamp to whole days and would re-process 1,601 docs).

**Path chosen for #3659:** **Path A** (preferred — narrow targeted bust-cache reingest), exercising the same code path as new ingest. Path B (one-shot SQL re-resolve script) was ruled out by the prior agent because `derived.rulings.ruling_number` is never written by scraper-framework, so reconstructing `entry_number → index` from existing rows would require lossy regex on `ruling_text` headings.

**Backfill scope (per the prior agent's diagnostics):** 13 distinct S3 keys, 32 affected ruling rows, all from a 20-minute capture window on 2026-04-27 03:44–04:04 UTC (~18 hours before #3655 merged).

**Before-and-after stub-rate:** captured in the post-deploy verification evidence comment on #3659 — the backfill itself runs after this PR merges and the new scraper image deploys to dev.

Closes #3659

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

Test coverage of the change:
- `_build_filters` — `s3_key_list` adds the `ANY(%s)` clause, no clause on `None` / empty list, combined with `county` produces the right param order (`["Santa Clara", keys]`).
- `_read_s3_key_list_file` — strips whitespace, skips blank + `#` lines, deduplicates preserving first-occurrence order, fails loud on empty / all-comments / missing files.
- `run_reingest` plumbing — `s3_key_list=...` reaches `reingest_batch` via the `_build_filters` output (clause string + param list).

422/422 reingest tests pass; 7473 passed, 3 skipped across the full scraper-framework package.

### Post-deploy verification
- [ ] Confirm new flag is reachable in deployed scraper image: `scripts/ecs-run.sh -- python3 /app/scripts/reingest_from_s3.py --help` shows `--s3-key-list PATH`.
- [ ] Run the backfill against dev: `scripts/ecs-run-task.sh` invoking `reingest_from_s3.py --county "Santa Clara" --s3-key-list /tmp/sc_xref_stub_keys.txt --bust-llm-cache --report-metrics --concurrency 5 --parse-workers 4`. The 13-key list is queried via `scripts/dev-db-query.sh` against `derived.documents` filtered by `s3_key ~ '/santa_clara/'` joined to `derived.rulings` matching `_XREF_LINE_RE`.
- [ ] Verify AC #1: post-backfill stub-rate ≤ 1% via the regex-only rewrite of the AC #1 query (per [drewthaler 2026-04-27 spotcheck](https://github.com/judgemind/judgemind/issues/3659#issuecomment-4330855571)). Pre-fix baseline: ~6% (32/545).
- [ ] Verify AC #2: re-query the 5 already-resolved rulings recorded in the prior agent's [AC #2 baseline table](https://github.com/judgemind/judgemind/issues/3659#issuecomment-4332307344); confirm `length(ruling_text)` is unchanged for all 5 (no regression).
- [ ] Verification evidence comment posted on #3659 (see A.8) with: (a) Path A confirmed, (b) S3 keys + ruling rows touched, (c) before-and-after stub-rate.
