### PR TITLE
feat(dx): centralize repo-walk --exclude-dir list in preflight.sh (#4308)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1238,6 +1238,23 @@ jobs:
         run: scripts/check-placeholder-gates.sh
 
   # ---------------------------------------------------------------
+  # Repo-walk exclusion canonicalization guard (#4308): every
+  # check-*.sh that walks the repo with grep must source preflight.sh
+  # and consume the canonical REPO_WALK_EXCLUSIONS list rather than
+  # hand-rolling its own list. Prevents the next #4300-style outage
+  # where a check missed `.claude` and tripped on test fixtures.
+  # The step name below intentionally avoids quoting the forbidden
+  # token (per docs/agent/code-standards.md §Hygiene-check CI steps
+  # and #2541/#2542).
+  # ---------------------------------------------------------------
+  repo-walk-exclusions-canonical-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce canonical repo-walk exclusion list across check scripts
+        run: scripts/check-repo-walk-exclusions-canonical.sh
+
+  # ---------------------------------------------------------------
   # Hardcoded color guard: enforce semantic design tokens in TSX
   # ---------------------------------------------------------------
   hardcoded-colors-check:
@@ -1909,7 +1926,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -481,6 +481,8 @@ The peer guard tests under `scripts/tests/test_check_*.sh` include a self-match 
 
 **`scripts/check-no-heredoc-pipe-shadow.sh`** — flags the silent-miscompile pattern `... | python3 << TAG` whose body reads stdin via `json.load(sys.stdin)` / `sys.stdin.read()`. Bash gives the heredoc precedence as Python's stdin, so the piped data is silently discarded and JSON parsing raises `Expecting value: line 1 column 1` at runtime. See #4267 (the guard) and #4252 (the `scripts/ecs-wait-task.sh` PR that surfaced the footgun).
 
+**Canonical repo-walk exclusion list (#4308).** Any new `scripts/check-*.sh` that runs `grep -rEn` over the repo must consume `REPO_WALK_EXCLUSIONS` from `scripts/preflight.sh` rather than hand-rolling its own `--exclude-dir=` list. The canonical baseline (`.git`, `.venv`, `node_modules`, `__pycache__`, `.next`, `.claude`, `.vite`, `tmp`, `dist`, `build`) is repo-wide policy — duplicating it across 10+ scripts is what caused #4300 (a missed `.claude` exclusion took main CI red for ~30 minutes). Per-check augmentations stay local to the script via `EXTRA_EXCLUDE_DIRS=(...)` appended to the canonical iteration. The hygiene gate `scripts/check-repo-walk-exclusions-canonical.sh` enforces the contract — see the `REPO_WALK_EXCLUSIONS` docstring in `scripts/preflight.sh` for the consumer pattern.
+
 ### Test profiling — find the long pole in a shell test
 
 When a `scripts/tests/test_*.sh` shell test gets slow and the cost is unclear ("which `# Test N:` section is dominant?"), run `scripts/profile-shell-test.sh` against it:

--- a/scripts/check-deprecated-models.sh
+++ b/scripts/check-deprecated-models.sh
@@ -18,8 +18,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Deprecated model identifiers ───────────────────────────────────────
 # Add new entries as Anthropic deprecates models.  Each entry is a string
@@ -45,17 +49,9 @@ DEPRECATED_MODELS=(
 )
 
 # ─── Directories and files to exclude ────────────────────────────────────
-# These contain configuration, documentation, or test fixtures where
-# deprecated model names may appear legitimately.
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".claude"
-    ".vite"
-)
+# Repo-walk dir exclusions come from REPO_WALK_EXCLUSIONS in preflight.sh
+# (canonical list — single source of truth, see #4308). No per-check
+# extras needed here.
 
 # Files that legitimately reference deprecated models (this script itself,
 # its tests, documentation about the deprecation check).
@@ -75,9 +71,9 @@ done
 alternation=$(IFS='|'; echo "${escaped_models[*]}")
 PATTERN="(${alternation})"
 
-# Build --exclude-dir arguments
+# Build --exclude-dir arguments from the canonical list.
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-hardcoded-models.sh
+++ b/scripts/check-hardcoded-models.sh
@@ -28,8 +28,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Model identifier patterns ────────────────────────────────────────
 # Match current and future Claude model IDs.  These patterns match
@@ -41,15 +45,9 @@ SCAN_DIR="${1:-$REPO_ROOT}"
 PATTERN='claude-(haiku|sonnet|opus)-[0-9][a-zA-Z0-9._-]*'
 
 # ─── Directories to exclude from scanning ─────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".claude"
-    ".vite"
-)
+# Repo-walk dir exclusions come from REPO_WALK_EXCLUSIONS in preflight.sh
+# (canonical list — single source of truth, see #4308). No per-check
+# extras needed here.
 
 # ─── Files to exclude (relative to repo root) ─────────────────────────
 # The source-of-truth file, this script, its tests, and the deprecated
@@ -69,9 +67,9 @@ EXCLUDE_PATH_PATTERNS=(
     "scripts/eval/*"
 )
 
-# ─── Build grep arguments ─────────────────────────────────────────────
+# ─── Build --exclude-dir arguments from the canonical list ─────────────
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-llm-json-loads.sh
+++ b/scripts/check-llm-json-loads.sh
@@ -31,8 +31,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Suspect patterns ─────────────────────────────────────────────────
 # Pattern 1: json.loads(...text<word-boundary>)
@@ -46,18 +50,12 @@ SCAN_DIR="${1:-$REPO_ROOT}"
 #   Allows leading/trailing whitespace for formatting tolerance.
 PATTERN='json\.loads\([^)]*\.text\b|json\.loads\(\s*raw_text\s*[,)]'
 
-# ─── Directories and files to exclude ─────────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".claude"
-    ".vite"
-    "tests"
-    "test"
-)
+# ─── Per-check extras on top of REPO_WALK_EXCLUSIONS ──────────────────
+# ``tests`` and ``test`` directories are excluded because LLM response
+# fixtures and assertions in tests legitimately call ``json.loads`` on
+# fake LLM-shaped strings; the production-source-only scope keeps the
+# guard signal clean. Repo-wide dir exclusions come from preflight.sh.
+EXTRA_EXCLUDE_DIRS=(tests test)
 
 # Allowlist — files where json.loads on .text or raw_text is legitimate
 # (non-LLM source).  Keep this list small and justified.  New entries
@@ -77,8 +75,10 @@ EXCLUDE_FILES=(
 )
 
 # ─── Build grep arguments ─────────────────────────────────────────────
+# Canonical list (REPO_WALK_EXCLUSIONS in preflight.sh, #4308) plus the
+# per-check extras above.
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}" ${EXTRA_EXCLUDE_DIRS[@]+"${EXTRA_EXCLUDE_DIRS[@]}"}; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-api-github-fetch.sh
+++ b/scripts/check-no-api-github-fetch.sh
@@ -33,21 +33,17 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT/packages/api/src}"
 
-# ─── Directories to exclude from the scan ────────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    "__pycache__"
-    "tmp"
-)
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
-# ─── Build common grep arguments ─────────────────────────────────────────
+# ─── Build --exclude-dir arguments from the canonical list ───────────────
+# (REPO_WALK_EXCLUSIONS lives in preflight.sh — single source of truth, #4308.)
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-ecs-wait-services-stable.sh
+++ b/scripts/check-no-ecs-wait-services-stable.sh
@@ -27,8 +27,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Pattern ─────────────────────────────────────────────────────────────
 # Match `aws ecs wait services-stable` with any internal whitespace run.
@@ -37,22 +41,9 @@ SCAN_DIR="${1:-$REPO_ROOT}"
 PATTERN='aws[[:space:]]+ecs[[:space:]]+wait[[:space:]]+services-stable'
 
 # ─── Directories to exclude from the scan ────────────────────────────────
-# Standard ignored directories (vendored dependencies, VCS metadata, build
-# output) plus local developer state (`.claude`, `.venv`).  These never
-# contain source-of-truth code we care about.
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".claude"
-    ".vite"
-    # Local developer scratch dir for agent workflows (not tracked; see
-    # CLAUDE.md §ALWAYS — Before Acting).  CI checkout has no tmp/, so
-    # excluding it only affects local runs and keeps behavior consistent.
-    "tmp"
-)
+# Repo-walk dir exclusions come from REPO_WALK_EXCLUSIONS in preflight.sh
+# (canonical list — single source of truth, see #4308). No per-check
+# extras needed here.
 
 # ─── Files that legitimately mention the pattern as context ──────────────
 # The check script and its test both have to spell the pattern literally.
@@ -68,10 +59,10 @@ EXCLUDE_FILES=(
     "scripts/tests/test_check_no_ecs_wait_services_stable.sh"
 )
 
-# ─── Build grep arguments ───────────────────────────────────────────────
+# ─── Build --exclude-dir arguments from the canonical list ──────────────
 
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-gnu-head.sh
+++ b/scripts/check-no-gnu-head.sh
@@ -25,24 +25,17 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT/scripts/tests}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Pattern ─────────────────────────────────────────────────────────────
 # Match `head` followed by optional whitespace, `-n`, optional whitespace,
 # and a negative number (dash + digit).  This is the GNU-only form.
 PATTERN='head[[:space:]]+-n[[:space:]]+-[0-9]'
-
-# ─── Directories to exclude from the scan ────────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".vite"
-    "tmp"
-)
 
 # ─── Files that legitimately mention the pattern as context ──────────────
 # The check script and its test must spell the pattern literally.
@@ -51,10 +44,10 @@ EXCLUDE_FILES=(
     "scripts/tests/test_check_no_gnu_head.sh"
 )
 
-# ─── Build grep arguments ───────────────────────────────────────────────
-
+# ─── Build --exclude-dir arguments from the canonical list ──────────────
+# (REPO_WALK_EXCLUSIONS lives in preflight.sh — single source of truth, #4308.)
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-graphql-instanceof.sh
+++ b/scripts/check-no-graphql-instanceof.sh
@@ -70,8 +70,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT/packages/api/src/graphql}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Pattern ─────────────────────────────────────────────────────────────
 # Match `instanceof` followed by one of the realm-fragile graphql-js
@@ -81,20 +85,10 @@ SCAN_DIR="${1:-$REPO_ROOT/packages/api/src/graphql}"
 # `GraphQLNonNull` without a `Type` suffix.
 PATTERN='instanceof[[:space:]]+GraphQL(ObjectType|InterfaceType|UnionType|List(Type)?|NonNull(Type)?)\b'
 
-# ─── Directories to exclude from the scan ────────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    "__pycache__"
-    "tmp"
-    ".next"
-    "dist"
-    "build"
-)
-
+# ─── Build --exclude-dir arguments from the canonical list ──────────────
+# (REPO_WALK_EXCLUSIONS lives in preflight.sh — single source of truth, #4308.)
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-opensearch-url-fallback.sh
+++ b/scripts/check-no-opensearch-url-fallback.sh
@@ -25,8 +25,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT/packages/api/tests}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Pattern ─────────────────────────────────────────────────────────────
 # Fixed-string match for the exact literal `process.env.OPENSEARCH_URL`.
@@ -35,19 +39,10 @@ SCAN_DIR="${1:-$REPO_ROOT/packages/api/tests}"
 # matching `process.env.TEST_OPENSEARCH_URL` or any other superset variant.
 PATTERN='process.env.OPENSEARCH_URL'
 
-# ─── Directories to exclude from the scan ────────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    "__pycache__"
-    "tmp"
-)
-
-# ─── Build grep arguments ─────────────────────────────────────────────────
-
+# ─── Build --exclude-dir arguments from the canonical list ───────────────
+# (REPO_WALK_EXCLUSIONS lives in preflight.sh — single source of truth, #4308.)
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-rebuild-db-skip-reset.sh
+++ b/scripts/check-no-rebuild-db-skip-reset.sh
@@ -26,8 +26,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Pattern ─────────────────────────────────────────────────────────────
 # Match `rebuild_db.py` followed (somewhere on the same line) by
@@ -39,18 +43,9 @@ SCAN_DIR="${1:-$REPO_ROOT}"
 PATTERN='rebuild_db\.py.*--skip-reset'
 
 # ─── Directories to exclude from the scan ────────────────────────────────
-# Standard ignored directories (vendored deps, VCS metadata, build output)
-# plus local developer state.
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".vite"
-    # Local developer scratch dir (not tracked).
-    "tmp"
-)
+# Repo-walk dir exclusions come from REPO_WALK_EXCLUSIONS in preflight.sh
+# (canonical list — single source of truth, see #4308). No per-check
+# extras needed here.
 
 # ─── Files that legitimately mention the pattern as context ──────────────
 # The check script and its test must spell the pattern literally.  Past
@@ -61,10 +56,10 @@ EXCLUDE_FILES=(
     "scripts/tests/test_check_no_rebuild_db_skip_reset.sh"
 )
 
-# ─── Build grep arguments ───────────────────────────────────────────────
+# ─── Build --exclude-dir arguments from the canonical list ──────────────
 
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-no-test-database-url-fallback.sh
+++ b/scripts/check-no-test-database-url-fallback.sh
@@ -24,8 +24,12 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT/packages/api/tests}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
 
 # ─── Pattern ─────────────────────────────────────────────────────────────
 # Fixed-string match for the exact literal `process.env.DATABASE_URL`.
@@ -34,19 +38,10 @@ SCAN_DIR="${1:-$REPO_ROOT/packages/api/tests}"
 # matching `process.env.TEST_DATABASE_URL` or any other superset variant.
 PATTERN='process.env.DATABASE_URL'
 
-# ─── Directories to exclude from the scan ────────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    "__pycache__"
-    "tmp"
-)
-
-# ─── Build grep arguments ─────────────────────────────────────────────────
-
+# ─── Build --exclude-dir arguments from the canonical list ───────────────
+# (REPO_WALK_EXCLUSIONS lives in preflight.sh — single source of truth, #4308.)
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-placeholder-gates.sh
+++ b/scripts/check-placeholder-gates.sh
@@ -29,20 +29,17 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SCAN_DIR="${1:-$REPO_ROOT}"
 
-# ─── Directories to exclude from scanning ─────────────────────────────
-EXCLUDE_DIRS=(
-    ".git"
-    ".venv"
-    "node_modules"
-    ".next"
-    "__pycache__"
-    ".claude"
-    ".vite"
-    "docs"
-)
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+# ─── Per-check extras on top of REPO_WALK_EXCLUSIONS ──────────────────
+# `docs/` is excluded because design docs and incident write-ups
+# routinely paraphrase the placeholder patterns this check looks for.
+EXTRA_EXCLUDE_DIRS=(docs)
 
 # ─── Files to exclude (relative to repo root) ─────────────────────────
 EXCLUDE_FILES=(
@@ -59,8 +56,10 @@ EXCLUDE_PATH_PATTERNS=(
 )
 
 # ─── Build grep exclude arguments ────────────────────────────────────
+# Canonical list (REPO_WALK_EXCLUSIONS in preflight.sh, #4308) plus the
+# per-check extras above.
 exclude_args=()
-for dir in "${EXCLUDE_DIRS[@]}"; do
+for dir in "${REPO_WALK_EXCLUSIONS[@]}" ${EXTRA_EXCLUDE_DIRS[@]+"${EXTRA_EXCLUDE_DIRS[@]}"}; do
     exclude_args+=("--exclude-dir=$dir")
 done
 

--- a/scripts/check-repo-walk-exclusions-canonical.sh
+++ b/scripts/check-repo-walk-exclusions-canonical.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# check-repo-walk-exclusions-canonical.sh — Forbid hand-rolled
+# `--exclude-dir=` lists in `scripts/check-*.sh` and require consumers
+# to source the canonical REPO_WALK_EXCLUSIONS list from preflight.sh
+# instead.
+#
+# permanent: true
+#
+# Why this guard exists (#4308 root cause):
+#
+#   Every repo-walking hygiene check (`scripts/check-*.sh` that runs
+#   `grep -rEn` over the repo) needs the same list of `--exclude-dir`
+#   flags: `.git`, `.venv`, `node_modules`, `__pycache__`, `.next`,
+#   `.claude`, `.vite`, `tmp`, `dist`, `build`. Before #4308 each new
+#   check re-derived the list from scratch and the lists drifted —
+#   missing `.claude` in #4296 caused #4300 (CI red on main for ~30
+#   minutes). The exclusion contract is repo-wide policy and must not
+#   live as duplicated literals across 10+ scripts.
+#
+#   The canonical list now lives in `scripts/preflight.sh` as the
+#   `REPO_WALK_EXCLUSIONS` array. Consumers must source preflight.sh
+#   and iterate that array. This guard rejects any new check script
+#   that hand-rolls a `--exclude-dir=` list instead.
+#
+# What it checks
+# ──────────────
+# 1. Greps `scripts/check-*.sh` for lines containing `--exclude-dir=`.
+# 2. For each script that has at least one such line, asserts that
+#    the script also sources `scripts/preflight.sh` AND iterates over
+#    `REPO_WALK_EXCLUSIONS` to build its `--exclude-dir` arguments.
+# 3. The check itself, the canonical list source (preflight.sh), and
+#    the test fixtures are exempt by path.
+#
+# Allowed shapes
+# ──────────────
+# OK (canonical-only):
+#     source "$SCRIPT_DIR/preflight.sh"
+#     for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
+#         exclude_args+=("--exclude-dir=$dir")
+#     done
+#
+# OK (canonical + per-check extras):
+#     source "$SCRIPT_DIR/preflight.sh"
+#     EXTRA_EXCLUDE_DIRS=(tests test)
+#     for dir in "${REPO_WALK_EXCLUSIONS[@]}" \
+#                ${EXTRA_EXCLUDE_DIRS[@]+"${EXTRA_EXCLUDE_DIRS[@]}"}; do
+#         exclude_args+=("--exclude-dir=$dir")
+#     done
+#
+# REJECTED (hand-rolled literals):
+#     EXCLUDE_DIRS=( ".git" ".venv" "node_modules" )
+#     for dir in "${EXCLUDE_DIRS[@]}"; do
+#         exclude_args+=("--exclude-dir=$dir")
+#     done
+#
+# REJECTED (inline flags):
+#     grep -r "$P" "$D" \
+#         --exclude-dir='.git' \
+#         --exclude-dir='.venv'
+#
+# Usage
+# ─────
+#   scripts/check-repo-walk-exclusions-canonical.sh           # exits 0 if clean, 1 if violations
+#   scripts/check-repo-walk-exclusions-canonical.sh [dir]     # scan a specific scripts dir
+#
+# Exit codes
+# ──────────
+#   0 — All check-*.sh scripts that use `--exclude-dir=` consume
+#       REPO_WALK_EXCLUSIONS from preflight.sh.
+#   1 — One or more scripts hand-roll a `--exclude-dir=` list.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCAN_DIR="${1:-$SCRIPT_DIR}"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+# ─── Files exempt from the canonical-consumer requirement ───────────
+# Each entry is a repo-relative path. The canonical list source
+# (preflight.sh), this guard itself, and its test fixtures must spell
+# `--exclude-dir=` literally and so cannot also satisfy the consumer
+# rule.
+EXEMPT_FILES=(
+    "scripts/preflight.sh"
+    "scripts/check-repo-walk-exclusions-canonical.sh"
+    "scripts/tests/test_check_repo_walk_exclusions_canonical.sh"
+)
+
+is_exempt() {
+    local path="$1"
+    local exempt
+    for exempt in "${EXEMPT_FILES[@]}"; do
+        if [[ "$path" == *"$exempt" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ─── Find every check-*.sh script that mentions --exclude-dir= ──────
+violations=0
+violation_details=()
+
+# Iterate over check-*.sh scripts in the scan directory. Use a shell
+# glob with nullglob to handle the no-match case cleanly. Bash 3.2 +
+# set -u: an empty array's `${arr[@]}` expansion is unbound, so guard
+# with the standard `${arr[@]+"${arr[@]}"}` idiom (see #3082).
+shopt -s nullglob
+candidates=("$SCAN_DIR"/check-*.sh)
+shopt -u nullglob
+
+for script in ${candidates[@]+"${candidates[@]}"}; do
+    if is_exempt "$script"; then
+        continue
+    fi
+
+    # Skip scripts that don't reference --exclude-dir= at all.
+    if ! grep -qF -- '--exclude-dir=' "$script" 2>/dev/null; then
+        continue
+    fi
+
+    # The script uses --exclude-dir=. Verify it consumes the canonical
+    # list:
+    #   1. Sources preflight.sh
+    #   2. References REPO_WALK_EXCLUSIONS (the array name)
+    sources_preflight=false
+    references_canonical=false
+
+    if grep -qE '(^|[^a-zA-Z_])(\.|source)[[:space:]]+[^[:space:]]*preflight\.sh' "$script" 2>/dev/null; then
+        sources_preflight=true
+    fi
+
+    if grep -qF 'REPO_WALK_EXCLUSIONS' "$script" 2>/dev/null; then
+        references_canonical=true
+    fi
+
+    if "$sources_preflight" && "$references_canonical"; then
+        # Script is canonical-aware. Good.
+        continue
+    fi
+
+    # Violation. Record what's missing.
+    rel_path="${script#$REPO_ROOT/}"
+    if [[ "$violations" -eq 0 ]]; then
+        echo "ERROR: One or more check-*.sh scripts hand-roll --exclude-dir= lists" >&2
+        echo "       instead of consuming the canonical REPO_WALK_EXCLUSIONS list." >&2
+        echo "" >&2
+        echo "  See #4308 for the root cause and migration pattern." >&2
+        echo "" >&2
+        echo "  Required shape:" >&2
+        echo "    source \"\$SCRIPT_DIR/preflight.sh\"" >&2
+        echo "    for dir in \"\${REPO_WALK_EXCLUSIONS[@]}\"; do" >&2
+        echo "        exclude_args+=(\"--exclude-dir=\$dir\")" >&2
+        echo "    done" >&2
+        echo "" >&2
+        echo "  Per-check extras (rare) go in EXTRA_EXCLUDE_DIRS=(...)" >&2
+        echo "  and are appended to the canonical list. See" >&2
+        echo "  scripts/preflight.sh REPO_WALK_EXCLUSIONS docstring." >&2
+        echo "" >&2
+        echo "  Violations:" >&2
+    fi
+
+    missing=()
+    "$sources_preflight" || missing+=("does not source scripts/preflight.sh")
+    "$references_canonical" || missing+=("does not reference REPO_WALK_EXCLUSIONS")
+
+    detail="    - $rel_path"
+    for note in "${missing[@]}"; do
+        detail+=$'\n'"      · $note"
+    done
+    violation_details+=("$detail")
+    violations=$((violations + 1))
+done
+
+# ─── Report ─────────────────────────────────────────────────────────
+if [[ $violations -gt 0 ]]; then
+    for d in "${violation_details[@]}"; do
+        echo "$d" >&2
+    done
+    echo "" >&2
+    echo "  Found $violations script(s) with hand-rolled --exclude-dir lists." >&2
+    echo "  Migrate by sourcing preflight.sh and iterating REPO_WALK_EXCLUSIONS." >&2
+    exit 1
+fi
+
+echo "All clean — every check-*.sh that uses --exclude-dir= consumes REPO_WALK_EXCLUSIONS."
+exit 0

--- a/scripts/check-scraper-image-shipped.sh
+++ b/scripts/check-scraper-image-shipped.sh
@@ -88,6 +88,9 @@ DOCKERFILE_REL="packages/scraper-framework/Dockerfile"
 SELF_REL="scripts/check-scraper-image-shipped.sh"
 TEST_REL="scripts/tests/test_check_scraper_image_shipped.sh"
 
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --repo-root)
@@ -130,6 +133,15 @@ fi
 # and /app/scripts/X.shell.
 PATTERN='/app/scripts/[A-Za-z_][A-Za-z0-9_-]*\.(py|sh)([^A-Za-z0-9_]|$)'
 
+# Build --exclude-dir args from the canonical REPO_WALK_EXCLUSIONS list
+# (preflight.sh — single source of truth, #4308) plus the per-check
+# extras below. ``docs/`` is descriptive prose, never an invocation site.
+EXTRA_EXCLUDE_DIRS=(docs)
+exclude_args=()
+for dir in "${REPO_WALK_EXCLUSIONS[@]}" ${EXTRA_EXCLUDE_DIRS[@]+"${EXTRA_EXCLUDE_DIRS[@]}"}; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
 # Compute hits. Allow grep to exit 1 (no match) without tripping the
 # whole script (we have set -uo pipefail, no -e, so this is fine).
 HITS=$(
@@ -142,16 +154,7 @@ HITS=$(
         --include='*.json' \
         --include='*.md' \
         --include='*.txt' \
-        --exclude-dir='.git' \
-        --exclude-dir='.venv' \
-        --exclude-dir='node_modules' \
-        --exclude-dir='__pycache__' \
-        --exclude-dir='dist' \
-        --exclude-dir='build' \
-        --exclude-dir='.next' \
-        --exclude-dir='docs' \
-        --exclude-dir='tmp' \
-        --exclude-dir='.claude' \
+        "${exclude_args[@]}" \
         2>/dev/null \
     | grep -v -F "$REPO_ROOT/$DOCKERFILE_REL:" \
     | grep -v -F "$REPO_ROOT/$SELF_REL:" \

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -299,6 +299,65 @@ preflight_rate_budget() {
 }
 
 # --------------------------------------------------------------------------
+# REPO_WALK_EXCLUSIONS — canonical list of directories that repo-walking
+#   hygiene checks must NEVER scan. Single source of truth for the
+#   `--exclude-dir=<X>` flags every `scripts/check-*.sh` script that runs
+#   `grep -rEn` over the repo needs to pass.
+#
+#   Why this exists (#4308 root cause): every new repo-walk hygiene check
+#   re-derived this list from scratch, and the lists drifted. The .claude/
+#   exclusion was missed in #4296 → caused #4300 (CI red on main for ~30
+#   minutes). The exclusion contract is repo-wide policy — duplicating
+#   literals across 10+ scripts guarantees the next miss.
+#
+#   Maintenance: add new entries here when a build output, vendored tree,
+#   or operator-managed scratch directory needs blanket exclusion. Do NOT
+#   remove an entry without auditing every consumer first.
+#
+#   Per-check augmentations (e.g. `tests`/`test` in check-llm-json-loads.sh,
+#   `docs` in check-placeholder-gates.sh, etc.) stay local to the script —
+#   they're domain-specific allowlists, not repo-wide policy.
+#
+#   Consumer pattern:
+#     # shellcheck source=./preflight.sh
+#     source "$SCRIPT_DIR/preflight.sh"
+#     EXTRA_EXCLUDE_DIRS=(tests test)         # optional per-check extras
+#     exclude_args=()
+#     for dir in "${REPO_WALK_EXCLUSIONS[@]}" \
+#                ${EXTRA_EXCLUDE_DIRS[@]+"${EXTRA_EXCLUDE_DIRS[@]}"}; do
+#         exclude_args+=("--exclude-dir=$dir")
+#     done
+#     grep -rEn "$PATTERN" "$REPO_ROOT" "${exclude_args[@]}"
+# --------------------------------------------------------------------------
+REPO_WALK_EXCLUSIONS=(
+    .git
+    .venv
+    node_modules
+    __pycache__
+    .next
+    .claude
+    .vite
+    tmp
+    dist
+    build
+)
+
+# --------------------------------------------------------------------------
+# repo_walk_exclude_args
+#   Print one `--exclude-dir=<X>` per line for every entry in
+#   REPO_WALK_EXCLUSIONS. Provided for callers that prefer a streaming
+#   interface to the array; the array form is the recommended pattern
+#   (see consumer block above) because it is bash-3.2 safe and lets each
+#   script append its own per-check extras inline.
+# --------------------------------------------------------------------------
+repo_walk_exclude_args() {
+    local dir
+    for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
+        printf -- '--exclude-dir=%s\n' "$dir"
+    done
+}
+
+# --------------------------------------------------------------------------
 # preflight_no_forbidden_syntax <command_string>
 #   Check a command string for forbidden shell patterns. Mirrors the checks
 #   in .claude/hooks/preflight-bash.sh but can be called from scripts.

--- a/scripts/tests/test_check_repo_walk_exclusions_canonical.sh
+++ b/scripts/tests/test_check_repo_walk_exclusions_canonical.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# test_check_repo_walk_exclusions_canonical.sh — Tests for
+# check-repo-walk-exclusions-canonical.sh.
+#
+# Covers:
+#   a — A check script with hand-rolled --exclude-dir= literals fails.
+#   b — A check script with inline `--exclude-dir='X'` flags fails.
+#   c — A check script that sources preflight.sh and iterates
+#       REPO_WALK_EXCLUSIONS passes.
+#   d — A check script that uses neither --exclude-dir= nor any walk
+#       (e.g. a wrapper script) is silently passed over.
+#   e — Per-check extras (EXTRA_EXCLUDE_DIRS) on top of the canonical
+#       list pass.
+#   f — The current real `scripts/` directory passes (sanity / regression).
+#   g — No self-match on the ci.yml step name that runs this guard.
+#   h — Empty scan directory passes.
+#
+# Usage:
+#   scripts/tests/test_check_repo_walk_exclusions_canonical.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-repo-walk-exclusions-canonical.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# Stage a fake "scripts" dir under TMPDIR_TEST that the check can scan.
+# We need to also stage a fake preflight.sh so the check's own source
+# call succeeds (the check sources `$SCRIPT_DIR/preflight.sh`, where
+# $SCRIPT_DIR is the directory of the *check itself*, not the scan
+# dir — so we don't actually need to stage preflight.sh in the temp
+# dir).
+stage_check_script() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    chmod +x "$path" 2>/dev/null || true
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test a: hand-rolled EXCLUDE_DIRS array → fail ─────────────────
+stage_check_script "check-foo.sh" '#!/usr/bin/env bash
+# Hand-rolled — no source, no canonical reference.
+EXCLUDE_DIRS=( ".git" ".venv" "node_modules" "__pycache__" )
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+grep -rE "FOO" /tmp "${exclude_args[@]}"
+' > /dev/null
+assert_fails "Hand-rolled EXCLUDE_DIRS array is rejected"
+reset_tmpdir
+
+# ─── Test b: inline --exclude-dir='...' flags → fail ───────────────
+stage_check_script "check-bar.sh" "#!/usr/bin/env bash
+# Inline literal flags — no source, no canonical reference.
+grep -rE \"BAR\" /tmp \\
+    --exclude-dir='.git' \\
+    --exclude-dir='.venv' \\
+    --exclude-dir='node_modules'
+" > /dev/null
+assert_fails "Inline --exclude-dir literal flags are rejected"
+reset_tmpdir
+
+# ─── Test c: canonical-only consumer → pass ────────────────────────
+stage_check_script "check-baz.sh" '#!/usr/bin/env bash
+# Sources preflight.sh and iterates REPO_WALK_EXCLUSIONS.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+exclude_args=()
+for dir in "${REPO_WALK_EXCLUSIONS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+grep -rE "BAZ" /tmp "${exclude_args[@]}"
+' > /dev/null
+assert_passes "Canonical-only consumer is accepted"
+reset_tmpdir
+
+# ─── Test d: no --exclude-dir at all → silently passes over ───────
+stage_check_script "check-quux.sh" '#!/usr/bin/env bash
+# Wrapper script — does not walk the repo.
+echo "hello"
+' > /dev/null
+assert_passes "Script that does not use --exclude-dir is ignored"
+reset_tmpdir
+
+# ─── Test e: canonical + per-check extras → pass ──────────────────
+stage_check_script "check-extras.sh" '#!/usr/bin/env bash
+# Sources preflight.sh and adds per-check extras.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+EXTRA_EXCLUDE_DIRS=(tests test)
+exclude_args=()
+for dir in "${REPO_WALK_EXCLUSIONS[@]}" ${EXTRA_EXCLUDE_DIRS[@]+"${EXTRA_EXCLUDE_DIRS[@]}"}; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+grep -rE "EXTRA" /tmp "${exclude_args[@]}"
+' > /dev/null
+assert_passes "Canonical + EXTRA_EXCLUDE_DIRS consumer is accepted"
+reset_tmpdir
+
+# ─── Test f: real scripts/ directory → pass (regression) ──────────
+# This is the load-bearing assertion: the migration in #4308 must
+# leave the real scripts/ directory clean. If a future agent adds a
+# new check-*.sh with hand-rolled excludes, this assertion fires.
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" "$SCRIPT_DIR" > /dev/null 2>&1; then
+    echo "PASS: Real scripts/ directory is canonical-clean (regression)"
+else
+    echo "FAIL: Real scripts/ directory has hand-rolled --exclude-dir lists"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test g: empty scan dir → pass ────────────────────────────────
+assert_passes "Empty scan directory passes"
+
+# ─── Test h: No self-match on ci.yml step name ────────────────────
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-repo-walk-exclusions-canonical.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `REPO_WALK_EXCLUSIONS` to `scripts/preflight.sh` as the single source of truth for the `--exclude-dir=` contract every `scripts/check-*.sh` that walks the repo with `grep` needs. Migrates all 12 hand-rolled callers to source `preflight.sh` and iterate the canonical array; per-check extras (`tests`/`test`, `docs`) stay local via `EXTRA_EXCLUDE_DIRS`. Adds a hygiene gate (`check-repo-walk-exclusions-canonical.sh`) that rejects any future check that hand-rolls its own list — wired into CI and auto-discovered by `scripts/run-ci-guards.sh` (#4334) for the pre-push hook.

Closes the #4300 class of bug at the source: previously every new repo-walk hygiene check re-derived the well-known list from scratch, and the lists drifted. The canonical baseline now uniformly includes `.claude` across every check (some checks were missing it before — this is the desired #4300 hardening).

Closes #4308

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts/check-repo-walk-exclusions-canonical.sh` passes (the new hygiene gate)
- [x] `scripts/tests/test_check_repo_walk_exclusions_canonical.sh` returns 8/8 pass
- [x] All 11 migrated `check-*.sh` test suites still pass (~150 assertions)

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only)
- [x] Verification evidence posted on issue (see A.8)
