### PR TITLE
fix(dispatcher): bump should_fire_cron walk cap to 8 days for weekly cron (#4317)

### DIFF
--- a/scripts/dispatcher/scheduled_skills.py
+++ b/scripts/dispatcher/scheduled_skills.py
@@ -30,10 +30,20 @@ from datetime import datetime, timedelta
 #: Lookback window used when ``last_triggered_at`` is NULL (first-ever fire or
 #: manually reset).  Walking 24 hours ensures that a cron whose exact minute
 #: already passed today is still found and fired once on the next daemon tick,
-#: matching standard cron "fire exactly once if missed" semantics.  24 hours
-#: also matches the existing 24h iteration-cap safety guard so the two
-#: constants stay in sync without an extra config knob.
+#: matching standard cron "fire exactly once if missed" semantics.
 _NULL_ANCHOR_LOOKBACK = timedelta(hours=24)
+
+#: Maximum minutes the walk will scan from ``anchor + 1m`` toward ``now``.
+#: Set to 8 days = 11,520 minutes so a weekly cron whose anchor is its prior
+#: fire (≈7 days = 10,080 minutes back) still finds its next match (issue
+#: #4317).  Wider than the NULL-anchor lookback so weekly cron rows fire at
+#: their target minute even after their first fire stamps
+#: ``last_triggered_at``.  Still bounds the walk so a daemon offline for
+#: many days does not enumerate hundreds of thousands of minutes — an
+#: offline-for-9+-days daemon hits the cap and yields control without
+#: firing on this tick (it will fire on a later tick once the daemon is
+#: caught up to within the 8-day window).
+_WALK_CAP_MINUTES = 60 * 24 * 8  # 11,520 minutes = 8 days
 
 
 # Field bounds, matching the standard 5-field cron layout:
@@ -162,15 +172,16 @@ def should_fire_cron(
     full :data:`_NULL_ANCHOR_LOOKBACK` (24 hours) from ``now``.  This
     ensures the most-recent past match within the last day is found
     and fired exactly once on this tick, even if the cron's target
-    minute already passed today.  The existing 24h iteration cap (see
-    below) bounds the walk identically, so no extra config knob is
-    needed.
+    minute already passed today.
 
     Bounds:
-      - The walk is capped at 24 hours so a daemon that was offline
-        for days does not enumerate hundreds of thousands of minutes.
-        A cron that fires at most daily is guaranteed to find its
-        match in 1440 iterations.
+      - The walk is capped at :data:`_WALK_CAP_MINUTES` (8 days =
+        11,520 minutes) so a daemon offline for very long does not
+        enumerate hundreds of thousands of minutes.  Hourly, daily,
+        and weekly crons all find their match within the cap; a
+        daemon offline for 9+ days hits the cap and skips firing on
+        this tick (it will fire on a later tick once the daemon is
+        caught up to within the 8-day window).
     """
     schedule = parse_cron(expression)
     if last_triggered_at is None:
@@ -192,7 +203,7 @@ def should_fire_cron(
             return True
         cursor += timedelta(minutes=1)
         iterations += 1
-        if iterations > 60 * 24:  # 24h safety cap
+        if iterations > _WALK_CAP_MINUTES:  # 8-day safety cap (issue #4317)
             break
     return False
 

--- a/scripts/dispatcher/tests/test_scheduled_skills_cron.py
+++ b/scripts/dispatcher/tests/test_scheduled_skills_cron.py
@@ -152,8 +152,9 @@ class TestShouldFireCron:
         assert should_fire_cron("0 14 * * *", last, now) is False
 
     def test_offline_for_days_caps_at_24h(self) -> None:
-        # Daemon offline for 7 days — the walk caps at 24h, but a
-        # daily cron is guaranteed to find its match within that window.
+        # Daemon offline for 7 days — well within the 8-day walk cap
+        # (#4317), and a daily cron is guaranteed to find its match.
+        # (Test name retained for git history; the cap is 8 days now.)
         last = datetime(2026, 4, 18, 14, 0, tzinfo=UTC)
         now = datetime(2026, 4, 25, 14, 0, tzinfo=UTC)
         assert should_fire_cron("0 14 * * *", last, now) is True
@@ -193,3 +194,47 @@ class TestShouldFireCron:
         assert (
             should_fire_cron("0 12 * * *", last_after_first_fire, now_second) is False
         )
+
+    # ------------------------------------------------------------------
+    # Weekly cron 8-day cap (issue #4317)
+    #
+    # Before the fix the walk was capped at 24h (1440 minutes), which
+    # silently truncated weekly crons after their first fire — the next
+    # match is 7 days = 10,080 minutes past the anchor, well beyond 1440.
+    # Bumping the cap to 8 days = 11,520 minutes lets weekly crons land
+    # while still bounding an offline-for-9+-days daemon.
+    # ------------------------------------------------------------------
+
+    def test_weekly_cron_after_first_fire_fires_next_week(self) -> None:
+        """AC #1: weekly Sunday 06:00Z cron fires the following Sunday.
+
+        Anchor (last_triggered_at) is 2026-05-03 06:00Z (a Sunday); now
+        is 2026-05-10 06:01Z (the next Sunday, one minute past the
+        target). Before the 24h cap fix this returned False; with the
+        8-day cap it correctly returns True.
+        """
+        prev_sunday = datetime(2026, 5, 3, 6, 0, tzinfo=UTC)
+        this_sunday = datetime(2026, 5, 10, 6, 1, tzinfo=UTC)
+        assert should_fire_cron("0 6 * * 0", prev_sunday, this_sunday) is True
+
+    def test_weekly_cron_no_premature_fire_mid_week(self) -> None:
+        """A weekly Sunday 06:00Z cron must not fire mid-week.
+
+        Anchor 2026-05-03 06:00Z (Sunday), now 2026-05-07 06:00Z
+        (Thursday). No matching minute in that range → False. Guards
+        against a too-greedy cap that would let unrelated minutes match.
+        """
+        anchor = datetime(2026, 5, 3, 6, 0, tzinfo=UTC)
+        thursday = datetime(2026, 5, 7, 6, 0, tzinfo=UTC)
+        assert should_fire_cron("0 6 * * 0", anchor, thursday) is False
+
+    def test_offline_for_eight_days_caps(self) -> None:
+        """Daemon offline > cap: walk caps at 8 days, daily cron still found.
+
+        anchor 9 days back, now today 14:00Z, schedule daily 14:00 — the
+        walk caps at 8 days = 11,520 minutes which is still enough to
+        find a daily match within the window.
+        """
+        last = datetime(2026, 4, 16, 14, 0, tzinfo=UTC)
+        now = datetime(2026, 4, 25, 14, 0, tzinfo=UTC)
+        assert should_fire_cron("0 14 * * *", last, now) is True


### PR DESCRIPTION
## Summary

Bumps `should_fire_cron`'s walk-iteration cap from 24h (1,440 minutes) to 8 days (11,520 minutes) so weekly cron rows fire correctly after their first fire stamps `last_triggered_at`. The 24h cap silently truncated the minute-by-minute walk before it could reach the next-week match (≈10,080 minutes out), making weekly crons fire exactly once via the NULL-anchor lookback and then never again — for example, the new `audit-llm-carry-forward` row added in #4309.

The cap is the offline-daemon-protection guard, not a "fires-at-most-daily" assertion. Bumping to 8 days preserves the offline protection (an offline-9+-day daemon still hits the cap and yields control) while supporting hourly, daily, and weekly cadences. Option B (O(1) `last_match_before`) is left as a future refactor as the issue suggests.

Closes #4317

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Confirm dispatcher daemon restarts on the new image (`scripts/verify-pr-in-deployed-sha.sh 4323` returns "landed in deployed SHA 918274d, distance: 0 commits")
- [x] Deploy run [25568172766](https://github.com/judgemind/judgemind/actions/runs/25568172766) green (Build+Push 1m42s, Deploy-to-Dev 2m51s)
- [x] Verification evidence posted on #4317
