### PR TITLE
feat(scraping): add SC format-B summary-table parser to _split_rulings (#4341)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sc_tentatives.py
@@ -435,7 +435,7 @@ def parse_case_title(text: str) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Multi-ruling PDF splitter (#4303)
+# Multi-ruling PDF splitter (#4303, format-B added in #4341)
 # ---------------------------------------------------------------------------
 #
 # Santa Clara multi-case PDFs use one of two formats:
@@ -451,16 +451,26 @@ def parse_case_title(text: str) -> str | None:
 #   B) Compact summary-table format (e.g. dept 6):
 #        A single ``LINE CASE NO. CASE TITLE TENTATIVE RULING`` header,
 #        then per-row entries on shared rows.  This format does NOT have
-#        per-case bare ``Line N`` boundaries, so the splitter falls through
-#        to the LLM path and the existing per-county prompt's anti-carry-
-#        forward rule (5b) is the only protection.
+#        per-case bare ``Line N`` boundaries on their own line for short
+#        rulings — pdfplumber's flat text output collapses the table
+#        columns and the format-A regex finds at most 1 entry.  Format B
+#        is parsed by ``_split_rulings_format_b`` using pdfplumber's
+#        ``extract_tables()`` API to read the structured columns
+#        directly: every row of the summary table whose CASE NO. column
+#        is non-empty becomes one SplitRuling, with ``case_number``,
+#        ``case_title``, and ``ruling_text`` (cell + continuation rows)
+#        populated deterministically from the table.  Format B requires
+#        the original PDF bytes — text-only callers fall back to format A
+#        for backward compatibility.  See #4341 (root cause #4339).
 #
-# The splitter targets format (A) — the dominant source of the
-# ``all_same_case_title_cluster`` signal in Santa Clara per the
-# cross-county audit (#4289 ran 2026-05-06).  21 distinct multi-case PDFs
-# all produced the same wrong ``case_title`` across rulings — exactly the
-# carry-forward fingerprint #3534 (Fresno) and #3649 (Riverside) fixed by
-# pre-LLM splitters.
+# The splitter handles both formats — format A is the dominant source of
+# the ``all_same_case_title_cluster`` signal in Santa Clara per the
+# cross-county audit (#4289 ran 2026-05-06; 21 distinct multi-case PDFs
+# all produced the same wrong ``case_title`` across rulings) and format
+# B drains the residual cluster of dept-6-style PDFs that the LLM-only
+# path was hallucinating generic titles for.  Same carry-forward
+# fingerprint #3534 (Fresno) and #3649 (Riverside) fixed by pre-LLM
+# splitters.
 
 # Entry boundary: a bare ``Line N`` label on its own line, case-insensitive.
 # pdfplumber's text output puts each ``Line N`` on its own line in the
@@ -540,41 +550,67 @@ class SplitRuling:
         self.department = department
 
 
-def _split_rulings(text: str) -> list[SplitRuling]:
-    """Split Santa Clara multi-ruling PDF text into per-entry ``SplitRuling`` objects.
+# Format-B summary-table header anchor (#4341).  pdfplumber's
+# ``extract_tables()`` produces the structured table when this header is
+# present on the page — see ``_split_rulings_format_b``.  The literal
+# header in the live PDFs is ``LINE CASE NO. CASE TITLE TENTATIVE RULING``.
+_SC_FORMAT_B_HEADER_RE = re.compile(
+    r"LINE\s+CASE\s+NO\.?\s+CASE\s+TITLE\s+TENTATIVE\s+RULING",
+    re.IGNORECASE,
+)
 
-    The page-1 preamble (calendar header, judge info, courtroom rules,
-    appearance instructions) is excluded by anchoring on the first
-    ``^Line\\s+\\d+\\s*$`` boundary — anything before the first numbered
-    entry is dropped.
+# Format-B per-row case number column.  pdfplumber may emit the case
+# number with internal whitespace (e.g. ``"24CV 443183"``) so we strip
+# whitespace before matching.  ``\d{2}(CV|PR)\d{6}`` is the canonical SC
+# case-number shape (see ``_CASE_NUMBER_RE``).
+_SC_FORMAT_B_CASE_NO_RE = re.compile(
+    r"^\s*(?P<case_number>\d{2}(?:CV|PR)\d{6})\s*$",
+    re.IGNORECASE,
+)
 
-    Returns an empty list if no numbered entries are found, which is the
-    expected outcome for compact summary-table PDFs (e.g. dept 6) and for
-    single-ruling PDFs that don't follow the expanded ``Line N`` format.
-    Single-element returns are also possible — the worker treats both
-    cases identically (fall through to the LLM path) because there is no
-    cross-entry carry-forward window with 0 or 1 entries.
+# Cross-reference inside a format-B summary-table cell:
+# ``See Line N below`` / ``see Line N above`` / ``See Line Item N below``.
+# When present, the format-B parser appends the corresponding format-A
+# ``Line N`` body section (when one exists in the same PDF) to the row's
+# ruling_text.  Only digits are captured.
+_SC_FORMAT_B_CROSSREF_RE = re.compile(
+    r"\bSee\s+Line(?:\s+Item)?\s+(?P<num>\d{1,3})\b",
+    re.IGNORECASE,
+)
 
-    Each returned ``SplitRuling`` has:
 
-      * ``ruling_index`` — the integer from the entry header (e.g. ``1``,
-        ``2``, ``3`` for a PDF with three rulings).
-      * ``case_number`` — extracted from the ``Case No.:`` header inside
-        the entry; ``None`` if the regex fails to match (the worker's
-        per-entry LLM enrichment will fill it in).
-      * ``case_title`` — extracted from the ``Case Name:`` header inside
-        the entry; ``None`` if absent (per-entry LLM enrichment falls back
-        to the existing case-title heuristics).
-      * ``ruling_text`` — the **verbatim** entry text from the boundary
-        through the next entry boundary (or the end of the document for
-        the last entry).  Includes the entry's own headers and body.
+def _normalize_table_cell(cell: str | None) -> str:
+    """Collapse newlines + multi-whitespace inside a single pdfplumber cell."""
+    if cell is None:
+        return ""
+    return " ".join(cell.replace("\n", " ").split())
 
-    motion_type and outcome are left ``None`` on purpose — Santa Clara
-    PDFs do not carry structured motion-type / outcome labels in their
-    per-entry headers, so deterministic regex extraction would produce a
-    high false-negative rate.  Letting the framework ``LlmExtractor``
-    populate those fields via per-entry enrichment matches the Riverside
-    pattern (#3649) and preserves correctness on single-ruling PDFs.
+
+def _is_format_b_header_row(row: list[str | None]) -> bool:
+    """Return True if a pdfplumber-extracted table row is the format-B header.
+
+    The first 4 cells must be (case-insensitive, leading-whitespace-tolerant)
+    ``"LINE"``, ``"CASE NO."``, ``"CASE TITLE"``, ``"TENTATIVE RULING"``.
+    Trailing cells (``None`` or empty) are ignored.
+    """
+    if len(row) < 4:
+        return False
+    expected = ("line", "case no.", "case title", "tentative ruling")
+    for col, want in zip(row[:4], expected, strict=False):
+        # Compare with normalized punctuation: pdfplumber may strip the
+        # trailing period from "CASE NO."  Tolerate either form.
+        normalized_loose = _normalize_table_cell(col).lower().rstrip(".")
+        if normalized_loose != want.rstrip("."):
+            return False
+    return True
+
+
+def _split_rulings_format_a(text: str) -> list[SplitRuling]:
+    """Format-A splitter — the original ``Line N`` boundary regex (#4303).
+
+    See module docstring §A for the exact pre-conditions.  Returns an
+    empty list when no ``Line N`` boundaries are present (typical of
+    compact summary-table PDFs and single-ruling PDFs).
     """
     matches = list(_SC_RULING_ENTRY_RE.finditer(text))
     if not matches:
@@ -624,6 +660,232 @@ def _split_rulings(text: str) -> list[SplitRuling]:
         )
 
     return rulings
+
+
+def _format_a_body_section(text: str, line_num: int) -> str | None:
+    """Find the ``Line N`` body section in ``text`` and return its content.
+
+    Used by the format-B parser to expand ``See Line N below`` cross-
+    references in summary-table cells.  Returns ``None`` if no such
+    section is present.
+
+    The section starts at the boundary ``^Line\\s+N\\s*$`` (case-
+    insensitive) and runs to the next ``^Line\\s+M\\s*$`` boundary or
+    the end of the document.  Returns the section body verbatim
+    (whitespace-stripped on both ends).
+    """
+    boundaries = [
+        (m.start(), m.end(), int(re.search(r"\d+", m.group("num")).group(0)))
+        for m in _SC_RULING_ENTRY_RE.finditer(text)
+        if re.search(r"\d+", m.group("num"))
+    ]
+    for i, (b_start, b_end, b_num) in enumerate(boundaries):
+        if b_num != line_num:
+            continue
+        section_start = b_end
+        section_end = boundaries[i + 1][0] if i + 1 < len(boundaries) else len(text)
+        section = text[section_start:section_end].strip()
+        if len(section) < _SC_MIN_ENTRY_BODY_LEN:
+            return None
+        return section
+    return None
+
+
+def _split_rulings_format_b(text: str, pdf_bytes: bytes) -> list[SplitRuling]:
+    """Format-B splitter — pdfplumber ``extract_tables()`` on summary tables.
+
+    See module docstring §B for the exact pre-conditions.  Returns an
+    empty list when no format-B summary table is found (the caller
+    should fall back to format A).
+
+    The parser walks every page of the PDF, looking for a table whose
+    first row matches the format-B header
+    (``LINE | CASE NO. | CASE TITLE | TENTATIVE RULING``).  Within each
+    matching table:
+
+    * A "case row" is a row whose CASE NO. column normalizes to a
+      single ``\\d{2}(CV|PR)\\d{6}`` token.  Such a row starts a new
+      ``SplitRuling``.
+    * Continuation rows (where CASE NO. is empty / ``None``) append
+      their TENTATIVE RULING column to the current case's
+      ``ruling_text``.
+    * Cells containing ``See Line N below`` (or similar) cause the
+      format-A body section for ``Line N``, when present, to be
+      appended after the table cell — preserving the long-form ruling
+      content the summary table cross-references.
+
+    ``ruling_index`` is assigned 1..N in the order rows are seen; this
+    is independent of the printed ``LINE`` column (which can be
+    discontinuous in the live PDFs, e.g. ``;``, ``1,2``, ``3-5``).
+
+    Robustness: any ``Exception`` from pdfplumber (corrupt PDF,
+    encrypted PDF, unexpected layout) returns ``[]`` so the caller
+    can fall back to format A or the LLM path.  The worker logs the
+    fall-through.
+    """
+    import io
+
+    rulings: list[SplitRuling] = []
+    next_index = 1
+    try:
+        with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+            for page in pdf.pages:
+                tables = page.extract_tables() or []
+                for table in tables:
+                    if not table or not _is_format_b_header_row(table[0]):
+                        continue
+                    current: SplitRuling | None = None
+                    for row in table[1:]:
+                        if not row:
+                            continue
+                        # Case-no column (col 1).
+                        cn_raw = _normalize_table_cell(row[1] if len(row) > 1 else None)
+                        cn_normalized = cn_raw.replace(" ", "").upper()
+                        cn_match = _SC_FORMAT_B_CASE_NO_RE.match(cn_normalized)
+                        if cn_match:
+                            # New case row — flush the previous case (if any)
+                            # and start fresh.
+                            if current is not None:
+                                rulings.append(current)
+                            title = _normalize_table_cell(row[2] if len(row) > 2 else None)
+                            ruling_chunk = _normalize_table_cell(row[3] if len(row) > 3 else None)
+                            current = SplitRuling(
+                                ruling_index=next_index,
+                                case_number=cn_match.group("case_number").upper(),
+                                ruling_text=ruling_chunk,
+                                case_title=title or None,
+                            )
+                            next_index += 1
+                        elif current is not None:
+                            # Continuation row — append the TENTATIVE RULING
+                            # column to the current case's ruling_text and
+                            # the CASE TITLE column (if non-empty) to the
+                            # current case's title (the dept-6 layout wraps
+                            # long titles across multiple rows).
+                            cont_title = _normalize_table_cell(row[2] if len(row) > 2 else None)
+                            cont_ruling = _normalize_table_cell(row[3] if len(row) > 3 else None)
+                            if cont_title:
+                                current.case_title = (
+                                    f"{current.case_title} {cont_title}".strip()
+                                    if current.case_title
+                                    else cont_title
+                                )
+                            if cont_ruling:
+                                current.ruling_text = (
+                                    f"{current.ruling_text}\n{cont_ruling}"
+                                    if current.ruling_text
+                                    else cont_ruling
+                                )
+                    # Flush the last case in this table.
+                    if current is not None:
+                        rulings.append(current)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "format_b_table_parse_error",
+            error=str(exc),
+        )
+        return []
+
+    if not rulings:
+        return []
+
+    # Expand ``See Line N below`` cross-references — when a summary-table
+    # cell points at a format-A body section, append that section to the
+    # row's ruling_text so the per-entry LLM enrichment sees the full
+    # long-form ruling, not just the cross-reference.
+    for r in rulings:
+        if not r.ruling_text:
+            continue
+        for m in _SC_FORMAT_B_CROSSREF_RE.finditer(r.ruling_text):
+            try:
+                line_num = int(m.group("num"))
+            except ValueError:
+                continue
+            section = _format_a_body_section(text, line_num)
+            if section:
+                r.ruling_text = f"{r.ruling_text}\n\n{section}"
+
+    return rulings
+
+
+def _split_rulings(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]:
+    """Split Santa Clara multi-ruling PDF text into per-entry ``SplitRuling`` objects.
+
+    Two parsing paths cover the two known SC layouts (see module docstring
+    §A and §B):
+
+    * **Format A** — ``Line N`` boundary regex on the flattened pdfplumber
+      text.  Always tried first; succeeds for dept 16 and other
+      departments that print per-case body sections with bare ``Line N``
+      headings.  When this path returns >= 2 entries, those are used
+      verbatim.
+    * **Format B** — pdfplumber ``extract_tables()`` on the original PDF
+      bytes.  Only attempted when format A returns < 2 entries AND the
+      flattened text contains the literal
+      ``LINE CASE NO. CASE TITLE TENTATIVE RULING`` header AND
+      ``pdf_bytes`` is supplied.  Each row of the summary table whose
+      CASE NO. column is non-empty becomes one ``SplitRuling``; the
+      TENTATIVE RULING column (plus continuation rows and any
+      cross-referenced format-A body sections) becomes ``ruling_text``.
+
+    Backward compat: callers that pass only ``text`` (the original
+    signature) still work — they get the format-A behavior, which is
+    correct for every layout that has per-case ``Line N`` boundaries
+    AND for any caller (e.g. the worker pre-#4341) that hasn't been
+    updated to thread PDF bytes through.
+
+    The page-1 preamble (calendar header, judge info, courtroom rules,
+    appearance instructions) is excluded by both paths — format A
+    anchors on the first ``^Line\\s+\\d+\\s*$`` boundary, format B
+    anchors on the table header row inside the structured-table output.
+
+    Returns an empty list if neither path can identify multi-ruling
+    structure, which is the expected outcome for genuinely single-
+    ruling PDFs.  Single-element returns are also possible; the worker
+    treats both cases identically (fall through to the LLM path)
+    because there is no cross-entry carry-forward window with 0 or 1
+    entries.
+
+    Each returned ``SplitRuling`` has:
+
+      * ``ruling_index`` — the integer from the entry header (format A)
+        or a 1..N positional counter assigned in row order
+        (format B).  Format A indices match the printed ``Line N``;
+        format B indices are positional because the printed ``LINE``
+        column in the summary table is non-contiguous (``;``, ``1,2``,
+        ``3-5``, etc.).
+      * ``case_number`` — extracted from the ``Case No.:`` header
+        (format A) or the CASE NO. column (format B); always uppercased
+        and whitespace-stripped.
+      * ``case_title`` — extracted from the ``Case Name:`` header
+        (format A) or the CASE TITLE column (format B); always
+        whitespace-normalized.
+      * ``ruling_text`` — the verbatim entry text (format A) or the
+        TENTATIVE RULING column plus continuation rows plus any
+        cross-referenced ``Line N`` body sections (format B).
+
+    motion_type and outcome are left ``None`` on purpose — Santa Clara
+    PDFs do not carry structured motion-type / outcome labels in their
+    per-entry headers, so deterministic regex extraction would produce a
+    high false-negative rate.  Letting the framework ``LlmExtractor``
+    populate those fields via per-entry enrichment matches the Riverside
+    pattern (#3649) and preserves correctness on single-ruling PDFs.
+    """
+    # Format A always runs first.  When it produces a usable multi-entry
+    # result, return it verbatim.
+    format_a = _split_rulings_format_a(text)
+    if len(format_a) >= 2:
+        return format_a
+
+    # Format B is conditional: needs the PDF bytes AND the literal
+    # summary-table header in the flattened text.  Otherwise we fall
+    # back to whatever format A produced (likely empty or single-entry).
+    if pdf_bytes is not None and _SC_FORMAT_B_HEADER_RE.search(text):
+        format_b = _split_rulings_format_b(text, pdf_bytes)
+        if len(format_b) >= 2:
+            return format_b
+
+    return format_a
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -838,37 +838,40 @@ def _try_sc_pdf_split(
     document_id: str,
     ruling_text: str,
     dispatch: Any,
+    raw_pdf_bytes: bytes | None = None,
 ) -> bool:
     """If *ruling_text* is a Santa Clara multi-ruling PDF, deterministically
     split it into per-case rulings and dispatch one synthetic split event per
     case via *dispatch*.  Returns True if the split ran, False otherwise.
 
     This path bypasses the framework LLM extractor — Santa Clara expanded-
-    format calendar PDFs use bare ``Line N`` boundaries (case-insensitive)
-    on their own line followed by ``Case Name:`` / ``Case No.:`` headers
-    that are cheap to parse with the regex-based ``_split_rulings``
-    function in ``courts.ca.sc_tentatives``.  Sending the whole PDF
-    through the LLM previously produced cross-entry contamination
-    (#4303): the LLM violated rule 5b of the Santa Clara extraction
-    prompt and copied the first entry's ``case_title`` /
-    ``motion_type`` onto subsequent entries.  The cross-county audit
-    (#4289 ran 2026-05-06) found 21 distinct multi-case Santa Clara
-    PDFs with the ``all_same_case_title_cluster`` fingerprint —
-    precisely the carry-forward signature #3534 / #3649 fixed for
-    Fresno / Riverside.
+    format calendar PDFs (format A — e.g. dept 16) use bare ``Line N``
+    boundaries on their own line followed by ``Case Name:`` /
+    ``Case No.:`` headers that are cheap to parse with the regex-based
+    ``_split_rulings`` function in ``courts.ca.sc_tentatives``.  Compact
+    summary-table PDFs (format B — e.g. dept 6) are parsed with
+    pdfplumber's structured ``extract_tables()`` API when *raw_pdf_bytes*
+    is supplied — see #4341.  Sending the whole PDF through the LLM
+    previously produced cross-entry contamination (#4303): the LLM
+    violated rule 5b of the Santa Clara extraction prompt and copied
+    the first entry's ``case_title`` / ``motion_type`` onto subsequent
+    entries.  The cross-county audit (#4289 ran 2026-05-06) found 21
+    distinct multi-case Santa Clara PDFs with the
+    ``all_same_case_title_cluster`` fingerprint — precisely the
+    carry-forward signature #3534 / #3649 fixed for Fresno / Riverside.
 
     Detection gate: only triggers when event is Santa Clara county
     **and** content format is ``"pdf"`` — avoids false-positive
     matches on other courts.
 
-    When ``_split_rulings`` returns ``[]`` (no ``Line N`` boundaries —
-    typical of compact summary-table PDFs like dept 6 and of single-
-    ruling PDFs) or a 1-element list, this function returns ``False``
-    so the existing LLM path handles enrichment.  The deterministic
-    regex extraction does not populate ``motion_type``/``outcome`` —
-    falling through to the framework ``LlmExtractor`` is what gives
-    those fields per-entry enrichment without any cross-entry carry-
-    forward window (single-ruling PDFs have nothing to carry forward).
+    When ``_split_rulings`` returns ``[]`` (no ``Line N`` boundaries
+    AND no parseable summary table — typical of single-ruling PDFs) or
+    a 1-element list, this function returns ``False`` so the existing
+    LLM path handles enrichment.  The deterministic extraction does not
+    populate ``motion_type``/``outcome`` — falling through to the
+    framework ``LlmExtractor`` is what gives those fields per-entry
+    enrichment without any cross-entry carry-forward window
+    (single-ruling PDFs have nothing to carry forward).
 
     Mirrors the SD/LA/Fresno/Riverside/SF pattern (``_try_sd_calendar_split``
     #2447, ``_try_la_html_split`` #2450, ``_try_fresno_pdf_split`` #3534,
@@ -884,7 +887,7 @@ def _try_sc_pdf_split(
     # the courts package at module load time.
     from courts.ca.sc_tentatives import _split_rulings
 
-    split_rulings = _split_rulings(ruling_text)
+    split_rulings = _split_rulings(ruling_text, pdf_bytes=raw_pdf_bytes)
     if not split_rulings:
         # No ``Line N`` boundaries found — fall through to LLM.
         logger.info(
@@ -2242,11 +2245,23 @@ class IngestionWorker:
             # is_pdf_binary() returns False, so raw_pdf_bytes stays None.
             # For MULTIMODAL counties, download the original PDF from S3 so
             # the multimodal path can send page images to the LLM.
+            #
+            # Santa Clara also needs the raw bytes for the format-B
+            # summary-table splitter (#4341).  The format-B parser uses
+            # pdfplumber's ``extract_tables()`` API on the original PDF —
+            # the flattened text doesn't preserve the column structure.
+            # Fetching here (rather than lazily inside the splitter)
+            # keeps S3 access in one place and avoids a second fetch
+            # later in the pipeline.
+            sc_county_match = (
+                content_format == "pdf"
+                and (event_data.get("county") or "").upper() == "SANTA CLARA"
+            )
             if raw_pdf_bytes is None and content_format == "pdf" and s3_key:
                 # ``strategy.use_multimodal`` is True for ExtractionMethod.MULTIMODAL
                 # AND for unconfigured counties (the helper preserves the worker's
                 # pre-refactor default-multimodal behavior, #4081).
-                if strategy.use_multimodal:
+                if strategy.use_multimodal or sc_county_match:
                     raw_pdf_bytes = self._fetch_raw_pdf_from_s3(s3_key, s3_bucket, document_id)
 
         # ------------------------------------------------------------------
@@ -3647,7 +3662,11 @@ class IngestionWorker:
         # deterministically from the per-entry ``Case No.:`` /
         # ``Case Name:`` headers when present.
         if ruling_text and _try_sc_pdf_split(
-            event_data, document_id, ruling_text, self.process_event
+            event_data,
+            document_id,
+            ruling_text,
+            self.process_event,
+            raw_pdf_bytes=raw_pdf_bytes,
         ):
             return True
 

--- a/packages/scraper-framework/tests/courts/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sc_tentatives.py
@@ -1122,22 +1122,199 @@ class TestSantaClaraPdfSplit:
         for idx in ruling_indices:
             assert idx < 10, f"trailing index label Line {idx} was not skipped"
 
-    def test_santa_clara_pdf_split_dept6_compact_table_falls_through(self) -> None:
-        """sc_dept6_tues.pdf uses the compact summary-table format (no per-
-        entry ``Line N`` boundaries on their own line).  The splitter
-        returns at most 1 entry, so the worker falls through to the LLM
-        path and the existing carry-forward protection (the LLM prompt's
-        rule 5b) is the only defense for this format.
+    def test_santa_clara_pdf_split_dept6_compact_table_text_only_falls_through(self) -> None:
+        """sc_dept6_tues.pdf uses the compact summary-table format (format B —
+        no per-entry ``Line N`` boundaries on their own line for short
+        rulings).  When ``_split_rulings`` is called with text only (no
+        ``pdf_bytes``), the format-A regex path returns at most 1 entry, so
+        the worker falls through to the LLM path.
 
-        This test pins the fall-through behavior so the splitter's
-        coverage gap is explicit.  A future PR can extend the splitter
-        to handle compact tables; until then, dept 6's residual carry-
-        forward risk is acknowledged here.
+        This pins the text-only fallback behavior.  When ``pdf_bytes`` is
+        supplied, the format-B path takes over and produces structured
+        rulings — see :meth:`test_santa_clara_pdf_split_dept6_summary_table_returns_ten_rulings`.
         """
         text = extract_pdf_text(_load_bytes("sc_dept6_tues.pdf"))
         rulings = _split_rulings(text)
-        # 0 or 1 entries — both trigger the worker's fall-through-to-LLM path.
+        # 0 or 1 entries — text-only fallback when format-B parser is not invoked.
         assert len(rulings) <= 1
+
+    def test_santa_clara_pdf_split_dept6_summary_table_returns_ten_rulings(self) -> None:
+        """sc_dept6_tues.pdf in format-B summary-table layout has 10 distinct
+        case rows.  When ``_split_rulings`` is called with ``pdf_bytes``,
+        the format-B parser uses pdfplumber's ``extract_tables()`` to read
+        the structured columns and returns one ``SplitRuling`` per case
+        row with ``case_number`` and ``case_title`` populated
+        deterministically (#4341, root-cause investigation #4339).
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        # The fixture has 10 distinct case rows in its summary table.
+        assert len(rulings) >= 10, (
+            f"format-B summary-table parser must emit >= 10 rulings; got {len(rulings)}"
+        )
+        for r in rulings:
+            assert r.case_number is not None, (
+                f"case_number is None at ruling_index {r.ruling_index}"
+            )
+            assert r.case_title is not None, f"case_title is None at ruling_index {r.ruling_index}"
+
+    def test_santa_clara_pdf_split_dept6_summary_table_titles(self) -> None:
+        """The format-B parser must extract the per-row case_title from the
+        summary table, not synthesize a generic carry-forward title.  The
+        fingerprint of the fix is that distinct case_numbers produce
+        distinct case_titles — exactly what the LLM-only path was failing
+        to do (#4339 documented 21 SC rulings sharing the hallucinated
+        title ``"Plaintiff v. FCA"``).
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        titles = [r.case_title for r in rulings]
+        # The summary table in this fixture (2026-03-03 dept-6 calendar)
+        # contains these 10 distinct case rows.  All must appear among the
+        # extracted titles (substring match — pdfplumber may collapse or
+        # spread whitespace differently from the printed text).
+        expected_substrings = [
+            "Huynh vs Redis Labs",
+            "Nicholas v. Compass",
+            "Ne Wang v. Daili Ren",
+            "Devin Shaffer",
+            "Discover Bank",
+            "Jessica Ebert",
+            "Pisamai Cuesta",
+            "Freelancer",
+            "Lee Casper v. Ford",
+            "Pahl & McCay",
+        ]
+        for needle in expected_substrings:
+            assert any(needle in (t or "") for t in titles), (
+                f"expected case_title containing {needle!r} not found in {titles!r}"
+            )
+        # And distinct case_numbers must produce distinct case_titles —
+        # the carry-forward fingerprint is identical case_titles across
+        # distinct case_numbers.
+        cn_to_title: dict[str, set[str]] = {}
+        for r in rulings:
+            assert r.case_number is not None
+            assert r.case_title is not None
+            cn_to_title.setdefault(r.case_number, set()).add(r.case_title)
+        # At least 10 distinct case_numbers with at least 10 distinct titles.
+        assert len(cn_to_title) >= 10
+        distinct_titles = {next(iter(ts)) for ts in cn_to_title.values()}
+        assert len(distinct_titles) >= 10, (
+            f"expected >= 10 distinct titles; got {len(distinct_titles)}: {distinct_titles!r}"
+        )
+
+    def test_santa_clara_pdf_split_dept6_summary_table_case_numbers(self) -> None:
+        """Each row's case_number must be extracted verbatim from the
+        ``CASE NO.`` column of the summary table.  Uppercase, no internal
+        whitespace.
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        case_numbers = {r.case_number for r in rulings}
+        # Ground truth from the fixture — every distinct case_number in
+        # the dept-6 summary table.
+        expected = {
+            "24CV443183",
+            "25CV460465",
+            "24CV448038",
+            "24CV441941",
+            "25CV458157",
+            "24CV442402",
+            "23CV428298",
+            "25CV468424",
+            "25CV474364",
+            "23CV419882",
+        }
+        missing = expected - case_numbers
+        assert not missing, f"expected case_numbers missing from format-B output: {missing!r}"
+
+    def test_santa_clara_pdf_split_dept6_summary_table_first_row(self) -> None:
+        """AC2: The fixture's first row resolves to ``case_number="24CV443183"``
+        and ``case_title="Huynh vs Redis Labs"`` (or close variant tolerating
+        ``"vs."``/``"vs"``/``"v."`` spelling).
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        # Find the ruling for case 24CV443183 (the first row in the summary).
+        match = next((r for r in rulings if r.case_number == "24CV443183"), None)
+        assert match is not None, (
+            "first summary-table row (case 24CV443183) is not in the format-B output"
+        )
+        assert match.case_title is not None
+        # Tolerant title check — "vs"/"vs."/"v." all acceptable.
+        normalized = match.case_title.lower()
+        assert "huynh" in normalized
+        assert "redis labs" in normalized
+
+    def test_santa_clara_pdf_split_dept6_summary_table_isolation(self) -> None:
+        """Each format-B ruling's text must contain only its own row's
+        content.  No cross-row contamination — that is the carry-forward
+        fingerprint #4339 documented.
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        by_cn = {r.case_number: r for r in rulings}
+        # Pick rows with clearly distinct parties.
+        r_huynh = by_cn["24CV443183"]
+        r_discover = by_cn["25CV458157"]
+        # The Pahl row exists in the table — assert its case_number landed
+        # so the test fails loudly if the case were to drop out.
+        assert "23CV419882" in by_cn
+        # Title isolation — each ruling's title must NOT contain another
+        # ruling's distinctive party tokens.
+        assert "Huynh" not in (r_discover.case_title or "")
+        assert "Discover" not in (r_huynh.case_title or "")
+        assert "Pahl" not in (r_huynh.case_title or "")
+        assert "Pahl" not in (r_discover.case_title or "")
+
+    def test_santa_clara_pdf_split_dept6_summary_table_no_pdf_bytes_falls_back(self) -> None:
+        """When ``pdf_bytes`` is None (text-only call), the format-B parser
+        must NOT run — the splitter falls back to format-A regex (which
+        returns 0-1 entries for this PDF).  This is the backward-compat
+        contract for callers that haven't been updated yet.
+        """
+        text = extract_pdf_text(_load_bytes("sc_dept6_tues.pdf"))
+        # Explicit pdf_bytes=None is the same as omitting the param.
+        rulings_none = _split_rulings(text, pdf_bytes=None)
+        rulings_omitted = _split_rulings(text)
+        assert len(rulings_none) <= 1
+        assert len(rulings_omitted) <= 1
+        # And the two calls return the same thing.
+        assert len(rulings_none) == len(rulings_omitted)
+
+    def test_santa_clara_pdf_split_dept6_summary_table_does_not_extract_motion_or_outcome(
+        self,
+    ) -> None:
+        """Same contract as format-A: the splitter populates only
+        case_number / case_title / ruling_text and leaves motion_type /
+        outcome as ``None`` for per-entry LLM enrichment.
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        assert len(rulings) > 0
+        for r in rulings:
+            assert r.motion_type is None
+            assert r.outcome is None
+
+    def test_santa_clara_pdf_split_dept16_format_a_unaffected_by_pdf_bytes(self) -> None:
+        """The format-A path (dept 16) must continue to work when ``pdf_bytes``
+        is passed — format-A short-circuits before format-B is consulted,
+        so the dept 16 result is identical with or without bytes.
+        """
+        pdf_bytes = _load_bytes("sc_dept16_wed.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings_text = _split_rulings(text)
+        rulings_with_bytes = _split_rulings(text, pdf_bytes=pdf_bytes)
+        # Same count, same case_numbers in the same order.
+        assert len(rulings_text) == len(rulings_with_bytes) == 9
+        assert [r.case_number for r in rulings_text] == [r.case_number for r in rulings_with_bytes]
 
     def test_santa_clara_pdf_split_dept1_summary_table_falls_through(self) -> None:
         """sc_dept1_tues.pdf uses ``LINE 1 CASENO TITLE ...`` on a single
@@ -1260,3 +1437,186 @@ class TestSantaClaraPdfSplit:
             assert hasattr(r, "outcome")
             assert hasattr(r, "hearing_date")
             assert hasattr(r, "department")
+
+
+# ---------------------------------------------------------------------------
+# Format-B helper coverage (#4341)
+# ---------------------------------------------------------------------------
+#
+# The format-B path has several defensive branches that the dept-6 fixture
+# cannot exercise on its own (e.g., header-row mismatch, body-section
+# fallback, malformed PDF bytes).  These tests cover the helpers directly
+# so the diff-coverage gate is satisfied without needing an additional
+# binary fixture.
+
+
+class TestSantaClaraFormatBHelpers:
+    """Unit tests for format-B summary-table parser helpers (#4341)."""
+
+    def test_is_format_b_header_row_matches_canonical(self) -> None:
+        from courts.ca.sc_tentatives import _is_format_b_header_row
+
+        assert _is_format_b_header_row(["LINE", "CASE NO.", "CASE TITLE", "TENTATIVE RULING"])
+        # Tolerate trailing None columns (pdfplumber pads to a fixed col count).
+        assert _is_format_b_header_row(
+            ["LINE", "CASE NO.", "CASE TITLE", "TENTATIVE RULING", None, None]
+        )
+
+    def test_is_format_b_header_row_tolerates_missing_period(self) -> None:
+        """pdfplumber may strip the trailing period from ``CASE NO.``"""
+        from courts.ca.sc_tentatives import _is_format_b_header_row
+
+        assert _is_format_b_header_row(["LINE", "CASE NO", "CASE TITLE", "TENTATIVE RULING"])
+
+    def test_is_format_b_header_row_case_insensitive(self) -> None:
+        from courts.ca.sc_tentatives import _is_format_b_header_row
+
+        assert _is_format_b_header_row(["line", "case no.", "case title", "tentative ruling"])
+
+    def test_is_format_b_header_row_too_short_returns_false(self) -> None:
+        """A row shorter than 4 cells cannot be the format-B header."""
+        from courts.ca.sc_tentatives import _is_format_b_header_row
+
+        assert not _is_format_b_header_row(["LINE", "CASE NO."])
+        assert not _is_format_b_header_row([])
+
+    def test_is_format_b_header_row_wrong_columns_returns_false(self) -> None:
+        """Non-matching columns return False."""
+        from courts.ca.sc_tentatives import _is_format_b_header_row
+
+        # First column wrong.
+        assert not _is_format_b_header_row(["FOO", "CASE NO.", "CASE TITLE", "TENTATIVE RULING"])
+        # Second column wrong.
+        assert not _is_format_b_header_row(["LINE", "BAR", "CASE TITLE", "TENTATIVE RULING"])
+        # Tentative ruling column missing.
+        assert not _is_format_b_header_row(["LINE", "CASE NO.", "CASE TITLE", "BAZ"])
+
+    def test_is_format_b_header_row_normalizes_whitespace(self) -> None:
+        """``\\n`` and runs of whitespace inside cells are collapsed."""
+        from courts.ca.sc_tentatives import _is_format_b_header_row
+
+        assert _is_format_b_header_row(
+            ["  LINE  ", "CASE\nNO.", "CASE\nTITLE", "TENTATIVE  RULING"]
+        )
+
+    def test_normalize_table_cell_handles_none(self) -> None:
+        from courts.ca.sc_tentatives import _normalize_table_cell
+
+        assert _normalize_table_cell(None) == ""
+        assert _normalize_table_cell("") == ""
+        assert _normalize_table_cell("foo\nbar") == "foo bar"
+        assert _normalize_table_cell("  foo   bar  ") == "foo bar"
+
+    def test_format_a_body_section_finds_present_line(self) -> None:
+        """The helper returns the body when ``Line N`` is present and long
+        enough."""
+        from courts.ca.sc_tentatives import _format_a_body_section
+
+        body = "x" * 200  # well over _SC_MIN_ENTRY_BODY_LEN.
+        text = f"preamble\nLine 11\n{body}\nLine 12\nstub\n"
+        section = _format_a_body_section(text, 11)
+        assert section is not None
+        assert body in section
+
+    def test_format_a_body_section_returns_none_for_missing_line(self) -> None:
+        """Returns None when no ``Line N`` boundary exists for the
+        requested number — covers the "iterate-and-fall-through" branch."""
+        from courts.ca.sc_tentatives import _format_a_body_section
+
+        text = "Line 1\n" + ("x" * 200) + "\nLine 2\n" + ("y" * 200) + "\n"
+        # Line 99 is not in the text; loop should fall through.
+        assert _format_a_body_section(text, 99) is None
+
+    def test_format_a_body_section_returns_none_for_too_short(self) -> None:
+        """Returns None when the matched section is below the minimum body
+        length — covers the trailing-label-style branch."""
+        from courts.ca.sc_tentatives import _format_a_body_section
+
+        text = "Line 1\nshort.\nLine 2\nyyy\n"
+        assert _format_a_body_section(text, 1) is None
+
+    def test_format_a_body_section_handles_no_line_boundaries(self) -> None:
+        """No boundaries at all → return None (defensive)."""
+        from courts.ca.sc_tentatives import _format_a_body_section
+
+        assert _format_a_body_section("", 1) is None
+        assert _format_a_body_section("plain prose without boundaries", 1) is None
+
+    def test_format_b_returns_empty_on_corrupt_pdf_bytes(self) -> None:
+        """Corrupt PDF bytes raise inside pdfplumber — the format-B parser
+        catches the exception and returns ``[]`` so the caller falls
+        back to format A."""
+        from courts.ca.sc_tentatives import _split_rulings_format_b
+
+        corrupt = b"Not actually a PDF"
+        result = _split_rulings_format_b("LINE CASE NO. CASE TITLE TENTATIVE RULING", corrupt)
+        assert result == []
+
+    def test_format_b_returns_empty_when_no_matching_table(self) -> None:
+        """The dept 1 PDF has no format-B summary table — every page's
+        ``extract_tables()`` either returns no tables or tables whose
+        first row does not match the format-B header.  Calling the
+        format-B parser directly returns ``[]`` so the public
+        ``_split_rulings`` falls back to format A.
+        """
+        from courts.ca.sc_tentatives import _split_rulings_format_b
+
+        pdf_bytes = _load_bytes("sc_dept1_tues.pdf")
+        result = _split_rulings_format_b("", pdf_bytes)
+        assert result == []
+
+    def test_split_rulings_format_b_skipped_when_pdf_bytes_none(self) -> None:
+        """Even when the format-B header is in the text, the parser is not
+        invoked when ``pdf_bytes`` is None — backward-compat branch.
+        """
+        text_with_header = "LINE CASE NO. CASE TITLE TENTATIVE RULING\n"
+        rulings = _split_rulings(text_with_header, pdf_bytes=None)
+        # No format-A boundaries either, so we get an empty list.
+        assert rulings == []
+
+    def test_split_rulings_format_b_skipped_when_header_absent(self) -> None:
+        """When the format-B header is absent from the text, the parser is
+        not invoked even when ``pdf_bytes`` is supplied."""
+        # Text has no LINE CASE NO. CASE TITLE TENTATIVE RULING header.
+        text = "Some random PDF text without the format-B header"
+        rulings = _split_rulings(text, pdf_bytes=b"%PDF-1.4 dummy")
+        assert rulings == []
+
+    def test_format_b_cross_reference_expansion(self) -> None:
+        """When a summary-table cell contains ``See Line N below`` and the
+        flattened text has a corresponding ``Line N`` body section, the
+        body section is appended to the row's ruling_text.
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        # The Freelancer row (25CV468424) has a "See Line 11 below" cell
+        # AND the flattened text has a Line 11 body section — so the
+        # cross-reference should be expanded.
+        freelancer = next((r for r in rulings if r.case_number == "25CV468424"), None)
+        assert freelancer is not None
+        # The Line 11 body content should have been appended.
+        assert "FREELANCER" in (freelancer.ruling_text or "")
+        assert "MOTION TO DISMISS" in (freelancer.ruling_text or "")
+
+    def test_format_b_continuation_row_appends_title_and_ruling(self) -> None:
+        """Continuation rows where col-1 is empty contribute their CASE
+        TITLE and TENTATIVE RULING columns to the current case.
+
+        This is exercised by the dept-6 fixture (the Nicholas v. Compass
+        Group row spans 2 title lines and 4 ruling lines), but we add an
+        explicit assertion so a regression in that branch is caught
+        directly.
+        """
+        pdf_bytes = _load_bytes("sc_dept6_tues.pdf")
+        text = extract_pdf_text(pdf_bytes)
+        rulings = _split_rulings(text, pdf_bytes=pdf_bytes)
+        nicholas = next((r for r in rulings if r.case_number == "25CV460465"), None)
+        assert nicholas is not None
+        # Title spans 2 lines: "Nicholas v. Compass\nGroup, et. Al." — the
+        # continuation must have appended "Group, et. Al." to the title.
+        assert "Compass" in (nicholas.case_title or "")
+        assert "Group" in (nicholas.case_title or "")
+        # Ruling spans 4 lines starting "Defendant moves for a demurrer..."
+        assert "demurrer" in (nicholas.ruling_text or "").lower()
+        assert "GRANTED" in (nicholas.ruling_text or "")


### PR DESCRIPTION
## Summary

Adds a format-B compact summary-table parser to the Santa Clara `_split_rulings` splitter. Dept-6-style multi-case calendar PDFs publish in a tabular layout that the format-A `Line N` regex cannot parse, so they previously fell through to the LLM, which hallucinated generic carry-forward titles ("Plaintiff v. FCA") across distinct cases — the carry-forward fingerprint root-caused in #4339. The new path uses pdfplumber's `extract_tables()` API on the original PDF bytes to read the structured columns directly and emit one `SplitRuling` per row.

Closes #4341

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` — clean)
- [x] Format check passes (`ruff format --check` — clean)
- [x] Tests pass (full scraper-framework suite: 7553 passed, 3 skipped, 0 failed)
- [x] CI green (canonical merge gate green at 317s; ci-passed=SUCCESS)

### Post-deploy verification
- [x] Code deployed (deploy-scraper.yml run 25575402949 succeeded; ingestion worker started 19:36 UTC with new image SHA e7db0de9). Drain of carry-forward cluster pending in follow-up #4354 — driving `all_same_case_title_cluster.count <= 2` requires `--bust-llm-cache --full-reparse` of the 15 affected SC parent S3 keys.
- [x] Verification evidence posted on issue #4341 (PARTIAL — code deployed; reingest follow-up tracked in #4354).

## Implementation notes

- **Backward compat preserved.** `_split_rulings(text)` (no `pdf_bytes`) still works exactly as before. Default `pdf_bytes=None` keeps every existing caller working.
- **Format A always runs first.** When format A returns ≥ 2 entries, the result is used verbatim — the new format-B path is the fallback when format A returns < 2 entries AND the text contains the literal `LINE CASE NO. CASE TITLE TENTATIVE RULING` header AND `pdf_bytes` is supplied.
- **Worker integration.** `_try_sc_pdf_split` accepts `raw_pdf_bytes: bytes | None = None` and threads it through. The `IngestionWorker.process_event` S3 fetch trigger was extended so SC documents (where `parse_document()` pre-extracts text and `is_pdf_binary()` returns False) get raw bytes fetched eagerly — one extra `s3:GetObject` per SC PDF event, accepted for the correctness gain.
- **Cross-reference expansion.** When a summary-table cell contains `See Line N below` and the flattened text has a corresponding `Line N` body section, the format-B parser appends that body to the row's `ruling_text` — preserves long-form rulings for per-entry LLM enrichment.

## Reframe note (AC2)

The issue body cites cases from a 2026-03-24 dept-6 PDF (`Yin Labson vs. FCA US LLC`, content-hash `483f1da9e800…`) that is **not** in the test fixtures. The existing fixture `packages/scraper-framework/tests/fixtures/sc_dept6_tues.pdf` is the 2026-03-03 dept-6 calendar — same format-B layout but different cases. Tests assert against the 10 distinct cases in the actual fixture (Huynh vs Redis Labs, Nicholas v. Compass, Ne Wang v. Daili Ren, Devin Shaffer, Discover Bank, Jessica Ebert, Pisamai Cuesta, Freelancer International, Lee Casper, Pahl & McCay). The implementation handles both PDFs equivalently because the structural pattern is identical. The AC's "or similar" language explicitly accommodates this — no separate `.txt` fixture file is added.

## Test coverage

- 26 new tests:
  - 8 `summary_table` integration tests against the dept-6 fixture
  - 14 helper unit tests (`_is_format_b_header_row`, `_normalize_table_cell`, `_format_a_body_section`, `_split_rulings_format_b` defensive paths)
  - 4 backward-compat / format-A regression tests
- Diff coverage: 94% (above the 90% gate)
- Full scraper-framework suite: 7553 passed

## Investigation reference

`docs/investigations/sc-batch-fca-clusters-2026-05.md` (#4339) — root-cause analysis showing 21 SC `all_same_case_title_cluster` rows are produced by 1 underlying PDF (15 mislabeled S3 keys all pointing at the same dept-6 1.6 MB blob) plus the LLM's hallucinated `"Plaintiff v. FCA"` title on the dept-6 format-B PDF. The S3 mislabeling is tracked separately under `docs/investigations/mislabeled-s3-writes-2026-04.md` and is out of scope here.
