### PR TITLE
feat(dx): wire check-subprocess-timeouts.sh into pre-push hook (#4328)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -757,6 +757,40 @@ if [ -n "$changed_scripts_py" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Subprocess-timeouts check — run whenever scripts/**/*.py changes
+# (excluding any tests/ path)
+# -------------------------------------------------------------------
+# Mirrors the CI `Verify every subprocess.run call in scripts has
+# timeout= or **kwargs` step inside the `scripts-tests (python)` job
+# (.github/workflows/ci.yml). The check enforces the #3213 / #3309
+# invariant that every subprocess.run / urllib.request.urlopen call
+# under scripts/**/*.py carries a bounded timeout (or a **kwargs splat
+# that delegates to the caller). An unbounded network egress on the
+# MainThread of a long-lived process can wedge the daemon silently
+# forever — the prime hypothesis for the #3205 silent-wedge class.
+#
+# The check script itself walks scripts/**/*.py and is sub-second, so
+# we only need to invoke it when a scripts/**/*.py file is in the diff.
+# Excludes paths containing /tests/ since the check itself ignores them.
+# Catches the #4316 / PR #4324 retro case where an agent burned a full
+# CI round trip on a one-line `timeout=30` miss. See #4328.
+changed_scripts_py_recursive=$(echo "$changed_files" | grep -E '^scripts/.*\.py$' | grep -v '/tests/' || true)
+if [ -n "$changed_scripts_py_recursive" ]; then
+    echo "pre-push: checking subprocess.run / urlopen timeouts in scripts/**/*.py..." >&2
+    if [ -x scripts/check-subprocess-timeouts.sh ]; then
+        if ! run_check "_" "scripts/check-subprocess-timeouts.sh" scripts/check-subprocess-timeouts.sh; then
+            echo "  A subprocess.run or urllib.request.urlopen call site in" >&2
+            echo "  scripts/**/*.py is missing a timeout= kwarg or **kwargs splat." >&2
+            echo "  Add timeout=<seconds> to each flagged call. See issues #3213" >&2
+            echo "  (subprocess.run) and #3309 (urlopen) for background." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-subprocess-timeouts.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Rebase silent-drop guard — run whenever an appended-list file changes
 # -------------------------------------------------------------------
 # Detects markers in WATCH_FILES that would be silently dropped by

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -972,6 +972,86 @@ YML
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# Scenario 20: scripts/*.py with bare subprocess.run rejected (#4328)
+# ───────────────────────────────────────────────────────────────────────
+# Seeds scripts/foo.py with a subprocess.run call that has no timeout=
+# kwarg and no **kwargs splat, copies the real check script into the
+# scratch repo (mirrors scenarios 5/18/19), and asserts the hook exits
+# non-zero with the expected FAILED message. Mirrors the CI step
+# "Verify every subprocess.run call in scripts has timeout= or **kwargs"
+# inside the scripts-tests (python) job.
+echo "[scenario 20] scripts/*.py with bare subprocess.run — hook rejects push (#4328)"
+init_workspace
+
+SUBP_TIMEOUTS_SH="$REPO_ROOT/scripts/check-subprocess-timeouts.sh"
+if [ ! -x "$SUBP_TIMEOUTS_SH" ]; then
+    report_skip "scripts/check-subprocess-timeouts.sh unavailable — cannot exercise"
+else
+    git -C "$WORK" checkout --quiet -b feature-bare-subprocess
+    mkdir -p "$WORK/scripts"
+    cp "$SUBP_TIMEOUTS_SH" "$WORK/scripts/check-subprocess-timeouts.sh"
+    chmod +x "$WORK/scripts/check-subprocess-timeouts.sh"
+    # Write a scripts/*.py file with a subprocess.run call that lacks a
+    # timeout= kwarg AND a **kwargs splat — exactly the shape #4328
+    # wires the hook to catch.
+    cat > "$WORK/scripts/foo.py" <<'PY'
+"""Test fixture for #4328 — bare subprocess.run with no timeout."""
+
+import subprocess
+
+
+def run_git_status() -> None:
+    """Run git status without a timeout — must be rejected by the hook."""
+    subprocess.run(["git", "status"], check=True)
+PY
+    git -C "$WORK" add scripts/foo.py scripts/check-subprocess-timeouts.sh
+    git -C "$WORK" commit --quiet -m "feat: add scripts/foo.py with bare subprocess.run"
+    feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+    run_hook "refs/heads/feature-bare-subprocess $feat_sha refs/heads/feature-bare-subprocess $ZERO_SHA"
+
+    if [ "$hook_rc" -eq 0 ]; then
+        report_fail "expected hook to reject bare subprocess.run (#4328), exit was 0" "$hook_out"
+    elif ! echo "$hook_out" | grep -q "FAILED: scripts/check-subprocess-timeouts.sh"; then
+        report_fail "expected 'FAILED: scripts/check-subprocess-timeouts.sh' in output (#4328)" "$hook_out"
+    elif ! echo "$hook_out" | grep -q "scripts/foo.py"; then
+        report_fail "expected hook output to name the violating file 'scripts/foo.py' (#4328)" "$hook_out"
+    else
+        report_pass "hook rejects push with bare subprocess.run in scripts/*.py (#4328)"
+    fi
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 21: docs-only push does NOT fire subprocess-timeouts (#4328 AC2)
+# ───────────────────────────────────────────────────────────────────────
+# A push that touches only docs/*.md must NOT invoke the
+# subprocess-timeouts check (per the AC: "no overhead on pure
+# docs/CI/Terraform pushes"). Verifies the hook's path filter is doing
+# its job. Asserts the hook does not emit the
+# "checking subprocess.run / urlopen timeouts" probe line.
+echo "[scenario 21] docs-only push — subprocess-timeouts gate must NOT fire (#4328 AC2)"
+init_workspace
+
+git -C "$WORK" checkout --quiet -b feature-docs-only
+mkdir -p "$WORK/docs"
+cat > "$WORK/docs/foo.md" <<'MD'
+# Sample doc
+
+This is a sample documentation file.
+MD
+git -C "$WORK" add docs/foo.md
+git -C "$WORK" commit --quiet -m "docs: add foo.md"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+run_hook "refs/heads/feature-docs-only $feat_sha refs/heads/feature-docs-only $ZERO_SHA"
+
+if echo "$hook_out" | grep -q "checking subprocess.run / urlopen timeouts"; then
+    report_fail "docs-only push must NOT fire subprocess-timeouts gate (#4328 AC2)" "$hook_out"
+else
+    report_pass "docs-only push skips subprocess-timeouts gate (#4328 AC2)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Wires `scripts/check-subprocess-timeouts.sh` into `.githooks/pre-push` so contributors catch missing `timeout=` kwargs on `subprocess.run` / `urllib.request.urlopen` calls before pushing. The new gate fires only when a `scripts/**/*.py` file (excluding `tests/`) is in the push diff, mirroring the CI step in `.github/workflows/ci.yml`. Catches the #4316 / PR #4324 retro case where an agent burned a full CI round trip on a one-line `timeout=30` miss.

Closes #4328

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`bash scripts/tests/test_pre_push.sh` — 21/21 PASS locally including the two new scenarios)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (pre-push hook + bash test only)
- [ ] Verification evidence posted on issue (see A.8)
