### PR TITLE
feat(scraping): register CA splitters under rebuild-ca-<county> aliases too (#4331)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives.py
@@ -790,6 +790,15 @@ class CCTentativeRulingsScraper(PdfLinkScraper):
         return doc
 
 
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-contra_costa`` instead of the live ``ca-cc-...`` id).
+# See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-contra_costa"]
+
+
 def default_config(s3_bucket: str = "") -> ScraperConfig:
     """Factory for the default Contra Costa scraper configuration."""
     from datetime import time as dtime

--- a/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
@@ -638,6 +638,15 @@ class FresnoTentativeRulingsScraper(PdfLinkScraper):
         return doc
 
 
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-fresno`` instead of the live ``ca-fresno-...`` id).
+# See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-fresno"]
+
+
 def default_config(s3_bucket: str = "") -> ScraperConfig:
     """Factory for the default Fresno tentative rulings scraper configuration."""
     from datetime import time as dtime

--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -2272,3 +2272,12 @@ _SCRAPER_CLASS_BY_ID: dict[str, type] = {
     "ca-la-tentatives-civil": LATentativeRulingsScraper,
     "ca-la-tentatives-appellate": LAAppellateTentativeRulingsScraper,
 }
+
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-los_angeles`` instead of the live ``ca-la-...`` id).
+# Both civil and appellate share this rebuild id since they're produced from
+# the same county slug.  See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-los_angeles"]

--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -493,6 +493,15 @@ class RiversideTentativeRulingsScraper(PdfLinkScraper):
         return doc
 
 
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-riverside`` instead of the live ``ca-riverside-...``
+# id).  See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-riverside"]
+
+
 def default_config(s3_bucket: str = "") -> ScraperConfig:
     from datetime import time as dtime
 

--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -844,6 +844,15 @@ class SCTentativeRulingsScraper(BaseScraper):
         return doc
 
 
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-santa_clara`` instead of the live ``ca-sc-...`` id).
+# See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-santa_clara"]
+
+
 def default_config(s3_bucket: str = "") -> ScraperConfig:
     """Create the default scraper configuration for Santa Clara County."""
     from datetime import time as dtime

--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -648,6 +648,15 @@ class SDCalendarScraper(BaseScraper):
 # ---------------------------------------------------------------------------
 
 
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-san_diego`` instead of the live ``ca-sd-calendar``
+# id).  See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-san_diego"]
+
+
 def default_config(s3_bucket: str = "") -> ScraperConfig:
     """Factory for the default San Diego calendar scraper configuration."""
     from datetime import time as dtime

--- a/packages/scraper-framework/src/courts/ca/sf_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_tentatives.py
@@ -405,6 +405,15 @@ class SFTentativeRulingsScraper(PdfLinkScraper):
         return doc
 
 
+# Extra scraper_ids under which this module's ``_split_rulings`` /
+# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
+# scripts that key on ``documents.scraper_id`` resolve the splitter on
+# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
+# which emits ``rebuild-ca-san_francisco`` instead of the live ``ca-sf-...`` id).
+# See #4331.
+_SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-san_francisco"]
+
+
 def default_config(s3_bucket: str = "") -> ScraperConfig:
     """Factory for the default SF Family Law scraper configuration."""
     from datetime import time as dtime

--- a/packages/scraper-framework/tests/test_llm_split_guards.py
+++ b/packages/scraper-framework/tests/test_llm_split_guards.py
@@ -57,9 +57,19 @@ def _load_registries() -> tuple[dict, dict]:
 
 
 def _llm_scraper_ids() -> list[str]:
-    """Return the list of scraper_ids in ``_LLM_SPLIT_REGISTRY`` after load."""
-    _, llm = _load_registries()
-    return sorted(llm.keys())
+    """Return the list of canonical scraper_ids in ``_LLM_SPLIT_REGISTRY``.
+
+    Filters out alias entries — scraper_ids registered via a module's
+    ``_SPLIT_REGISTRY_ALIASES`` (e.g. ``rebuild-ca-<county>``, see #4331).
+    Aliases register the splitter callables but NOT a corresponding
+    ``_SCRAPER_REGISTRY`` class, because the rebuild path does not invoke
+    ``parse_document`` (audit / drain scripts only call the splitter
+    directly).  The pre-split guard test below operates on
+    ``parse_document`` source, so it must run only against canonical
+    scraper_ids that actually have a registered class.
+    """
+    scraper_registry, llm = _load_registries()
+    return sorted(sid for sid in llm if sid in scraper_registry)
 
 
 # Parametrize at collection time so each scraper gets its own test ID.

--- a/packages/scraper-framework/tests/test_split_registry.py
+++ b/packages/scraper-framework/tests/test_split_registry.py
@@ -1,0 +1,336 @@
+"""Regression tests for the splitter alias mechanism (#4331).
+
+The discovery loop in ``scripts/reingest_from_s3.py:_load_scraper_registry``
+walks every court module that exposes ``default_config()`` and registers its
+``_split_rulings`` / ``_llm_extract_rulings`` callables in the ``_SPLIT_REGISTRY``
+/ ``_LLM_SPLIT_REGISTRY`` dicts under the canonical ``scraper_id``.  These
+tests verify that any module exporting an additional ``_SPLIT_REGISTRY_ALIASES``
+list also registers the same callables under each alias scraper_id.
+
+Why aliases are needed.  ``scripts/rebuild_db.py`` reconstructs rows from S3
+by emitting a synthetic ``rebuild-{state}-{county}`` scraper_id (rather than
+the live ``ca-{abbrev}-...`` id).  Audit and drain scripts that key on
+``documents.scraper_id`` look up ``_SPLIT_REGISTRY[scraper_id]`` directly —
+without an alias entry, every rebuild-path row silently no-ops because the
+canonical scraper_id never matches.  Issue #4331 documents the failure mode:
+21 SC ``all_same_case_title_cluster`` rows were stuck on the rebuild path
+because ``ca-sc-tentatives-civil`` was registered but ``rebuild-ca-santa_clara``
+was not.
+
+This test file enforces the contract that:
+
+1. Every module declaring ``_SPLIT_REGISTRY_ALIASES`` registers each alias.
+2. Each alias resolves to the SAME callable as the canonical scraper_id
+   (so the splitter behaviour is identical regardless of which id surfaces).
+3. Every county that has a splitter has a matching ``rebuild-ca-<county>``
+   alias — so a future scraper_id rename can't silently break splitter
+   resolution on rebuild rows.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import pkgutil
+import sys
+from types import ModuleType
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import the reingest module from scripts/
+# ---------------------------------------------------------------------------
+
+_SCRIPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "..",
+    "scripts",
+)
+sys.path.insert(0, _SCRIPTS_DIR)
+reingest = importlib.import_module("reingest_from_s3")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _discover_modules_with_aliases() -> list[ModuleType]:
+    """Return every court module that exports ``_SPLIT_REGISTRY_ALIASES``.
+
+    Walks the same ``courts`` package tree as ``_load_scraper_registry``.
+    Skips modules that fail to import (the discovery loop in production
+    code does the same — see #4331).
+    """
+    import courts
+
+    out: list[ModuleType] = []
+    for _importer, modname, ispkg in pkgutil.walk_packages(courts.__path__, prefix="courts."):
+        if ispkg:
+            continue
+        try:
+            mod = importlib.import_module(modname)
+        except Exception:  # noqa: BLE001
+            continue
+        aliases = getattr(mod, "_SPLIT_REGISTRY_ALIASES", None)
+        if aliases:
+            out.append(mod)
+    return out
+
+
+def _config_factories(mod: ModuleType) -> list:
+    """Return all ``default_config*`` factory callables defined in ``mod``."""
+    out = []
+    for name, obj in inspect.getmembers(mod, inspect.isfunction):
+        if (name == "default_config" or name.startswith("default_config_")) and (
+            obj.__module__ == mod.__name__
+        ):
+            out.append(obj)
+    return out
+
+
+def _canonical_scraper_ids(mod: ModuleType) -> list[str]:
+    """Return the canonical scraper_id for every ``default_config*`` factory."""
+    return sorted({factory().scraper_id for factory in _config_factories(mod)})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAliasesPlumbedIntoRegistry:
+    """``_SPLIT_REGISTRY_ALIASES`` must register the same callables as the canonical id."""
+
+    def _reload_registries(self) -> None:
+        reingest._SCRAPER_REGISTRY.clear()
+        reingest._SPLIT_REGISTRY.clear()
+        reingest._LLM_SPLIT_REGISTRY.clear()
+        reingest._load_scraper_registry()
+
+    def test_at_least_one_module_declares_aliases(self) -> None:
+        """A baseline: at least one module must declare _SPLIT_REGISTRY_ALIASES.
+
+        Otherwise this test file is exercising nothing.  The Santa Clara
+        splitter (#4331's canonical reproducer) is required to register
+        ``rebuild-ca-santa_clara``; if that ever disappears, the entire
+        alias mechanism has regressed.
+        """
+        modules = _discover_modules_with_aliases()
+        assert modules, (
+            "No court modules export _SPLIT_REGISTRY_ALIASES — the alias "
+            "mechanism added in #4331 has regressed.  At minimum, "
+            "courts.ca.sc_tentatives must declare "
+            "['rebuild-ca-santa_clara']."
+        )
+
+    def test_every_alias_registers_split_fn_when_canonical_does(self) -> None:
+        """If a module's canonical scraper_id has a regex splitter, every alias must too."""
+        self._reload_registries()
+        for mod in _discover_modules_with_aliases():
+            split_fn = getattr(mod, "_split_rulings", None)
+            if split_fn is None:
+                # Module has aliases but no regex splitter — only the LLM
+                # path matters here; covered by the next test.
+                continue
+            for canonical_id in _canonical_scraper_ids(mod):
+                assert reingest._SPLIT_REGISTRY.get(canonical_id) is split_fn, (
+                    f"Canonical scraper_id {canonical_id!r} from "
+                    f"{mod.__name__} did not register _split_rulings."
+                )
+            for alias in mod._SPLIT_REGISTRY_ALIASES:
+                assert reingest._SPLIT_REGISTRY.get(alias) is split_fn, (
+                    f"Alias scraper_id {alias!r} declared by {mod.__name__} "
+                    f"did not register the module's _split_rulings function "
+                    f"in _SPLIT_REGISTRY.  This is the #4331 failure mode — "
+                    f"audit / drain on rebuild rows silently no-ops."
+                )
+
+    def test_every_alias_registers_llm_split_fn_when_canonical_does(self) -> None:
+        """If a module's canonical scraper_id has an LLM splitter, every alias must too."""
+        self._reload_registries()
+        for mod in _discover_modules_with_aliases():
+            llm_split_fn = getattr(mod, "_llm_extract_rulings", None)
+            if llm_split_fn is None:
+                continue
+            for canonical_id in _canonical_scraper_ids(mod):
+                assert reingest._LLM_SPLIT_REGISTRY.get(canonical_id) is llm_split_fn, (
+                    f"Canonical scraper_id {canonical_id!r} from "
+                    f"{mod.__name__} did not register _llm_extract_rulings."
+                )
+            for alias in mod._SPLIT_REGISTRY_ALIASES:
+                assert reingest._LLM_SPLIT_REGISTRY.get(alias) is llm_split_fn, (
+                    f"Alias scraper_id {alias!r} declared by {mod.__name__} "
+                    f"did not register the module's _llm_extract_rulings "
+                    f"function in _LLM_SPLIT_REGISTRY (#4331)."
+                )
+
+
+class TestSantaClaraReproducerSatisfied:
+    """Direct regression for the #4331 reproducer (post-deploy verification of #4321)."""
+
+    def test_rebuild_ca_santa_clara_resolves_to_sc_splitter(self) -> None:
+        """``_SPLIT_REGISTRY['rebuild-ca-santa_clara']`` must resolve.
+
+        This is the literal failure mode from #4331: SC's
+        ``all_same_case_title_cluster`` rows in the dev DB carried
+        ``scraper_id='rebuild-ca-santa_clara'`` and the drain script's
+        ``resolve_split_fn`` looked up the registry with that key, got
+        ``None``, and skipped every cluster.
+        """
+        reingest._SCRAPER_REGISTRY.clear()
+        reingest._SPLIT_REGISTRY.clear()
+        reingest._LLM_SPLIT_REGISTRY.clear()
+        reingest._load_scraper_registry()
+
+        assert "rebuild-ca-santa_clara" in reingest._SPLIT_REGISTRY, (
+            "rebuild-ca-santa_clara not registered in _SPLIT_REGISTRY — "
+            "drain_splitter_carry_forward_clusters.resolve_split_fn() "
+            "will return None and skip every SC rebuild-path cluster (#4331)."
+        )
+
+        from courts.ca import sc_tentatives  # type: ignore[import-not-found]
+
+        assert reingest._SPLIT_REGISTRY["rebuild-ca-santa_clara"] is sc_tentatives._split_rulings, (
+            "rebuild-ca-santa_clara resolves to a function but not the SC "
+            "splitter — alias plumbing crossed wires."
+        )
+
+
+class TestEverySplitterCountyHasRebuildAlias:
+    """Lock-in: every county with a splitter must register a rebuild alias.
+
+    Without this, future splitter additions can silently regress the same
+    rebuild-path bug #4331 fixed.  Yes, it duplicates the per-module
+    declarations — that's the point.  This test fails loudly the first time
+    a new splitter ships without a matching alias.
+    """
+
+    # Mapping enforced by this test.  Every entry corresponds to one CA county
+    # whose scraper module exports ``_split_rulings`` and/or
+    # ``_llm_extract_rulings``.  The mapping is intentionally hand-curated
+    # rather than derived from sluggified config.county — that derivation is
+    # the test we want, but circularly deriving it from the module would
+    # silently mask a missing alias.  Update this dict when adding a new
+    # splitter for a new county.
+    _EXPECTED_REBUILD_ALIASES: dict[str, str] = {
+        "courts.ca.sc_tentatives": "rebuild-ca-santa_clara",
+        "courts.ca.cc_tentatives": "rebuild-ca-contra_costa",
+        "courts.ca.fresno_tentatives": "rebuild-ca-fresno",
+        "courts.ca.la_tentatives": "rebuild-ca-los_angeles",
+        "courts.ca.sf_tentatives": "rebuild-ca-san_francisco",
+        "courts.ca.riverside_tentatives": "rebuild-ca-riverside",
+        "courts.ca.sd_calendar": "rebuild-ca-san_diego",
+    }
+
+    @pytest.mark.parametrize(
+        "module_path,expected_alias",
+        sorted(_EXPECTED_REBUILD_ALIASES.items()),
+    )
+    def test_module_declares_rebuild_alias(self, module_path: str, expected_alias: str) -> None:
+        """Each tracked splitter module must include the expected rebuild alias."""
+        mod = importlib.import_module(module_path)
+        aliases = getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or []
+        assert expected_alias in aliases, (
+            f"{module_path} is missing the expected rebuild alias "
+            f"{expected_alias!r} from _SPLIT_REGISTRY_ALIASES.  Without it, "
+            f"audit / drain scripts that key on documents.scraper_id will "
+            f"silently no-op on rebuild-path rows (#4331)."
+        )
+
+    def test_every_module_with_splitter_is_tracked(self) -> None:
+        """Every module exporting a splitter must appear in the expected dict.
+
+        Catches the case where a new county's splitter ships without anyone
+        adding it to ``_EXPECTED_REBUILD_ALIASES`` here.  If you hit this
+        assertion: add a row to the dict above and add
+        ``_SPLIT_REGISTRY_ALIASES`` to the new module.
+        """
+        import courts
+
+        modules_with_splitters: list[str] = []
+        for _importer, modname, ispkg in pkgutil.walk_packages(courts.__path__, prefix="courts."):
+            if ispkg:
+                continue
+            try:
+                mod = importlib.import_module(modname)
+            except Exception:  # noqa: BLE001
+                continue
+            has_splitter = any(
+                callable(getattr(mod, attr, None))
+                for attr in ("_split_rulings", "_llm_extract_rulings")
+            )
+            if has_splitter:
+                modules_with_splitters.append(modname)
+
+        untracked = set(modules_with_splitters) - set(self._EXPECTED_REBUILD_ALIASES.keys())
+        assert not untracked, (
+            f"These modules export a splitter but are not tracked in "
+            f"TestEverySplitterCountyHasRebuildAlias._EXPECTED_REBUILD_ALIASES: "
+            f"{sorted(untracked)}.  Add the rebuild-ca-<county> alias to "
+            f"the module's _SPLIT_REGISTRY_ALIASES and add the expected "
+            f"alias to the test dict (#4331)."
+        )
+
+
+class TestAliasContractIsolated:
+    """The alias mechanism itself, exercised in isolation against a synthetic module."""
+
+    def test_alias_registers_in_split_registry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A synthetic module with _SPLIT_REGISTRY_ALIASES + _split_rulings must register both."""
+        import types
+
+        # Build a fake module the discovery loop can consume.  We reach
+        # straight into the loop's getattr() targets so the test exercises
+        # the exact registration contract without needing to fake a full
+        # courts.* tree.
+        fake_split = lambda text: []  # noqa: E731 — minimal sentinel
+        fake_mod = types.ModuleType("courts.ca.fake_alias_test")
+        fake_mod._split_rulings = fake_split  # type: ignore[attr-defined]
+        fake_mod._SPLIT_REGISTRY_ALIASES = ["rebuild-ca-fake-test"]  # type: ignore[attr-defined]
+
+        # Mimic what _load_scraper_registry does for the alias plumbing.
+        scraper_id = "ca-fake-test"
+        split_fn = getattr(fake_mod, "_split_rulings", None)
+        split_aliases = getattr(fake_mod, "_SPLIT_REGISTRY_ALIASES", []) or []
+
+        # Snapshot + restore the global registries so we don't leak state.
+        saved_split = dict(reingest._SPLIT_REGISTRY)
+        saved_llm = dict(reingest._LLM_SPLIT_REGISTRY)
+        try:
+            if split_fn is not None and callable(split_fn):
+                reingest._SPLIT_REGISTRY[scraper_id] = split_fn
+                for alias in split_aliases:
+                    reingest._SPLIT_REGISTRY[alias] = split_fn
+
+            assert reingest._SPLIT_REGISTRY[scraper_id] is fake_split
+            assert reingest._SPLIT_REGISTRY["rebuild-ca-fake-test"] is fake_split
+        finally:
+            reingest._SPLIT_REGISTRY.clear()
+            reingest._SPLIT_REGISTRY.update(saved_split)
+            reingest._LLM_SPLIT_REGISTRY.clear()
+            reingest._LLM_SPLIT_REGISTRY.update(saved_llm)
+
+    def test_module_without_aliases_still_registers_canonical_only(self) -> None:
+        """Modules omitting _SPLIT_REGISTRY_ALIASES must still register their canonical id.
+
+        Backward compatibility for any future splitter that doesn't need a
+        rebuild alias.
+        """
+        reingest._SCRAPER_REGISTRY.clear()
+        reingest._SPLIT_REGISTRY.clear()
+        reingest._LLM_SPLIT_REGISTRY.clear()
+        reingest._load_scraper_registry()
+
+        # Just confirm the registry has *something* in it — the per-module
+        # checks above confirm specifics.  This is a smoke test against
+        # an obvious regression: someone makes _SPLIT_REGISTRY_ALIASES
+        # required and accidentally drops every module that doesn't declare it.
+        assert reingest._SPLIT_REGISTRY, (
+            "_SPLIT_REGISTRY is empty after _load_scraper_registry() — the "
+            "alias mechanism may have inadvertently broken canonical "
+            "registration for modules without _SPLIT_REGISTRY_ALIASES."
+        )

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -363,6 +363,18 @@ def _load_scraper_registry() -> None:
 
             _SCRAPER_REGISTRY[scraper_id] = scraper_cls
 
+            # Module-level alias list: extra scraper_ids under which this
+            # module's ``_split_rulings`` / ``_llm_extract_rulings`` should
+            # also be registered.  Required so rebuild-path rows
+            # (``rebuild-{state}-{county}``, emitted by
+            # ``scripts/rebuild_db.py`` when reconstructing rows from S3)
+            # resolve to the same splitter as live-captured rows.  Without
+            # this, any audit or drain that keys on ``documents.scraper_id``
+            # silently no-ops on every rebuild row (#4331).  The list is
+            # optional — modules without aliases simply register under the
+            # canonical scraper_id only.
+            split_aliases: list[str] = getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or []
+
             # Register split function if the module exports one.
             # Convention: a module-level ``_split_rulings`` callable
             # indicates that the scraper produces multi-ruling documents
@@ -370,6 +382,8 @@ def _load_scraper_registry() -> None:
             split_fn = getattr(mod, "_split_rulings", None)
             if split_fn is not None and callable(split_fn):
                 _SPLIT_REGISTRY[scraper_id] = split_fn
+                for alias in split_aliases:
+                    _SPLIT_REGISTRY[alias] = split_fn
 
             # Register LLM-based split function if available.
             # Convention: a module-level ``_llm_extract_rulings`` callable
@@ -378,6 +392,8 @@ def _load_scraper_registry() -> None:
             llm_split_fn = getattr(mod, "_llm_extract_rulings", None)
             if llm_split_fn is not None and callable(llm_split_fn):
                 _LLM_SPLIT_REGISTRY[scraper_id] = llm_split_fn
+                for alias in split_aliases:
+                    _LLM_SPLIT_REGISTRY[alias] = llm_split_fn
 
 
 FETCH_DOCUMENTS_QUERY = """


### PR DESCRIPTION
## Summary

Adds an opt-in `_SPLIT_REGISTRY_ALIASES: list[str]` module-level constant honoured by `_load_scraper_registry()` in `scripts/reingest_from_s3.py`. Every CA scraper that exports `_split_rulings` and/or `_llm_extract_rulings` now declares its corresponding `rebuild-ca-<county>` alias so audit/drain scripts that key on `documents.scraper_id` resolve the splitter for rebuild-path rows. Without this, `scripts/rebuild_db.py`-emitted rows (synthetic `rebuild-ca-<county>` ids) silently no-op on every audit/drain that calls `_SPLIT_REGISTRY[scraper_id]` directly — the failure mode discovered during post-deploy verification of #4321.

Closes #4331

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` — scraper-framework + scripts/reingest_from_s3.py)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (full scraper-framework test suite — 7545 passed locally)
- [x] CI green

### Post-deploy verification

- [x] Drain script ran on dev: `scripts/ecs-run-task.sh scripts/drain_splitter_carry_forward_clusters.py -- --county "Santa Clara"` (task `719c2ee0949b4245b2a995d4f90d790d`)
- [x] Alias resolution probe on deployed image (task `31959808b69845329262e61afe8dd71f`) confirms every `rebuild-ca-<county>` alias resolves to the correct splitter
- [x] Verification evidence posted on issue (see #4331 comment)
