### PR TITLE
feat(dx): self-diagnosing Fix block for SplitRuling propagation-check violations (#4322)

### DIFF
--- a/scripts/check_split_ruling_fields_propagated.py
+++ b/scripts/check_split_ruling_fields_propagated.py
@@ -445,6 +445,90 @@ def discover_reingest_propagation(
 
 
 # ---------------------------------------------------------------------------
+# Fix-block guidance: copy-pasteable patch for scope-table omissions
+# ---------------------------------------------------------------------------
+
+
+def _suggest_worker_fn_name(stem: str, worker_path: Path) -> tuple[str, bool]:
+    """Look for an existing ``_try_<county>[_<format>]_split`` function in
+    *worker_path* that matches the dataclass module *stem*.
+
+    The convention is ``_try_<county>_<format>_split`` where ``<county>`` is
+    typically the module stem with ``_tentatives`` stripped (e.g. stem
+    ``sc_tentatives`` → county ``sc``) and ``<format>`` is one of ``pdf`` /
+    ``html`` / ``calendar`` (or absent).  If a real match is found, return
+    ``(name, True)``; otherwise return a conventional placeholder
+    ``(_try_<county>_pdf_split, False)`` so the Fix block is still
+    copy-pasteable — the operator just edits the format if needed.
+    """
+    county = stem
+    if county.endswith("_tentatives"):
+        county = county[: -len("_tentatives")]
+
+    if not worker_path.is_file():
+        return (f"_try_{county}_pdf_split", False)
+
+    try:
+        tree = ast.parse(
+            worker_path.read_text(encoding="utf-8"), filename=str(worker_path)
+        )
+    except SyntaxError:
+        return (f"_try_{county}_pdf_split", False)
+
+    prefix = f"_try_{county}_"
+    suffix = "_split"
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name.startswith(prefix)
+            and node.name.endswith(suffix)
+        ):
+            return (node.name, True)
+    # No match — also try the bare ``_try_<county>_split`` shape (no format
+    # token) before falling back to the placeholder.
+    bare = f"_try_{county}_split"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == bare:
+            return (bare, True)
+
+    return (f"_try_{county}_pdf_split", False)
+
+
+def _suggest_scope_entry(dc: DataclassDef, worker_path: Path) -> str:
+    """Build a copy-pasteable Fix block for a ``*SplitRuling`` dataclass
+    that is missing from ``_DATACLASS_SCOPE``.
+
+    The block reproduces the exact dict-literal shape used in the live
+    scope table so the operator can paste it in without reformatting.
+    """
+    # The scope key matches what ``discover_dataclasses`` uses: bare class
+    # name, except for plain ``SplitRuling`` which is disambiguated by
+    # ``@<module-stem>`` suffix.
+    if dc.class_name == "SplitRuling":
+        scope_key = f"SplitRuling@{Path(dc.file_path).stem}"
+    else:
+        scope_key = dc.class_name
+
+    worker_fn, real = _suggest_worker_fn_name(Path(dc.file_path).stem, worker_path)
+    worker_comment = (
+        "" if real else "  # adjust if the worker hook has a different name"
+    )
+
+    lines = [
+        "",
+        "Fix: Add this entry to _DATACLASS_SCOPE in "
+        "scripts/check_split_ruling_fields_propagated.py:",
+        "",
+        f'    "{scope_key}": {{',
+        f'        "worker_fn": "{worker_fn}",{worker_comment}',
+        '        "reingest": True,',
+        "    },",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # Cross-check
 # ---------------------------------------------------------------------------
 
@@ -647,8 +731,39 @@ def main(argv: list[str] | None = None) -> int:
             )
 
     if blocking:
+        # Index dataclasses by bare class name so we can look up file_path
+        # when emitting the Fix block for ``<class itself>`` (scope-table)
+        # violations.  The bare name is unique enough for the scope-omission
+        # case — when two SplitRuling classes share the bare name (Fresno
+        # + Riverside today), both must be registered in _DATACLASS_SCOPE,
+        # so two scope violations fire and each gets its own Fix block.
+        # We map class_name → list[DataclassDef] to handle that case.
+        dc_by_name: dict[str, list[DataclassDef]] = {}
+        for dc in dataclasses:
+            dc_by_name.setdefault(dc.class_name, []).append(dc)
+
         for v in blocking:
             print(v.render())
+            if v.target == "scope":
+                # Find the DataclassDef that produced this violation so the
+                # Fix block can name the source-file stem (needed for the
+                # ``SplitRuling@<stem>`` disambiguator) and probe worker.py
+                # for an existing ``_try_<county>_split`` function.
+                candidates = dc_by_name.get(v.dataclass_name, [])
+                # If multiple dataclasses share the bare name, emit one Fix
+                # block per — they are independently scope-violating.
+                # Otherwise the loop runs at most once.
+                emitted_keys: set[str] = set()
+                for dc in candidates:
+                    fix_block = _suggest_scope_entry(dc, worker_path)
+                    # Avoid duplicates if a single iteration of the outer
+                    # blocking loop encounters the same DataclassDef again
+                    # via a different violation.
+                    key = f"{dc.class_name}@{Path(dc.file_path).stem}"
+                    if key in emitted_keys:
+                        continue
+                    emitted_keys.add(key)
+                    print(fix_block, file=sys.stderr)
         print(
             f"\nFound {len(blocking)} *SplitRuling propagation gap(s).  "
             "Either propagate the field through the worker / reingest path, "

--- a/scripts/tests/test_check_split_ruling_fields_propagated.sh
+++ b/scripts/tests/test_check_split_ruling_fields_propagated.sh
@@ -375,6 +375,145 @@ else
 fi
 rm -f "$live_scan_output"
 
+# ─── Test 12: Fix block emitted for missing _DATACLASS_SCOPE entry ───────
+# When a new ``*SplitRuling`` is missing from _DATACLASS_SCOPE, the check's
+# error output must include a copy-pasteable Fix block under a ``Fix:``
+# heading.  Issue #4322.
+write_dataclass xyz_tentatives XYZSplitRuling ruling_index case_number
+write_worker _try_la_html_split case_number ruling_text
+write_reingest case_number ruling_text
+TESTS=$((TESTS + 1))
+last_combined=$(mktemp)
+set +e
+python3 "$PY_SCRIPT" \
+    --scraper-framework "$TMPDIR_TEST/src" \
+    --reingest "$TMPDIR_TEST/reingest.py" \
+    --quiet-whitelisted \
+    > "$last_combined" 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 1 ]] \
+    && grep -q "^Fix:" "$last_combined" \
+    && grep -q '"XYZSplitRuling"' "$last_combined" \
+    && grep -q '"reingest": True' "$last_combined"; then
+    echo "PASS: Test 12 — Fix block emitted with literal scope-entry patch"
+else
+    echo "FAIL: Test 12 — output missing Fix block / patch literal"
+    echo "  rc: $rc"
+    echo "  combined: $(cat "$last_combined")"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_combined"
+reset_tmpdir
+
+# ─── Test 13: Fix block disambiguates SplitRuling by module stem ─────────
+# A plain ``SplitRuling`` class (Fresno/Riverside/SF/SC convention) gets
+# its scope key suggested as ``SplitRuling@<module-stem>`` so the operator
+# can paste it directly into the disambiguated table.  Issue #4322.
+courts_dir="$TMPDIR_TEST/src/courts/ca"
+mkdir -p "$courts_dir"
+cat > "$courts_dir/abc_tentatives.py" <<'PYEOF'
+class SplitRuling:
+    __slots__ = (
+        "ruling_index",
+        "case_number",
+        "ruling_text",
+    )
+    def __init__(self, ruling_index, case_number, ruling_text):
+        self.ruling_index = ruling_index
+        self.case_number = case_number
+        self.ruling_text = ruling_text
+PYEOF
+write_worker _try_la_html_split case_number ruling_text
+write_reingest case_number ruling_text
+TESTS=$((TESTS + 1))
+last_combined=$(mktemp)
+set +e
+python3 "$PY_SCRIPT" \
+    --scraper-framework "$TMPDIR_TEST/src" \
+    --reingest "$TMPDIR_TEST/reingest.py" \
+    --quiet-whitelisted \
+    > "$last_combined" 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 1 ]] \
+    && grep -q '"SplitRuling@abc_tentatives"' "$last_combined"; then
+    echo "PASS: Test 13 — Fix block uses SplitRuling@<stem> for disambiguated key"
+else
+    echo "FAIL: Test 13 — Fix block did not name SplitRuling@abc_tentatives"
+    echo "  rc: $rc"
+    echo "  combined: $(cat "$last_combined")"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_combined"
+reset_tmpdir
+
+# ─── Test 14: Fix block uses real worker fn name when one exists ─────────
+# When ``_try_<county>_<format>_split`` exists in worker.py, the Fix
+# block's ``"worker_fn"`` field uses the real name (no placeholder /
+# adjust-comment).  Issue #4322 AC #2.
+write_dataclass xyz_tentatives XYZSplitRuling ruling_index case_number
+# Worker has a real _try_xyz_pdf_split function — the Fix block should
+# pick it up and omit the "adjust if the worker hook has a different name"
+# comment.
+write_worker _try_xyz_pdf_split case_number
+write_reingest case_number
+TESTS=$((TESTS + 1))
+last_combined=$(mktemp)
+set +e
+python3 "$PY_SCRIPT" \
+    --scraper-framework "$TMPDIR_TEST/src" \
+    --worker "$TMPDIR_TEST/src/ingestion/worker.py" \
+    --reingest "$TMPDIR_TEST/reingest.py" \
+    --quiet-whitelisted \
+    > "$last_combined" 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 1 ]] \
+    && grep -q '"_try_xyz_pdf_split"' "$last_combined" \
+    && ! grep -q "adjust if the worker hook" "$last_combined"; then
+    echo "PASS: Test 14 — Fix block uses real worker fn name (no placeholder comment)"
+else
+    echo "FAIL: Test 14 — Fix block did not pick up real _try_xyz_pdf_split"
+    echo "  rc: $rc"
+    echo "  combined: $(cat "$last_combined")"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_combined"
+reset_tmpdir
+
+# ─── Test 15: Fix block falls back to placeholder when no worker fn ──────
+# When no ``_try_<county>_*_split`` function exists in worker.py, the Fix
+# block uses the conventional ``_try_<county>_pdf_split`` placeholder and
+# includes the "adjust if the worker hook has a different name" comment.
+# Issue #4322 AC #2 (negative).
+write_dataclass xyz_tentatives XYZSplitRuling ruling_index case_number
+write_worker _try_la_html_split case_number ruling_text
+write_reingest case_number ruling_text
+TESTS=$((TESTS + 1))
+last_combined=$(mktemp)
+set +e
+python3 "$PY_SCRIPT" \
+    --scraper-framework "$TMPDIR_TEST/src" \
+    --worker "$TMPDIR_TEST/src/ingestion/worker.py" \
+    --reingest "$TMPDIR_TEST/reingest.py" \
+    --quiet-whitelisted \
+    > "$last_combined" 2>&1
+rc=$?
+set -e
+if [[ $rc -eq 1 ]] \
+    && grep -q '"_try_xyz_pdf_split"' "$last_combined" \
+    && grep -q "adjust if the worker hook" "$last_combined"; then
+    echo "PASS: Test 15 — Fix block uses placeholder + adjust-comment when no worker fn matches"
+else
+    echo "FAIL: Test 15 — Fix block missing placeholder _try_xyz_pdf_split + adjust-comment"
+    echo "  rc: $rc"
+    echo "  combined: $(cat "$last_combined")"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_combined"
+reset_tmpdir
+
 # ─── Self-match guard — N/A ──────────────────────────────────────────────
 # The peer ``check-no-*.sh`` self-match helper is for guards that grep
 # arbitrary text and might match their own ci.yml step name.  This


### PR DESCRIPTION
## Summary

Make `scripts/check_split_ruling_fields_propagated.py` self-diagnosing when a new `*SplitRuling` dataclass is missing from `_DATACLASS_SCOPE`. The check now emits a copy-pasteable `Fix:` block — a literal dict-entry the operator pastes directly into the scope table — alongside the existing `VIOLATION:` line. Auto-detects the conventional worker function name (`_try_<county>_*_split`) by AST-walking `packages/scraper-framework/src/ingestion/worker.py`; falls back to a placeholder with an `# adjust if the worker hook has a different name` comment when no real match exists.

Saves a CI iteration on every new county splitter (SC #4303, SF #4304, and future additions).

Closes #4322

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_split_ruling_fields_propagated.sh` — 15/15)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check / dev-time tooling only)
