### PR TITLE
feat(dx): catch arr=() + iterate-empty bash 3.2 footgun (#4336)

### DIFF
--- a/scripts/check-bash-set-u-empty-array.sh
+++ b/scripts/check-bash-set-u-empty-array.sh
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
-# check-bash-set-u-empty-array.sh — Forbid the bash 5.x footgun where
-# ``declare -a <name>`` (without ``=()``) is later expanded as
-# ``${#<name>[@]}`` or ``"${<name>[@]}"`` under ``set -u``.
+# check-bash-set-u-empty-array.sh — Forbid two sibling bash + ``set -u``
+# empty-array footguns:
+#
+#   (A) ``declare -a <name>`` (without ``=()``) is later expanded as
+#       ``${#<name>[@]}`` or ``"${<name>[@]}"``. Trips on bash 5.x
+#       (Linux CI), passes on bash 3.2 (macOS).
+#
+#   (B) ``<name>=()`` is later iterated as ``"${<name>[@]}"`` /
+#       ``"${<name>[*]}"`` while still empty (no intervening
+#       ``<name>+=(...)`` or ``<name>=(...)``-with-content). Trips on
+#       bash 3.2 (macOS), passes on bash 5.x.
+#
+# Both are different declaration forms of the same root-cause class:
+# declared-but-empty indexed arrays read with ``[@]`` / ``[*]`` under
+# nounset, where bash 3.2 and bash 5.x disagree on what ``unbound``
+# means.
 #
 # Why this check exists
 # ---------------------
-# ``declare -a <name>`` declares an indexed array but does NOT assign
-# it. On bash 3.2 (macOS operator laptops), reading
+# Shape (A): ``declare -a <name>`` declares an indexed array but does
+# NOT assign it. On bash 3.2 (macOS operator laptops), reading
 # ``${#empty_declared_array[@]}`` returns 0 cleanly. On bash 5.x (Linux
 # CI runners) under ``set -u``, the same read trips ``unbound
 # variable``:
@@ -23,6 +36,20 @@
 # empty array, so the subsequent ``${#<name>[@]}`` read sees a
 # bound-but-empty array and returns 0 on every bash version.
 #
+# Shape (B): ``<name>=()`` initialises the array empty, but iterating
+# ``"${<name>[@]}"`` while it is *still* empty trips ``unbound
+# variable`` on bash 3.2 — the inverse-direction skew of shape (A).
+# The size read ``${#<name>[@]}`` itself is fine on bash 3.2, but the
+# ``[@]`` / ``[*]`` element-expansion form is not. Surfaced in #4332's
+# ``scripts/run-ci-guards.sh`` umbrella (worked around at lines 254 +
+# 280 with ``if [ "${#arr[@]}" -gt 0 ]`` length guards); tracked here
+# as #4336.
+#
+# The canonical fix for shape (B) is the same length-guard one-liner:
+# wrap iteration in ``if [ "${#<name>[@]}" -gt 0 ]; then`` so the
+# loop body is skipped when the array is empty. Pre-populating the
+# array with at least one assignment before reading also fixes it.
+#
 # Detection strategy
 # ------------------
 # This check is line-text-based (not AST-based) so it runs in a few
@@ -33,13 +60,12 @@
 #      anywhere in the file. If not, skip the file — no nounset, no
 #      bug.
 #
-#   2. Find every ``declare -a <name>`` (or ``typeset -a <name>``)
-#      that is NOT immediately followed by ``=`` — i.e. a bare declare
-#      without an inline assignment. Record the line number and the
-#      array name.
-#
-#   3. For each (name, declare_line) pair: scan the file from
-#      ``declare_line + 1`` to EOF looking for either:
+#   2. (Shape A) Find every ``declare -a <name>`` (or ``typeset -a
+#      <name>``) that is NOT immediately followed by ``=`` — i.e. a
+#      bare declare without an inline assignment. Record the line
+#      number and the array name. For each (name, declare_line) pair:
+#      scan the file from ``declare_line + 1`` to EOF looking for
+#      either:
 #        - an assignment ``<name>=(`` or ``<name>+=(`` (clears the bug
 #          — array is bound before any read), OR
 #        - a read ``${#<name>[@]}`` or ``"${<name>[@]}"`` or
@@ -47,10 +73,30 @@
 #      Whichever comes first determines the verdict: read-first → flag,
 #      assign-first → safe.
 #
+#   3. (Shape B) Find every bare-empty ``<name>=()`` declaration —
+#      i.e. an indexed-array initialiser where the parens are empty
+#      (whitespace-only between ``(`` and ``)``). Record the line
+#      number and the array name. For each (name, decl_line) pair:
+#      scan from ``decl_line + 1`` to EOF looking for either:
+#        - an assignment ``<name>=(`` or ``<name>+=(`` (the bug is
+#          cleared the moment any element appends or a fresh
+#          assignment lands), OR
+#        - an iteration-form read ``"${<name>[@]}"`` or
+#          ``"${<name>[*]}"`` (i.e. element expansion, NOT the size
+#          form ``${#<name>[@]}`` which is bash-3.2-safe — flags the
+#          bug).
+#      Same first-wins verdict logic.
+#
 # What it does NOT flag
 # ---------------------
 #   - ``declare -a <name>=()`` — the inline form is fine.
-#   - ``<name>=()`` — the no-declare form is fine.
+#   - ``<name>=()`` followed by ``<name>+=(...)`` BEFORE any iteration
+#     read — append-then-iterate is bash-3.2-safe because the array is
+#     no longer empty by the time iteration runs.
+#   - ``<name>=()`` whose only subsequent reads are size form
+#     ``${#<name>[@]}`` / ``${#<name>[*]}`` — bash 3.2 handles size
+#     reads of empty initialised arrays cleanly.
+#   - ``<name>=("a" "b")`` with content — not bare-empty, not flagged.
 #   - ``declare -a <name>`` followed by ``<name>+=(...)`` BEFORE any
 #     ``${#<name>[@]}`` read — append-then-read is bash 3.2 / 5.x
 #     compatible because ``+=`` on an undeclared array binds it.
@@ -74,10 +120,9 @@
 # Exit codes
 # ----------
 #   0 — No violations found.
-#   1 — One or more shell scripts have ``declare -a <name>`` followed
-#       by ``${#<name>[@]}`` (or ``"${<name>[@]}"``) under ``set -u``
-#       without an intervening assignment. The offending lines are
-#       printed with file:line:content plus the suggested fix.
+#   1 — One or more shell scripts trip shape (A) or shape (B). The
+#       offending lines are printed with file:line:content plus the
+#       suggested fix.
 
 set -euo pipefail
 
@@ -140,6 +185,16 @@ NOUNSET_REGEX='^[[:space:]]*set[[:space:]]+(-[a-zA-Z]*u[a-zA-Z]*([[:space:]]|$)|
 # NOT followed by ``=`` (i.e. bare declare). Captures <name> in
 # BASH_REMATCH[2].
 DECLARE_BARE_REGEX='^[[:space:]]*(declare|typeset)[[:space:]]+-[a-zA-Z]*a[[:space:]]+([A-Za-z_][A-Za-z0-9_]*)([[:space:]]|$)'
+
+# Match a bare-empty array initialiser ``<name>=()`` — i.e. the parens
+# are empty (whitespace-only between ``(`` and ``)``). Captures <name>
+# in BASH_REMATCH[1]. Anchored at start-of-line (with optional
+# leading whitespace) so a substring like ``foo=()`` inside an
+# expression is not picked up. Excludes ``declare -a <name>=()`` /
+# ``local -a <name>=()`` / ``readonly <name>=()`` and friends — those
+# inline-assignment forms are not the bare-empty pattern this check
+# targets, and they also fall under shape (A)'s "inline OK" carve-out.
+EMPTY_INIT_REGEX='^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=\([[:space:]]*\)[[:space:]]*$'
 
 for file in "${sh_files[@]}"; do
     # Skip allow-listed files.
@@ -256,17 +311,133 @@ for file in "${sh_files[@]}"; do
 
         decl_idx=$((decl_idx + 1))
     done
+
+    # Pass 3: find bare-empty ``<name>=()`` lines and check for an
+    # iteration-form read (``"${<name>[@]}"`` / ``"${<name>[*]}"``)
+    # that fires *before* any intervening ``<name>+=(...)`` or
+    # ``<name>=(...)``-with-content assignment. Same first-wins
+    # verdict logic as Pass 2 but with a different declaration
+    # matcher and a stricter read regex (size form ``${#<name>[@]}``
+    # is not flagged — it is bash-3.2-safe).
+    init_idx=0
+    while (( init_idx < nlines )); do
+        iline="${lines[$init_idx]}"
+
+        # Skip comments.
+        if [[ "$iline" =~ ^[[:space:]]*# ]]; then
+            init_idx=$((init_idx + 1))
+            continue
+        fi
+
+        if [[ "$iline" =~ $EMPTY_INIT_REGEX ]]; then
+            iname="${BASH_REMATCH[1]}"
+
+            # Build name-specific patterns. Same assignment regex as
+            # Pass 2 — ``<name>=(`` or ``<name>+=(`` clears the bug
+            # by binding the array with at least one (or about to be
+            # one) element.
+            #
+            # The read regex is *stricter* than Pass 2's: it matches
+            # the bare element-expansion forms ``${<name>[@]}`` and
+            # ``${<name>[*]}`` only — i.e. ``[@]`` or ``[*]``
+            # IMMEDIATELY followed by ``}``. It deliberately does
+            # NOT match the size form ``${#<name>[@]}`` (bash-3.2-
+            # safe on an empty initialised array; flagging it here
+            # would over-report).
+            #
+            # Anchoring rationale: same as Pass 2 — leading
+            # ``[^A-Za-z0-9_]`` (or start-of-line) before the name
+            # ensures a substring like ``foo_bar=`` does not match
+            # when the array is ``foo``.
+            #
+            # Guarded-form exemption: lines containing the defensive
+            # parameter-expansion guard ``${<name>[@]+"${<name>[@]}"}``
+            # (or the ``[*]`` variant) are exempted in the scan
+            # below before the read regex is applied. The leading
+            # ``[@]+...`` substitutes nothing when the array is
+            # unset OR empty — the canonical bash-3.2-safe idiom for
+            # "iterate this maybe-empty array under set -u" — and
+            # the inner ``${<name>[@]}`` only evaluates when the
+            # array is non-empty, so it is not a footgun. We detect
+            # the guarded form via a substring presence check
+            # (``[@]+`` or ``[*]+`` after ``${<name>``) and skip
+            # the line.
+            iassign_regex="(^|[^A-Za-z0-9_])${iname}\\+?=\\("
+            iread_regex="\\\$\\{${iname}\\[[@*]\\]\\}"
+            iguarded_regex="\\\$\\{${iname}\\[[@*]\\]\\+"
+
+            iscan_idx=$((init_idx + 1))
+            iverdict=""
+            iverdict_line=0
+            iverdict_content=""
+            while (( iscan_idx < nlines )); do
+                isline="${lines[$iscan_idx]}"
+
+                # Skip comments inside the scan.
+                if [[ "$isline" =~ ^[[:space:]]*# ]]; then
+                    iscan_idx=$((iscan_idx + 1))
+                    continue
+                fi
+
+                # Check assignment first — it is the safe outcome.
+                if [[ "$isline" =~ $iassign_regex ]]; then
+                    iverdict="assigned"
+                    break
+                fi
+
+                # Skip lines using the guarded ``${name[@]+...}``
+                # parameter-expansion idiom. The line is bash-3.2-
+                # safe even when the array is empty, so do not
+                # treat it as a flagged read. The scan continues
+                # past the guarded line — the array is still empty
+                # afterward, so a later unguarded iteration would
+                # still be flagged.
+                if [[ "$isline" =~ $iguarded_regex ]]; then
+                    iscan_idx=$((iscan_idx + 1))
+                    continue
+                fi
+
+                if [[ "$isline" =~ $iread_regex ]]; then
+                    iverdict="read"
+                    iverdict_line=$((iscan_idx + 1))
+                    iverdict_content="$isline"
+                    break
+                fi
+
+                iscan_idx=$((iscan_idx + 1))
+            done
+
+            if [[ "$iverdict" == "read" ]]; then
+                report_lines+=("  [$iname=() iterated empty under set -u (bash 3.2 footgun)]")
+                report_lines+=("    $file:$((init_idx + 1)): $iline")
+                report_lines+=("    $file:$iverdict_line: $iverdict_content")
+                report_lines+=("    fix: guard with 'if [ \"\${#$iname[@]}\" -gt 0 ]; then ... fi'")
+                report_lines+=("         or pre-populate '$iname' before iterating")
+                violations=$((violations + 1))
+            fi
+        fi
+
+        init_idx=$((init_idx + 1))
+    done
 done
 
 if (( violations > 0 )); then
-    echo "ERROR: bash 5.x set -u + declare -a empty-array footgun(s) detected in scripts/**/*.sh."
+    echo "ERROR: bash + set -u empty-array footgun(s) detected in scripts/**/*.sh."
     echo ""
-    echo "  'declare -a <name>' declares an indexed array but does NOT"
-    echo "  assign it. On bash 3.2 (macOS) reading \${#<name>[@]} returns"
-    echo "  0 cleanly; on bash 5.x (Linux CI) under 'set -u' the same"
-    echo "  read trips '<name>: unbound variable'. Fix: replace"
-    echo "  'declare -a <name>' with '<name>=()' so the variable is"
-    echo "  bound to an empty array at declaration time."
+    echo "  Shape (A) — 'declare -a <name>' declares an indexed array"
+    echo "  but does NOT assign it. On bash 3.2 (macOS) reading"
+    echo "  \${#<name>[@]} returns 0 cleanly; on bash 5.x (Linux CI)"
+    echo "  under 'set -u' the same read trips '<name>: unbound"
+    echo "  variable'. Fix: replace 'declare -a <name>' with"
+    echo "  '<name>=()' so the variable is bound to an empty array at"
+    echo "  declaration time."
+    echo ""
+    echo "  Shape (B) — '<name>=()' initialises the array empty, but"
+    echo "  iterating \"\${<name>[@]}\" / \"\${<name>[*]}\" while it is"
+    echo "  still empty trips 'unbound variable' on bash 3.2 (the"
+    echo "  inverse-direction skew of shape A). Fix: guard iteration"
+    echo "  with 'if [ \"\${#<name>[@]}\" -gt 0 ]; then ... fi', or"
+    echo "  pre-populate the array before iterating."
     echo ""
     for line in "${report_lines[@]}"; do
         echo "$line"
@@ -275,8 +446,8 @@ if (( violations > 0 )); then
     echo "  Total violations: $violations"
     echo ""
     echo "  See: scripts/check-bash-set-u-empty-array.sh header for the"
-    echo "  full rationale and #4143 / PR #4140 for the originating"
-    echo "  incident."
+    echo "  full rationale, #4143 / PR #4140 for shape (A), and"
+    echo "  #4332 / #4336 for shape (B)."
     exit 1
 fi
 

--- a/scripts/check-scraper-image-shipped.sh
+++ b/scripts/check-scraper-image-shipped.sh
@@ -199,10 +199,12 @@ FIRST_REF_LINES=()
 _already_seen() {
     local needle="$1"
     local existing
-    if [[ ${#SCRIPT_NAMES[@]} -eq 0 ]]; then
-        return 1
-    fi
-    for existing in "${SCRIPT_NAMES[@]}"; do
+    # ``${SCRIPT_NAMES[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336). Even though SCRIPT_NAMES=()
+    # was initialised above, an empty initialised array still
+    # trips ``unbound variable`` on bash 3.2 when expanded with
+    # ``"${arr[@]}"`` — verified probe in #4336.
+    for existing in ${SCRIPT_NAMES[@]+"${SCRIPT_NAMES[@]}"}; do
         if [[ "$existing" == "$needle" ]]; then
             return 0
         fi
@@ -229,10 +231,12 @@ while IFS= read -r line; do
     done <<< "$tokens"
 done <<< "$HITS"
 
-# Bash 3.2 + set -u: empty-array expansion is a fatal "unbound variable"
-# unless the array was assigned at least once. We assigned to SCRIPT_NAMES
-# above (even if no items were appended), so "${SCRIPT_NAMES[@]}" is safe
-# below — but a guard for the empty case is clearer.
+# Bash 3.2 + set -u: ``arr=()`` initialises the array empty, but
+# expanding ``"${arr[@]}"`` while it is still empty trips a fatal
+# ``unbound variable`` (verified probe in #4336 — assignment alone is
+# NOT enough; an actual element must land first, OR the iteration must
+# be guarded with ``${arr[@]+...}`` or a length check). We size-check
+# below so the early-exit path doesn't even attempt iteration.
 if [[ ${#SCRIPT_NAMES[@]} -eq 0 ]]; then
     echo "OK: no /app/scripts/<name>.{py,sh} references found outside the scraper Dockerfile"
     exit 0

--- a/scripts/tests/test_adopt_pr.sh
+++ b/scripts/tests/test_adopt_pr.sh
@@ -26,7 +26,9 @@ ORIG_PATH_SAVE=""
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             # Abort any in-progress rebases in worktrees
             if git -C "$d" rev-parse --git-dir > /dev/null 2>&1; then

--- a/scripts/tests/test_check_bash_set_u_empty_array.sh
+++ b/scripts/tests/test_check_bash_set_u_empty_array.sh
@@ -237,6 +237,205 @@ EOF
 assert_fails "Violations across multiple files are detected"
 reset_tmpdir
 
+# ─── Shape (B) tests — bare ``arr=()`` + iterate-empty footgun ───────────
+# These cover the bash 3.2 (macOS) inverse-direction skew: ``arr=()``
+# initialises the array empty, but ``for x in "${arr[@]}"`` while
+# still empty trips ``unbound variable`` on bash 3.2 even though the
+# size form ``${#arr[@]}`` is fine. Tracked as #4336.
+
+# ─── Test B1: Canonical shape — arr=() + for loop iterate empty ──────────
+# This is the verbatim shape from the issue body's `Verify:` line.
+write_file "bad_arr_init_iterate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+arr=()
+for x in "${arr[@]}"; do
+    echo "got: $x"
+done
+EOF
+assert_fails "arr=() + for x in \"\${arr[@]}\" iterate-empty triggers shape (B)"
+reset_tmpdir
+
+# ─── Test B2: ``[*]`` star expansion variant → fails ─────────────────────
+write_file "bad_arr_star_expand.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+items=()
+echo "${items[*]}"
+EOF
+assert_fails "items=() + \"\${items[*]}\" expansion triggers shape (B)"
+reset_tmpdir
+
+# ─── Test B3: Echo-then-iterate (no for loop) → fails ────────────────────
+# A bare expansion outside a for loop is the same root-cause class.
+write_file "bad_arr_bare_expand.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+xs=()
+echo "${xs[@]}"
+EOF
+assert_fails "xs=() + bare \"\${xs[@]}\" expansion triggers shape (B)"
+reset_tmpdir
+
+# ─── Test B4: Safe — arr=() + size-only read → passes ────────────────────
+# The size form ``${#arr[@]}`` is bash-3.2-safe on an empty initialised
+# array. Pass 3 must NOT flag size-only reads.
+write_file "good_arr_size_only.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+if [[ ${#arr[@]} -eq 0 ]]; then
+    echo "empty"
+fi
+EOF
+assert_passes "arr=() + size-only \${#arr[@]} read passes (size form is bash-3.2-safe)"
+reset_tmpdir
+
+# ─── Test B5: Safe — arr=() + append-then-iterate → passes ───────────────
+write_file "good_arr_append_then_iterate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+arr+=("x")
+arr+=("y")
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=() + append-then-iterate (canonical safe pattern) passes"
+reset_tmpdir
+
+# ─── Test B6: Safe — arr=() + reassign-with-content + iterate → passes ───
+write_file "good_arr_reassign_iterate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+arr=("a" "b" "c")
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=() + reassign-with-content + iterate passes"
+reset_tmpdir
+
+# ─── Test B7: Length-guard alone (without += or [@]+ guard) → fails ─────
+# A length guard ``if [ "${#arr[@]}" -gt 0 ]; then`` is the runtime
+# fix recommended by the check's report message — it makes the
+# iteration safe at run time. But the static check cannot reason
+# about ``if`` block scopes, and the AC's static criterion is "no
+# ``arr+=(...)`` or ``arr=(...)`` assignment intervenes" (see #4336
+# AC#1). So the static check still flags this shape; users should
+# either pre-populate the array, use the ``${arr[@]+...}``
+# parameter-expansion guard (Test B8), or accept that the iteration
+# is unreachable at run time anyway. This test documents the
+# limitation so future maintainers don't accidentally weaken the
+# check trying to recognise length guards.
+write_file "bad_arr_length_guard_only.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+if [ "${#arr[@]}" -gt 0 ]; then
+    for v in "${arr[@]}"; do
+        echo "$v"
+    done
+fi
+EOF
+assert_fails "arr=() + length-guard alone (no += / [@]+ guard) still flags (static-scan limitation)"
+reset_tmpdir
+
+# ─── Test B8: Safe — arr=() + ${arr[@]+...} guarded expansion → passes ──
+# The defensive parameter-expansion guard ``${arr[@]+"${arr[@]}"}``
+# is bash-3.2-safe even on an empty initialised array because the
+# leading ``[@]+...`` substitutes nothing when the array is empty.
+write_file "good_arr_param_guard.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+for v in ${arr[@]+"${arr[@]}"}; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=() + \${arr[@]+...} parameter-expansion guard passes"
+reset_tmpdir
+
+# ─── Test B9: Safe — arr=() without nounset → passes ─────────────────────
+# Without set -u, the iteration of an empty initialised array is a
+# no-op on every bash version.
+write_file "good_arr_no_nounset.sh" <<'EOF'
+#!/usr/bin/env bash
+arr=()
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=() + iterate-empty without set -u passes"
+reset_tmpdir
+
+# ─── Test B10: Safe — arr=("x") with content → passes (not bare-empty) ──
+# A non-empty initialiser is not the bare-empty shape this check
+# targets. The Pass 3 declaration regex requires whitespace-only
+# between the parens.
+write_file "good_arr_init_with_content.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=("x" "y")
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=(\"x\" \"y\") with content + iterate passes (not bare-empty)"
+reset_tmpdir
+
+# ─── Test B11: Lookalike names (foo_bar vs foo) → passes ─────────────────
+# Same anchoring rationale as the existing Test 12: a substring like
+# ``foo_bar=("a")`` must not count as an assignment to ``foo``.
+write_file "good_lookalike_b.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+foo=()
+foo_bar=("a" "b")
+echo "${#foo_bar[@]}"
+foo+=("x")
+echo "${foo[@]}"
+EOF
+assert_passes "Lookalike names (foo_bar) are not confused with the declared name (foo) for shape (B)"
+reset_tmpdir
+
+# ─── Test B12: Verbatim issue body Verify clause (sanity) ────────────────
+# AC#1 Verify line: drop a probe ``tmp/probe.sh`` containing
+# ``set -uo pipefail; arr=(); for x in "${arr[@]}"; do echo "$x"; done``
+# and run the check against ``tmp/``. Exits non-zero with the probe
+# filename + line number. Reproduce that flow here.
+TESTS=$((TESTS + 1))
+PROBE_DIR="$TMPDIR_TEST/probe_root"
+mkdir -p "$PROBE_DIR/scripts"
+cat > "$PROBE_DIR/scripts/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+arr=()
+for x in "${arr[@]}"; do
+    echo "$x"
+done
+EOF
+chmod +x "$PROBE_DIR/scripts/probe.sh"
+PROBE_OUT_FILE="$TMPDIR_TEST/probe_output.txt"
+"$CHECK_SCRIPT" "$PROBE_DIR" > "$PROBE_OUT_FILE" 2>&1 && probe_rc=0 || probe_rc=$?
+if [[ "$probe_rc" -eq 0 ]]; then
+    echo "FAIL: AC#1 Verify probe — expected check to exit non-zero, got 0"
+    FAILURES=$((FAILURES + 1))
+elif ! grep -q "probe.sh" "$PROBE_OUT_FILE"; then
+    echo "FAIL: AC#1 Verify probe — output missing probe filename"
+    cat "$PROBE_OUT_FILE"
+    FAILURES=$((FAILURES + 1))
+elif ! grep -qE "probe.sh:[0-9]+" "$PROBE_OUT_FILE"; then
+    echo "FAIL: AC#1 Verify probe — output missing line number"
+    cat "$PROBE_OUT_FILE"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: AC#1 Verify probe — check fails with probe filename + line number"
+fi
+rm -rf "$PROBE_DIR" "$PROBE_OUT_FILE"
+
 # ─── Test 15: Self-scan — real repo scripts/ tree → passes ─────────────
 TESTS=$((TESTS + 1))
 if "$CHECK_SCRIPT" "$REPO_ROOT" > /dev/null 2>&1; then

--- a/scripts/tests/test_check_duplicate_pr.sh
+++ b/scripts/tests/test_check_duplicate_pr.sh
@@ -30,7 +30,9 @@ ORIG_PATH_SAVE=""
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi

--- a/scripts/tests/test_check_oneshot_imports.sh
+++ b/scripts/tests/test_check_oneshot_imports.sh
@@ -21,7 +21,11 @@ TESTS=0
 # Cleanup any temp files on exit
 TEMP_FILES=()
 cleanup() {
-    for f in "${TEMP_FILES[@]}"; do
+    # ``${TEMP_FILES[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336) — without it, an early test
+    # failure that fires the EXIT trap before any
+    # create_temp_script call would crash the trap itself.
+    for f in ${TEMP_FILES[@]+"${TEMP_FILES[@]}"}; do
         rm -f "$f"
     done
 }

--- a/scripts/tests/test_check_schema_drift.sh
+++ b/scripts/tests/test_check_schema_drift.sh
@@ -36,7 +36,9 @@ ORIG_PATH_SAVE=""
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -27,7 +27,9 @@ ORIG_PATH_SAVE=""
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi

--- a/scripts/tests/test_notify_telegram_exit_codes.sh
+++ b/scripts/tests/test_notify_telegram_exit_codes.sh
@@ -34,7 +34,9 @@ TEMP_DIRS=()
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi

--- a/scripts/tests/test_preflight.sh
+++ b/scripts/tests/test_preflight.sh
@@ -32,7 +32,9 @@ TEMP_DIRS=()
 cleanup() {
     # Errors during cleanup must not cause a non-zero exit
     set +e
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             # Remove worktrees before deleting (only if it's a git repo)
             if git -C "$d" rev-parse --git-dir > /dev/null 2>&1; then

--- a/scripts/tests/test_preflight_branch_fresh.sh
+++ b/scripts/tests/test_preflight_branch_fresh.sh
@@ -33,7 +33,9 @@ ORIG_PWD=$(pwd)
 cleanup() {
     set +eu
     cd "$ORIG_PWD" || true
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi

--- a/scripts/tests/test_preflight_wrappers.sh
+++ b/scripts/tests/test_preflight_wrappers.sh
@@ -33,7 +33,9 @@ TESTS=0
 TEMP_DIRS=()
 cleanup() {
     set +e
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             if git -C "$d" rev-parse --git-dir > /dev/null 2>&1; then
                 git -C "$d" worktree list --porcelain 2>/dev/null \

--- a/scripts/tests/test_unblock_issue.sh
+++ b/scripts/tests/test_unblock_issue.sh
@@ -32,7 +32,9 @@ ORIG_PATH_SAVE=""
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi

--- a/scripts/tests/test_verify_pr_in_deployed_sha.sh
+++ b/scripts/tests/test_verify_pr_in_deployed_sha.sh
@@ -34,7 +34,9 @@ ORIG_PATH_SAVE="$PATH"
 
 cleanup() {
     set +eu
-    for d in "${TEMP_DIRS[@]}"; do
+    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
+    # bash 3.2 + set -u (see #4336).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
         if [[ -n "$d" && -d "$d" ]]; then
             rm -rf "$d"
         fi


### PR DESCRIPTION
## Summary

Extends `scripts/check-bash-set-u-empty-array.sh` with a Pass 3 that catches the
sibling `arr=()` + iterate-empty footgun on bash 3.2 (macOS) — the
inverse-direction skew of the existing Pass 2's `declare -a` footgun on bash 5.x.
Verified probe with system `bash 3.2.57` confirms `arr=()` alone is NOT
sufficient: the array must be populated via `+=` or the iteration must be guarded
(`${arr[@]+...}` parameter expansion or `if [ "${#arr[@]}" -gt 0 ]`) to be
bash-3.2-safe under `set -u`. Also fixes the 12 sites the new check immediately
found — all converged on the canonical `${arr[@]+"${arr[@]}"}` guard pattern
already used in `test_progress_sh.sh`.

Closes #4336

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI guard / shell-script tooling only)
- [x] Verification evidence posted on issue (see A.8)
