### PR TITLE
fix(dx): check-shipped-pr.sh filters candidates whose body Closes a different issue (#4327)

### DIFF
--- a/scripts/_check_shipped_pr_closes_other.py
+++ b/scripts/_check_shipped_pr_closes_other.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_closes_other.py — Filter out PR candidates whose body
+# closes a different issue, for scripts/check-shipped-pr.sh.
+#
+# Reads `gh pr view --json body` JSON on stdin (other fields are ignored).
+# Reads the current issue number from CHECK_SHIPPED_ISSUE_NUM env var.
+# Exits 0 ("filter this candidate out") if the PR body contains a
+# closing-keyword reference (`Closes #N` / `Fixes #N` / `Resolves #N`,
+# case-insensitive, all 9 GitHub verb forms) that names AT LEAST ONE issue
+# whose number is NOT the current issue. Exits 1 ("keep this candidate")
+# otherwise — including the canonical case of an empty body or a body that
+# only contains free prose with no closing keywords (which is exactly the
+# placeholder-titled WIP PR shape that motivates the script).
+#
+# venv: none
+# permanent: true
+#
+# Why "names a different issue" rather than "any closing keyword present":
+# A PR whose body says `Closes #N` for the *same* issue is the canonical
+# happy-path PR and should be retained as a candidate (any false positive
+# in that case would be the duplicate-PR check's job to flag, not ours).
+# A PR whose body contains BOTH `Closes #<this-issue>` AND
+# `Closes #<other-issue>` should also be retained — it explicitly closes
+# the issue we're checking. Only a PR whose only closing-keyword
+# references point at OTHER issues is filtered out.
+#
+# Closing keywords recognized (https://docs.github.com/en/issues/tracking-
+# your-work-with-issues/linking-a-pull-request-to-an-issue):
+#   close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved.
+# Each followed by `#N`, `owner/repo#N`, or
+# `https://github.com/owner/repo/issues/N`.
+
+import json
+import os
+import re
+import sys
+
+# All 9 GitHub closing-keyword verbs, case-insensitive.
+_CLOSE_VERBS = (
+    "close",
+    "closes",
+    "closed",
+    "fix",
+    "fixes",
+    "fixed",
+    "resolve",
+    "resolves",
+    "resolved",
+)
+
+# Regex captures the issue/PR number after a closing keyword in any of
+# the three GitHub-recognized forms:
+#   Closes #N
+#   Closes owner/repo#N
+#   Closes https://github.com/owner/repo/issues/N
+# `(?i)` for case-insensitive verbs. `\b` ensures we don't match e.g.
+# "preclose" or "fixed-up". Uses non-capturing groups for the verb and
+# the optional owner/repo prefix so the only capture group is the issue
+# number itself.
+_CLOSE_VERB_ALT = "|".join(_CLOSE_VERBS)
+_CLOSE_KEYWORD_RE = re.compile(
+    r"(?i)\b(?:" + _CLOSE_VERB_ALT + r")\s*:?\s*"
+    r"(?:[\w.\-]+/[\w.\-]+)?"  # optional owner/repo prefix
+    r"#(\d+)"
+)
+_CLOSE_URL_RE = re.compile(
+    r"(?i)\b(?:" + _CLOSE_VERB_ALT + r")\s*:?\s*"
+    r"https?://github\.com/[\w.\-]+/[\w.\-]+/issues/(\d+)"
+)
+
+
+def extract_closed_issue_numbers(body: str) -> set[int]:
+    """Return the set of issue numbers a PR body's closing keywords reference."""
+    if not body:
+        return set()
+    nums: set[int] = set()
+    for m in _CLOSE_KEYWORD_RE.finditer(body):
+        try:
+            nums.add(int(m.group(1)))
+        except (TypeError, ValueError):
+            continue
+    for m in _CLOSE_URL_RE.finditer(body):
+        try:
+            nums.add(int(m.group(1)))
+        except (TypeError, ValueError):
+            continue
+    return nums
+
+
+def main() -> int:
+    issue_num_str = os.environ.get("CHECK_SHIPPED_ISSUE_NUM", "")
+    try:
+        current_issue = int(issue_num_str)
+    except (TypeError, ValueError):
+        # Without a current issue number we cannot decide; fail open
+        # (exit 1 = keep the candidate). Caller will still apply the
+        # file-overlap threshold.
+        return 1
+
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        # Malformed PR JSON — fail open.
+        return 1
+
+    body = data.get("body") or ""
+    closed = extract_closed_issue_numbers(body)
+    if not closed:
+        # No closing-keyword references — canonical placeholder-PR
+        # shape. Keep candidate.
+        return 1
+    if current_issue in closed:
+        # PR explicitly closes the issue we're checking (with or
+        # without also closing other issues). Keep candidate — this is
+        # the legitimate happy-path PR, and the duplicate-PR check is
+        # the right gate for that case.
+        return 1
+    # Every closing-keyword reference in the PR body points at an issue
+    # OTHER than the one we're checking. Filter this candidate out.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -166,8 +166,27 @@ for pr_num in "${prs_array[@]}"; do
     [[ -z "$pr_num" ]] && continue
     pr_json=""
     if ! pr_json=$("$GH_BIN" pr view "$pr_num" --repo "$REPO" \
-        --json number,title,mergedAt,baseRefName,files \
+        --json number,title,body,mergedAt,baseRefName,files \
         2>/dev/null); then
+        continue
+    fi
+
+    # Closes-keyword filter (#4327). If the PR body contains a closing
+    # keyword (`Closes #N` / `Fixes #N` / `Resolves #N`, case-insensitive,
+    # all 9 GitHub verb forms) that names ONLY issues other than the one
+    # we're checking, skip this candidate — the PR shipped a different
+    # issue's work, and the file overlap is incidental (e.g. a previous
+    # PR introduced the file the current issue is about to extend).
+    # Canonical placeholder-titled WIP PRs have empty bodies and so do
+    # NOT trip this filter — exit 1 from the helper means "keep". The
+    # helper exits 0 only when EVERY closing-keyword reference points
+    # at a different issue. See #4327 for the worked example
+    # (issue #4317 vs PR #3426).
+    closes_other_exit=0
+    printf '%s' "$pr_json" | CHECK_SHIPPED_ISSUE_NUM="$issue_num" python3 \
+        "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_closes_other.py" \
+        2>/dev/null || closes_other_exit=$?
+    if [[ "$closes_other_exit" -eq 0 ]]; then
         continue
     fi
 

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -529,6 +529,178 @@ else
     fail "extracts EVERY (#N) token from multi-token headline (regression #4214)" "exit=$exit_code output=$output"
 fi
 
+# ─── Test 14: PR body has `Closes #N` for a DIFFERENT issue → exit 1 ─────
+
+# Regression for #4327. Issue body cites scripts/foo.sh; a closed PR
+# touched that file but its body says `Closes #999` — i.e. it shipped a
+# DIFFERENT issue's work. The closes-other-issue filter must drop this
+# candidate even though file overlap clears the high-confidence
+# threshold (1 added overlap). Pre-fix: shipped: PR #1234.
+# Post-fix: not-shipped (the only candidate was filtered out).
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.", "title": "dx: extend scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Closes the unrelated bug (#1234)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "body": "## Summary\n\nFixed unrelated bug.\n\nCloses #999\n", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-15T00:00:00Z", "number": 1234, "title": "fix: unrelated bug (#999)"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$output" == *"not-shipped:"* ]]; then
+    pass "exits 1 when candidate PR's body Closes a different issue (regression #4327)"
+else
+    fail "exits 1 when candidate PR's body Closes a different issue (regression #4327)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 15: PR body has `Fixes #N` for a DIFFERENT issue → exit 1 ──────
+
+# Same shape as Test 14 but uses `Fixes` (lowercase, different verb).
+# All 9 GitHub closing-keyword verbs (close/closes/closed/fix/fixes/
+# fixed/resolve/resolves/resolved) are recognized case-insensitively.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: foo"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "fix unrelated (#5555)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "body": "fixes #888", "files": [{"path": "scripts/foo.sh", "additions": 50, "deletions": 0}], "mergedAt": "2026-04-15T00:00:00Z", "number": 5555, "title": "fix: unrelated"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$output" == *"not-shipped:"* ]]; then
+    pass "exits 1 when candidate PR's body Fixes a different issue (lowercase, regression #4327)"
+else
+    fail "exits 1 when candidate PR's body Fixes a different issue (lowercase)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 16: PR body has `Closes #N` for the SAME issue → exit 0 ────────
+
+# A PR whose body says `Closes #<this-issue>` is the legitimate happy-
+# path PR — it explicitly closes the issue we're checking. Keep it as
+# a candidate (exit 0). The duplicate-PR check is the right gate for
+# the "same issue, different open PR" case, not this one.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: foo"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "feat: foo (#7777)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "body": "## Summary\n\nAdded foo.\n\nCloses #2831", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-15T00:00:00Z", "number": 7777, "title": "feat: foo"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"7777"* ]]; then
+    pass "exits 0 when candidate PR's body Closes the SAME issue we're checking (regression #4327)"
+else
+    fail "exits 0 when candidate PR's body Closes the SAME issue we're checking" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 17: canonical placeholder PR (empty body) still ships → exit 0 ─
+
+# The canonical case from #2831 ↔ PR #3229: PR title is `WIP: ralph
+# output` (placeholder), body is empty (no `Closes #N` keyword fired
+# the auto-close). The closes-other-issue filter must NOT drop this —
+# an empty body has no closing-keyword references at all, so the
+# filter exits 1 (keep) and the candidate proceeds to file-overlap
+# check. This guards against accidentally over-filtering the very
+# zombie shape the script was built to catch.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: foo"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "WIP: ralph output (#3229)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "body": "", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-24T00:00:00Z", "number": 3229, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3229"* ]]; then
+    pass "canonical placeholder PR (empty body) still reports shipped (regression #4327, AC2)"
+else
+    fail "canonical placeholder PR (empty body) still reports shipped (regression #4327, AC2)" "exit=$exit_code output=$output"
+fi
+
 # Restore PATH for cleanup
 export PATH="$ORIG_PATH_SAVE"
 

--- a/scripts/tests/test_check_shipped_pr_closes_other.py
+++ b/scripts/tests/test_check_shipped_pr_closes_other.py
@@ -1,0 +1,222 @@
+# venv: none
+"""Tests for ``scripts/_check_shipped_pr_closes_other.py``.
+
+The helper is the closes-other-issue filter for ``check-shipped-pr.sh``
+(issue #4327). It reads ``gh pr view --json body`` JSON on stdin and the
+current issue number from ``CHECK_SHIPPED_ISSUE_NUM`` env var, and exits
+0 ("filter this candidate out") only when EVERY closing-keyword
+reference in the PR body points at an issue OTHER than the one being
+checked.
+
+The canonical placeholder PR (empty body, no closing keywords) must
+NOT be filtered out — that is the exact zombie-issue shape the script
+was built to catch (#2831 ↔ PR #3229).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "_check_shipped_pr_closes_other.py"
+
+
+def _import_helper_module():
+    """Load the helper script as ``check_shipped_pr_closes_other``."""
+    spec = importlib.util.spec_from_file_location(
+        "check_shipped_pr_closes_other", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_shipped_pr_closes_other"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def helper():
+    return _import_helper_module()
+
+
+# ─── extract_closed_issue_numbers ─────────────────────────────────────
+
+
+def test_extract_basic_closes_keyword(helper):
+    """`Closes #N` is the canonical form."""
+    assert helper.extract_closed_issue_numbers("Closes #4317") == {4317}
+
+
+def test_extract_all_nine_verbs_case_insensitive(helper):
+    """All 9 GitHub closing keywords (close/closes/closed/fix/fixes/
+    fixed/resolve/resolves/resolved) are recognized case-insensitively.
+    """
+    body = (
+        "close #1\n"
+        "Closes #2\n"
+        "CLOSED #3\n"
+        "fix #4\n"
+        "Fixes #5\n"
+        "FIXED #6\n"
+        "resolve #7\n"
+        "Resolves #8\n"
+        "RESOLVED #9\n"
+    )
+    assert helper.extract_closed_issue_numbers(body) == {1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+
+def test_extract_owner_repo_prefix(helper):
+    """`Closes owner/repo#N` is the cross-repo form GitHub recognizes.
+
+    Empirically rare in this repo but the helper supports it for
+    completeness — the GitHub auto-close API treats this form
+    identically to the bare ``#N`` form.
+    """
+    body = "Closes judgemind/judgemind#4317"
+    assert helper.extract_closed_issue_numbers(body) == {4317}
+
+
+def test_extract_full_url_form(helper):
+    """`Closes https://github.com/owner/repo/issues/N` is the long form
+    GitHub also accepts.
+    """
+    body = "Closes https://github.com/judgemind/judgemind/issues/4317"
+    assert helper.extract_closed_issue_numbers(body) == {4317}
+
+
+def test_extract_with_colon(helper):
+    """`Closes: #N` (with colon) is sometimes used; GitHub accepts it."""
+    body = "Closes: #4317"
+    assert helper.extract_closed_issue_numbers(body) == {4317}
+
+
+def test_extract_multiple_keywords_in_one_body(helper):
+    """A body with multiple closing keywords returns all referenced
+    issues. The PR-#3426 case from #4317's reproduction has only one
+    (`Closes #3424`) but multi-issue PRs do exist.
+    """
+    body = "## Summary\n\nLots of work.\n\nCloses #100\nFixes #200\nResolves #300\n"
+    assert helper.extract_closed_issue_numbers(body) == {100, 200, 300}
+
+
+def test_extract_empty_body(helper):
+    """Empty body returns empty set — the canonical placeholder-PR
+    shape that #2831 ↔ #3229 motivates the check from.
+    """
+    assert helper.extract_closed_issue_numbers("") == set()
+    assert helper.extract_closed_issue_numbers(None) == set()  # type: ignore[arg-type]
+
+
+def test_extract_freeform_prose_no_match(helper):
+    """A body with prose that mentions issues but doesn't use a closing
+    keyword returns empty set. ``See #1234`` and ``related to #5678``
+    do not auto-close on GitHub, so they shouldn't trigger the filter.
+    """
+    body = "See #1234 for context. This builds on #5678. Discussion in #999."
+    assert helper.extract_closed_issue_numbers(body) == set()
+
+
+def test_extract_no_word_boundary_breakage(helper):
+    """The `\\b` word boundary must allow `Closes` at start of line and
+    after whitespace, but not match inside a longer word.
+    """
+    # Match: at start, after whitespace, after newline.
+    assert helper.extract_closed_issue_numbers("Closes #1") == {1}
+    assert helper.extract_closed_issue_numbers(" Closes #2") == {2}
+    assert helper.extract_closed_issue_numbers("\nCloses #3") == {3}
+    # Don't match: substring of a longer identifier. ``preclose`` /
+    # ``unfixed`` are unusual but should not falsely trigger the filter.
+    assert helper.extract_closed_issue_numbers("preclose #99") == set()
+    assert helper.extract_closed_issue_numbers("unfixed #99") == set()
+
+
+# ─── main() — the exit-code contract the bash wrapper depends on ──────
+
+
+def _run_main(helper, monkeypatch, body: str, current_issue: str | int) -> int:
+    """Drive the helper's main() with synthetic stdin + env."""
+    import io
+    import json
+
+    monkeypatch.setenv("CHECK_SHIPPED_ISSUE_NUM", str(current_issue))
+    stdin_payload = json.dumps({"body": body})
+    monkeypatch.setattr(sys, "stdin", io.StringIO(stdin_payload))
+    return helper.main()
+
+
+def test_main_filter_out_when_pr_closes_other_issue(helper, monkeypatch):
+    """The motivating case for #4327. PR body says `Closes #3424` but
+    we're checking issue #4317 — the helper exits 0 (filter out).
+    """
+    assert _run_main(helper, monkeypatch, "Closes #3424", 4317) == 0
+
+
+def test_main_keep_when_pr_closes_same_issue(helper, monkeypatch):
+    """The legitimate happy-path PR. PR body says `Closes #4317` and
+    we're checking issue #4317 — keep the candidate (exit 1).
+    """
+    assert _run_main(helper, monkeypatch, "Closes #4317", 4317) == 1
+
+
+def test_main_keep_when_pr_closes_same_and_other(helper, monkeypatch):
+    """A PR that closes BOTH the current issue and another issue is
+    legitimate (the current issue's intent shipped) — keep the candidate.
+    """
+    body = "Closes #4317\nFixes #100"
+    assert _run_main(helper, monkeypatch, body, 4317) == 1
+
+
+def test_main_keep_when_empty_body_no_keywords(helper, monkeypatch):
+    """The canonical placeholder PR (#2831 ↔ #3229) — empty body, no
+    closing keywords. Keep the candidate so the file-overlap check can
+    still match the zombie shape.
+    """
+    assert _run_main(helper, monkeypatch, "", 4317) == 1
+
+
+def test_main_keep_when_freeform_prose(helper, monkeypatch):
+    """Body with prose but no closing keywords (just `See #N` /
+    `related to #N`) — keep the candidate. Only explicit closing
+    keywords filter the candidate out.
+    """
+    body = "See #100 for related context. Builds on #200."
+    assert _run_main(helper, monkeypatch, body, 4317) == 1
+
+
+def test_main_filter_with_lowercase_fixes(helper, monkeypatch):
+    """Lowercase verbs are recognized — the regex is case-insensitive.
+
+    Real-world bodies use both `Closes #N` and `fixes #N` interchangeably.
+    """
+    assert _run_main(helper, monkeypatch, "fixes #888", 4317) == 0
+
+
+def test_main_fail_open_on_malformed_json(helper, monkeypatch):
+    """Malformed PR JSON on stdin — fail open (exit 1, keep candidate).
+
+    The wrapper's overall flow already drops candidates whose `gh pr
+    view` call errored upstream of this helper, so a malformed JSON
+    here is unusual; failing open lets the file-overlap check apply
+    rather than silently dropping the candidate.
+    """
+    import io
+
+    monkeypatch.setenv("CHECK_SHIPPED_ISSUE_NUM", "4317")
+    monkeypatch.setattr(sys, "stdin", io.StringIO("not-json"))
+    assert helper.main() == 1
+
+
+def test_main_fail_open_on_missing_issue_num(helper, monkeypatch):
+    """If `CHECK_SHIPPED_ISSUE_NUM` is unset/blank, the helper cannot
+    decide — fail open (exit 1, keep candidate). Caller falls back to
+    file-overlap check.
+    """
+    import io
+    import json
+
+    monkeypatch.delenv("CHECK_SHIPPED_ISSUE_NUM", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps({"body": "Closes #1"})))
+    assert helper.main() == 1


### PR DESCRIPTION
## Summary

Adds a closes-keyword filter to `scripts/check-shipped-pr.sh` so a candidate PR whose body says `Closes #N` / `Fixes #N` / `Resolves #N` for ONLY OTHER issues is dropped before the file-overlap check fires. Eliminates the false-positive class observed on issue #4317, where PR #3426 (`Closes #3424` — a different fix) tripped a 3-file overlap because it created the test files #4317 listed as targets for new regression tests.

The canonical placeholder-PR shape (#2831 ↔ PR #3229: empty body, no closing keywords) is intentionally NOT filtered — that is the exact zombie-issue shape this script was built to catch.

Closes #4327

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (tooling script + Python helper used by `/task` and `/dispatcher`; not deployed to ECS or any service)
- [x] Verification evidence posted on issue (see A.8)
