### PR TITLE
feat(dx): scripts/run-ci-guards.sh umbrella + pre-push hook integration (#4332)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -813,6 +813,39 @@ if [ -n "$changed_watch_files" ]; then
 fi
 
 # -------------------------------------------------------------------
+# CI guard umbrella — run every scripts/check-*.{sh,py} guard locally
+# -------------------------------------------------------------------
+# Mirrors the dozen+ ``scripts/check-*`` jobs in ``.github/workflows/ci.yml``
+# so a guard failure is caught locally before the network round-trip.
+# Self-maintaining: dropping a new ``scripts/check-foo.sh`` into the tree
+# makes it pick up automatically (no umbrella-script edit required).
+#
+# Bypass with ``SKIP_CI_GUARDS=1 git push`` for the rare case an operator
+# needs to push partial work knowing one guard will fail. The bypass is
+# noisy on stderr so it's hard to miss. CI will still run every guard.
+#
+# See issue #4332 (motivating retro: PR #4325 / sql-column-check) and
+# scripts/run-ci-guards.sh for the discovery rules and skip list.
+if [ -x scripts/run-ci-guards.sh ]; then
+    if [ "${SKIP_CI_GUARDS:-0}" = "1" ]; then
+        echo "" >&2
+        echo "WARNING: SKIP_CI_GUARDS=1 — bypassing scripts/run-ci-guards.sh." >&2
+        echo "         CI will still run every guard. Use only when you" >&2
+        echo "         intentionally want to push partial work knowing one" >&2
+        echo "         or more guards will fail." >&2
+    else
+        echo "pre-push: running CI guard umbrella (scripts/run-ci-guards.sh)..." >&2
+        if ! run_check "_" "scripts/run-ci-guards.sh" scripts/run-ci-guards.sh; then
+            echo "  One or more CI guards failed. See the failure list above." >&2
+            echo "  Bypass: SKIP_CI_GUARDS=1 git push (CI still runs every guard)." >&2
+            failures=$((failures + 1))
+        fi
+    fi
+else
+    echo "  WARNING: scripts/run-ci-guards.sh not found or not executable — skipping" >&2
+fi
+
+# -------------------------------------------------------------------
 # PR existence check (advisory — runs before push completes)
 # -------------------------------------------------------------------
 # Git has no native post-push hook. We check here as the closest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
             githooks:
               - '.githooks/**'
               - 'scripts/tests/test_pre_push.sh'
+              - 'scripts/tests/test_run_ci_guards.sh'
+              - 'scripts/run-ci-guards.sh'
               - '.github/workflows/ci.yml'
             dispatcher-terminals:
               - 'scripts/dispatcher/daemon.py'

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -154,6 +154,27 @@ If lint fails: `.venv/bin/ruff check --fix src/ tests/` then `.venv/bin/ruff for
 
 Common ruff pitfalls: **I001** (unsorted imports, `--fix` resolves), **F401** (unused imports, remove them), **UP017** (use `datetime.now(datetime.UTC)`). Format and lint are **separate commands** — run BOTH.
 
+### CI guard umbrella (`scripts/run-ci-guards.sh`)
+
+The pre-push hook also runs `scripts/run-ci-guards.sh`, an auto-discovery umbrella that mirrors the dozen+ `scripts/check-*` jobs in `.github/workflows/ci.yml`. Self-maintaining: dropping a new `scripts/check-foo.sh` into the tree makes it pick up automatically — no umbrella-script edit required.
+
+**Run manually before pushing:**
+```
+scripts/run-ci-guards.sh         # run every applicable guard
+scripts/run-ci-guards.sh --list  # show the discovered guard list without running
+```
+
+**Bypass for the rare case of intentionally pushing partial work:**
+```
+SKIP_CI_GUARDS=1 git push        # CI still runs every guard
+```
+
+The bypass emits a noisy stderr WARNING so it's hard to miss. Use only when one or more guards are known to fail and you are pushing partial work intentionally — otherwise fix the failure first.
+
+**Skip list.** Several guards are not amenable to running blind from the local tree (need an issue/PR-number argument, need network access for `gh pr list`, depend on `npm ci` of `packages/web/`, depend on Docker, or run in scheduled-cron contexts against the dev DB). The umbrella's built-in `SKIP_LIST` excludes them; see the comment at the top of `scripts/run-ci-guards.sh` for the full list and rationale. Per-file opt-out is also available via a `# ci-guards: skip` marker in the first 20 lines of the guard file.
+
+See #4332 for the motivating retro (PR #4325 hit a CI-only `sql-column-check` failure that would have surfaced locally with this umbrella).
+
 ### Test assertion hygiene (enforced in CI)
 
 Blind exception swallows inside test files hide bugs: if the call under test raises, the test silently passes on a never-executed code path (see #2443). CI enforces this via `scripts/check-test-except-pass.sh`, which forbids the following patterns inside any file under a `tests/` directory:

--- a/scripts/run-ci-guards.sh
+++ b/scripts/run-ci-guards.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# run-ci-guards.sh — Umbrella runner for every scripts/check-*.{sh,py} guard.
+#
+# permanent: true
+#
+# Discovers every executable matching ``scripts/check-*.sh`` and
+# ``scripts/check-*.py`` and runs them in alphabetical order against the
+# local working tree. Wired into ``.githooks/pre-push`` so guard failures
+# surface locally before the CI round trip.
+#
+# Why
+# ───
+# CI runs ~30 ``check-*`` guards as separate workflow jobs (see
+# ``.github/workflows/ci.yml``). Pre-#4332, pre-push only ran a hand-picked
+# subset (markdown links, schema drift, dispatcher-image deps, etc.); the
+# remaining guards only ran in CI, which means a one-line lint nit costs a
+# full ~3-minute CI round trip to discover. PR #4325 (closing #4321) hit
+# exactly this footgun on ``sql-column-check`` — see issue #4332 for the
+# motivating retro.
+#
+# This runner closes the gap. It is self-maintaining: dropping a new
+# ``scripts/check-foo.sh`` into the tree makes it pick up automatically,
+# no umbrella-script edit required.
+#
+# Discovery rules
+# ───────────────
+# 1. Glob ``scripts/check-*.sh`` and ``scripts/check-*.py``.
+# 2. Skip the umbrella itself and any script in the SKIP_LIST below.
+# 3. When both ``check-foo.sh`` AND ``check-foo.py`` exist, run only the
+#    ``.sh`` (it is the canonical wrapper; the ``.py`` is its
+#    implementation). Same logic as the ``.github/workflows/ci.yml``
+#    invocations — they call the ``.sh`` not the ``.py``.
+# 4. A guard can opt out by adding ``# ci-guards: skip`` within the first
+#    20 lines of the file. Use this for guards that depend on network /
+#    issue context / Docker / npm-installed deps.
+#
+# SKIP_LIST entries (built-in, no per-file marker required) — these are
+# guards that are not amenable to running blind from the local tree:
+#
+#   * check-issue-author.sh        — needs an issue number argument
+#   * check-duplicate-pr.sh        — needs an issue number argument
+#   * check-shipped-pr.sh          — needs an issue number argument
+#   * check-blocked-issues.sh      — scans live GitHub issues
+#   * check-task-recovery.sh       — needs a worktree path argument
+#   * check-pr-title.sh            — needs a PR number / title input
+#   * check-graphql-queries.sh     — requires ``packages/web`` npm install
+#   * check-migration-number-collision.{sh,py}
+#                                  — requires ``gh pr list`` for cross-PR
+#                                    diff and a ``--base`` argument
+#   * check_schema_drift.sh        — already wired in pre-push, requires
+#                                    Docker. Filename uses underscores so
+#                                    it would not match this glob anyway,
+#                                    listed defensively.
+#   * check-diff-coverage.sh       — interactive tooling helper that takes
+#                                    a positional ``<package>`` argument;
+#                                    not a CI guard.
+#   * check-scraper-zero-record-runner.py
+#   * check-scraper-zero-record-streak.py
+#   * check-short-unsubstantive-rulings.py
+#                                  — scheduled-cron data-quality scripts
+#                                    that run inside ECS against the dev
+#                                    DB (``import psycopg`` + DATABASE_URL).
+#                                    Wired by deploy-scraper.yml /
+#                                    scraper-zero-record-check.yml /
+#                                    short-unsubstantive-ruling-check.yml,
+#                                    not by ci.yml.
+#
+# Usage
+# ─────
+#
+#   scripts/run-ci-guards.sh                    # run every applicable guard
+#   scripts/run-ci-guards.sh --list             # print the discovered guard list and exit
+#   SKIP_CI_GUARDS=1 scripts/run-ci-guards.sh   # bypass; emit a warning to stderr
+#
+# Exit codes
+# ──────────
+#
+#   0 — every applicable guard passed (or SKIP_CI_GUARDS=1 was set).
+#   1 — one or more guards failed.
+#   2 — usage / discovery error (e.g. invoked from outside the repo).
+
+set -uo pipefail
+
+# ────────────────────────────────────────────────────────────────────
+# SKIP_CI_GUARDS=1 bypass — emit a warning, exit 0
+# ────────────────────────────────────────────────────────────────────
+if [ "${SKIP_CI_GUARDS:-0}" = "1" ]; then
+    echo "WARNING: SKIP_CI_GUARDS=1 — bypassing scripts/run-ci-guards.sh." >&2
+    echo "         CI will still run every guard. Use only when you" >&2
+    echo "         intentionally want to push partial work knowing one" >&2
+    echo "         or more guards will fail." >&2
+    exit 0
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Resolve the repo root from the script's own location
+# ────────────────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+SELF_BASENAME="$(basename "${BASH_SOURCE[0]}")"
+
+if [ ! -d "$SCRIPTS_DIR" ]; then
+    echo "ERROR: scripts/ directory not found under repo root $REPO_ROOT" >&2
+    exit 2
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Built-in skip list
+# ────────────────────────────────────────────────────────────────────
+# Scripts that cannot be run blind from the local tree are skipped here
+# rather than by per-file marker so we don't have to touch every guard
+# file. Match by basename — both .sh and .py variants are skipped if
+# named here.
+SKIP_LIST=(
+    "check-issue-author.sh"
+    "check-duplicate-pr.sh"
+    "check-shipped-pr.sh"
+    "check-blocked-issues.sh"
+    "check-task-recovery.sh"
+    "check-pr-title.sh"
+    "check-graphql-queries.sh"
+    "check-migration-number-collision.sh"
+    "check-migration-number-collision.py"
+    "check-diff-coverage.sh"
+    "check-scraper-zero-record-runner.py"
+    "check-scraper-zero-record-streak.py"
+    "check-short-unsubstantive-rulings.py"
+)
+
+# is_in_skip_list <basename> -> 0 if skipped, 1 otherwise
+is_in_skip_list() {
+    local name="$1"
+    local entry
+    for entry in "${SKIP_LIST[@]}"; do
+        [ "$name" = "$entry" ] && return 0
+    done
+    return 1
+}
+
+# has_opt_out_marker <path> -> 0 if "# ci-guards: skip" appears in
+# the first 20 lines, 1 otherwise.
+has_opt_out_marker() {
+    local path="$1"
+    head -n 20 "$path" 2>/dev/null | grep -qE '^[[:space:]]*#[[:space:]]*ci-guards:[[:space:]]*skip[[:space:]]*$'
+}
+
+# ────────────────────────────────────────────────────────────────────
+# Discover guards
+# ────────────────────────────────────────────────────────────────────
+# Glob alphabetically into a sorted list. We prefer `find` over a bare
+# glob so non-existent matches don't trip set -u. Sort is locale-stable
+# (LC_ALL=C) so the order is deterministic across machines.
+shopt -s nullglob
+
+discovered=()
+while IFS= read -r path; do
+    [ -n "$path" ] && discovered+=("$path")
+done < <(LC_ALL=C find "$SCRIPTS_DIR" -maxdepth 1 -type f \
+            \( -name 'check-*.sh' -o -name 'check-*.py' \) | LC_ALL=C sort)
+
+if [ "${#discovered[@]}" -eq 0 ]; then
+    echo "ERROR: no scripts/check-*.{sh,py} guards discovered under $SCRIPTS_DIR" >&2
+    exit 2
+fi
+
+# Build the list of basenames present so we can de-duplicate .sh/.py pairs.
+declare -a basenames_present=()
+for path in "${discovered[@]}"; do
+    basenames_present+=("$(basename "$path")")
+done
+
+# basename_present <basename> -> 0 if present, 1 otherwise
+basename_present() {
+    local name="$1"
+    local entry
+    for entry in "${basenames_present[@]}"; do
+        [ "$entry" = "$name" ] && return 0
+    done
+    return 1
+}
+
+# ────────────────────────────────────────────────────────────────────
+# Filter discovered guards into the runnable list
+# ────────────────────────────────────────────────────────────────────
+runnable=()
+skipped=()
+for path in "${discovered[@]}"; do
+    name="$(basename "$path")"
+
+    # Skip the umbrella itself defensively (we are already a check-*
+    # naming-pattern miss because the umbrella is "run-ci-guards", but
+    # leave the guard for any future renaming).
+    if [ "$name" = "$SELF_BASENAME" ]; then
+        skipped+=("$name (umbrella self)")
+        continue
+    fi
+
+    # Built-in skip list
+    if is_in_skip_list "$name"; then
+        skipped+=("$name (built-in skip)")
+        continue
+    fi
+
+    # Per-file opt-out marker
+    if has_opt_out_marker "$path"; then
+        skipped+=("$name (# ci-guards: skip)")
+        continue
+    fi
+
+    # When both check-foo.sh and check-foo.py exist, run only the .sh.
+    # The .py is the implementation; the .sh is the canonical wrapper.
+    case "$name" in
+        check-*.py)
+            stem="${name%.py}"
+            sh_companion="${stem}.sh"
+            if basename_present "$sh_companion"; then
+                skipped+=("$name (.sh wrapper companion: $sh_companion)")
+                continue
+            fi
+            ;;
+    esac
+
+    # Executability check: .sh files MUST be executable (we run them
+    # directly). .py files do not — CI invokes them via ``python3 …``
+    # so a missing +x bit is the CI-canonical state for several guards
+    # (e.g. check-sql-columns.py at PR #4325 retro time was -rw-r--r--).
+    case "$name" in
+        check-*.py)
+            ;;  # always runnable via python3 below
+        *)
+            if [ ! -x "$path" ]; then
+                skipped+=("$name (not executable)")
+                continue
+            fi
+            ;;
+    esac
+
+    runnable+=("$path")
+done
+
+# ────────────────────────────────────────────────────────────────────
+# --list mode: print the discovered/runnable list and exit 0
+# ────────────────────────────────────────────────────────────────────
+if [ "${1:-}" = "--list" ]; then
+    echo "Discovered: ${#discovered[@]} guard(s)"
+    echo "Runnable:   ${#runnable[@]} guard(s)"
+    # Empty-array iteration under bash 3.2 + set -u trips
+    # ``unbound variable`` on ``"${arr[@]}"`` even when the array is
+    # initialised as ``arr=()``.  Guard with a length check so the
+    # umbrella is correct on macOS operator laptops too. Same root
+    # cause class as ``scripts/check-bash-set-u-empty-array.sh`` —
+    # but we declare-and-init so that check itself does not fire.
+    if [ "${#runnable[@]}" -gt 0 ]; then
+        for path in "${runnable[@]}"; do
+            echo "  RUN  $(basename "$path")"
+        done
+    fi
+    if [ "${#skipped[@]}" -gt 0 ]; then
+        echo "Skipped:    ${#skipped[@]} guard(s)"
+        for entry in "${skipped[@]}"; do
+            echo "  SKIP $entry"
+        done
+    fi
+    exit 0
+fi
+
+# ────────────────────────────────────────────────────────────────────
+# Run the guards
+# ────────────────────────────────────────────────────────────────────
+echo "run-ci-guards: running ${#runnable[@]} guard(s) (${#skipped[@]} skipped)..." >&2
+
+failures=0
+failed_names=()
+
+# Empty-runnable guard: under bash 3.2 + set -u, iterating
+# ``"${runnable[@]}"`` when the array is empty trips ``unbound
+# variable`` even when initialised as ``runnable=()``. Skip the loop
+# entirely in that case — there's nothing to run.
+if [ "${#runnable[@]}" -eq 0 ]; then
+    echo "run-ci-guards: no runnable guard(s); nothing to do." >&2
+    exit 0
+fi
+
+for path in "${runnable[@]}"; do
+    name="$(basename "$path")"
+    log_file="${TMPDIR:-/tmp}/run-ci-guards-${name//\//_}.log"
+
+    # cd to repo root so guards using $(pwd) or relative paths see the
+    # expected working tree, matching how CI invokes them from
+    # `actions/checkout` at the repo root.
+    #
+    # .py files are invoked via python3 explicitly so guards that ship
+    # without a +x bit (the CI-canonical state for check-sql-columns.py
+    # and friends — CI calls them as ``python3 scripts/check-foo.py``)
+    # still run from this umbrella.
+    rc=0
+    case "$name" in
+        check-*.py)
+            (cd "$REPO_ROOT" && python3 "$path") > "$log_file" 2>&1 || rc=$?
+            ;;
+        *)
+            (cd "$REPO_ROOT" && "$path") > "$log_file" 2>&1 || rc=$?
+            ;;
+    esac
+
+    if [ "$rc" -ne 0 ]; then
+        failures=$((failures + 1))
+        failed_names+=("$name")
+        echo "" >&2
+        echo "  FAILED: $name (exit $rc)" >&2
+        echo "  Last 20 lines of output:" >&2
+        tail -n 20 "$log_file" | sed 's/^/    /' >&2
+        echo "  Full log: $log_file" >&2
+    fi
+done
+
+# ────────────────────────────────────────────────────────────────────
+# Report
+# ────────────────────────────────────────────────────────────────────
+if [ "$failures" -gt 0 ]; then
+    echo "" >&2
+    echo "════════════════════════════════════════════════════════════════════" >&2
+    echo "run-ci-guards: $failures of ${#runnable[@]} guard(s) failed:" >&2
+    for fname in "${failed_names[@]}"; do
+        echo "  - $fname" >&2
+    done
+    echo "" >&2
+    echo "Fix the issues above and re-run.  These are the same guards CI" >&2
+    echo "runs — catching them locally saves a full CI round trip." >&2
+    echo "" >&2
+    echo "To bypass (with CI still running every guard):" >&2
+    echo "  SKIP_CI_GUARDS=1 git push" >&2
+    echo "════════════════════════════════════════════════════════════════════" >&2
+    exit 1
+fi
+
+echo "run-ci-guards: all ${#runnable[@]} guard(s) passed." >&2
+exit 0

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -33,6 +33,8 @@
 #  13. Real TS change still fires lint    'checking TypeScript package' present (#2877 AC2)
 #  18. Non-ASCII tf description rejected  em-dash in description -> hook fails (#3923)
 #  19. Stale ci-passed.needs entry rejected  hook fails before actionlint (#4207)
+#  22. CI-guard umbrella fires + rejects     scripts/run-ci-guards.sh stub fail -> hook fails (#4332)
+#  23. SKIP_CI_GUARDS=1 bypasses umbrella    bypass var skips run-ci-guards.sh, prints WARNING (#4332)
 #
 # Run:
 #   scripts/tests/test_pre_push.sh
@@ -1049,6 +1051,96 @@ if echo "$hook_out" | grep -q "checking subprocess.run / urlopen timeouts"; then
     report_fail "docs-only push must NOT fire subprocess-timeouts gate (#4328 AC2)" "$hook_out"
 else
     report_pass "docs-only push skips subprocess-timeouts gate (#4328 AC2)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 22: CI-guard umbrella fires and rejects on stub failure (#4332)
+# ───────────────────────────────────────────────────────────────────────
+# Seeds scripts/run-ci-guards.sh as a stub that fails, makes a trivial
+# change so the hook runs, and asserts the hook exits non-zero with the
+# expected FAILED message. This exercises the umbrella's wiring without
+# depending on the real ~70-guard run (which would explode the test
+# suite duration). The real umbrella's discovery + run logic is covered
+# by scripts/run-ci-guards.sh's own list-mode probe and the AC4
+# verification (drop-and-detect a check-zzz-probe.sh).
+echo "[scenario 22] CI-guard umbrella fires + rejects on stub failure (#4332)"
+init_workspace
+git -C "$WORK" checkout --quiet -b feature-ci-guards-fail
+mkdir -p "$WORK/scripts"
+cat > "$WORK/scripts/run-ci-guards.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub umbrella: respect SKIP_CI_GUARDS, otherwise always fail loudly.
+if [ "${SKIP_CI_GUARDS:-0}" = "1" ]; then
+    echo "WARNING: SKIP_CI_GUARDS=1 — bypassing scripts/run-ci-guards.sh." >&2
+    exit 0
+fi
+echo "STUB: simulated guard failure" >&2
+exit 1
+STUB
+chmod +x "$WORK/scripts/run-ci-guards.sh"
+# Trivial top-level change so the hook actually runs (the umbrella step
+# is unconditional once `scripts/run-ci-guards.sh` is executable, but we
+# still want a non-empty diff so the hook proceeds past its early exit
+# branches).
+echo "scenario 22" >> "$WORK/README.md"
+git -C "$WORK" add scripts/run-ci-guards.sh README.md
+git -C "$WORK" commit --quiet -m "feat: stub failing run-ci-guards.sh"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+run_hook "refs/heads/feature-ci-guards-fail $feat_sha refs/heads/feature-ci-guards-fail $ZERO_SHA"
+
+if [ "$hook_rc" -eq 0 ]; then
+    report_fail "expected hook to reject failing run-ci-guards.sh stub (#4332), exit was 0" "$hook_out"
+elif ! echo "$hook_out" | grep -q "running CI guard umbrella"; then
+    report_fail "expected pre-push to log 'running CI guard umbrella' (#4332)" "$hook_out"
+elif ! echo "$hook_out" | grep -q "FAILED: scripts/run-ci-guards.sh"; then
+    report_fail "expected 'FAILED: scripts/run-ci-guards.sh' in output (#4332)" "$hook_out"
+else
+    report_pass "hook rejects push when run-ci-guards.sh fails (#4332)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 23: SKIP_CI_GUARDS=1 bypasses the umbrella (#4332)
+# ───────────────────────────────────────────────────────────────────────
+# Same stub setup as scenario 22, but invoke the hook with SKIP_CI_GUARDS=1.
+# The umbrella block in pre-push must take the bypass branch — emitting a
+# WARNING line and skipping the run entirely. This means the FAILED line
+# from scenario 22 must NOT appear, and the hook's exit code is determined
+# by the rest of the checks (which all pass on this trivial diff).
+echo "[scenario 23] SKIP_CI_GUARDS=1 bypasses the umbrella (#4332)"
+init_workspace
+git -C "$WORK" checkout --quiet -b feature-ci-guards-bypass
+mkdir -p "$WORK/scripts"
+cat > "$WORK/scripts/run-ci-guards.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub umbrella: respect SKIP_CI_GUARDS, otherwise always fail loudly.
+if [ "${SKIP_CI_GUARDS:-0}" = "1" ]; then
+    echo "WARNING: SKIP_CI_GUARDS=1 — bypassing scripts/run-ci-guards.sh." >&2
+    exit 0
+fi
+echo "STUB: simulated guard failure" >&2
+exit 1
+STUB
+chmod +x "$WORK/scripts/run-ci-guards.sh"
+echo "scenario 23" >> "$WORK/README.md"
+git -C "$WORK" add scripts/run-ci-guards.sh README.md
+git -C "$WORK" commit --quiet -m "feat: stub run-ci-guards.sh (bypass test)"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+# Run the hook with SKIP_CI_GUARDS=1 set in env. We cannot reuse run_hook
+# directly because it doesn't inject env vars; do it inline.
+hook_out="$(cd "$WORK" && SKIP_CI_GUARDS=1 echo "refs/heads/feature-ci-guards-bypass $feat_sha refs/heads/feature-ci-guards-bypass $ZERO_SHA" \
+    | SKIP_CI_GUARDS=1 "$HOOK" origin "$REMOTE" 2>&1)" \
+    && hook_rc=0 || hook_rc=$?
+
+if echo "$hook_out" | grep -q "FAILED: scripts/run-ci-guards.sh"; then
+    report_fail "SKIP_CI_GUARDS=1 must skip the umbrella, but FAILED appeared (#4332)" "$hook_out"
+elif ! echo "$hook_out" | grep -q "SKIP_CI_GUARDS=1"; then
+    report_fail "expected SKIP_CI_GUARDS=1 bypass WARNING in output (#4332)" "$hook_out"
+elif ! echo "$hook_out" | grep -q "bypassing scripts/run-ci-guards.sh"; then
+    report_fail "expected 'bypassing scripts/run-ci-guards.sh' WARNING in output (#4332)" "$hook_out"
+else
+    report_pass "SKIP_CI_GUARDS=1 bypasses the umbrella with WARNING (#4332)"
 fi
 
 # ───────────────────────────────────────────────────────────────────────

--- a/scripts/tests/test_run_ci_guards.sh
+++ b/scripts/tests/test_run_ci_guards.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# test_run_ci_guards.sh — Unit tests for scripts/run-ci-guards.sh (#4332).
+#
+# Exercises the umbrella's discovery, skip-list, marker-based opt-out, and
+# bypass paths against a synthetic scripts/ tree so we can probe behaviour
+# without depending on the real ~70-guard run (which would explode the
+# scripts-tests shard duration). End-to-end coverage of the real run lives
+# in scripts/tests/test_pre_push.sh scenarios 22 and 23.
+#
+# Why a synthetic tree
+# ────────────────────
+# The umbrella resolves its repo root from the script's own location
+# (``$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)``), so we copy the
+# real umbrella into a throwaway scripts/ directory under TMPDIR_TEST and
+# seed exactly the guard files we want each scenario to discover. This
+# isolates the test from any real check-*.sh / check-*.py guard the
+# operator's working tree happens to contain.
+#
+# Scenarios covered
+# ─────────────────
+#   1.  Empty scripts/ tree — exits 2 (discovery error)
+#   2.  Single passing guard — exits 0, listed as RUN
+#   3.  Single failing guard — exits 1, names the failure
+#   4.  Built-in skip list (check-issue-author.sh) — exits 0, listed as SKIP
+#   5.  Per-file marker (# ci-guards: skip) — exits 0, listed as SKIP
+#   6.  .sh/.py companion de-dup — only the .sh runs
+#   7.  --list mode prints discovery without running guards
+#   8.  Non-executable .py runs anyway (CI-canonical state for #4332 retro)
+#   9.  Non-executable .sh is skipped with reason
+#  10.  SKIP_CI_GUARDS=1 emits WARNING and exits 0 without running guards
+#
+# Run:
+#   scripts/tests/test_run_ci_guards.sh
+#
+# Exits non-zero if any scenario fails.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+UMBRELLA_REAL="$REPO_ROOT/scripts/run-ci-guards.sh"
+
+if [ ! -x "$UMBRELLA_REAL" ]; then
+    echo "FAIL: real umbrella not found or not executable at $UMBRELLA_REAL" >&2
+    exit 1
+fi
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass=0
+fail=0
+
+report_pass() {
+    pass=$((pass + 1))
+    echo "  PASS: $1"
+}
+
+report_fail() {
+    fail=$((fail + 1))
+    echo "  FAIL: $1" >&2
+    if [ -n "${2-}" ]; then
+        echo "--- output ---" >&2
+        echo "$2" >&2
+        echo "--- end ---" >&2
+    fi
+}
+
+# Build a synthetic repo with a copy of the real umbrella.
+# Returns the synthetic scripts/ directory path on stdout.
+seed_synthetic_scripts() {
+    local synth_id="$1"
+    local synth_root="$TMPDIR_TEST/synth-$synth_id"
+    rm -rf "$synth_root"
+    mkdir -p "$synth_root/scripts"
+    cp "$UMBRELLA_REAL" "$synth_root/scripts/run-ci-guards.sh"
+    chmod +x "$synth_root/scripts/run-ci-guards.sh"
+    echo "$synth_root/scripts"
+}
+
+# Run the synthetic umbrella, capture stdout+stderr and exit code.
+# Usage: run_synth <synth-scripts-dir> [args...]
+run_synth() {
+    local synth_scripts="$1"
+    shift
+    out_buf="$("$synth_scripts/run-ci-guards.sh" "$@" 2>&1)" \
+        && rc_buf=0 || rc_buf=$?
+}
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 1: empty scripts/ tree — exits 2 (discovery error)
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 1] empty scripts/ tree — exits 2 (discovery error)"
+synth_scripts="$(seed_synthetic_scripts s1)"
+# Don't seed any check-* files.
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 2 ]; then
+    report_fail "expected exit 2 on empty tree, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "no scripts/check-"; then
+    report_fail "expected 'no scripts/check-*' error message" "$out_buf"
+else
+    report_pass "empty scripts/ tree exits 2 with discovery error"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 2: single passing guard — exits 0
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 2] single passing guard — exits 0"
+synth_scripts="$(seed_synthetic_scripts s2)"
+cat > "$synth_scripts/check-pass.sh" <<'SH'
+#!/usr/bin/env bash
+echo "passing guard"
+exit 0
+SH
+chmod +x "$synth_scripts/check-pass.sh"
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected exit 0 with single passing guard, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "all 1 guard(s) passed"; then
+    report_fail "expected 'all 1 guard(s) passed' summary" "$out_buf"
+else
+    report_pass "single passing guard exits 0"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 3: single failing guard — exits 1, names failure
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 3] single failing guard — exits 1, names failure"
+synth_scripts="$(seed_synthetic_scripts s3)"
+cat > "$synth_scripts/check-fail.sh" <<'SH'
+#!/usr/bin/env bash
+echo "deliberate failure"
+exit 1
+SH
+chmod +x "$synth_scripts/check-fail.sh"
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 with single failing guard, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "FAILED: check-fail.sh"; then
+    report_fail "expected 'FAILED: check-fail.sh' in output" "$out_buf"
+elif ! echo "$out_buf" | grep -q "deliberate failure"; then
+    report_fail "expected guard's stderr to surface in output" "$out_buf"
+else
+    report_pass "single failing guard exits 1 and names the failure"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 4: built-in skip list — check-issue-author.sh skipped
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 4] built-in skip list — check-issue-author.sh skipped"
+synth_scripts="$(seed_synthetic_scripts s4)"
+# Seed both a passing guard and an issue-author.sh stub. The latter would
+# fail if invoked (it requires an issue number), but the built-in skip
+# list should keep it from running.
+cat > "$synth_scripts/check-pass.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$synth_scripts/check-pass.sh"
+cat > "$synth_scripts/check-issue-author.sh" <<'SH'
+#!/usr/bin/env bash
+echo "this should never fire — built-in skip list violated"
+exit 1
+SH
+chmod +x "$synth_scripts/check-issue-author.sh"
+run_synth "$synth_scripts" --list
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected --list to exit 0, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "SKIP check-issue-author.sh (built-in skip)"; then
+    report_fail "expected 'SKIP check-issue-author.sh (built-in skip)'" "$out_buf"
+else
+    report_pass "built-in skip list excludes check-issue-author.sh"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 5: per-file marker (# ci-guards: skip) — guard skipped
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 5] per-file marker — guard skipped"
+synth_scripts="$(seed_synthetic_scripts s5)"
+# Marker variant — should be skipped despite being a normal check-*.sh.
+cat > "$synth_scripts/check-marker.sh" <<'SH'
+#!/usr/bin/env bash
+# ci-guards: skip
+echo "marker guard ran — bug"
+exit 1
+SH
+chmod +x "$synth_scripts/check-marker.sh"
+run_synth "$synth_scripts" --list
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected --list to exit 0, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "SKIP check-marker.sh (# ci-guards: skip)"; then
+    report_fail "expected 'SKIP check-marker.sh (# ci-guards: skip)'" "$out_buf"
+else
+    report_pass "per-file marker excludes check-marker.sh"
+fi
+# And verify the marker actually prevents execution: a full run should pass.
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "marker guard ran despite skip marker (rc=$rc_buf)" "$out_buf"
+else
+    report_pass "marker guard not invoked during full run"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 6: .sh/.py companion de-dup — only .sh runs
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 6] .sh/.py companion de-dup — only .sh runs"
+synth_scripts="$(seed_synthetic_scripts s6)"
+# Both files exist; .py would fail if invoked, .sh passes.
+cat > "$synth_scripts/check-companion.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$synth_scripts/check-companion.sh"
+cat > "$synth_scripts/check-companion.py" <<'PY'
+import sys
+print("py companion ran — bug", file=sys.stderr)
+sys.exit(1)
+PY
+# Intentionally do NOT chmod +x the .py — companion de-dup must work
+# regardless of executability.
+run_synth "$synth_scripts" --list
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected --list to exit 0, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "RUN  check-companion.sh"; then
+    report_fail "expected 'RUN check-companion.sh' in --list output" "$out_buf"
+elif ! echo "$out_buf" | grep -q "SKIP check-companion.py (.sh wrapper companion: check-companion.sh)"; then
+    report_fail "expected '.sh wrapper companion' skip line" "$out_buf"
+else
+    report_pass ".sh/.py companion de-dup runs only the .sh"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 7: --list mode prints without running
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 7] --list mode prints discovery without running guards"
+synth_scripts="$(seed_synthetic_scripts s7)"
+cat > "$synth_scripts/check-shouldnotrun.sh" <<'SH'
+#!/usr/bin/env bash
+echo "RAN" > "$0.touched"
+exit 0
+SH
+chmod +x "$synth_scripts/check-shouldnotrun.sh"
+run_synth "$synth_scripts" --list
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected --list to exit 0, got $rc_buf" "$out_buf"
+elif [ -f "$synth_scripts/check-shouldnotrun.sh.touched" ]; then
+    report_fail "--list mode invoked the guard (touched sentinel file present)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "RUN  check-shouldnotrun.sh"; then
+    report_fail "expected 'RUN check-shouldnotrun.sh' in --list output" "$out_buf"
+else
+    report_pass "--list mode prints discovery without running guards"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 8: non-executable .py runs anyway via python3 (CI-canonical
+#              state — see check-sql-columns.py at PR #4325 retro time)
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 8] non-executable .py runs anyway via python3 (#4332)"
+synth_scripts="$(seed_synthetic_scripts s8)"
+cat > "$synth_scripts/check-py-noexec.py" <<'PY'
+import sys
+print("py guard ran")
+sys.exit(0)
+PY
+# Intentionally leave -rw-r--r--.
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected exit 0 with non-executable .py guard, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "all 1 guard(s) passed"; then
+    report_fail "expected 'all 1 guard(s) passed' (non-exec .py should run)" "$out_buf"
+else
+    report_pass "non-executable .py guard runs via python3 (#4332)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 9: non-executable .sh is skipped with reason
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 9] non-executable .sh is skipped with reason"
+synth_scripts="$(seed_synthetic_scripts s9)"
+cat > "$synth_scripts/check-sh-noexec.sh" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+# Intentionally do NOT chmod +x.
+run_synth "$synth_scripts" --list
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected --list to exit 0, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "SKIP check-sh-noexec.sh (not executable)"; then
+    report_fail "expected 'SKIP check-sh-noexec.sh (not executable)' in --list" "$out_buf"
+else
+    report_pass "non-executable .sh is skipped with reason"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 10: SKIP_CI_GUARDS=1 emits WARNING and exits 0
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 10] SKIP_CI_GUARDS=1 emits WARNING and exits 0"
+synth_scripts="$(seed_synthetic_scripts s10)"
+# Seed a guard that would fail if invoked — bypass must short-circuit.
+cat > "$synth_scripts/check-fail.sh" <<'SH'
+#!/usr/bin/env bash
+echo "this must never run"
+exit 1
+SH
+chmod +x "$synth_scripts/check-fail.sh"
+out_buf="$(SKIP_CI_GUARDS=1 "$synth_scripts/run-ci-guards.sh" 2>&1)" \
+    && rc_buf=0 || rc_buf=$?
+if [ "$rc_buf" -ne 0 ]; then
+    report_fail "expected SKIP_CI_GUARDS=1 to exit 0, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "SKIP_CI_GUARDS=1"; then
+    report_fail "expected 'SKIP_CI_GUARDS=1' WARNING in output" "$out_buf"
+elif ! echo "$out_buf" | grep -q "bypassing scripts/run-ci-guards.sh"; then
+    report_fail "expected 'bypassing scripts/run-ci-guards.sh' WARNING" "$out_buf"
+elif echo "$out_buf" | grep -q "this must never run"; then
+    report_fail "SKIP_CI_GUARDS=1 invoked the guard despite bypass" "$out_buf"
+else
+    report_pass "SKIP_CI_GUARDS=1 bypasses with WARNING and exits 0"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Summary
+# ───────────────────────────────────────────────────────────────────────
+echo ""
+echo "────────────────────────────────────────────────────────────────"
+echo "test_run_ci_guards.sh: $pass passed, $fail failed"
+echo "────────────────────────────────────────────────────────────────"
+
+if [ "$fail" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/run-ci-guards.sh` — an auto-discovery umbrella that runs every executable matching `scripts/check-*.{sh,py}` against the local working tree — and wires it into `.githooks/pre-push` after the existing per-package / migration / workflow checks. Closes the loop where a one-line CI-only guard nit (e.g. PR #4325 / `sql-column-check`) used to cost a full ~3-minute CI round trip to discover. Self-maintaining via auto-discovery; per-file `# ci-guards: skip` opt-out marker; built-in `SKIP_LIST` for guards that need GH/network/Docker/argument context. `SKIP_CI_GUARDS=1` env-var bypass with a noisy stderr WARNING.

Closes #4332

## Test plan

### Automated checks
- [x] Lint passes — pre-push hook ran clean against this commit (umbrella + bash-compat + bash-set-u-empty-array + script-headers).
- [x] Format check passes — n/a (shell + markdown only).
- [x] Tests pass locally — `scripts/tests/test_pre_push.sh` (23/23 — adds scenarios 22 + 23 for #4332) and `scripts/tests/test_run_ci_guards.sh` (11/11 — new).
- [x] CI green — canonical merge gate green (mergeable=MERGEABLE, ci-passed=success, 99 passed / 0 failed / 1 superseded-pending).

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling only; the umbrella ships in the repo and runs locally + via `.githooks/pre-push`).
- [x] Verification evidence posted on issue (see A.8).
