### PR TITLE
fix(scraping): Santa Clara multi-case PDF splitter (#4303)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -435,6 +435,198 @@ def parse_case_title(text: str) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Multi-ruling PDF splitter (#4303)
+# ---------------------------------------------------------------------------
+#
+# Santa Clara multi-case PDFs use one of two formats:
+#
+#   A) "Line N" expanded format (most departments — e.g. dept 16):
+#        Each case starts on a line containing only ``Line N`` (case-
+#        insensitive), followed by ``Case Name:`` and ``Case No.:`` headers
+#        and the per-case ruling body.  Trailing ``Line N`` labels with no
+#        body (e.g. cases that were taken off-calendar after the calendar
+#        was published) appear at the end of the PDF — these are skipped
+#        because their entry body is empty.
+#
+#   B) Compact summary-table format (e.g. dept 6):
+#        A single ``LINE CASE NO. CASE TITLE TENTATIVE RULING`` header,
+#        then per-row entries on shared rows.  This format does NOT have
+#        per-case bare ``Line N`` boundaries, so the splitter falls through
+#        to the LLM path and the existing per-county prompt's anti-carry-
+#        forward rule (5b) is the only protection.
+#
+# The splitter targets format (A) — the dominant source of the
+# ``all_same_case_title_cluster`` signal in Santa Clara per the
+# cross-county audit (#4289 ran 2026-05-06).  21 distinct multi-case PDFs
+# all produced the same wrong ``case_title`` across rulings — exactly the
+# carry-forward fingerprint #3534 (Fresno) and #3649 (Riverside) fixed by
+# pre-LLM splitters.
+
+# Entry boundary: a bare ``Line N`` label on its own line, case-insensitive.
+# pdfplumber's text output puts each ``Line N`` on its own line in the
+# Santa Clara expanded format — the splitter anchors on this.
+# Negative lookahead for ``Line\s+\d+\s*$`` followed by another ``Line\s+\d+\s*$``
+# (a trailing index label) is unnecessary because we filter on body length
+# below.
+_SC_RULING_ENTRY_RE = re.compile(
+    r"^(?P<num>Line\s+\d{1,3})\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Within an entry, the structured per-case headers Santa Clara uses in the
+# expanded format.  These are deterministic enough to extract case_number
+# and case_title without involving the LLM.  Matching is case-insensitive.
+_SC_CASE_NO_HEADER_RE = re.compile(
+    r"^Case\s+No\.?:\s*(?P<case_number>\d{2}(?:CV|PR)\d{6})\s*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+_SC_CASE_NAME_HEADER_RE = re.compile(
+    r"^Case\s+Name:\s*(?P<case_title>[^\n]+)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Body sanity threshold: a real ruling has at least this many characters of
+# body text after the boundary.  Trailing index labels (``Line 10`` through
+# ``Line 15`` at the end of a calendar PDF) have only single-digit page-
+# footer noise after them — those are not rulings and must be skipped.
+# 80 chars is comfortably below the smallest real ruling body in the
+# fixtures (the smallest is ~430 chars for a "see Line N above" cross-
+# reference entry, which is still legitimate calendar content) and well
+# above the page-footer noise.
+_SC_MIN_ENTRY_BODY_LEN = 80
+
+
+class SplitRuling:
+    """A single ruling extracted from a multi-ruling Santa Clara PDF.
+
+    Mirrors ``courts.ca.riverside_tentatives.SplitRuling`` (#3649).  The
+    splitter populates ``case_number`` and ``case_title`` deterministically
+    from the per-entry ``Case No.:`` / ``Case Name:`` headers when present,
+    and leaves ``motion_type`` / ``outcome`` ``None`` so per-entry LLM
+    enrichment runs against only the entry's own text — eliminating the
+    cross-entry carry-forward window (#4303).
+    """
+
+    __slots__ = (
+        "ruling_index",
+        "case_number",
+        "ruling_text",
+        "case_title",
+        "motion_type",
+        "outcome",
+        "hearing_date",
+        "department",
+    )
+
+    def __init__(
+        self,
+        ruling_index: int,
+        case_number: str | None,
+        ruling_text: str,
+        case_title: str | None = None,
+        motion_type: str | None = None,
+        outcome: str | None = None,
+        hearing_date: Any = None,
+        department: str | None = None,
+    ) -> None:
+        self.ruling_index = ruling_index
+        self.case_number = case_number
+        self.ruling_text = ruling_text
+        self.case_title = case_title
+        self.motion_type = motion_type
+        self.outcome = outcome
+        self.hearing_date = hearing_date
+        self.department = department
+
+
+def _split_rulings(text: str) -> list[SplitRuling]:
+    """Split Santa Clara multi-ruling PDF text into per-entry ``SplitRuling`` objects.
+
+    The page-1 preamble (calendar header, judge info, courtroom rules,
+    appearance instructions) is excluded by anchoring on the first
+    ``^Line\\s+\\d+\\s*$`` boundary — anything before the first numbered
+    entry is dropped.
+
+    Returns an empty list if no numbered entries are found, which is the
+    expected outcome for compact summary-table PDFs (e.g. dept 6) and for
+    single-ruling PDFs that don't follow the expanded ``Line N`` format.
+    Single-element returns are also possible — the worker treats both
+    cases identically (fall through to the LLM path) because there is no
+    cross-entry carry-forward window with 0 or 1 entries.
+
+    Each returned ``SplitRuling`` has:
+
+      * ``ruling_index`` — the integer from the entry header (e.g. ``1``,
+        ``2``, ``3`` for a PDF with three rulings).
+      * ``case_number`` — extracted from the ``Case No.:`` header inside
+        the entry; ``None`` if the regex fails to match (the worker's
+        per-entry LLM enrichment will fill it in).
+      * ``case_title`` — extracted from the ``Case Name:`` header inside
+        the entry; ``None`` if absent (per-entry LLM enrichment falls back
+        to the existing case-title heuristics).
+      * ``ruling_text`` — the **verbatim** entry text from the boundary
+        through the next entry boundary (or the end of the document for
+        the last entry).  Includes the entry's own headers and body.
+
+    motion_type and outcome are left ``None`` on purpose — Santa Clara
+    PDFs do not carry structured motion-type / outcome labels in their
+    per-entry headers, so deterministic regex extraction would produce a
+    high false-negative rate.  Letting the framework ``LlmExtractor``
+    populate those fields via per-entry enrichment matches the Riverside
+    pattern (#3649) and preserves correctness on single-ruling PDFs.
+    """
+    matches = list(_SC_RULING_ENTRY_RE.finditer(text))
+    if not matches:
+        return []
+
+    rulings: list[SplitRuling] = []
+    for i, match in enumerate(matches):
+        # ``Line N`` -> integer.
+        num_str = match.group("num")
+        digits = re.search(r"\d+", num_str)
+        if not digits:
+            continue
+        try:
+            entry_num = int(digits.group(0))
+        except ValueError:
+            continue
+
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+
+        body = text[start:end].strip()
+        if len(body) < _SC_MIN_ENTRY_BODY_LEN:
+            # Trailing index label (e.g. dept 16 emits ``Line 10`` through
+            # ``Line 15`` as bare labels at the end of the PDF for cases
+            # that were dropped from the calendar after publication).
+            # Skip — there is no ruling here.
+            continue
+
+        # Extract structured headers when present.  These are case-
+        # insensitive and tolerant of the headers appearing anywhere in
+        # the body (the dept 16 format has them as the first two lines
+        # after ``Line N``; other departments may emit them later).
+        case_no_match = _SC_CASE_NO_HEADER_RE.search(body)
+        case_name_match = _SC_CASE_NAME_HEADER_RE.search(body)
+        case_number = case_no_match.group("case_number").upper() if case_no_match else None
+        case_title = (
+            " ".join(case_name_match.group("case_title").split()) if case_name_match else None
+        )
+
+        rulings.append(
+            SplitRuling(
+                ruling_index=entry_num,
+                case_number=case_number,
+                ruling_text=body,
+                case_title=case_title,
+            )
+        )
+
+    return rulings
+
+
+# ---------------------------------------------------------------------------
 # Scraper
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -833,6 +833,158 @@ def _try_sf_pdf_split(
     return True
 
 
+def _try_sc_pdf_split(
+    event_data: dict[str, Any],
+    document_id: str,
+    ruling_text: str,
+    dispatch: Any,
+) -> bool:
+    """If *ruling_text* is a Santa Clara multi-ruling PDF, deterministically
+    split it into per-case rulings and dispatch one synthetic split event per
+    case via *dispatch*.  Returns True if the split ran, False otherwise.
+
+    This path bypasses the framework LLM extractor — Santa Clara expanded-
+    format calendar PDFs use bare ``Line N`` boundaries (case-insensitive)
+    on their own line followed by ``Case Name:`` / ``Case No.:`` headers
+    that are cheap to parse with the regex-based ``_split_rulings``
+    function in ``courts.ca.sc_tentatives``.  Sending the whole PDF
+    through the LLM previously produced cross-entry contamination
+    (#4303): the LLM violated rule 5b of the Santa Clara extraction
+    prompt and copied the first entry's ``case_title`` /
+    ``motion_type`` onto subsequent entries.  The cross-county audit
+    (#4289 ran 2026-05-06) found 21 distinct multi-case Santa Clara
+    PDFs with the ``all_same_case_title_cluster`` fingerprint —
+    precisely the carry-forward signature #3534 / #3649 fixed for
+    Fresno / Riverside.
+
+    Detection gate: only triggers when event is Santa Clara county
+    **and** content format is ``"pdf"`` — avoids false-positive
+    matches on other courts.
+
+    When ``_split_rulings`` returns ``[]`` (no ``Line N`` boundaries —
+    typical of compact summary-table PDFs like dept 6 and of single-
+    ruling PDFs) or a 1-element list, this function returns ``False``
+    so the existing LLM path handles enrichment.  The deterministic
+    regex extraction does not populate ``motion_type``/``outcome`` —
+    falling through to the framework ``LlmExtractor`` is what gives
+    those fields per-entry enrichment without any cross-entry carry-
+    forward window (single-ruling PDFs have nothing to carry forward).
+
+    Mirrors the SD/LA/Fresno/Riverside/SF pattern (``_try_sd_calendar_split``
+    #2447, ``_try_la_html_split`` #2450, ``_try_fresno_pdf_split`` #3534,
+    ``_try_riverside_pdf_split`` #3649, ``_try_sf_pdf_split`` #4304).
+    """
+    county = event_data.get("county") or ""
+    if county.upper() != "SANTA CLARA":
+        return False
+    if event_data.get("content_format") != "pdf":
+        return False
+
+    # Lazy import to avoid a circular dependency between the worker and
+    # the courts package at module load time.
+    from courts.ca.sc_tentatives import _split_rulings
+
+    split_rulings = _split_rulings(ruling_text)
+    if not split_rulings:
+        # No ``Line N`` boundaries found — fall through to LLM.
+        logger.info(
+            "santa_clara_split_fall_through",
+            extra={
+                "document_id": document_id,
+                "reason": "no_numbered_entries",
+                "raw_len": len(split_rulings),
+                "scraper_id": event_data.get("scraper_id"),
+                "extraction_method": "santa_clara_pdf_deterministic",
+            },
+        )
+        return False
+    if len(split_rulings) == 1:
+        # Single-entry PDF — the deterministic regex extraction does
+        # not populate motion_type/outcome.  Fall through to the LLM
+        # path so framework extraction fills those fields.  There is
+        # no carry-forward window with a single entry, so the LLM is
+        # safe to use here.
+        logger.info(
+            "santa_clara_split_fall_through",
+            extra={
+                "document_id": document_id,
+                "reason": "single_ruling_pdf",
+                "raw_len": len(split_rulings),
+                "scraper_id": event_data.get("scraper_id"),
+                "extraction_method": "santa_clara_pdf_deterministic",
+            },
+        )
+        return False
+
+    logger.info(
+        "Santa Clara PDF deterministic split dispatching %d ruling(s)",
+        len(split_rulings),
+        extra={
+            "document_id": document_id,
+            "ruling_count": len(split_rulings),
+            "scraper_id": event_data.get("scraper_id"),
+            "extraction_method": "santa_clara_pdf_deterministic",
+        },
+    )
+
+    from .split_ids import make_split_document_id
+
+    # At this point len(split_rulings) > 1 — always generate split doc IDs.
+    for idx, sr in enumerate(split_rulings):
+        split_doc_id = make_split_document_id(document_id, idx)
+        hearing_date_value: str | None = None
+        if sr.hearing_date is not None:
+            hearing_date_value = (
+                sr.hearing_date.date().isoformat()
+                if isinstance(sr.hearing_date, datetime)
+                else str(sr.hearing_date)
+            )
+
+        # ``_split_processed=True`` short-circuits the worker's per-doc
+        # split-attempt path; ``_llm_extracted`` is intentionally LEFT
+        # FALSE so the synthetic event flows through the per-field LLM
+        # enrichment path (``_llm_enrich_fields``) and motion_type /
+        # outcome get populated for each entry individually.  Each
+        # entry's enrichment runs against only its own text, so cross-
+        # entry carry-forward is impossible.  This matches the
+        # Riverside splitter's fall-through behavior (#3649).
+        split_event: dict[str, Any] = {
+            **event_data,
+            "document_id": split_doc_id,
+            "_original_document_id": document_id,
+            "_split_processed": True,
+            "_split_index": idx,
+            "_split_count": len(split_rulings),
+            "ruling_text": sr.ruling_text,
+            "ruling_text_html": None,
+            "case_number": sr.case_number or event_data.get("case_number"),
+            "case_title": sr.case_title or event_data.get("case_title"),
+            "department": sr.department or event_data.get("department"),
+            "motion_type": sr.motion_type or event_data.get("motion_type"),
+            "outcome": sr.outcome or event_data.get("outcome"),
+            "hearing_date": hearing_date_value or event_data.get("hearing_date"),
+        }
+        try:
+            dispatch(split_event)
+        except Exception as _exc:
+            from framework.llm_enrichment import LlmEnrichmentExhaustedError
+
+            if not isinstance(_exc, LlmEnrichmentExhaustedError):
+                raise
+            logger.critical(
+                "per-child enrichment exhausted on Santa Clara PDF split — ruling permanently lost",
+                extra={
+                    "document_id": document_id,
+                    "_split_index": idx,
+                    "_split_count": len(split_rulings),
+                    "case_number": sr.case_number or event_data.get("case_number"),
+                    "error": str(_exc),
+                },
+            )
+
+    return True
+
+
 # Fields that LLM extraction can populate when missing from the scraper event.
 EXTRACTABLE_FIELDS = (
     "hearing_date",
@@ -3468,6 +3620,33 @@ class IngestionWorker:
         # ``_llm_enrich_fields`` (each entry processed individually, so no
         # cross-entry carry-forward window).
         if ruling_text and _try_sf_pdf_split(
+            event_data, document_id, ruling_text, self.process_event
+        ):
+            return True
+
+        # ------------------------------------------------------------------
+        # Santa Clara multi-ruling PDF deterministic split (#4303)
+        # ------------------------------------------------------------------
+        # Santa Clara expanded-format calendar PDFs (e.g. dept 16) use bare
+        # ``Line N`` boundaries on their own line followed by ``Case Name:``
+        # and ``Case No.:`` headers.  The LLM previously violated rule 5b
+        # of the Santa Clara extraction prompt and copied the first entry's
+        # ``case_title`` / ``motion_type`` onto subsequent entries — the
+        # cross-county audit (#4289 ran 2026-05-06) found 21 distinct
+        # multi-case Santa Clara PDFs with this exact carry-forward
+        # fingerprint.  The deterministic ``_split_rulings`` in
+        # ``sc_tentatives`` is county+format gated (Santa Clara + pdf only)
+        # so it never fires for other counties.  Compact summary-table
+        # PDFs (e.g. dept 6) and single-ruling PDFs (``_split_rulings``
+        # returns ``[]`` or a 1-element list) fall through to the normal
+        # LLM path below.  Like the Riverside / SF splitters, the Santa
+        # Clara splitter does NOT extract motion_type / outcome — those
+        # are left to per-entry LLM enrichment via ``_llm_enrich_fields``
+        # (each entry processed individually, so no cross-entry carry-
+        # forward window).  case_number and case_title ARE extracted
+        # deterministically from the per-entry ``Case No.:`` /
+        # ``Case Name:`` headers when present.
+        if ruling_text and _try_sc_pdf_split(
             event_data, document_id, ruling_text, self.process_event
         ):
             return True

--- a/packages/scraper-framework/tests/courts/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sc_tentatives.py
@@ -27,6 +27,8 @@ from courts.ca.sc_tentatives import (
     LANDING_URL,
     SantaClaraCourtDirectory,
     SCTentativeRulingsScraper,
+    SplitRuling,
+    _split_rulings,
     extract_departments,
     extract_pdf_links_from_dept_page,
     extract_pdf_text,
@@ -977,3 +979,284 @@ class TestDateAwareDirectoryLookup:
         result = scraper.parse_document(doc)
         assert result.judge_name == "Live Judge"
         scraper._court_directory.get_mapping_for_date.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _split_rulings — Santa Clara multi-case PDF deterministic splitter (#4303)
+# ---------------------------------------------------------------------------
+#
+# Regression coverage for the carry-forward bug documented in #4303.  The
+# Riverside splitter (#3649) eliminated this same class of bug for Riverside
+# PDFs by splitting before LLM enrichment so each entry's enrichment runs
+# against only its own text.  These tests pin the Santa Clara splitter to
+# the same contract: each ``Line N``-bounded entry is a separate
+# SplitRuling, the page-1 preamble is dropped, trailing index-only labels
+# (``Line 10``..``Line 15`` at the end of the calendar) are skipped, and
+# compact summary-table PDFs and single-ruling PDFs return ``[]`` or a
+# 1-element list so the worker falls through to the LLM path.
+
+
+class TestSantaClaraPdfSplit:
+    """Unit tests for _split_rulings against real Santa Clara fixture PDFs."""
+
+    def test_santa_clara_pdf_split_dept16_returns_nine_rulings(self) -> None:
+        """sc_dept16_wed.pdf has 9 valid expanded-format entries (Lines 1-9)
+        plus 6 trailing index labels (Lines 10-15) without bodies — the
+        splitter must return 9 rulings and skip the trailing labels.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        assert len(rulings) == 9
+        # Indices match the PDF's printed numbering 1..9.
+        assert [r.ruling_index for r in rulings] == [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    def test_santa_clara_pdf_split_dept16_case_numbers_match_pdf(self) -> None:
+        """Each split must carry the case_number from its own ``Case No.:``
+        header.  Ground truth is from the fixture PDF's per-entry headers."""
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        case_numbers = [r.case_number for r in rulings]
+        # Ground truth from the fixture (verified via probe).  Lines 3+4
+        # share a case (consolidated motions on Ford Motor Company suit),
+        # Lines 6+7 share a case (joined motion + cross-reference) — these
+        # duplicates are CORRECT, not carry-forward leakage.
+        assert case_numbers == [
+            "24CV448974",  # Line 1: Wells Fargo v. Bagdriwicz
+            "24CV445397",  # Line 2: Kwong v. Yang
+            "24CV447738",  # Line 3: Jara Jurado v. Ford
+            "24CV447738",  # Line 4: Jara Jurado v. Ford (consolidated)
+            "25CV464528",  # Line 5: Vora v. Sunnyvale Gardens
+            "24CV439631",  # Line 6: Ben Abdallah v. Fackler
+            "24CV439631",  # Line 7: Ben Abdallah v. Fackler (joined)
+            "23CV413738",  # Line 8: Emerging Growth Staffing v. DFO
+            "25CV456254",  # Line 9: Hogan v. Moore
+        ]
+
+    def test_santa_clara_pdf_split_dept16_case_titles_per_entry(self) -> None:
+        """Each split must carry its own ``case_title`` — the carry-forward
+        fingerprint is identical case_titles across distinct case_numbers,
+        so this test is the primary regression for #4303.
+
+        Lines 1, 2, 3, 5, 6, 8, 9 all have distinct case_numbers, so their
+        case_titles must all be distinct from each other.  Lines 3+4 and
+        6+7 share case_numbers and SHOULD share titles (legitimate
+        consolidation, not carry-forward).
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        # Build {case_number: case_title} mapping; every distinct
+        # case_number must have exactly one distinct case_title.
+        cn_to_title: dict[str, set[str]] = {}
+        for r in rulings:
+            assert r.case_number is not None
+            assert r.case_title is not None
+            cn_to_title.setdefault(r.case_number, set()).add(r.case_title)
+        for case_number, titles in cn_to_title.items():
+            assert len(titles) == 1, (
+                f"case_number {case_number} has {len(titles)} distinct titles: {titles}"
+            )
+        # And distinct case_numbers should mostly have distinct titles —
+        # the 7 distinct case_numbers in dept16 must produce 7 distinct
+        # titles (no leakage across cases).
+        distinct_titles = {next(iter(ts)) for ts in cn_to_title.values()}
+        assert len(distinct_titles) == len(cn_to_title), (
+            "Distinct case_numbers must produce distinct case_titles "
+            f"(got {len(distinct_titles)} titles for {len(cn_to_title)} case_numbers)"
+        )
+
+    def test_santa_clara_pdf_split_dept16_entry_text_isolation(self) -> None:
+        """Entry N's ruling_text must contain only its own header + body —
+        no cross-entry contamination from other entries' headers/bodies.
+
+        This is the core invariant the splitter must guarantee: the LLM
+        that runs against ``ruling_text`` should never see another
+        entry's text, which is what enables it to violate the anti-
+        carry-forward rule (5b in the per-county system prompt).
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        # Pick three entries with clearly distinct parties for cross-
+        # entry leakage assertions:
+        #   Line 1: Wells Fargo / Bagdriwicz   (24CV448974)
+        #   Line 2: Kwong / Yang               (24CV445397)
+        #   Line 8: Emerging Growth / DFO      (23CV413738)
+        by_idx = {r.ruling_index: r for r in rulings}
+        r1, r2, r8 = by_idx[1], by_idx[2], by_idx[8]
+        assert "Wells Fargo" in r1.ruling_text
+        assert "Bagdriwicz" in r1.ruling_text
+        assert "Kwong" not in r1.ruling_text
+        assert "Emerging Growth" not in r1.ruling_text
+        assert "Kwong" in r2.ruling_text
+        assert "Yang" in r2.ruling_text
+        assert "Wells Fargo" not in r2.ruling_text
+        assert "Emerging Growth" in r8.ruling_text
+        assert "DFO" in r8.ruling_text
+        assert "Wells Fargo" not in r8.ruling_text
+        assert "Kwong" not in r8.ruling_text
+
+    def test_santa_clara_pdf_split_dept16_preamble_is_dropped(self) -> None:
+        """Page-1 boilerplate (UDC video instructions, courtroom rules,
+        scheduling notice) must NOT appear in any per-entry ruling_text.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        for r in rulings:
+            # Page-1 preamble markers from the dept 16 fixture.
+            assert "Unicorn Digital Courtroom" not in r.ruling_text, (
+                f"Entry {r.ruling_index} contains preamble UDC text"
+            )
+            assert "phone-only appearances" not in r.ruling_text.lower(), (
+                f"Entry {r.ruling_index} contains preamble phone-only text"
+            )
+
+    def test_santa_clara_pdf_split_dept16_skips_trailing_index_labels(self) -> None:
+        """Trailing ``Line 10``..``Line 15`` labels at the end of the
+        dept 16 fixture have no body — they are calendar lines that were
+        cleared after publication.  The splitter must skip them rather
+        than emitting empty SplitRuling objects.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        # No ruling indexed 10 or above — those are trailing labels.
+        ruling_indices = [r.ruling_index for r in rulings]
+        for idx in ruling_indices:
+            assert idx < 10, f"trailing index label Line {idx} was not skipped"
+
+    def test_santa_clara_pdf_split_dept6_compact_table_falls_through(self) -> None:
+        """sc_dept6_tues.pdf uses the compact summary-table format (no per-
+        entry ``Line N`` boundaries on their own line).  The splitter
+        returns at most 1 entry, so the worker falls through to the LLM
+        path and the existing carry-forward protection (the LLM prompt's
+        rule 5b) is the only defense for this format.
+
+        This test pins the fall-through behavior so the splitter's
+        coverage gap is explicit.  A future PR can extend the splitter
+        to handle compact tables; until then, dept 6's residual carry-
+        forward risk is acknowledged here.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept6_tues.pdf"))
+        rulings = _split_rulings(text)
+        # 0 or 1 entries — both trigger the worker's fall-through-to-LLM path.
+        assert len(rulings) <= 1
+
+    def test_santa_clara_pdf_split_dept1_summary_table_falls_through(self) -> None:
+        """sc_dept1_tues.pdf uses ``LINE 1 CASENO TITLE ...`` on a single
+        line (summary-table format) plus a single ``Calendar Line # 3 - 4``
+        body section — neither matches the bare ``Line N`` boundary
+        pattern.  The splitter returns ``[]`` so the worker falls through.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept1_tues.pdf"))
+        rulings = _split_rulings(text)
+        assert rulings == []
+
+    def test_santa_clara_pdf_split_empty_text_returns_empty(self) -> None:
+        """Empty text returns an empty list (defensive)."""
+        assert _split_rulings("") == []
+
+    def test_santa_clara_pdf_split_no_line_boundaries_returns_empty(self) -> None:
+        """Text without any ``Line N`` boundaries returns empty (defensive)."""
+        text = "Some random text without any line N boundaries"
+        assert _split_rulings(text) == []
+
+    def test_santa_clara_pdf_split_skips_too_short_entries(self) -> None:
+        """Entries whose body is shorter than the threshold are skipped.
+
+        This is the same defense that lets the dept 16 splitter ignore
+        the trailing ``Line 10``..``Line 15`` labels — those have only
+        a few chars of page-footer noise after them and must not be
+        emitted as empty SplitRuling objects.
+        """
+        text = (
+            "Line 1\n"
+            "Short stub.\n"
+            "Line 2\n"
+            "Case Name: Foo v. Bar\n"
+            "Case No.: 25CV111111\n"
+            "Plaintiff Foo moves for summary judgment.  The motion is granted "
+            "based on the undisputed evidence and applicable law.  This is a "
+            "long-enough body to clear the minimum-entry threshold and be "
+            "emitted as a real SplitRuling.\n"
+        )
+        rulings = _split_rulings(text)
+        # Entry 1 is below the threshold; only entry 2 survives.
+        assert len(rulings) == 1
+        assert rulings[0].ruling_index == 2
+        assert rulings[0].case_number == "25CV111111"
+        assert rulings[0].case_title == "Foo v. Bar"
+
+    def test_santa_clara_pdf_split_two_digit_entry_numbers(self) -> None:
+        """Entry indices can be 1-3 digits (defensive — Santa Clara
+        calendars sometimes run >9 entries, e.g. dept 16's calendar
+        labels Line 10..15 even when only 9 are ruled on).
+        """
+        body = (
+            "Case Name: Foo v. Bar\n"
+            "Case No.: 25CV111111\n"
+            "The motion is granted based on the undisputed evidence and "
+            "applicable law.  This body is long enough to clear the "
+            "minimum-entry threshold.\n"
+        )
+        body_alpha = body.replace("Foo v. Bar", "Alpha v. Beta").replace("25CV111111", "25CV222222")
+        body_gamma = body.replace("Foo v. Bar", "Gamma v. Delta").replace(
+            "25CV111111", "25CV333333"
+        )
+        text = f"Line 9\n{body}\nLine 10\n{body_alpha}\nLine 11\n{body_gamma}\n"
+        rulings = _split_rulings(text)
+        assert [r.ruling_index for r in rulings] == [9, 10, 11]
+        assert [r.case_number for r in rulings] == [
+            "25CV111111",
+            "25CV222222",
+            "25CV333333",
+        ]
+
+    def test_santa_clara_pdf_split_handles_missing_case_no_header(self) -> None:
+        """Entries without a structured ``Case No.:`` header must still be
+        emitted (case_number=None) so the worker's per-entry LLM
+        enrichment can fill it in.  This defends against future
+        Santa Clara format variants that drop the header.
+        """
+        text = (
+            "Line 1\n"
+            "Plaintiff Foo moves for summary judgment.  The motion is granted "
+            "based on the undisputed evidence and applicable law.  This body "
+            "has no Case No. header.\n"
+        )
+        rulings = _split_rulings(text)
+        assert len(rulings) == 1
+        assert rulings[0].case_number is None
+        assert rulings[0].case_title is None
+        assert "summary judgment" in rulings[0].ruling_text
+
+    def test_santa_clara_pdf_split_does_not_extract_motion_or_outcome(self) -> None:
+        """The Santa Clara splitter intentionally leaves motion_type and
+        outcome as ``None`` — those are populated by per-entry LLM
+        enrichment via ``_llm_enrich_fields``.
+
+        This is the same behavioural choice as the Riverside splitter
+        (#3649): per-entry LLM enrichment runs against only the entry's
+        own text, so the LLM can never carry-forward motion_type /
+        outcome from one entry onto another.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        assert len(rulings) > 0
+        for r in rulings:
+            assert r.motion_type is None, "splitter must not populate motion_type"
+            assert r.outcome is None, "splitter must not populate outcome"
+
+    def test_santa_clara_pdf_split_returns_split_ruling_instances(self) -> None:
+        """Splitter must return ``SplitRuling`` instances so the worker's
+        ``_try_sc_pdf_split`` dispatcher can read the typed attributes."""
+        text = extract_pdf_text(_load_bytes("sc_dept16_wed.pdf"))
+        rulings = _split_rulings(text)
+        for r in rulings:
+            assert isinstance(r, SplitRuling)
+            # Required attributes per SplitRuling.__slots__.
+            assert hasattr(r, "ruling_index")
+            assert hasattr(r, "case_number")
+            assert hasattr(r, "ruling_text")
+            assert hasattr(r, "case_title")
+            assert hasattr(r, "motion_type")
+            assert hasattr(r, "outcome")
+            assert hasattr(r, "hearing_date")
+            assert hasattr(r, "department")

--- a/packages/scraper-framework/tests/test_ingestion_worker.py
+++ b/packages/scraper-framework/tests/test_ingestion_worker.py
@@ -265,6 +265,53 @@ def _make_fake_sf_rulings() -> list:
     ]
 
 
+def _make_sc_event(**overrides: object) -> dict:
+    """Return a Santa Clara PDF-like event payload (#4303)."""
+    base: dict = {
+        "document_id": "aaaaaaaa-0000-0000-0000-000000000007",
+        "scraper_id": "ca-sc-tentatives-civil",
+        "state": "CA",
+        "county": "Santa Clara",
+        "court": "Superior Court",
+        "source_url": "https://santaclara.courts.ca.gov/tentativerulings/7",
+        "content_format": "pdf",
+        "content_hash": "stu678",
+        "s3_key": "ca/santa_clara/superior_court/raw/stu678.pdf",
+        "s3_bucket": "judgemind-document-archive-dev",
+        "ruling_text": (
+            "Line 1\n"
+            "Case Name: Foo v. Bar\n"
+            "Case No.: 25CV111111\n"
+            "The motion is GRANTED.  Body text long enough to clear the "
+            "minimum-entry threshold.\n"
+            "Line 2\n"
+            "Case Name: Alpha v. Beta\n"
+            "Case No.: 25CV222222\n"
+            "The demurrer is overruled.  Body text long enough to clear "
+            "the minimum-entry threshold.\n"
+        ),
+        "hearing_date": "2026-03-04",
+        "capture_timestamp": "2026-03-03T23:00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_fake_sc_rulings() -> list:
+    """Return 3 fake Santa Clara SplitRuling objects for testing (#4303)."""
+    from courts.ca.sc_tentatives import SplitRuling
+
+    return [
+        SplitRuling(
+            ruling_index=i + 1,
+            case_number=f"25CV{i:06d}",
+            case_title=f"Plaintiff{i} v. Defendant{i}",
+            ruling_text=f"Santa Clara ruling {i}\nThe motion is granted.",
+        )
+        for i in range(3)
+    ]
+
+
 def _make_fake_extracted_rulings() -> list[ExtractedRuling]:
     """Return 3 fake ExtractedRuling objects for LLM split path testing.
 
@@ -1140,6 +1187,145 @@ class TestNonExhaustionExceptionsReraise:
         event = _make_llm_event()
         with pytest.raises(ValueError, match="non-exhaustion error on split child"):
             worker.process_event(event)
+
+    def test_santa_clara_pdf_reraises_non_exhaustion_exception(self) -> None:
+        """_try_sc_pdf_split re-raises ValueError on non-exhaustion exception (#4303)."""
+        fake_rulings = _make_fake_sc_rulings()  # >1 to pass single-ruling guard
+
+        def raises_value_error(event_data: dict) -> None:
+            raise ValueError("non-exhaustion error")
+
+        with patch("courts.ca.sc_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_sc_event()
+            from ingestion.worker import _try_sc_pdf_split
+
+            with pytest.raises(ValueError, match="non-exhaustion error"):
+                _try_sc_pdf_split(
+                    event, event["document_id"], event["ruling_text"], raises_value_error
+                )
+
+    def test_santa_clara_pdf_split_skips_non_sc_county(self) -> None:
+        """_try_sc_pdf_split returns False (skips) when county != Santa Clara (#4303)."""
+        from ingestion.worker import _try_sc_pdf_split
+
+        # Riverside event with SC-like text — must be skipped because county is wrong.
+        event = _make_riverside_event()
+        result = _try_sc_pdf_split(
+            event,
+            event["document_id"],
+            "Line 1\nCase No.: 25CV111111\nThe motion is granted.",
+            lambda _e: None,
+        )
+        assert result is False
+
+    def test_santa_clara_pdf_split_skips_non_pdf_format(self) -> None:
+        """_try_sc_pdf_split returns False (skips) when content_format != pdf (#4303)."""
+        from ingestion.worker import _try_sc_pdf_split
+
+        # SC event with html format — must be skipped (gate is pdf-only).
+        event = _make_sc_event(content_format="html")
+        result = _try_sc_pdf_split(
+            event,
+            event["document_id"],
+            "Line 1\nCase No.: 25CV111111\nThe motion is granted.",
+            lambda _e: None,
+        )
+        assert result is False
+
+    def test_santa_clara_pdf_split_falls_through_for_no_numbered_entries(self) -> None:
+        """_try_sc_pdf_split returns False when splitter finds no numbered entries.
+
+        This is the compact-summary-table path (e.g. dept 6) — the LLM
+        path runs normally so the existing prompt's anti-carry-forward
+        rule remains the only protection until a future PR extends the
+        splitter to compact tables.
+        """
+        from ingestion.worker import _try_sc_pdf_split
+
+        event = _make_sc_event()
+        with patch("courts.ca.sc_tentatives._split_rulings", return_value=[]):
+            result = _try_sc_pdf_split(
+                event,
+                event["document_id"],
+                "Some compact summary table without Line N markers",
+                lambda _e: None,
+            )
+        assert result is False
+
+    def test_santa_clara_pdf_split_falls_through_for_single_ruling_pdf(self) -> None:
+        """_try_sc_pdf_split returns False when splitter finds exactly 1 entry.
+
+        The deterministic regex extraction does not populate
+        motion_type/outcome.  Falling through to the LLM path lets the
+        per-field enrichment fill those fields — there is no carry-
+        forward window with a single entry (matches Riverside #3649).
+        """
+        from courts.ca.sc_tentatives import SplitRuling
+        from ingestion.worker import _try_sc_pdf_split
+
+        single_ruling = [
+            SplitRuling(
+                ruling_index=1,
+                case_number="25CV111111",
+                case_title="Foo v. Bar",
+                ruling_text="Lone ruling text",
+            )
+        ]
+        event = _make_sc_event()
+        with patch("courts.ca.sc_tentatives._split_rulings", return_value=single_ruling):
+            result = _try_sc_pdf_split(
+                event,
+                event["document_id"],
+                event["ruling_text"],
+                lambda _e: None,
+            )
+        assert result is False
+
+    def test_santa_clara_pdf_split_dispatches_with_split_metadata(self) -> None:
+        """When the splitter finds multiple entries, each dispatched event carries
+        the synthetic split metadata that ``IngestionWorker.process_event`` uses
+        to short-circuit redundant LLM split attempts and route to per-field
+        enrichment (#4303 — mirrors #3649 contract).
+
+        This test pins the dispatch contract: ``_split_processed=True`` (so
+        the worker's outer split-attempt path is skipped on the recursive
+        call), AND ``_llm_extracted`` is NOT set to True (so per-field LLM
+        enrichment STILL runs against each child's ruling_text individually,
+        eliminating the cross-entry carry-forward window).
+        """
+        from ingestion.worker import _try_sc_pdf_split
+
+        captured: list[dict] = []
+
+        def capture(event_data: dict) -> None:
+            captured.append(event_data)
+
+        fake_rulings = _make_fake_sc_rulings()
+        with patch("courts.ca.sc_tentatives._split_rulings", return_value=fake_rulings):
+            event = _make_sc_event()
+            result = _try_sc_pdf_split(event, event["document_id"], event["ruling_text"], capture)
+
+        assert result is True
+        assert len(captured) == 3
+        for idx, child in enumerate(captured):
+            assert child["_split_processed"] is True, (
+                f"child {idx} missing _split_processed — would re-trigger split path"
+            )
+            # Critical contract: _llm_extracted must NOT be True so per-field
+            # LLM enrichment runs for each child individually.  Mirrors the
+            # Riverside splitter's behavior — the SC splitter does not
+            # populate motion_type/outcome deterministically.
+            assert not child.get("_llm_extracted", False), (
+                f"child {idx} has _llm_extracted=True — would skip per-field "
+                f"enrichment and lose motion_type/outcome"
+            )
+            assert child["_original_document_id"] == event["document_id"]
+            # Each child's document_id must be unique (split_ids salt by index).
+            assert child["document_id"] != event["document_id"]
+            # Each child carries its own ruling text, case_number, and case_title.
+            assert child["case_number"] == fake_rulings[idx].case_number
+            assert child["case_title"] == fake_rulings[idx].case_title
+            assert child["ruling_text"] == fake_rulings[idx].ruling_text
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/check_split_ruling_fields_propagated.py
+++ b/scripts/check_split_ruling_fields_propagated.py
@@ -105,8 +105,9 @@ _INTERNAL_FIELDS: frozenset[str] = frozenset({"ruling_index"})
 _DATACLASS_SCOPE: dict[str, dict[str, object]] = {
     "LASplitRuling": {"worker_fn": "_try_la_html_split", "reingest": True},
     "SDSplitRuling": {"worker_fn": "_try_sd_calendar_split", "reingest": True},
-    # Fresno + Riverside + SF all name their dataclass plain ``SplitRuling`` —
-    # we disambiguate by source-file path during dataclass discovery.
+    # Fresno + Riverside + SF + Santa Clara all name their dataclass plain
+    # ``SplitRuling`` — we disambiguate by source-file path during dataclass
+    # discovery.
     "SplitRuling@fresno_tentatives": {
         "worker_fn": "_try_fresno_pdf_split",
         "reingest": True,
@@ -117,6 +118,10 @@ _DATACLASS_SCOPE: dict[str, dict[str, object]] = {
     },
     "SplitRuling@sf_tentatives": {
         "worker_fn": "_try_sf_pdf_split",
+        "reingest": True,
+    },
+    "SplitRuling@sc_tentatives": {
+        "worker_fn": "_try_sc_pdf_split",
         "reingest": True,
     },
     # CC has no worker dispatcher today — its split path runs only via the


### PR DESCRIPTION
## Summary

Adds a deterministic pre-LLM splitter for Santa Clara multi-case tentative ruling PDFs, mirroring the Fresno (#3534) and Riverside (#3649) pattern. The splitter targets the dominant carry-forward source — the expanded `Line N` calendar format used by departments such as dept 16 — which the cross-county audit (#4289) flagged with 21 `all_same_case_title_cluster` PDFs and 26 `motion_type_contradiction` rows. Each `Line N`-bounded entry becomes a synthetic split event so per-entry LLM enrichment runs against only its own text, eliminating the cross-entry carry-forward window. Compact summary-table PDFs (dept 6) and single-ruling PDFs fall through to the existing LLM path — explicitly pinned in tests so the residual coverage gap is visible.

Closes #4303

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification
- [x] Deploy Scraper workflow succeeded (run `25565839718`); new ingestion-worker task running on the merged image (`judgemind/scraper:5ca86ea`).
- [x] Splitter regression tests confirmed via `pytest -k 'santa_clara_pdf_split'` (15 splitter + 6 worker-hook tests, all PASS) — splits `sc_dept16_wed.pdf` into 9 rulings with distinct per-entry case_titles, eliminating the carry-forward fingerprint.
- [ ] Audit-count drain (`all_same_case_title_cluster <= 2`, `motion_type_contradiction <= 5`) — **carried over to follow-up #4320** because the existing dev DB has no parent docs left for Santa Clara (every row is already a UUID-v5 split-child) so `_full_reparse_document` correctly skips them under the #2416 guard. The new splitter will run automatically on FUTURE Santa Clara captures; clearing the historical signal needs the drain script in #4320.
- [x] Verification evidence posted on issue #4303.
