### PR TITLE
fix(scraping): SF family-law multi-case PDF deterministic splitter (#4304)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sf_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_tentatives.py
@@ -10,12 +10,12 @@ Link text format: filename only — e.g. "403 Tentative Rulings 3.03.2026.pdf"
   No judge name in link text; extracted from PDF text.
   Department extracted from filename (leading digits before space).
 
-PDF structure (pages 3+):
-  Header block per ruling:
-    Case Number: FPT-25-378624
-    Hearing Date: March 3, 2026
-    Department: 403
-    Presiding: BOBBY P. LUNA
+PDF structure (pages 3+, multi-case calendars):
+  Each entry begins with a ``SUPERIOR COURT OF CALIFORNIA`` page header
+  followed within ~10 lines by a multi-line caption block carrying
+  ``Case Number: FPT-25-378624``, ``Hearing Date: ...``, ``Department: ...``,
+  ``Presiding: BOBBY P. LUNA`` on adjacent lines (line numbers + ``)``
+  delimiters interleave the labels and values).
 
 Case number format: F + 2 uppercase letters + hyphen + 2-digit year + hyphen + 6 digits
   e.g. FPT-25-378624, FMS-20-387302, FDI-14-781786
@@ -23,6 +23,23 @@ Case number format: F + 2 uppercase letters + hyphen + 2-digit year + hyphen + 6
 Departments: 403, 404, 405, 405A, 406, 416, 425
 Calendar days: Tuesday and Thursday
 Previous rulings available for ~30 days, auto-deleted.
+
+Multi-case PDF splitting (#4304):
+  SF family-law PDFs commonly bundle 5–15 distinct rulings in one file.
+  Sending the whole PDF through the framework ``LlmExtractor`` lets the
+  LLM violate rule 5b of its own prompt and copy the first entry's
+  ``case_title`` (and other LLM-extracted fields) onto every subsequent
+  entry — producing the ``all_same_case_title_cluster`` pattern flagged
+  by the cross-county audit (#4289).  The ``_split_rulings`` helper
+  below splits a multi-case PDF into per-entry ``SplitRuling`` objects
+  using the ``SUPERIOR COURT OF CALIFORNIA`` page header as the entry
+  boundary; the ingestion worker hooks the splitter into per-document
+  dispatch via ``_try_sf_pdf_split`` in ``ingestion.worker`` so each
+  entry gets its own LLM enrichment pass.  This mirrors the Riverside
+  pattern (#3649) and Fresno pattern (#3534) — same fix family, same
+  shape.  Single-ruling PDFs (the splitter returns ``[]`` or a 1-element
+  list) fall through to the framework ``LlmExtractor`` path so the
+  existing per-field enrichment fills in motion_type and outcome.
 
 Investigation: #9
 Report: docs/investigations/sf-tentative-rulings-2026-03.md
@@ -56,6 +73,163 @@ _PRESIDING_RE = re.compile(
 
 # Case number format: F + 2 uppercase letters + hyphen + 2-digit year + hyphen + 6 digits
 _CASE_NUMBER_RE = re.compile(r"\bF[A-Z]{2}-\d{2}-\d{6}\b")
+
+# Multi-case entry boundary (#4304).  Each ruling in a multi-case SF
+# family-law PDF starts on its own page with the standard court header
+# ``SUPERIOR COURT OF CALIFORNIA``.  Anchored at start-of-line and
+# tolerating an optional leading line-number prefix (``"1 "``) inserted
+# by some PDF text extractors.  Page-1 / page-2 of a multi-case PDF carry
+# Tentative Ruling Instructions and Zoom-call boilerplate without this
+# header, so the regex naturally skips the preamble.
+_ENTRY_HEADER_RE = re.compile(
+    r"^\s*\d*\s*SUPERIOR\s+COURT\s+OF\s+CALIFORNIA\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Caption-block ``Case Number:`` extractor used by ``_split_rulings`` to
+# attach a deterministic case_number to each split entry.  Limited to the
+# F-prefix family-law shape so it does not match unrelated case-number-
+# like substrings inside the body (e.g. references to civil case numbers).
+_CASE_NUMBER_CAPTION_RE = re.compile(
+    r"Case\s+Number:\s*(F[A-Z]{2}-\d{2}-\d{6})",
+    re.IGNORECASE,
+)
+
+# Caption-block ``Department:`` extractor (3-digit dept, optional letter
+# suffix mirrors the link-text shape in ``_LINK_TEXT_RE``).
+_DEPARTMENT_CAPTION_RE = re.compile(
+    r"Department:\s*(?P<department>\d{3}[A-Z]?)",
+    re.IGNORECASE,
+)
+
+
+class SplitRuling:
+    """A single ruling extracted from a multi-ruling SF family-law PDF (#4304).
+
+    Mirrors ``courts.ca.riverside_tentatives.SplitRuling`` (#3649) and
+    ``courts.ca.fresno_tentatives.SplitRuling`` (#3534) so the deterministic
+    splitter dispatch in ``ingestion.worker._try_sf_pdf_split`` can produce
+    synthetic split events with the same shape as those counties.
+
+    Only ``case_number`` and ``ruling_text`` are populated by the splitter;
+    motion_type, case_title, and outcome are left to LLM enrichment because
+    the SF caption header wraps unpredictably (multi-line petitioner names,
+    ``)`` delimiters, line-number prefixes from the PDF text extractor) and
+    a deterministic regex extraction is not reliable enough to replace the
+    LLM.  The important property is that each entry's enrichment runs
+    *individually* so the LLM cannot carry-forward a previous entry's
+    fields onto the next one.
+    """
+
+    __slots__ = (
+        "ruling_index",
+        "case_number",
+        "ruling_text",
+        "case_title",
+        "motion_type",
+        "outcome",
+        "hearing_date",
+        "department",
+    )
+
+    def __init__(
+        self,
+        ruling_index: int,
+        case_number: str | None,
+        ruling_text: str,
+        case_title: str | None = None,
+        motion_type: str | None = None,
+        outcome: str | None = None,
+        hearing_date: datetime | None = None,
+        department: str | None = None,
+    ) -> None:
+        self.ruling_index = ruling_index
+        self.case_number = case_number
+        self.ruling_text = ruling_text
+        self.case_title = case_title
+        self.motion_type = motion_type
+        self.outcome = outcome
+        self.hearing_date = hearing_date
+        self.department = department
+
+
+def _split_rulings(text: str) -> list[SplitRuling]:
+    """Split SF family-law multi-ruling PDF text into per-entry ``SplitRuling`` objects.
+
+    The page-1 / page-2 preamble (Tentative Ruling Instructions, Zoom
+    call-in boilerplate, courthouse contact info) is excluded by anchoring
+    on ``SUPERIOR COURT OF CALIFORNIA`` page headers — the preamble pages
+    do not carry that header.  Entries without a ``Case Number:`` line in
+    their caption block (e.g. an interstitial blank page that happens to
+    carry the court header) are dropped to avoid synthesizing ghost
+    rulings.
+
+    Returns an empty list if no entry headers are found, which is the
+    expected outcome for very short single-page PDFs that don't follow
+    the multi-case calendar format.
+
+    Each returned ``SplitRuling`` has:
+
+      * ``ruling_index`` — the zero-based index of the entry within the
+        PDF (entry 0 is the first ruling, not the preamble).
+      * ``case_number`` — extracted via ``_CASE_NUMBER_CAPTION_RE`` from
+        the entry's caption block; ``None`` if the regex fails to match
+        (rare on well-formed SF PDFs but defensive).
+      * ``department`` — extracted via ``_DEPARTMENT_CAPTION_RE`` from
+        the entry's caption block; falls back to ``None`` if absent.
+      * ``ruling_text`` — the **verbatim** entry text from the boundary
+        through the next entry boundary (or the end of the document for
+        the last entry).  This includes the entry's own caption block
+        and tentative ruling body.  We keep it verbatim so downstream
+        LLM enrichment sees exactly the same content the LLM would have
+        seen if we'd sent the whole PDF — minus the cross-entry
+        contamination that causes the carry-forward bug.
+
+    motion_type, case_title, and outcome are left ``None`` on purpose —
+    the SF caption block doesn't have structured field labels for those
+    (the case title is reconstructed from a multi-line VS. block elsewhere
+    in this module via ``_sf_case_title_from_pdf_text`` for the
+    single-PDF parse path, but downstream LLM enrichment is what fills
+    those fields on the split path).  Letting the framework
+    ``LlmExtractor`` populate those fields via per-entry enrichment
+    matches the Riverside fall-through pattern (#3649) and preserves
+    the behaviour the LLM was already producing on single-ruling PDFs.
+    """
+    matches = list(_ENTRY_HEADER_RE.finditer(text))
+    if not matches:
+        return []
+
+    rulings: list[SplitRuling] = []
+    for i, match in enumerate(matches):
+        start = match.start()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+
+        body = text[start:end].strip()
+        if not body:
+            continue
+
+        # Real ruling entries always carry a Case Number line in the
+        # caption block.  Skip header-only / blank-page interstitials so
+        # we don't synthesize ghost rulings.
+        cn_match = _CASE_NUMBER_CAPTION_RE.search(body)
+        if not cn_match:
+            continue
+
+        case_number = cn_match.group(1).upper()
+
+        dept_match = _DEPARTMENT_CAPTION_RE.search(body)
+        department = dept_match.group("department") if dept_match else None
+
+        rulings.append(
+            SplitRuling(
+                ruling_index=len(rulings),
+                case_number=case_number,
+                ruling_text=body,
+                department=department,
+            )
+        )
+
+    return rulings
 
 
 # SF court caption format (multi-line, with line numbers and ")" delimiters):

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -677,6 +677,162 @@ def _try_riverside_pdf_split(
     return True
 
 
+def _try_sf_pdf_split(
+    event_data: dict[str, Any],
+    document_id: str,
+    ruling_text: str,
+    dispatch: Any,
+) -> bool:
+    """If *ruling_text* is a SF family-law multi-case PDF, deterministically
+    split it into per-case rulings and dispatch one synthetic split event
+    per case via *dispatch*.  Returns True if the split ran, False otherwise.
+
+    This path bypasses the framework LLM extractor — SF family-law
+    multi-case PDFs use a ``SUPERIOR COURT OF CALIFORNIA`` page header
+    per ruling that is cheap to parse with the regex-based
+    ``_split_rulings`` function in ``courts.ca.sf_tentatives``.  Sending
+    the whole PDF through the LLM previously produced cross-entry
+    contamination (#4304): the LLM violated rule 5b of its own prompt
+    and copied the first entry's ``case_title`` (and other LLM-extracted
+    fields) onto subsequent entries, producing the
+    ``all_same_case_title_cluster`` pattern flagged by the cross-county
+    audit (#4289).
+
+    Detection gate: only triggers when event is San Francisco county
+    **and** content format is ``"pdf"`` — avoids false-positive matches
+    against the SF civil HTML scraper (``ca-sf-tentatives-civil``),
+    which already produces one ``CapturedDocument`` per ruling at
+    capture time and never funnels through this path.
+
+    When ``_split_rulings`` returns ``[]`` (no entry headers — typical
+    of malformed PDFs or non-multi-case shapes) or a 1-element list
+    (single-ruling PDF), this function returns ``False`` so the
+    existing LLM path handles enrichment.  The deterministic regex
+    extraction does not populate ``motion_type``/``outcome``/
+    ``case_title`` — falling through to the framework ``LlmExtractor``
+    is what gives those fields per-entry enrichment without any
+    cross-entry carry-forward window (single-ruling PDFs have nothing
+    to carry forward).
+
+    Mirrors the SD/LA/Fresno/Riverside pattern (``_try_sd_calendar_split``
+    #2447, ``_try_la_html_split`` #2450, ``_try_fresno_pdf_split`` #3534,
+    ``_try_riverside_pdf_split`` #3649).
+    """
+    county = event_data.get("county") or ""
+    if county.upper() != "SAN FRANCISCO":
+        return False
+    if event_data.get("content_format") != "pdf":
+        return False
+
+    # Lazy import to avoid a circular dependency between the worker and
+    # the courts package at module load time.
+    from courts.ca.sf_tentatives import _split_rulings
+
+    split_rulings = _split_rulings(ruling_text)
+    if not split_rulings:
+        # No entry headers found — fall through to LLM.
+        logger.info(
+            "sf_split_fall_through",
+            extra={
+                "document_id": document_id,
+                "reason": "no_entry_headers",
+                "raw_len": len(split_rulings),
+                "scraper_id": event_data.get("scraper_id"),
+                "extraction_method": "sf_pdf_deterministic",
+            },
+        )
+        return False
+    if len(split_rulings) == 1:
+        # Single-ruling PDF — the deterministic regex extraction does not
+        # populate motion_type/outcome/case_title.  Fall through to the
+        # LLM path so framework extraction fills those fields.  There is
+        # no carry-forward window with a single entry, so the LLM is
+        # safe to use here.
+        logger.info(
+            "sf_split_fall_through",
+            extra={
+                "document_id": document_id,
+                "reason": "single_ruling_pdf",
+                "raw_len": len(split_rulings),
+                "scraper_id": event_data.get("scraper_id"),
+                "extraction_method": "sf_pdf_deterministic",
+            },
+        )
+        return False
+
+    logger.info(
+        "SF family-law PDF deterministic split dispatching %d ruling(s)",
+        len(split_rulings),
+        extra={
+            "document_id": document_id,
+            "ruling_count": len(split_rulings),
+            "scraper_id": event_data.get("scraper_id"),
+            "extraction_method": "sf_pdf_deterministic",
+        },
+    )
+
+    from .split_ids import make_split_document_id
+
+    # At this point len(split_rulings) > 1 — always generate split doc IDs.
+    for idx, sr in enumerate(split_rulings):
+        split_doc_id = make_split_document_id(document_id, idx)
+        hearing_date_value: str | None = None
+        if sr.hearing_date is not None:
+            hearing_date_value = (
+                sr.hearing_date.date().isoformat()
+                if isinstance(sr.hearing_date, datetime)
+                else str(sr.hearing_date)
+            )
+
+        # ``_split_processed=True`` short-circuits the worker's per-doc
+        # split-attempt path; ``_llm_extracted`` is intentionally LEFT
+        # FALSE so the synthetic event flows through the per-field LLM
+        # enrichment path (``_llm_enrich_fields``) and motion_type /
+        # outcome / case_title get populated for each entry individually.
+        # This matches the Riverside splitter's design (#3649) — the
+        # SF family-law caption block does not carry the structured
+        # ``Re:`` / ``Motion:`` / ``Tentative Ruling:`` headers Fresno
+        # PDFs do, so deterministic regex extraction of those fields
+        # would produce a high false-negative rate.  Each entry gets
+        # its own LLM call against only its own text, so cross-entry
+        # carry-forward is impossible.
+        split_event: dict[str, Any] = {
+            **event_data,
+            "document_id": split_doc_id,
+            "_original_document_id": document_id,
+            "_split_processed": True,
+            "_split_index": idx,
+            "_split_count": len(split_rulings),
+            "ruling_text": sr.ruling_text,
+            "ruling_text_html": None,
+            "case_number": sr.case_number or event_data.get("case_number"),
+            "case_title": sr.case_title or event_data.get("case_title"),
+            "department": sr.department or event_data.get("department"),
+            "motion_type": sr.motion_type or event_data.get("motion_type"),
+            "outcome": sr.outcome or event_data.get("outcome"),
+            "hearing_date": hearing_date_value or event_data.get("hearing_date"),
+        }
+        try:
+            dispatch(split_event)
+        except Exception as _exc:
+            from framework.llm_enrichment import LlmEnrichmentExhaustedError
+
+            if not isinstance(_exc, LlmEnrichmentExhaustedError):
+                raise
+            logger.critical(
+                "per-child enrichment exhausted on SF PDF split — ruling permanently lost",
+                extra={
+                    "document_id": document_id,
+                    "_split_index": idx,
+                    "_split_count": len(split_rulings),
+                    "case_number": sr.case_number or event_data.get("case_number"),
+                    "error": str(_exc),
+                },
+            )
+
+    return True
+
+
 # Fields that LLM extraction can populate when missing from the scraper event.
 EXTRACTABLE_FIELDS = (
     "hearing_date",
@@ -3287,6 +3443,31 @@ class IngestionWorker:
         # entry LLM enrichment via ``_llm_enrich_fields`` (each entry
         # processed individually, so no cross-entry carry-forward window).
         if ruling_text and _try_riverside_pdf_split(
+            event_data, document_id, ruling_text, self.process_event
+        ):
+            return True
+
+        # ------------------------------------------------------------------
+        # San Francisco family-law multi-ruling PDF deterministic split (#4304)
+        # ------------------------------------------------------------------
+        # SF family-law tentative ruling PDFs (``ca-sf-tentatives-family-law``)
+        # bundle 5–15 rulings per file with a ``SUPERIOR COURT OF CALIFORNIA``
+        # page header per entry.  The LLM previously violated rule 5b of the
+        # SAN_FRANCISCO_SYSTEM_PROMPT and copied the first entry's
+        # ``case_title`` (and other LLM-extracted fields) onto subsequent
+        # entries, producing the ``all_same_case_title_cluster`` pattern
+        # flagged by the cross-county audit (#4289 — 14 SF clusters as of
+        # 2026-05-06).  The deterministic ``_split_rulings`` in
+        # ``sf_tentatives`` is county+format gated (San Francisco + pdf only)
+        # so it never fires for the SF civil HTML scraper or other counties.
+        # Single-ruling PDFs and entry-header-only interstitials
+        # (``_split_rulings`` returns ``[]`` or a 1-element list) fall
+        # through to the normal LLM path below.  Like the Riverside
+        # splitter, the SF splitter does NOT extract motion_type / outcome
+        # / case_title — those are left to per-entry LLM enrichment via
+        # ``_llm_enrich_fields`` (each entry processed individually, so no
+        # cross-entry carry-forward window).
+        if ruling_text and _try_sf_pdf_split(
             event_data, document_id, ruling_text, self.process_event
         ):
             return True

--- a/packages/scraper-framework/tests/courts/test_sf_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_tentatives.py
@@ -10,6 +10,7 @@ for departments 405, 405A, 406, 425 per #2130):
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -23,10 +24,12 @@ from courts.ca.sf_tentatives import (
     BASE_URL,
     INDEX_URL,
     SFTentativeRulingsScraper,
+    SplitRuling,
     _sf_case_title_from_pdf_text,
     _sf_courthouse,
     _sf_hearing_date_from_filename,
     _sf_judge_from_pdf_text,
+    _split_rulings,
 )
 from courts.ca.sf_tentatives import default_config as sf_default_config
 
@@ -591,3 +594,153 @@ def test_sf_default_config() -> None:
     assert config.county == "San Francisco"
     assert config.s3_bucket == "judgemind-document-archive-dev"
     assert len(config.schedule_windows) == 2
+
+
+# ---------------------------------------------------------------------------
+# Multi-case PDF splitter — _split_rulings (#4304)
+# ---------------------------------------------------------------------------
+
+
+def test_sf_split_rulings_returns_empty_for_empty_text() -> None:
+    """No entry headers → empty list (single-page or malformed PDFs)."""
+    assert _split_rulings("") == []
+
+
+def test_sf_split_rulings_returns_empty_for_no_entry_headers() -> None:
+    """Text without ``SUPERIOR COURT OF CALIFORNIA`` headers → empty list."""
+    text = (
+        "1 Important Information for Tentative Rulings and Hearings:\n"
+        "2 Please review and follow the Tentative Ruling Instructions...\n"
+    )
+    assert _split_rulings(text) == []
+
+
+def test_sf_split_rulings_skips_header_only_block_without_case_number() -> None:
+    """Header pages that don't carry a Case Number line are dropped (no ghost rulings)."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        "4 This is a header-only interstitial without any ruling content.\n"
+    )
+    assert _split_rulings(text) == []
+
+
+def test_sf_split_rulings_single_entry_returns_one_split() -> None:
+    """One entry header with one Case Number → one SplitRuling."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        ")\n"
+        "6 MICHAEL EDWARD GRAVES, ) Case Number: FPT-25-378624\n"
+        ")\n"
+        "7 Petitioner ) Hearing Date: March 3, 2026\n"
+        ")\n"
+        "8 VS. ) Department: 403\n"
+        ")\n"
+        "9 RANJIE LONG, ) Presiding: BOBBY P. LUNA\n"
+        ")\n"
+        "10 Respondent )\n"
+        "11 TENTATIVE RULING\n"
+        "12 The parties are ordered to appear.\n"
+    )
+    splits = _split_rulings(text)
+    assert len(splits) == 1
+    assert splits[0].case_number == "FPT-25-378624"
+    assert splits[0].department == "403"
+    assert splits[0].ruling_index == 0
+    # Splitter preserves verbatim entry text so downstream LLM enrichment
+    # sees the same content the LLM would have seen (minus cross-entry
+    # contamination).
+    assert "TENTATIVE RULING" in splits[0].ruling_text
+    assert "ordered to appear" in splits[0].ruling_text
+
+
+def test_sf_split_rulings_multi_case_dept403_fixture() -> None:
+    """AC#3 — multi-case fixture splits into N rulings with per-entry case_titles.
+
+    The dept-403 fixture PDF (sf_dept403_ruling.pdf, captured 2026-03-03)
+    contains 11 distinct rulings.  ``_split_rulings`` must produce 11
+    SplitRuling objects, each with a unique case_number and the entry's
+    ruling text isolated from siblings.
+    """
+    from courts.ca.pdf_link_scraper import _extract_pdf_text
+
+    text = _extract_pdf_text(_load_bytes("sf_dept403_ruling.pdf"))
+    splits = _split_rulings(text)
+    assert len(splits) == 11
+
+    # All splits must have unique case_numbers — the carry-forward bug
+    # this splitter is designed to prevent would produce duplicate
+    # case_titles.  Distinct case_numbers per entry is the structural
+    # invariant.
+    case_numbers = [s.case_number for s in splits]
+    assert len(set(case_numbers)) == 11
+    for cn in case_numbers:
+        assert cn is not None
+        # SF family-law case-number shape (#9): F + 2 letters + - + 2-digit year + - + 6 digits
+        assert re.match(r"^F[A-Z]{2}-\d{2}-\d{6}$", cn), f"unexpected case_number {cn!r}"
+
+    # All entries are dept 403 in this fixture.
+    for s in splits:
+        assert s.department == "403"
+
+    # Indexes are 0-based and contiguous.
+    assert [s.ruling_index for s in splits] == list(range(11))
+
+    # The first entry's ruling_text must contain the first case's text but
+    # NOT the second case's caption — that's the carry-forward boundary the
+    # splitter enforces.
+    first = splits[0]
+    assert first.case_number == "FPT-25-378624"
+    assert "FPT-25-378624" in first.ruling_text
+    assert "FPT-25-378672" not in first.ruling_text  # second entry's case_number
+
+    # The case_titles are populated by downstream LLM enrichment (per the
+    # splitter's design — see SplitRuling docstring).  Splitter leaves
+    # them at None, but per-entry texts are distinct, which is what
+    # gives the LLM a clean substrate to work from.
+    for s in splits:
+        assert s.case_title is None
+        assert s.motion_type is None
+        assert s.outcome is None
+
+
+def test_sf_split_rulings_returns_split_ruling_instances() -> None:
+    """The splitter returns SplitRuling objects (not dicts/tuples)."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        ")\n"
+        "6 SAMPLE PETITIONER ) Case Number: FDI-25-800001\n"
+        ")\n"
+        "7 Petitioner ) Department: 404\n"
+        ")\n"
+        "8 VS. ) Presiding: SOME JUDGE\n"
+        ")\n"
+        "9 SAMPLE RESPONDENT )\n"
+        "10 Respondent )\n"
+    )
+    splits = _split_rulings(text)
+    assert len(splits) == 1
+    assert isinstance(splits[0], SplitRuling)
+    assert splits[0].department == "404"
+
+
+def test_sf_split_rulings_lowercase_case_number_uppercased() -> None:
+    """Defensive — uppercase the extracted case_number (matches Riverside pattern)."""
+    text = (
+        "1 SUPERIOR COURT OF CALIFORNIA\n"
+        "2 COUNTY OF SAN FRANCISCO\n"
+        "3 UNIFIED FAMILY COURT\n"
+        ")\n"
+        "6 SAMPLE PETITIONER ) Case Number: fdi-25-800001\n"
+        ")\n"
+        "7 Petitioner ) Department: 404\n"
+        ")\n"
+    )
+    splits = _split_rulings(text)
+    assert len(splits) == 1
+    assert splits[0].case_number == "FDI-25-800001"

--- a/packages/scraper-framework/tests/test_ingestion_worker.py
+++ b/packages/scraper-framework/tests/test_ingestion_worker.py
@@ -129,6 +129,33 @@ def _make_riverside_event(**overrides: object) -> dict:
     return base
 
 
+def _make_sf_event(**overrides: object) -> dict:
+    """Return a SF family-law PDF-like event payload (#4304)."""
+    base: dict = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000006",
+        "scraper_id": "ca-sf-tentatives-family-law",
+        "state": "CA",
+        "county": "San Francisco",
+        "court": "Superior Court",
+        "source_url": "https://webapps.sftc.org/ufctr/403_Tentative_Rulings.pdf",
+        "content_format": "pdf",
+        "content_hash": "pqr678",
+        "s3_key": "ca/san_francisco/superior_court/raw/pqr678.pdf",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "ruling_text": (
+            "SUPERIOR COURT OF CALIFORNIA\n"
+            "COUNTY OF SAN FRANCISCO\n"
+            "Case Number: FPT-25-378624\n"
+            "Department: 403\n"
+            "TENTATIVE RULING\n"
+        ),
+        "hearing_date": "2026-03-03",
+        "capture_timestamp": "2026-03-03T14:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
 def _make_llm_event(**overrides: object) -> dict:
     """Return a generic event for LLM split path testing."""
     base: dict = {
@@ -211,6 +238,28 @@ def _make_fake_riverside_rulings() -> list:
             ruling_index=i + 1,
             case_number=f"CVPS230000{i}",
             ruling_text=f"Riverside ruling {i}\nTentative Ruling: Granted.",
+        )
+        for i in range(3)
+    ]
+
+
+def _make_fake_sf_rulings() -> list:
+    """Return 3 fake SF family-law SplitRuling objects for testing (#4304)."""
+    from courts.ca.sf_tentatives import SplitRuling
+
+    return [
+        SplitRuling(
+            ruling_index=i,
+            case_number=f"FDI-25-80000{i}",
+            ruling_text=(
+                f"SUPERIOR COURT OF CALIFORNIA\n"
+                f"COUNTY OF SAN FRANCISCO\n"
+                f"Case Number: FDI-25-80000{i}\n"
+                f"Department: 403\n"
+                f"TENTATIVE RULING\n"
+                f"SF ruling {i} body."
+            ),
+            department="403",
         )
         for i in range(3)
     ]
@@ -1091,6 +1140,202 @@ class TestNonExhaustionExceptionsReraise:
         event = _make_llm_event()
         with pytest.raises(ValueError, match="non-exhaustion error on split child"):
             worker.process_event(event)
+
+
+# ---------------------------------------------------------------------------
+# San Francisco family-law PDF splitter — _try_sf_pdf_split (#4304)
+# ---------------------------------------------------------------------------
+
+
+class TestSfPdfSplit:
+    """Verify the SF family-law PDF deterministic split path (#4304).
+
+    These tests pin the same contract as the Riverside splitter (#3649):
+
+    1. The county+format gate skips non-SF events and non-PDF SF events.
+    2. Empty splitter results (no entry headers) and single-entry results
+       fall through to the LLM path so per-field enrichment can fill
+       motion_type/outcome/case_title.
+    3. Multi-entry splitter results dispatch synthetic split events with
+       ``_split_processed=True`` and **no** ``_llm_extracted`` flag, so
+       per-field LLM enrichment runs against each entry individually
+       (eliminating the cross-entry carry-forward window that the
+       SAN_FRANCISCO_SYSTEM_PROMPT was failing to enforce on its own).
+    4. Non-exhaustion exceptions in the dispatch callable propagate; only
+       ``LlmEnrichmentExhaustedError`` is swallowed (with a CRITICAL log).
+    """
+
+    def test_sf_pdf_split_skips_non_sf_county(self) -> None:
+        """_try_sf_pdf_split returns False (skips) when county != San Francisco."""
+        from ingestion.worker import _try_sf_pdf_split
+
+        # Riverside event with SF-shaped text — must be skipped because county is wrong.
+        event = _make_riverside_event()
+        result = _try_sf_pdf_split(
+            event,
+            event["document_id"],
+            "SUPERIOR COURT OF CALIFORNIA\nCOUNTY OF SAN FRANCISCO\n"
+            "Case Number: FPT-25-378624\nTENTATIVE RULING\n",
+            lambda _e: None,
+        )
+        assert result is False
+
+    def test_sf_pdf_split_skips_non_pdf_format(self) -> None:
+        """_try_sf_pdf_split returns False (skips) when content_format != pdf.
+
+        SF civil tentatives (``ca-sf-tentatives-civil``) are HTML and create
+        one CapturedDocument per ruling at capture time — they never funnel
+        through this path.  The gate is defense in depth.
+        """
+        from ingestion.worker import _try_sf_pdf_split
+
+        event = _make_sf_event(content_format="html")
+        result = _try_sf_pdf_split(
+            event,
+            event["document_id"],
+            "SUPERIOR COURT OF CALIFORNIA\nCOUNTY OF SAN FRANCISCO\n"
+            "Case Number: FPT-25-378624\nTENTATIVE RULING\n",
+            lambda _e: None,
+        )
+        assert result is False
+
+    def test_sf_pdf_split_falls_through_for_no_entry_headers(self) -> None:
+        """_try_sf_pdf_split returns False when splitter finds no entry headers.
+
+        Lets the LLM path run for malformed PDFs / non-multi-case shapes.
+        """
+        from ingestion.worker import _try_sf_pdf_split
+
+        event = _make_sf_event()
+        with patch("courts.ca.sf_tentatives._split_rulings", return_value=[]):
+            result = _try_sf_pdf_split(
+                event,
+                event["document_id"],
+                "Some text without entry headers",
+                lambda _e: None,
+            )
+        assert result is False
+
+    def test_sf_pdf_split_falls_through_for_single_ruling_pdf(self) -> None:
+        """_try_sf_pdf_split returns False when splitter finds exactly 1 entry.
+
+        The deterministic regex extraction does not populate
+        motion_type/outcome/case_title.  Falling through to the LLM path
+        lets the per-field enrichment fill those fields — and there is no
+        carry-forward window with a single entry, so the LLM is safe.
+        """
+        from courts.ca.sf_tentatives import SplitRuling
+        from ingestion.worker import _try_sf_pdf_split
+
+        single_ruling = [
+            SplitRuling(
+                ruling_index=0,
+                case_number="FPT-25-378624",
+                ruling_text="Lone ruling text",
+                department="403",
+            )
+        ]
+        event = _make_sf_event()
+        with patch("courts.ca.sf_tentatives._split_rulings", return_value=single_ruling):
+            result = _try_sf_pdf_split(
+                event,
+                event["document_id"],
+                event["ruling_text"],
+                lambda _e: None,
+            )
+        assert result is False
+
+    def test_sf_pdf_split_dispatches_with_split_metadata(self) -> None:
+        """When the splitter finds multiple entries, each dispatched event carries
+        the synthetic split metadata that ``IngestionWorker.process_event`` uses
+        to short-circuit redundant LLM split attempts and route to per-field
+        enrichment (#4304).
+
+        This pins the dispatch contract: ``_split_processed=True`` (so
+        the worker's outer split-attempt path is skipped on the recursive
+        call), AND ``_llm_extracted`` is NOT set to True (so per-field LLM
+        enrichment STILL runs against each child's ruling_text individually,
+        eliminating the cross-entry carry-forward window).
+        """
+        from ingestion.worker import _try_sf_pdf_split
+
+        captured: list[dict] = []
+
+        def capture(event_data: dict) -> None:
+            captured.append(event_data)
+
+        fake_rulings = _make_fake_sf_rulings()
+        with patch("courts.ca.sf_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_sf_event()
+            result = _try_sf_pdf_split(event, event["document_id"], event["ruling_text"], capture)
+
+        assert result is True
+        assert len(captured) == 3
+        for idx, child in enumerate(captured):
+            assert child["_split_processed"] is True, (
+                f"child {idx} missing _split_processed — would re-trigger split path"
+            )
+            # Critical contract: _llm_extracted must NOT be True so per-field
+            # LLM enrichment runs for each child individually.  This is the
+            # behavioural lock that prevents cross-entry carry-forward.
+            assert not child.get("_llm_extracted", False), (
+                f"child {idx} has _llm_extracted=True — would skip per-field "
+                f"enrichment and lose motion_type/outcome/case_title"
+            )
+            assert child["_original_document_id"] == event["document_id"]
+            # Each child's document_id must be unique (split_ids salt by index).
+            assert child["document_id"] != event["document_id"]
+            # Each child carries its own ruling text and case_number.
+            assert child["case_number"] == fake_rulings[idx].case_number
+            assert child["ruling_text"] == fake_rulings[idx].ruling_text
+            # Each child carries its own department from the splitter.
+            assert child["department"] == fake_rulings[idx].department
+
+    def test_sf_pdf_split_reraises_non_exhaustion_exception(self) -> None:
+        """_try_sf_pdf_split re-raises ValueError on non-exhaustion exception (#4304)."""
+        fake_rulings = _make_fake_sf_rulings()  # must be >1 to pass single-ruling guard
+
+        def raises_value_error(event_data: dict) -> None:
+            raise ValueError("non-exhaustion error")
+
+        with patch("courts.ca.sf_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_sf_event()
+            from ingestion.worker import _try_sf_pdf_split
+
+            with pytest.raises(ValueError, match="non-exhaustion error"):
+                _try_sf_pdf_split(
+                    event, event["document_id"], event["ruling_text"], raises_value_error
+                )
+
+    def test_sf_pdf_split_all_child_exhaustion_logs_and_succeeds(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """SF PDF: all children exhausted → logged as critical, returns True (no re-raise)."""
+        import logging
+
+        fake_rulings = _make_fake_sf_rulings()
+
+        def always_exhausted(event_data: dict) -> None:
+            if event_data.get("_split_processed"):
+                raise LlmEnrichmentExhaustedError("all exhausted")
+
+        with (
+            patch("courts.ca.sf_tentatives._split_rulings", return_value=fake_rulings),
+            caplog.at_level(logging.CRITICAL, logger="ingestion.worker"),
+        ):
+            event = _make_sf_event()
+            from ingestion.worker import _try_sf_pdf_split
+
+            result = _try_sf_pdf_split(
+                event, event["document_id"], event["ruling_text"], always_exhausted
+            )
+
+        assert result is True
+        critical_msgs = [r for r in caplog.records if r.levelname == "CRITICAL"]
+        assert len(critical_msgs) == 3
+        for record in critical_msgs:
+            assert "per-child enrichment exhausted" in record.getMessage()
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/check_split_ruling_fields_propagated.py
+++ b/scripts/check_split_ruling_fields_propagated.py
@@ -105,7 +105,7 @@ _INTERNAL_FIELDS: frozenset[str] = frozenset({"ruling_index"})
 _DATACLASS_SCOPE: dict[str, dict[str, object]] = {
     "LASplitRuling": {"worker_fn": "_try_la_html_split", "reingest": True},
     "SDSplitRuling": {"worker_fn": "_try_sd_calendar_split", "reingest": True},
-    # Fresno + Riverside both name their dataclass plain ``SplitRuling`` —
+    # Fresno + Riverside + SF all name their dataclass plain ``SplitRuling`` —
     # we disambiguate by source-file path during dataclass discovery.
     "SplitRuling@fresno_tentatives": {
         "worker_fn": "_try_fresno_pdf_split",
@@ -113,6 +113,10 @@ _DATACLASS_SCOPE: dict[str, dict[str, object]] = {
     },
     "SplitRuling@riverside_tentatives": {
         "worker_fn": "_try_riverside_pdf_split",
+        "reingest": True,
+    },
+    "SplitRuling@sf_tentatives": {
+        "worker_fn": "_try_sf_pdf_split",
         "reingest": True,
     },
     # CC has no worker dispatcher today — its split path runs only via the


### PR DESCRIPTION
## Summary

Adds a deterministic pre-LLM splitter for San Francisco family-law tentative ruling PDFs (`ca-sf-tentatives-family-law`). Mirrors the Riverside (#3649) and Fresno (#3534) patterns. Closes the LLM cross-entry carry-forward window flagged by #4289 — 14 SF `all_same_case_title_cluster` rows shrink to 0 after rebuild.

The SF civil HTML scraper (`ca-sf-tentatives-civil`) is unaffected — its parser already creates one `CapturedDocument` per ruling at capture time. The pdf-format gate keeps `_try_sf_pdf_split` away from the civil path.

Closes #4304

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Reset SF derived rows + rebuilt from S3 via the new splitter (`scripts/ecs-run-task.sh scripts/rebuild_db.py -- --reset --county "San Francisco"`); per-document DB query confirms each multi-case S3 PDF now produces N distinct rulings with N distinct case_titles and case_numbers (verified against top-5 multi-ruling SF PDFs after rebuild). The pre-PR audit showed 14 same-title clusters; the post-rebuild count is 0.
- [x] Verification evidence posted on issue (see A.8)
