### PR TITLE
feat(scraping): schedule audit_llm_carry_forward as a weekly periodic skill (#4309)

### DIFF
--- a/.claude/skills/audit-llm-carry-forward/SKILL.md
+++ b/.claude/skills/audit-llm-carry-forward/SKILL.md
@@ -1,0 +1,240 @@
+---
+description: Weekly LLM carry-forward audit across CA counties — runs scripts/audit_llm_carry_forward.py, applies per-axis thresholds, files agent/ready follow-ups for trips, and posts a heartbeat comment on the long-lived audit-log issue. Triggered by the daemon scheduler weekly.
+argument-hint: agent_id
+maxTurns: 60
+---
+
+# /audit-llm-carry-forward skill
+
+Run the weekly LLM carry-forward audit across every CA county. This skill is non-interactive — it runs probes, applies thresholds, files issues / posts comments, and returns a verdict without LLM review of the probe output.
+
+**Trigger:** The dispatcher daemon fires this skill weekly (Sunday 06:00 UTC) via the `audit-llm-carry-forward` row in `dispatcher.scheduled_skills` (migration 63, issue #4309).
+
+Do not ask for confirmation. Work autonomously through every step.
+
+---
+
+## Step 0 — Setup
+
+Establish the output directory for this run. The worktree root is the repo root.
+
+Create the output directory:
+
+```
+mkdir -p tmp/llm-carry-forward
+```
+
+The state file `tmp/llm-carry-forward/last_totals.json` is written by the probe at the end of each successful run. It is intentionally NOT committed — every fresh ECS task starts without a baseline, which means the first ECS-launched run is silent on noisy-axis jump checks. That is acceptable: fixed-threshold axes (`outcome_continue`, `all_same_case_title_cluster`) fire on every run, and the noisy axes calibrate themselves on the second-and-later runs once a long-lived state location lands. State persistence is a follow-up (see Step 5 retrospective).
+
+---
+
+## Step 1 — Run the probe
+
+Run the probe wrapper, writing the findings envelope to the output path:
+
+```
+packages/scraper-framework/.venv/bin/python scripts/dispatcher/llm_carry_forward_probe.py --output tmp/llm-carry-forward/findings.json --state tmp/llm-carry-forward/last_totals.json
+```
+
+The script reads `DATABASE_URL` from the environment (injected by the ECS task definition), invokes `audit_llm_carry_forward.run_audit()` over every CA county, applies thresholds, and writes a JSON envelope:
+
+```json
+{
+  "summary": { ... full run_audit output ... },
+  "totals_by_county": {"County": {"axis": count, ...}},
+  "findings": [
+    {
+      "probe": "outcome_continue",
+      "county": "...",
+      "title": "[llm-carry-forward outcome_continue ...] ...",
+      "body": "...",
+      "severity": "warning",
+      "should_file_issue": true,
+      "details": { ... }
+    }
+  ],
+  "comment_markdown": "## Weekly LLM carry-forward audit\n..."
+}
+```
+
+On DB error the script exits non-zero — let the failure propagate so the scheduler records the run as failed.
+
+---
+
+## Step 2 — Read the findings envelope
+
+Read the envelope file:
+
+```
+cat tmp/llm-carry-forward/findings.json
+```
+
+Parse the JSON envelope. The two pieces you act on next:
+
+* `findings` — list of threshold trips. Each entry has `should_file_issue` (always true today; reserved for future heartbeat-only findings).
+* `comment_markdown` — pre-rendered weekly heartbeat comment for the long-lived audit-log issue.
+
+If `findings` is empty, skip to Step 4 — there is no follow-up issue to file, just the heartbeat comment.
+
+---
+
+## Step 3 — File a follow-up issue per finding (with dedup)
+
+For each entry in `findings`:
+
+### Sub-step 3.0 — Check for an existing open issue (MANDATORY dedup gate)
+
+Extract the bracketed prefix from the finding's `title` (e.g. `[llm-carry-forward outcome_continue Riverside]`). Search for an existing open issue with that prefix to avoid filing duplicates each week:
+
+```
+gh issue list --repo judgemind/judgemind --label source/audit-llm-carry-forward --state open --search "[FINDING_PREFIX] in:title" --json number,title
+```
+
+Replace `FINDING_PREFIX` with the bracketed prefix from the finding's title (e.g. `[llm-carry-forward outcome_continue Riverside]`).
+
+**Branch on result:**
+
+* **One or more open issues match** (dedup hit): pick the lowest-numbered match and append a comment with the finding's `body` instead of filing a new issue. Skip `gh issue create`.
+
+  Write the finding's `body` to a temp file:
+
+  ```
+  tmp/llm-carry-forward/comment-N.txt
+  ```
+
+  (`N` is the finding's index in the `findings` array, 0-based.)
+
+  Then post the comment:
+
+  ```
+  gh issue comment ISSUE_NUMBER --repo judgemind/judgemind --body-file tmp/llm-carry-forward/comment-N.txt
+  ```
+
+  Record the comment URL.
+
+* **No match** (no existing open issue): proceed with `gh issue create` (sub-step 3.1).
+
+### Sub-step 3.1 — Create a new issue (only when no existing open issue found)
+
+Write the finding's `body` to a temp file:
+
+```
+tmp/llm-carry-forward/issue-N.txt
+```
+
+Then file the issue:
+
+```
+gh issue create --repo judgemind/judgemind --title "FINDING_TITLE" --label "source/audit-llm-carry-forward" --label "area/scraping" --label "area/ingestion" --label "type/bug" --label "priority/p2" --label "agent/ready" --body-file tmp/llm-carry-forward/issue-N.txt
+```
+
+Replace `FINDING_TITLE` with the finding's `title` field verbatim.
+
+**Important:** Never use `priority/p0`. The maximum priority for this audit is p2.
+
+Record the issue URL.
+
+Repeat sub-steps 3.0–3.1 for every finding in the `findings` array.
+
+---
+
+## Step 4 — Post the weekly heartbeat comment on the audit-log issue
+
+Find the long-lived audit-log issue. It is the open issue labeled `source/audit-llm-carry-forward-log` (singular — there should be exactly one).
+
+```
+gh issue list --repo judgemind/judgemind --label source/audit-llm-carry-forward-log --state open --json number --limit 5
+```
+
+**Branch on result:**
+
+* **One open issue exists:** post the heartbeat comment as a reply.
+
+  Write the heartbeat to a file (use the `comment_markdown` field from the envelope):
+
+  ```
+  tmp/llm-carry-forward/heartbeat.txt
+  ```
+
+  Post:
+
+  ```
+  gh issue comment LOG_ISSUE_NUMBER --repo judgemind/judgemind --body-file tmp/llm-carry-forward/heartbeat.txt
+  ```
+
+* **No matching open issue:** create the long-lived audit-log issue once. Subsequent weeks will append comments to it.
+
+  Write the body to:
+
+  ```
+  tmp/llm-carry-forward/log-body.txt
+  ```
+
+  Body content:
+
+  ```
+  ## Long-lived LLM carry-forward audit log
+
+  This issue is the heartbeat target for the `/audit-llm-carry-forward`
+  weekly scheduled skill (issue #4309). Each Sunday the skill posts a
+  comment with per-county counts. Threshold trips are filed as separate
+  `agent/ready` follow-up issues with title prefix
+  `[llm-carry-forward …]`.
+
+  Do not close this issue — it stays open as the rolling log. The first
+  weekly heartbeat appears below.
+  ```
+
+  Then create:
+
+  ```
+  gh issue create --repo judgemind/judgemind --title "audit-log: LLM carry-forward weekly audit" --label "source/audit-llm-carry-forward-log" --label "area/scraping" --label "type/operations" --body-file tmp/llm-carry-forward/log-body.txt
+  ```
+
+  After creating the log issue, post the heartbeat as a comment on the new issue (same `gh issue comment` recipe as above, with the new issue number).
+
+* **More than one open issue:** treat the lowest-numbered match as canonical, post the heartbeat there, and emit a `WARN` line in your output noting the duplicates so an operator can close the extras.
+
+---
+
+## Step 5 — Return verdict
+
+Emit a summary so the dispatcher's `handle_scheduled_skill` function records success. Output exactly this envelope with the actual values substituted:
+
+```
+FILED ISSUES
+
+Weekly LLM carry-forward audit complete.
+Findings: N total threshold trips.
+Filed N new follow-up issues, commented on M existing follow-ups.
+Heartbeat posted on audit-log issue #LOG_ISSUE.
+
+Filed issues: (list issue URLs, or "none" if 0 filed)
+Commented on existing follow-ups: (list comment URLs, or "none" if 0)
+Heartbeat URL: (URL of the heartbeat comment)
+```
+
+The `FILED ISSUES` header (or any non-empty output containing `FILED ISSUES` / `NO ACTIONABLE FINDINGS` / `SHIPPED` / `PASSED`) signals success to `handle_scheduled_skill` (agent-runner-entrypoint.sh ~line 2085).
+
+If there were zero findings AND a heartbeat comment posted, emit:
+
+```
+NO ACTIONABLE FINDINGS
+
+Weekly LLM carry-forward audit clean.
+All thresholds within expected bounds.
+Heartbeat posted on audit-log issue #LOG_ISSUE.
+
+Heartbeat URL: (URL of the heartbeat comment)
+```
+
+---
+
+## Guardrails
+
+- **No `$()` in shell commands.** Retrieve dynamic values (issue numbers, URLs) as separate tool calls and substitute manually.
+- **No heredocs, no quoted strings with `&&` or `;`.** Use Write tool for multi-line content.
+- **All temp files go in `tmp/llm-carry-forward/`.** Never `/tmp/`.
+- **If `llm_carry_forward_probe.py` exits non-zero, do not proceed to Steps 3–5.** Let the scheduler record the failure and retry next week.
+- **Never file p0 issues.** The maximum priority is p2 — this audit is preventative, not emergency-grade.
+- **Never modify probe output.** `llm_carry_forward_probe.py` (and the underlying `audit_llm_carry_forward.py`) are authoritative; this skill is a delivery wrapper only.

--- a/packages/api/migrations/63_dispatcher-llm-carry-forward-skill.sql
+++ b/packages/api/migrations/63_dispatcher-llm-carry-forward-skill.sql
@@ -1,0 +1,64 @@
+-- Up Migration
+--
+-- Dispatcher v2 — /audit-llm-carry-forward periodic skill (issue #4309).
+--
+-- Registers the /audit-llm-carry-forward skill as a row in
+-- dispatcher.scheduled_skills so the daemon's _scheduled_skills_tick
+-- fires it once a week. The skill runs scripts/audit_llm_carry_forward.py
+-- across every CA county, applies per-check thresholds (see the skill's
+-- backend at scripts/dispatcher/llm_carry_forward_probe.py), and either
+--   - posts a summary comment on a long-lived audit-log issue, OR
+--   - files a new agent/ready follow-up issue when any threshold trips.
+--
+-- The bug class — silent LLM carry-forward in multi-case CA tentative-
+-- ruling PDFs — was documented in #3649 and went unnoticed for months.
+-- A weekly periodic sweep keeps that quiet failure from re-emerging
+-- between manual /spotcheck invocations.
+--
+-- Design notes
+-- ------------
+-- * name='audit-llm-carry-forward' matches the skill dir name
+--   (.claude/skills/audit-llm-carry-forward/) and the slash-command
+--   (/audit-llm-carry-forward) per the entrypoint contract:
+--   phase=<name> -> claude -p <skill_invocation>.
+--
+-- * trigger_kind='cron', trigger_value='0 6 * * 0' — fires weekly on
+--   Sunday at 06:00 UTC. Sunday morning is intentionally off-peak so
+--   the audit doesn't compete with weekday spotcheck/audit traffic for
+--   the dispatcher concurrency budget. Operators can temporarily
+--   override the trigger_value to '*/5 * * * *' in the DB for one-cycle
+--   verification, then restore.
+--
+-- * ON CONFLICT (name) DO NOTHING — idempotent; re-applying this
+--   migration after rollback does not duplicate the row or overwrite
+--   operator overrides already in place.
+--
+-- Rollback
+-- --------
+-- DELETE FROM dispatcher.scheduled_skills WHERE name='audit-llm-carry-forward'.
+-- The skill dir and audit_llm_carry_forward.py / llm_carry_forward_probe.py
+-- remain (no code is auto-deleted).
+
+INSERT INTO dispatcher.scheduled_skills (
+    name, skill_invocation, trigger_kind, trigger_value, enabled, notes
+)
+VALUES (
+    'audit-llm-carry-forward',
+    '/audit-llm-carry-forward',
+    'cron',
+    '0 6 * * 0',
+    true,
+    'Weekly LLM carry-forward audit across CA counties (issue #4309). '
+    || 'Fires Sunday 06:00 UTC; runs scripts/audit_llm_carry_forward.py '
+    || 'via scripts/dispatcher/llm_carry_forward_probe.py and either '
+    || 'posts a summary comment on the long-lived audit-log issue or '
+    || 'files an agent/ready follow-up when per-check thresholds trip. '
+    || 'Bug class — silent LLM rule-5b carry-forward in multi-case PDFs — '
+    || 'first documented in #3649; weekly cadence keeps it from going '
+    || 'silent again between manual /spotcheck invocations.'
+)
+ON CONFLICT (name) DO NOTHING;
+
+
+-- Down Migration
+DELETE FROM dispatcher.scheduled_skills WHERE name = 'audit-llm-carry-forward';

--- a/scripts/dispatcher/llm_carry_forward_probe.py
+++ b/scripts/dispatcher/llm_carry_forward_probe.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""LLM carry-forward periodic-probe backend — /audit-llm-carry-forward skill (#4309).
+
+Wraps :func:`scripts.audit_llm_carry_forward.run_audit` with threshold logic
+and emits a structured findings list the SKILL.md wrapper consumes.
+
+Threshold rules (from issue #4309):
+
+* ``outcome_continue`` — any non-zero count for any county is worth flagging.
+  This is the strongest carry-forward signal and the bug class baseline as
+  of 2026-05-06 was a single county at total=5; a clean run is zero.
+
+* ``all_same_case_title_cluster`` — splitter-protected counties (Riverside,
+  Fresno, San Diego, LA, post-#4286 wiring) should produce ≤ 4. Threshold:
+  > 5 per non-Riverside county. Riverside has a historical backlog of
+  pre-splitter rulings (baseline 167 on 2026-05-06); flag only when
+  Riverside crosses ``riverside_legacy_cap`` (default 80) so the report
+  remains actionable until a reingest sweep clears that history.
+
+* ``motion_type_contradiction`` and ``case_title_text_mismatch`` — noisy
+  per-rule axes that the LLM trips on for legitimate reasons (motion-type
+  taxonomy gaps, party-name redaction). Flag only on a > 25% jump versus
+  the previous run's per-county count. On the first ever run there is no
+  prior baseline, so these axes are silent until the second fire.
+
+A finding's ``should_file_issue`` field tells the SKILL.md wrapper whether
+to file an ``agent/ready`` follow-up (true) or just append to the long-lived
+audit-log issue (false). The default is to file when ANY county trips a
+threshold; otherwise the wrapper posts a heartbeat comment.
+
+Usage::
+
+    scripts/dispatcher/llm_carry_forward_probe.py \\
+        --output tmp/llm-carry-forward/findings.json \\
+        --state tmp/llm-carry-forward/last_totals.json
+
+The ``--state`` path is read for prior totals (jump-detection) and rewritten
+on success. Missing state file => first-run mode (no jump-detection).
+
+Exit codes:
+    0   Probe completed; JSON written.
+    1   DATABASE_URL missing, DB connection failed, audit error.
+"""
+# venv: scraper-framework
+# permanent: true
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Threshold defaults (overridable via CLI). Sourced from issue #4309's
+# 2026-05-06 baseline.
+DEFAULT_CLUSTER_THRESHOLD: int = 5
+DEFAULT_RIVERSIDE_LEGACY_CAP: int = 80
+DEFAULT_NOISY_JUMP_FRACTION: float = 0.25  # 25% jump
+RIVERSIDE_NAMES: frozenset[str] = frozenset({"riverside"})
+
+NOISY_AXES: tuple[str, ...] = (
+    "motion_type_contradiction",
+    "case_title_text_mismatch",
+)
+
+
+@dataclass
+class Finding:
+    """A single threshold-trip finding for the SKILL.md wrapper."""
+
+    probe: str  # e.g. "outcome_continue", "cluster_riverside", "jump_motion_type"
+    county: str
+    title: str
+    body: str
+    severity: str  # "info" | "warning" | "critical"
+    should_file_issue: bool
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def _is_riverside(county: str) -> bool:
+    """Case-insensitive Riverside detector."""
+    return county.lower() in RIVERSIDE_NAMES
+
+
+def evaluate(
+    summary: dict[str, Any],
+    *,
+    prior_totals: dict[str, dict[str, int]] | None = None,
+    cluster_threshold: int = DEFAULT_CLUSTER_THRESHOLD,
+    riverside_legacy_cap: int = DEFAULT_RIVERSIDE_LEGACY_CAP,
+    noisy_jump_fraction: float = DEFAULT_NOISY_JUMP_FRACTION,
+) -> list[Finding]:
+    """Apply per-county thresholds to ``summary`` (the ``run_audit`` output).
+
+    ``prior_totals`` maps ``county -> {axis: count}`` from the previous
+    successful run. ``None`` => first-run mode (skip noisy-axis jump check).
+    """
+    findings: list[Finding] = []
+    counties: dict[str, dict[str, Any]] = summary.get("counties", {})
+
+    for county_name in sorted(counties):
+        c = counties[county_name]
+        # --- outcome_continue: any non-zero is worth a fire -----------------
+        oc_count = int(c["outcome_continue"]["count"])
+        if oc_count > 0:
+            findings.append(
+                Finding(
+                    probe="outcome_continue",
+                    county=county_name,
+                    title=(
+                        f"[llm-carry-forward outcome_continue {county_name}] "
+                        f"{oc_count} ruling(s) with definitive outcome but "
+                        f"continuance text"
+                    ),
+                    body=_render_axis_body(
+                        county_name,
+                        "outcome_continue",
+                        oc_count,
+                        c["outcome_continue"]["examples"],
+                        rule=(
+                            "Any non-zero `outcome_continue` count is a strong "
+                            "LLM rule-5b carry-forward signal. The LLM emitted "
+                            "outcome=granted/denied for a ruling whose text "
+                            "starts with continuance boilerplate — almost "
+                            "certainly the page-1 outcome was copied onto a "
+                            "page-N continuance entry."
+                        ),
+                    ),
+                    severity="warning",
+                    should_file_issue=True,
+                    details={
+                        "count": oc_count,
+                        "examples": c["outcome_continue"]["examples"],
+                    },
+                )
+            )
+
+        # --- all_same_case_title_cluster: threshold per county --------------
+        cluster_count = int(c["all_same_case_title_cluster"]["count"])
+        if _is_riverside(county_name):
+            cluster_cap = riverside_legacy_cap
+            cap_label = (
+                f"Riverside legacy cap ({riverside_legacy_cap}) — pre-#4286 "
+                f"backlog still on file. Drop the cap to {cluster_threshold} "
+                f"once the post-#4286 reingest sweep clears history."
+            )
+        else:
+            cluster_cap = cluster_threshold
+            cap_label = (
+                f"Splitter-protected counties should be ≤ {cluster_threshold}. "
+                f"Counts above this strongly suggest the splitter regressed or "
+                f"a multi-case PDF shape is uncovered."
+            )
+        if cluster_count > cluster_cap:
+            findings.append(
+                Finding(
+                    probe="all_same_case_title_cluster",
+                    county=county_name,
+                    title=(
+                        f"[llm-carry-forward cluster {county_name}] "
+                        f"{cluster_count} same-title clusters > cap "
+                        f"({cluster_cap})"
+                    ),
+                    body=_render_axis_body(
+                        county_name,
+                        "all_same_case_title_cluster",
+                        cluster_count,
+                        c["all_same_case_title_cluster"]["examples"],
+                        rule=cap_label,
+                    ),
+                    severity="warning",
+                    should_file_issue=True,
+                    details={
+                        "count": cluster_count,
+                        "cap": cluster_cap,
+                        "examples": c["all_same_case_title_cluster"]["examples"],
+                    },
+                )
+            )
+
+        # --- noisy axes: % jump vs prior run --------------------------------
+        if prior_totals is not None:
+            prior_county = prior_totals.get(county_name, {})
+            for axis in NOISY_AXES:
+                cur_count = int(c[axis]["count"])
+                prior_count = int(prior_county.get(axis, 0))
+                jump = _percent_jump(prior_count, cur_count)
+                if jump is not None and jump > noisy_jump_fraction:
+                    findings.append(
+                        Finding(
+                            probe=f"jump_{axis}",
+                            county=county_name,
+                            title=(
+                                f"[llm-carry-forward jump {axis} {county_name}] "
+                                f"{prior_count} -> {cur_count} "
+                                f"(+{jump:.0%})"
+                            ),
+                            body=_render_jump_body(
+                                county_name,
+                                axis,
+                                prior_count,
+                                cur_count,
+                                jump,
+                                c[axis]["examples"],
+                                noisy_jump_fraction,
+                            ),
+                            severity="warning",
+                            should_file_issue=True,
+                            details={
+                                "axis": axis,
+                                "prior_count": prior_count,
+                                "current_count": cur_count,
+                                "jump_fraction": jump,
+                                "examples": c[axis]["examples"],
+                            },
+                        )
+                    )
+    return findings
+
+
+def _percent_jump(prior: int, current: int) -> float | None:
+    """Return fractional jump (e.g. 0.30 == +30%) or ``None`` when meaningless.
+
+    Returns ``None`` when the prior count is zero (no baseline) AND the
+    current count is below a small floor (5) — sub-floor noise should not
+    fire. When the prior is zero but current is >= floor, returns infinity-
+    flavored 1.0 so it always trips a > 0 threshold.
+    """
+    if current <= prior:
+        return None
+    if prior == 0:
+        # Avoid division by zero. Only fire when current crosses a small
+        # absolute floor; below that the axis is sub-noise.
+        if current >= 5:
+            return float("inf")
+        return None
+    return (current - prior) / prior
+
+
+def _render_axis_body(
+    county: str,
+    axis: str,
+    count: int,
+    examples: list[dict[str, Any]],
+    *,
+    rule: str,
+) -> str:
+    """Render an issue body for a fixed-threshold axis."""
+    lines: list[str] = []
+    lines.append("## LLM carry-forward audit threshold tripped")
+    lines.append("")
+    lines.append(f"**County:** {county}")
+    lines.append(f"**Axis:** `{axis}`")
+    lines.append(f"**Count:** {count}")
+    lines.append("")
+    lines.append("### Rule")
+    lines.append(rule)
+    lines.append("")
+    lines.append("### Examples")
+    if examples:
+        for ex in examples:
+            lines.append(f"- `{json.dumps(ex, default=str)}`")
+    else:
+        lines.append("_(no examples returned by run_audit)_")
+    lines.append("")
+    lines.append(
+        "### Repro\n"
+        "```\n"
+        "scripts/ecs-run-task.sh scripts/audit_llm_carry_forward.py "
+        f"-- --county {county} --json\n"
+        "```\n"
+    )
+    lines.append(
+        "Filed automatically by the `/audit-llm-carry-forward` weekly "
+        "scheduled skill (issue #4309). Background context lives in #3649 "
+        "(original LLM rule-5b carry-forward bug) and #4289 (audit script)."
+    )
+    return "\n".join(lines)
+
+
+def _render_jump_body(
+    county: str,
+    axis: str,
+    prior: int,
+    current: int,
+    jump: float,
+    examples: list[dict[str, Any]],
+    threshold: float,
+) -> str:
+    """Render an issue body for a noisy-axis jump finding."""
+    if jump == float("inf"):
+        jump_str = "previous run was 0; current crossed the absolute floor"
+    else:
+        jump_str = f"+{jump:.0%} (threshold: +{threshold:.0%})"
+    lines: list[str] = []
+    lines.append("## LLM carry-forward audit jump detected")
+    lines.append("")
+    lines.append(f"**County:** {county}")
+    lines.append(f"**Axis:** `{axis}`")
+    lines.append(f"**Prior run:** {prior}")
+    lines.append(f"**Current run:** {current}")
+    lines.append(f"**Jump:** {jump_str}")
+    lines.append("")
+    lines.append(
+        "### Rule\n"
+        "Noisy axes (`motion_type_contradiction`, `case_title_text_mismatch`) "
+        "fire only on jumps >= 25% over the previous run's count. The trip "
+        "above suggests a regression — most likely the LLM started "
+        "mis-attributing a motion-type or party-name signal it previously "
+        "got right."
+    )
+    lines.append("")
+    lines.append("### Examples")
+    if examples:
+        for ex in examples:
+            lines.append(f"- `{json.dumps(ex, default=str)}`")
+    else:
+        lines.append("_(no examples returned by run_audit)_")
+    lines.append("")
+    lines.append(
+        "### Repro\n"
+        "```\n"
+        "scripts/ecs-run-task.sh scripts/audit_llm_carry_forward.py "
+        f"-- --county {county} --json\n"
+        "```\n"
+    )
+    lines.append(
+        "Filed automatically by the `/audit-llm-carry-forward` weekly "
+        "scheduled skill (issue #4309)."
+    )
+    return "\n".join(lines)
+
+
+def extract_county_totals(summary: dict[str, Any]) -> dict[str, dict[str, int]]:
+    """Project a ``run_audit`` summary down to ``{county: {axis: count}}``."""
+    out: dict[str, dict[str, int]] = {}
+    for county_name, c in summary.get("counties", {}).items():
+        out[county_name] = {
+            axis: int(c[axis]["count"])
+            for axis in (
+                "outcome_continue",
+                "motion_type_contradiction",
+                "case_title_text_mismatch",
+                "all_same_case_title_cluster",
+            )
+        }
+    return out
+
+
+def render_summary_comment(summary: dict[str, Any], findings: list[Finding]) -> str:
+    """Render a weekly heartbeat comment for the long-lived audit-log issue.
+
+    Posted whether or not any threshold tripped — the heartbeat tells
+    operators the periodic skill is still alive and lists the per-county
+    counts they would otherwise have to gather by hand.
+    """
+    lines: list[str] = []
+    totals = summary.get("totals", {})
+    lines.append("## Weekly LLM carry-forward audit")
+    lines.append("")
+    lines.append(f"**Total CA rulings audited:** {totals.get('rulings_audited', 0)}")
+    lines.append(
+        f"**outcome_continue:** {totals.get('outcome_continue', 0)} | "
+        f"**motion_type_contradiction:** {totals.get('motion_type_contradiction', 0)} | "
+        f"**case_title_text_mismatch:** {totals.get('case_title_text_mismatch', 0)} | "
+        f"**all_same_case_title_cluster:** {totals.get('all_same_case_title_cluster', 0)}"
+    )
+    lines.append("")
+    if findings:
+        lines.append(
+            f"**{len(findings)} threshold trip(s)** — see filed follow-up issues "
+            f"with title prefix `[llm-carry-forward …]`."
+        )
+        for f in findings:
+            lines.append(f"- {f.title}")
+    else:
+        lines.append("All thresholds clean — no follow-up issues filed.")
+    lines.append("")
+    # Per-county table (compact)
+    lines.append("### Per-county counts")
+    lines.append("")
+    lines.append("| County | Rulings | OutCont | MTypeMis | TitleMis | TitleClust |")
+    lines.append("|---|---:|---:|---:|---:|---:|")
+    for county_name in sorted(summary.get("counties", {})):
+        c = summary["counties"][county_name]
+        lines.append(
+            f"| {county_name} | {c['total_rulings']} | "
+            f"{c['outcome_continue']['count']} | "
+            f"{c['motion_type_contradiction']['count']} | "
+            f"{c['case_title_text_mismatch']['count']} | "
+            f"{c['all_same_case_title_cluster']['count']} |"
+        )
+    lines.append("")
+    lines.append("_Filed automatically by `/audit-llm-carry-forward` (issue #4309)._")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=("Run the LLM carry-forward periodic probe and emit findings JSON.")
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the findings + summary JSON envelope.",
+    )
+    parser.add_argument(
+        "--state",
+        default=None,
+        help=(
+            "Path to read+write per-county totals across runs (jump-detection). "
+            "Missing on first run is OK — noisy-axis jump checks are silent "
+            "until a baseline exists."
+        ),
+    )
+    parser.add_argument(
+        "--cluster-threshold",
+        type=int,
+        default=DEFAULT_CLUSTER_THRESHOLD,
+        help=(
+            f"Per-county all_same_case_title_cluster cap (default: "
+            f"{DEFAULT_CLUSTER_THRESHOLD})."
+        ),
+    )
+    parser.add_argument(
+        "--riverside-legacy-cap",
+        type=int,
+        default=DEFAULT_RIVERSIDE_LEGACY_CAP,
+        help=(
+            f"Riverside-only cluster cap until reingest sweep clears legacy "
+            f"history (default: {DEFAULT_RIVERSIDE_LEGACY_CAP})."
+        ),
+    )
+    parser.add_argument(
+        "--noisy-jump-fraction",
+        type=float,
+        default=DEFAULT_NOISY_JUMP_FRACTION,
+        help=(
+            f"Fractional jump that triggers a flag on noisy axes (default: "
+            f"{DEFAULT_NOISY_JUMP_FRACTION:.2f} == 25%%)."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _load_state(path: str | None) -> dict[str, dict[str, int]] | None:
+    """Best-effort load of prior per-county totals. Returns None if missing."""
+    if not path:
+        return None
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data  # type: ignore[return-value]
+
+
+def _save_state(path: str | None, totals: dict[str, dict[str, int]]) -> None:
+    """Best-effort save of current per-county totals."""
+    if not path:
+        return
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(totals, fh, indent=2, sort_keys=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        sys.stderr.write("llm_carry_forward_probe: DATABASE_URL not set\n")
+        return 1
+
+    # Lazy import — keeps the module importable without psycopg in CI.
+    try:
+        from scripts.audit_llm_carry_forward import run_audit  # noqa: PLC0415
+    except ImportError:  # pragma: no cover — defensive
+        sys.path.insert(
+            0,
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+            ),
+        )
+        from scripts.audit_llm_carry_forward import run_audit  # noqa: PLC0415
+
+    try:
+        summary = run_audit(dsn)
+    except Exception as exc:  # pragma: no cover — live DB failures
+        sys.stderr.write(f"llm_carry_forward_probe: audit error: {exc}\n")
+        return 1
+
+    prior = _load_state(args.state)
+    findings = evaluate(
+        summary,
+        prior_totals=prior,
+        cluster_threshold=args.cluster_threshold,
+        riverside_legacy_cap=args.riverside_legacy_cap,
+        noisy_jump_fraction=args.noisy_jump_fraction,
+    )
+
+    envelope = {
+        "summary": summary,
+        "totals_by_county": extract_county_totals(summary),
+        "findings": [asdict(f) for f in findings],
+        "comment_markdown": render_summary_comment(summary, findings),
+    }
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(envelope, fh, indent=2, default=str)
+
+    # Persist for next run's jump-detection.
+    _save_state(args.state, envelope["totals_by_county"])
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/scripts/dispatcher/tests/test_llm_carry_forward_probe.py
+++ b/scripts/dispatcher/tests/test_llm_carry_forward_probe.py
@@ -1,0 +1,452 @@
+"""Unit tests for scripts/dispatcher/llm_carry_forward_probe.py (issue #4309).
+
+Fixture-driven — no live database. Each test feeds a synthetic ``run_audit``
+summary into :func:`evaluate` and asserts the threshold logic produces the
+expected findings.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Make ``scripts`` importable without installing the repo as a package.
+# parents[2] from scripts/dispatcher/tests/ is scripts/.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher.llm_carry_forward_probe import (  # noqa: E402
+    DEFAULT_CLUSTER_THRESHOLD,
+    DEFAULT_RIVERSIDE_LEGACY_CAP,
+    Finding,
+    _load_state,
+    _percent_jump,
+    _save_state,
+    evaluate,
+    extract_county_totals,
+    render_summary_comment,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build synthetic ``run_audit`` summaries
+# ---------------------------------------------------------------------------
+
+
+def _county_bucket(
+    *,
+    rulings: int = 100,
+    outcome_continue: int = 0,
+    motion_type_contradiction: int = 0,
+    case_title_text_mismatch: int = 0,
+    cluster: int = 0,
+    examples: list | None = None,
+) -> dict:
+    """Build one county dict matching the run_audit shape."""
+    ex = examples or []
+    return {
+        "total_rulings": rulings,
+        "outcome_continue": {"count": outcome_continue, "examples": ex},
+        "motion_type_contradiction": {
+            "count": motion_type_contradiction,
+            "examples": ex,
+        },
+        "case_title_text_mismatch": {
+            "count": case_title_text_mismatch,
+            "examples": ex,
+        },
+        "all_same_case_title_cluster": {"count": cluster, "examples": ex},
+    }
+
+
+def _summary(counties: dict[str, dict]) -> dict:
+    """Wrap a counties dict in the run_audit envelope."""
+    return {
+        "filter": {"county": None, "since": None},
+        "counties": counties,
+        "totals": {
+            "rulings_audited": sum(c["total_rulings"] for c in counties.values()),
+            "outcome_continue": sum(
+                c["outcome_continue"]["count"] for c in counties.values()
+            ),
+            "motion_type_contradiction": sum(
+                c["motion_type_contradiction"]["count"] for c in counties.values()
+            ),
+            "case_title_text_mismatch": sum(
+                c["case_title_text_mismatch"]["count"] for c in counties.values()
+            ),
+            "all_same_case_title_cluster": sum(
+                c["all_same_case_title_cluster"]["count"] for c in counties.values()
+            ),
+        },
+        "all_clean": all(
+            c["outcome_continue"]["count"] == 0
+            and c["motion_type_contradiction"]["count"] == 0
+            and c["case_title_text_mismatch"]["count"] == 0
+            and c["all_same_case_title_cluster"]["count"] == 0
+            for c in counties.values()
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
+# outcome_continue — any non-zero is a flag
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_continue_any_nonzero_flags() -> None:
+    summary = _summary({"Ventura": _county_bucket(outcome_continue=1)})
+    findings = evaluate(summary, prior_totals=None)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.probe == "outcome_continue"
+    assert f.county == "Ventura"
+    assert f.should_file_issue is True
+    assert "outcome_continue" in f.title
+    assert "Ventura" in f.title
+
+
+def test_outcome_continue_zero_does_not_flag() -> None:
+    summary = _summary({"Ventura": _county_bucket(outcome_continue=0)})
+    findings = evaluate(summary, prior_totals=None)
+    # No findings at all when every axis is zero.
+    assert findings == []
+
+
+def test_outcome_continue_per_county_isolation() -> None:
+    """Each county trips its own finding."""
+    summary = _summary(
+        {
+            "Ventura": _county_bucket(outcome_continue=1),
+            "Santa Clara": _county_bucket(outcome_continue=2),
+            "Orange": _county_bucket(outcome_continue=0),
+        }
+    )
+    findings = [
+        f for f in evaluate(summary, prior_totals=None) if f.probe == "outcome_continue"
+    ]
+    assert {f.county for f in findings} == {"Ventura", "Santa Clara"}
+
+
+# ---------------------------------------------------------------------------
+# all_same_case_title_cluster — non-Riverside threshold (default 5)
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_below_default_threshold_does_not_flag() -> None:
+    summary = _summary({"San Diego": _county_bucket(cluster=DEFAULT_CLUSTER_THRESHOLD)})
+    findings = evaluate(summary, prior_totals=None)
+    # exactly == cap is not a trip; only > cap fires.
+    assert findings == []
+
+
+def test_cluster_above_default_threshold_flags() -> None:
+    summary = _summary(
+        {"San Diego": _county_bucket(cluster=DEFAULT_CLUSTER_THRESHOLD + 1)}
+    )
+    findings = evaluate(summary, prior_totals=None)
+    cluster_findings = [f for f in findings if f.probe == "all_same_case_title_cluster"]
+    assert len(cluster_findings) == 1
+    f = cluster_findings[0]
+    assert f.county == "San Diego"
+    assert f.should_file_issue is True
+    assert f.details["cap"] == DEFAULT_CLUSTER_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# all_same_case_title_cluster — Riverside legacy cap
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_riverside_below_legacy_cap_does_not_flag() -> None:
+    """Riverside has a documented backlog of 167 as of 2026-05-06; the legacy
+    cap (default 80) lets that history pass while still catching new growth.
+    """
+    summary = _summary(
+        {"Riverside": _county_bucket(cluster=DEFAULT_RIVERSIDE_LEGACY_CAP)}
+    )
+    findings = evaluate(summary, prior_totals=None)
+    # exactly == legacy cap is not a trip.
+    assert findings == []
+
+
+def test_cluster_riverside_above_legacy_cap_flags() -> None:
+    summary = _summary(
+        {"Riverside": _county_bucket(cluster=DEFAULT_RIVERSIDE_LEGACY_CAP + 1)}
+    )
+    findings = evaluate(summary, prior_totals=None)
+    cluster_findings = [f for f in findings if f.probe == "all_same_case_title_cluster"]
+    assert len(cluster_findings) == 1
+    assert cluster_findings[0].details["cap"] == DEFAULT_RIVERSIDE_LEGACY_CAP
+
+
+def test_cluster_riverside_uses_separate_cap_from_others() -> None:
+    """Riverside at 100 should pass (under legacy cap 80? no — over). Pick a
+    value that is over the default cluster_threshold (5) but under the
+    Riverside legacy cap (80)."""
+    summary = _summary(
+        {
+            "Riverside": _county_bucket(cluster=50),
+            "Ventura": _county_bucket(cluster=50),
+        }
+    )
+    findings = evaluate(summary, prior_totals=None)
+    cluster_counties = {
+        f.county for f in findings if f.probe == "all_same_case_title_cluster"
+    }
+    # Riverside (under legacy cap 80) does NOT flag; Ventura (over cap 5) does.
+    assert "Ventura" in cluster_counties
+    assert "Riverside" not in cluster_counties
+
+
+def test_cluster_riverside_case_insensitive() -> None:
+    """Riverside detector handles different casing variants."""
+    summary = _summary(
+        {"riverside": _county_bucket(cluster=10)},  # lowercase
+    )
+    findings = evaluate(summary, prior_totals=None)
+    cluster_findings = [f for f in findings if f.probe == "all_same_case_title_cluster"]
+    # 10 is below the Riverside legacy cap (80), so no flag — confirms the
+    # detector matched riverside as Riverside, not as a non-Riverside county
+    # (which would have flagged at threshold 5).
+    assert cluster_findings == []
+
+
+# ---------------------------------------------------------------------------
+# motion_type_contradiction / case_title_text_mismatch — % jump only
+# ---------------------------------------------------------------------------
+
+
+def test_noisy_axes_silent_on_first_run() -> None:
+    """No prior_totals means first-run mode — noisy axes never fire."""
+    summary = _summary({"Ventura": _county_bucket(motion_type_contradiction=999)})
+    findings = evaluate(summary, prior_totals=None)
+    # No noisy-axis fires; outcome_continue and cluster are zero.
+    assert findings == []
+
+
+def test_noisy_axes_jump_above_threshold_flags() -> None:
+    """+30% jump on a noisy axis (over the +25% default) should fire."""
+    summary = _summary({"Ventura": _county_bucket(motion_type_contradiction=130)})
+    findings = evaluate(
+        summary,
+        prior_totals={"Ventura": {"motion_type_contradiction": 100}},
+    )
+    jump_findings = [f for f in findings if f.probe.startswith("jump_")]
+    assert len(jump_findings) == 1
+    f = jump_findings[0]
+    assert f.probe == "jump_motion_type_contradiction"
+    assert f.details["prior_count"] == 100
+    assert f.details["current_count"] == 130
+    assert 0.29 < f.details["jump_fraction"] < 0.31
+
+
+def test_noisy_axes_jump_below_threshold_silent() -> None:
+    """+10% jump (under +25%) should not fire."""
+    summary = _summary({"Ventura": _county_bucket(motion_type_contradiction=110)})
+    findings = evaluate(
+        summary,
+        prior_totals={"Ventura": {"motion_type_contradiction": 100}},
+    )
+    jump_findings = [f for f in findings if f.probe.startswith("jump_")]
+    assert jump_findings == []
+
+
+def test_noisy_axes_decrease_silent() -> None:
+    """A drop in count never fires."""
+    summary = _summary({"Ventura": _county_bucket(case_title_text_mismatch=50)})
+    findings = evaluate(
+        summary,
+        prior_totals={"Ventura": {"case_title_text_mismatch": 100}},
+    )
+    assert all(not f.probe.startswith("jump_") for f in findings)
+
+
+def test_noisy_axes_zero_to_nonzero_below_floor_silent() -> None:
+    """Prior=0, current=2 must not fire (below 5-floor)."""
+    summary = _summary({"Ventura": _county_bucket(motion_type_contradiction=2)})
+    findings = evaluate(
+        summary,
+        prior_totals={"Ventura": {"motion_type_contradiction": 0}},
+    )
+    assert all(not f.probe.startswith("jump_") for f in findings)
+
+
+def test_noisy_axes_zero_to_floor_fires() -> None:
+    """Prior=0, current=5 fires (crosses the 5-floor)."""
+    summary = _summary({"Ventura": _county_bucket(motion_type_contradiction=5)})
+    findings = evaluate(
+        summary,
+        prior_totals={"Ventura": {"motion_type_contradiction": 0}},
+    )
+    jump_findings = [f for f in findings if f.probe.startswith("jump_")]
+    assert len(jump_findings) == 1
+
+
+def test_noisy_axes_threshold_override() -> None:
+    """Custom --noisy-jump-fraction is honored."""
+    summary = _summary({"Ventura": _county_bucket(motion_type_contradiction=110)})
+    findings = evaluate(
+        summary,
+        prior_totals={"Ventura": {"motion_type_contradiction": 100}},
+        noisy_jump_fraction=0.05,  # 5% → 10% jump fires
+    )
+    jump_findings = [f for f in findings if f.probe.startswith("jump_")]
+    assert len(jump_findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# _percent_jump
+# ---------------------------------------------------------------------------
+
+
+def test_percent_jump_normal() -> None:
+    assert _percent_jump(100, 130) == 0.30
+
+
+def test_percent_jump_zero_prior_below_floor() -> None:
+    assert _percent_jump(0, 4) is None
+
+
+def test_percent_jump_zero_prior_at_floor() -> None:
+    assert _percent_jump(0, 5) == float("inf")
+
+
+def test_percent_jump_no_change() -> None:
+    assert _percent_jump(50, 50) is None
+
+
+def test_percent_jump_decrease() -> None:
+    assert _percent_jump(100, 50) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_county_totals + state round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_extract_county_totals_shape() -> None:
+    summary = _summary(
+        {
+            "Ventura": _county_bucket(outcome_continue=2, cluster=3),
+            "San Diego": _county_bucket(case_title_text_mismatch=10),
+        }
+    )
+    totals = extract_county_totals(summary)
+    assert totals["Ventura"]["outcome_continue"] == 2
+    assert totals["Ventura"]["all_same_case_title_cluster"] == 3
+    assert totals["Ventura"]["motion_type_contradiction"] == 0
+    assert totals["San Diego"]["case_title_text_mismatch"] == 10
+
+
+def test_state_roundtrip(tmp_path) -> None:
+    """_save_state writes JSON readable by _load_state."""
+    path = str(tmp_path / "state.json")
+    totals = {"Ventura": {"outcome_continue": 1, "motion_type_contradiction": 7}}
+    _save_state(path, totals)
+    loaded = _load_state(path)
+    assert loaded == totals
+
+
+def test_load_state_missing_returns_none(tmp_path) -> None:
+    """Missing state file is first-run mode (returns None)."""
+    path = str(tmp_path / "absent.json")
+    assert _load_state(path) is None
+
+
+def test_load_state_malformed_returns_none(tmp_path) -> None:
+    """Malformed JSON is treated as first-run."""
+    path = tmp_path / "bad.json"
+    path.write_text("not json{", encoding="utf-8")
+    assert _load_state(str(path)) is None
+
+
+def test_load_state_none_path_returns_none() -> None:
+    """Explicit None path is first-run mode."""
+    assert _load_state(None) is None
+
+
+# ---------------------------------------------------------------------------
+# render_summary_comment
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_comment_clean_run() -> None:
+    """Clean run renders a heartbeat with totals and 'all clean' line."""
+    summary = _summary(
+        {
+            "Ventura": _county_bucket(rulings=200),
+            "Riverside": _county_bucket(rulings=400),
+        }
+    )
+    text = render_summary_comment(summary, [])
+    assert "Weekly LLM carry-forward audit" in text
+    assert "All thresholds clean" in text
+    assert "Ventura" in text
+    assert "Riverside" in text
+
+
+def test_render_summary_comment_with_findings() -> None:
+    """Comment with findings names the trips and counts them."""
+    summary = _summary({"Ventura": _county_bucket(outcome_continue=2)})
+    findings = evaluate(summary, prior_totals=None)
+    text = render_summary_comment(summary, findings)
+    assert "1 threshold trip" in text or "1 threshold trips" in text
+    assert "outcome_continue" in text
+
+
+# ---------------------------------------------------------------------------
+# Finding shape — title + body invariants for SKILL.md consumption
+# ---------------------------------------------------------------------------
+
+
+def test_finding_title_starts_with_bracketed_prefix() -> None:
+    """SKILL.md dedups by bracketed title prefix; titles must start with `[`."""
+    summary = _summary({"Ventura": _county_bucket(outcome_continue=1)})
+    findings = evaluate(summary, prior_totals=None)
+    for f in findings:
+        assert f.title.startswith("[llm-carry-forward "), (
+            f"finding title must start with '[llm-carry-forward ' for SKILL.md "
+            f"dedup search; got {f.title!r}"
+        )
+
+
+def test_finding_body_includes_county_axis_repro() -> None:
+    """Bodies should self-describe enough that an agent can act on them."""
+    summary = _summary({"Ventura": _county_bucket(outcome_continue=1)})
+    findings = evaluate(summary, prior_totals=None)
+    f = findings[0]
+    assert "Ventura" in f.body
+    assert "outcome_continue" in f.body
+    # Repro stanza references the audit script and county filter.
+    assert "audit_llm_carry_forward.py" in f.body
+    assert "--county Ventura" in f.body
+
+
+def test_findings_serializable_to_json() -> None:
+    """The probe writes findings via dataclasses.asdict + json.dumps; ensure
+    everything in the Finding round-trips cleanly."""
+    summary = _summary(
+        {
+            "Ventura": _county_bucket(
+                outcome_continue=1, cluster=10, examples=[{"k": "v"}]
+            )
+        }
+    )
+    findings = evaluate(summary, prior_totals=None)
+    from dataclasses import asdict
+
+    payload = json.dumps([asdict(f) for f in findings], default=str)
+    parsed = json.loads(payload)
+    assert isinstance(parsed, list)
+    assert all(isinstance(item, dict) for item in parsed)
+    assert all("title" in item and "body" in item for item in parsed)
+
+
+def test_evaluate_returns_finding_instances() -> None:
+    """Type guard: evaluate returns Finding objects, not dicts."""
+    summary = _summary({"Ventura": _county_bucket(outcome_continue=1)})
+    findings = evaluate(summary, prior_totals=None)
+    assert all(isinstance(f, Finding) for f in findings)

--- a/scripts/dispatcher/tests/test_scheduled_skills_llm_carry_forward_row.py
+++ b/scripts/dispatcher/tests/test_scheduled_skills_llm_carry_forward_row.py
@@ -1,0 +1,66 @@
+"""Migration test for migration 63 — audit-llm-carry-forward scheduled skill row (#4309).
+
+Asserts that the migration file inserts a row for the audit-llm-carry-forward
+skill with the expected name, skill_invocation, trigger_kind, trigger_value,
+and enabled=true. Models the pattern from
+test_scheduled_skills_dispatcher_audit_row.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "packages"
+    / "api"
+    / "migrations"
+    / "63_dispatcher-llm-carry-forward-skill.sql"
+)
+
+
+def _migration_text() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.is_file(), (
+        f"expected migration file at {MIGRATION_PATH}; issue #4309 ships migration 63"
+    )
+
+
+def test_llm_carry_forward_row_seeded() -> None:
+    """Migration 63 must INSERT the audit-llm-carry-forward row."""
+    text = _migration_text()
+    assert "INSERT INTO dispatcher.scheduled_skills" in text
+    assert "'audit-llm-carry-forward'" in text
+    assert "'/audit-llm-carry-forward'" in text
+    assert "'cron'" in text
+    # Sunday 06:00 UTC weekly cadence.
+    assert "'0 6 * * 0'" in text
+
+
+def test_llm_carry_forward_row_enabled() -> None:
+    """Migration 63 INSERT row must have enabled=true."""
+    text = _migration_text()
+    assert "true" in text, "enabled column must be set to true"
+
+
+def test_llm_carry_forward_row_idempotent() -> None:
+    """Migration 63 INSERT must use ON CONFLICT (name) DO NOTHING."""
+    text = _migration_text()
+    assert "ON CONFLICT (name) DO NOTHING" in text
+
+
+def test_llm_carry_forward_down_migration() -> None:
+    """Migration 63 must have a Down Migration block that deletes the row."""
+    text = _migration_text()
+    assert "-- Down Migration" in text
+    assert "DELETE FROM dispatcher.scheduled_skills" in text
+    assert "'audit-llm-carry-forward'" in text
+
+
+def test_llm_carry_forward_references_issue() -> None:
+    """The notes / comments should reference issue #4309 for traceability."""
+    text = _migration_text()
+    assert "#4309" in text


### PR DESCRIPTION
## Summary

Wires `scripts/audit_llm_carry_forward.py` (#4289 / PR #4302) into the dispatcher's periodic-skill scheduler as a weekly Sunday 06:00 UTC cron. Migration 63 registers the row, a thin probe wrapper applies the issue's per-axis thresholds, and a new `/audit-llm-carry-forward` SKILL.md files agent/ready follow-ups for trips and posts a heartbeat comment on the long-lived audit-log issue.

Closes #4309

### What this prevents

The bug class — silent LLM rule-5b carry-forward in multi-case CA tentative-ruling PDFs — was first documented in #3649 and went unnoticed for months. PR #4286 fixed Riverside via a deterministic pre-LLM splitter, but any CA county with a custom LLM prompt and no splitter is at the same risk. A weekly periodic sweep means the bug class can no longer go silent again between manual `/spotcheck` invocations.

### Threshold rules (from issue body)

- `outcome_continue`: any non-zero count for any county fires (strongest carry-forward signal).
- `all_same_case_title_cluster`: > 5 per non-Riverside county; > 80 for Riverside (legacy backlog cap until post-#4286 reingest sweep clears history).
- `motion_type_contradiction`, `case_title_text_mismatch`: > 25% jump versus the prior run, with a 5-count absolute floor to silence sub-noise. Silent on the first ECS-launched fire (no baseline yet) and self-calibrating thereafter.

All three thresholds are CLI flags (`--cluster-threshold`, `--riverside-legacy-cap`, `--noisy-jump-fraction`) so an operator can tune via the `notes` column without code changes.

### Files

- `packages/api/migrations/63_dispatcher-llm-carry-forward-skill.sql` — INSERT + ON CONFLICT DO NOTHING, idempotent.
- `scripts/dispatcher/llm_carry_forward_probe.py` — wraps `audit_llm_carry_forward.run_audit()` with threshold logic, renders heartbeat + per-finding bodies, manages the `last_totals.json` state file.
- `.claude/skills/audit-llm-carry-forward/SKILL.md` — runs the probe, dedups by bracketed title prefix, files agent/ready follow-ups for trips, posts a heartbeat on the long-lived `source/audit-llm-carry-forward-log` issue (creating it on the first fire).
- `scripts/dispatcher/tests/test_llm_carry_forward_probe.py` — 32 fixture-driven threshold-trip tests.
- `scripts/dispatcher/tests/test_scheduled_skills_llm_carry_forward_row.py` — 6 migration-text assertions matching the dispatcher-audit and daily-report patterns.

### Note on the AC's `Verify:` query

The first AC's literal `Verify:` query references a `schedule` column that does not exist on `dispatcher.scheduled_skills` — the actual schema has `trigger_kind` + `trigger_value`. The implementation matches the actual schema; verification on dev uses `SELECT name, trigger_kind, trigger_value, enabled, last_triggered_at FROM dispatcher.scheduled_skills WHERE name = 'audit-llm-carry-forward'`. Called out in the process summary comment on the issue.

### Known limitation (filed as #4317)

Post-deploy verification surfaced a pre-existing bug in `should_fire_cron`: a 24-hour iteration cap silently kills weekly cron rows after the first fire. The first fire works (NULL-anchor 24h lookback). Filed as `priority/p1 agent/ready` so the dispatcher's own scheduler picks it up before the second weekly slot opens.

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (38 new tests; full dispatcher suite 2271 passed locally)
- [x] CI green

### Post-deploy verification
- [x] Migration 63 applied on dev — `dispatcher.scheduled_skills` row present with `enabled=true`, `trigger_kind='cron'`, `trigger_value='0 6 * * 0'`.
- [x] dispatcher daemon image at merge SHA contains the new SKILL.md and probe (deploy-dispatcher run 25566438291 succeeded).
- [x] `should_fire_cron` correctly schedules the first fire (NULL-anchor 24h lookback verified locally).
- [x] Verification evidence posted on issue (see A.8 + #4317 caveat).
