### PR TITLE
test(dx): extract _temp_cleanup_helpers.sh for shell-test EXIT-trap boilerplate (#4343)

### DIFF
--- a/scripts/dispatcher/tests/test_progress_sh.sh
+++ b/scripts/dispatcher/tests/test_progress_sh.sh
@@ -42,23 +42,8 @@ HELPER="$SCRIPT_DIR/dispatcher/progress.sh"
 FAILURES=0
 TESTS=0
 
-TEMP_DIRS=()
-TEMP_FILES=()
-# shellcheck disable=SC2329  # invoked indirectly via `trap cleanup EXIT`.
-cleanup() {
-    set +e
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
-    for f in ${TEMP_FILES[@]+"${TEMP_FILES[@]}"}; do
-        if [[ -n "$f" && -e "$f" ]]; then
-            rm -f "$f"
-        fi
-    done
-}
-trap cleanup EXIT
+# Cleanup of temp dirs + files via the shared helper (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -81,7 +66,7 @@ fail() {
 make_psql_stub() {
     local tmp
     tmp=$(mktemp -d -t progress_test.XXXXXX)
-    TEMP_DIRS+=("$tmp")
+    register_temp_dir "$tmp"
     mkdir -p "$tmp/bin"
     cat > "$tmp/bin/psql" <<STUB
 #!/usr/bin/env bash
@@ -122,7 +107,7 @@ fi
 
 run_no_args() {
     local err rc
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     "$HELPER" 2>"$err"
     rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -141,7 +126,7 @@ run_no_args
 
 run_one_arg() {
     local err rc
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     "$HELPER" only-one-arg 2>"$err"
     rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -161,7 +146,7 @@ run_one_arg
 # Empty-string second arg should also be rejected (treated as missing).
 run_empty_milestone() {
     local err rc
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     "$HELPER" agent-1 "" 2>"$err"
     rc=$?
     if [[ $rc -eq 0 ]]; then
@@ -182,7 +167,7 @@ run_empty_milestone
 
 run_no_db_url() {
     local err rc
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     # `env -u` removes DATABASE_URL even if the surrounding test env set one.
     env -u DATABASE_URL "$HELPER" agent-1 ralph "iter 3" 2>"$err"
     rc=$?
@@ -204,9 +189,9 @@ run_no_db_url
 
 run_no_psql() {
     local err rc bin_only
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     bin_only=$(mktemp -d -t progress_nopath.XXXXXX)
-    TEMP_DIRS+=("$bin_only")
+    register_temp_dir "$bin_only"
     # Symlink only the binaries the script (and its shebang) need:
     # `env` and `bash`. This guarantees `psql` is unfindable while the
     # script's `#!/usr/bin/env bash` shebang still resolves. Falls back
@@ -239,7 +224,7 @@ run_no_psql
 run_stubbed_success() {
     local stub_dir rc err
     stub_dir=$(make_psql_stub)
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     echo 0 > "$stub_dir/psql.exit_code"
 
     PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \
@@ -298,7 +283,7 @@ run_stubbed_success
 run_stubbed_db_error() {
     local stub_dir rc err
     stub_dir=$(make_psql_stub)
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     echo 2 > "$stub_dir/psql.exit_code"
 
     PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \
@@ -330,7 +315,7 @@ run_stubbed_db_error
 run_injection_safe() {
     local stub_dir rc err evil
     stub_dir=$(make_psql_stub)
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     echo 0 > "$stub_dir/psql.exit_code"
 
     evil="'; DROP TABLE dispatcher.agents; --"
@@ -391,7 +376,7 @@ run_injection_safe
 run_optional_detail() {
     local stub_dir rc err
     stub_dir=$(make_psql_stub)
-    err=$(mktemp -t progress_test_err.XXXXXX); TEMP_FILES+=("$err")
+    err=$(mktemp -t progress_test_err.XXXXXX); register_temp_file "$err"
     echo 0 > "$stub_dir/psql.exit_code"
 
     PATH="$stub_dir/bin:$PATH" DATABASE_URL="postgresql://stub@localhost:0/x" \

--- a/scripts/tests/_temp_cleanup_helpers.sh
+++ b/scripts/tests/_temp_cleanup_helpers.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# _temp_cleanup_helpers.sh — Shared EXIT-trap cleanup for shell-test fixtures.
+#
+# Source this file (do NOT execute it) from a shell test to register
+# temporary directories and files for automatic cleanup on exit.
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+#   . "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+#
+#   tmp=$(mktemp -d)
+#   register_temp_dir "$tmp"
+#
+#   tmpfile=$(mktemp)
+#   register_temp_file "$tmpfile"
+#
+# The first call to ``register_temp_dir`` / ``register_temp_file``
+# installs an EXIT trap that ``rm -rf`` (for dirs) / ``rm -f`` (for
+# files) every registered path. Re-installation is idempotent — calling
+# either helper after the trap is already set is a no-op for the trap
+# itself.
+#
+# Why this helper exists
+# ----------------------
+# Before #4343, ~12+ shell test fixtures hand-rolled the same
+# EXIT-trap cleanup pattern. Each copy independently had to remember
+# three concerns and get them all right:
+#
+#   1. **Guarded iteration** for bash 3.2 + ``set -u``. The naive form
+#      ``for d in "${TEMP_DIRS[@]}"`` trips ``unbound variable`` on
+#      bash 3.2 when the array was declared but never populated. The
+#      bash-3.2-safe idiom is
+#      ``for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do`` — the
+#      ``[@]+...`` substitutes nothing when the array is empty/unset,
+#      and the inner ``${TEMP_DIRS[@]}`` only evaluates when the array
+#      is non-empty. See #4336 / scripts/check-bash-set-u-empty-array.sh
+#      Pass 3 for the full rationale.
+#
+#   2. **``set +eu`` scope** inside the trap body so an individual
+#      ``rm -rf`` failure on one entry does not propagate up and
+#      stomp on a later one (or the test's actual exit code).
+#
+#   3. **Existence check** before ``rm`` so a path that was already
+#      removed (or that ``mktemp`` failed to create) does not produce
+#      a spurious error.
+#
+# This helper bakes all three concerns in once, audited once. The
+# ``scripts/check-bash-set-u-empty-array.sh`` Pass 3 guard prevents
+# future drift on the iteration form, but the boilerplate itself is
+# still copy-paste churn — the sourceable helper turns that into one
+# ``source`` line plus one ``register_temp_*`` call per resource.
+#
+# Compatibility
+# -------------
+# bash 3.2 compatible — no bash 4+ features (no ``mapfile``, no
+# associative arrays, no namerefs, no ``${var,,}`` case-conversion).
+#
+# Trap composition
+# ----------------
+# The helper installs a single ``EXIT`` trap that calls the internal
+# ``_temp_cleanup_helpers__cleanup`` function. The cleanup function
+# does THREE things, in order:
+#
+#   1. Run any registered cleanup hooks (``register_cleanup_hook
+#      <fn>``), in registration order. Hooks are bash functions in
+#      the caller's scope — typical use is restoring a saved ``PATH``
+#      or running ``git rebase --abort``.
+#   2. ``rm -rf`` registered directories (``register_temp_dir``).
+#   3. ``rm -f`` registered files (``register_temp_file``).
+#
+# This three-phase design means a test that needs both standard
+# temp-dir cleanup AND a custom step (PATH restore, mock-server
+# teardown) can use this helper without rolling its own trap.
+# Hooks run BEFORE the rm phase so a hook can rely on registered
+# directories still existing.
+#
+# A test that needs more invasive cleanup (e.g.
+# ``test_adopt_pr.sh``'s in-progress-rebase recovery loop with
+# branching logic on git state) is welcome to roll its own trap
+# instead of registering a hook — the hook API is for one-line
+# restorations, not multi-line procedures.
+#
+# Idempotence
+# -----------
+# Sourcing this file twice is safe — the registration arrays are
+# initialised only on first source (``${_var:-}`` guards) and the
+# trap installer flag ``_TEMP_CLEANUP_HELPERS__TRAP_INSTALLED`` is
+# checked before re-running ``trap``. This matters when a test
+# sources both this helper and another helper that itself sources
+# this one.
+#
+# When the trap is installed
+# --------------------------
+# At SOURCE time, not lazily on first ``register_*`` call. This
+# matches the eager-install behavior of the hand-rolled boilerplate
+# the helper replaces, and avoids a footgun where the first
+# ``register_*`` happens inside a command-substitution subshell
+# (e.g. ``bindir=$(make_stub_bin)``): in that case a lazy installer
+# would install the trap in the subshell, the parent shell would
+# never see the trap, and registered paths would not be cleaned up.
+# Eager install at source time guarantees the parent shell owns the
+# trap and the registration arrays.
+
+# ── Module-private state ──────────────────────────────────────────────────
+# Initialised on first source. The ``${_var-}`` guards make re-sourcing
+# safe (the existing array is preserved). Both arrays are declared as
+# empty bare arrays here; consumers register entries via the helpers
+# below, and the cleanup function uses the bash-3.2-safe guarded
+# iteration form ``${_TEMP_CLEANUP_HELPERS__DIRS[@]+...}`` to avoid the
+# empty-array footgun documented in #4336.
+
+if [[ -z "${_TEMP_CLEANUP_HELPERS__SOURCED:-}" ]]; then
+    _TEMP_CLEANUP_HELPERS__SOURCED=1
+    _TEMP_CLEANUP_HELPERS__DIRS=()
+    _TEMP_CLEANUP_HELPERS__FILES=()
+    _TEMP_CLEANUP_HELPERS__HOOKS=()
+fi
+
+# ── Trap body ─────────────────────────────────────────────────────────────
+# Removes every registered directory / file. Runs with ``set +eu`` so a
+# failed ``rm`` on one entry does not abort cleanup of the rest.
+# Existence checks before ``rm`` avoid spurious errors when a path was
+# already removed by the test body (or never created because mktemp
+# failed). The ``${arr[@]+...}`` parameter-expansion guard is the
+# canonical bash-3.2-safe idiom for iterating a maybe-empty array
+# under ``set -u`` — see scripts/check-bash-set-u-empty-array.sh Pass 3.
+# shellcheck disable=SC2329  # invoked indirectly via ``trap ... EXIT``.
+_temp_cleanup_helpers__cleanup() {
+    set +eu
+    # Phase 1: run registered hooks in registration order. A hook is
+    # a bash function name in the caller's scope; we invoke it via
+    # the runtime command resolver so the function lookup happens at
+    # trap-fire time rather than registration time. ``|| true`` is
+    # belt-and-suspenders — ``set +eu`` already prevents propagation,
+    # but the explicit ignore makes the intent loud.
+    for hook in ${_TEMP_CLEANUP_HELPERS__HOOKS[@]+"${_TEMP_CLEANUP_HELPERS__HOOKS[@]}"}; do
+        if [[ -n "$hook" ]]; then
+            "$hook" || true
+        fi
+    done
+    # Phase 2: rm -rf registered directories.
+    for d in ${_TEMP_CLEANUP_HELPERS__DIRS[@]+"${_TEMP_CLEANUP_HELPERS__DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    # Phase 3: rm -f registered files.
+    for f in ${_TEMP_CLEANUP_HELPERS__FILES[@]+"${_TEMP_CLEANUP_HELPERS__FILES[@]}"}; do
+        if [[ -n "$f" && -e "$f" ]]; then
+            rm -f "$f"
+        fi
+    done
+}
+
+# ── Eager trap installer ──────────────────────────────────────────────────
+# Install the EXIT trap right now, at source time, in the shell that is
+# sourcing this file (not inside any subshell). See the "When the trap
+# is installed" header comment for why eager-install rather than lazy
+# is the right behavior for this helper's contract.
+trap _temp_cleanup_helpers__cleanup EXIT
+
+# ── Public API ────────────────────────────────────────────────────────────
+
+# register_temp_dir <path>
+#   Append <path> to the cleanup list and ensure the EXIT trap is
+#   installed. The path will be ``rm -rf``'d on exit if it still exists
+#   and is a directory.
+register_temp_dir() {
+    if [[ $# -ne 1 ]]; then
+        echo "register_temp_dir: expected 1 argument, got $#" >&2
+        return 2
+    fi
+    if [[ -z "$1" ]]; then
+        echo "register_temp_dir: empty path" >&2
+        return 2
+    fi
+    _TEMP_CLEANUP_HELPERS__DIRS+=("$1")
+}
+
+# register_temp_file <path>
+#   Append <path> to the cleanup list and ensure the EXIT trap is
+#   installed. The path will be ``rm -f``'d on exit if it still
+#   exists.
+register_temp_file() {
+    if [[ $# -ne 1 ]]; then
+        echo "register_temp_file: expected 1 argument, got $#" >&2
+        return 2
+    fi
+    if [[ -z "$1" ]]; then
+        echo "register_temp_file: empty path" >&2
+        return 2
+    fi
+    _TEMP_CLEANUP_HELPERS__FILES+=("$1")
+}
+
+# register_cleanup_hook <function-name>
+#   Append <function-name> to the cleanup-hook list and ensure the
+#   EXIT trap is installed. Hooks run BEFORE the rm phase so they
+#   can rely on registered directories/files still existing.
+#
+#   Typical use: a test mocks ``$PATH`` and needs to restore it on
+#   exit. Save the original PATH at setup time, define a tiny
+#   restore function, and register it:
+#
+#       ORIG_PATH_SAVE="$PATH"
+#       restore_path() { export PATH="$ORIG_PATH_SAVE"; }
+#       register_cleanup_hook restore_path
+#
+#   <function-name> must be the NAME of a bash function visible in
+#   the caller's scope at trap-fire time. The function is invoked
+#   with no arguments under ``set +eu`` so a failing hook does not
+#   abort the rest of cleanup.
+register_cleanup_hook() {
+    if [[ $# -ne 1 ]]; then
+        echo "register_cleanup_hook: expected 1 argument, got $#" >&2
+        return 2
+    fi
+    if [[ -z "$1" ]]; then
+        echo "register_cleanup_hook: empty hook name" >&2
+        return 2
+    fi
+    _TEMP_CLEANUP_HELPERS__HOOKS+=("$1")
+}

--- a/scripts/tests/test_check_aws_bool_flags.sh
+++ b/scripts/tests/test_check_aws_bool_flags.sh
@@ -18,12 +18,11 @@ CHECK_SCRIPT="$SCRIPT_DIR/check-aws-bool-flags.sh"
 FAILURES=0
 TESTS=0
 
-# Use a temp directory so we don't pollute scripts/
+# Use a temp directory so we don't pollute scripts/. Cleanup via the
+# shared helper (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 TMPDIR_TEST=$(mktemp -d)
-cleanup() {
-    rm -rf "$TMPDIR_TEST"
-}
-trap cleanup EXIT
+register_temp_dir "$TMPDIR_TEST"
 
 create_test_script() {
     local name="$1"

--- a/scripts/tests/test_check_bash_set_u_empty_array.sh
+++ b/scripts/tests/test_check_bash_set_u_empty_array.sh
@@ -25,11 +25,11 @@ CHECK_SCRIPT="$SCRIPT_DIR/check-bash-set-u-empty-array.sh"
 FAILURES=0
 TESTS=0
 
+# Cleanup of temp directories on exit via the shared helper (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+
 TMPDIR_TEST="$(mktemp -d)"
-cleanup() {
-    rm -rf "$TMPDIR_TEST"
-}
-trap cleanup EXIT
+register_temp_dir "$TMPDIR_TEST"
 
 mkdir -p "$TMPDIR_TEST/scripts"
 

--- a/scripts/tests/test_check_duplicate_pr.sh
+++ b/scripts/tests/test_check_duplicate_pr.sh
@@ -25,23 +25,16 @@ TESTS=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
+# Cleanup of temp directories + PATH restore via the shared helper
+# (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 ORIG_PATH_SAVE=""
-
-cleanup() {
-    set +eu
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
+restore_path() {
     if [[ -n "$ORIG_PATH_SAVE" ]]; then
         export PATH="$ORIG_PATH_SAVE"
     fi
 }
-trap cleanup EXIT
+register_cleanup_hook restore_path
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -77,7 +70,7 @@ fi
 # ── Set up a mock gh CLI on PATH for the remaining tests ──────────────────
 
 MOCK_BIN_DIR=$(mktemp -d)
-TEMP_DIRS+=("$MOCK_BIN_DIR")
+register_temp_dir "$MOCK_BIN_DIR"
 ORIG_PATH_SAVE="$PATH"
 export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
 

--- a/scripts/tests/test_check_oneshot_imports.sh
+++ b/scripts/tests/test_check_oneshot_imports.sh
@@ -18,25 +18,15 @@ CHECK_SCRIPT="$SCRIPT_DIR/check-oneshot-imports.sh"
 FAILURES=0
 TESTS=0
 
-# Cleanup any temp files on exit
-TEMP_FILES=()
-cleanup() {
-    # ``${TEMP_FILES[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336) — without it, an early test
-    # failure that fires the EXIT trap before any
-    # create_temp_script call would crash the trap itself.
-    for f in ${TEMP_FILES[@]+"${TEMP_FILES[@]}"}; do
-        rm -f "$f"
-    done
-}
-trap cleanup EXIT
+# Cleanup any temp files on exit via the shared helper (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 
 create_temp_script() {
     local name="$1"
     local content="$2"
     local path="$SCRIPT_DIR/$name"
     printf '%s\n' "$content" > "$path"
-    TEMP_FILES+=("$path")
+    register_temp_file "$path"
     echo "$path"
 }
 

--- a/scripts/tests/test_check_schema_drift.sh
+++ b/scripts/tests/test_check_schema_drift.sh
@@ -31,23 +31,16 @@ TESTS=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
+# Cleanup of temp directories + PATH restore via the shared helper
+# (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 ORIG_PATH_SAVE=""
-
-cleanup() {
-    set +eu
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
+restore_path() {
     if [[ -n "$ORIG_PATH_SAVE" ]]; then
         export PATH="$ORIG_PATH_SAVE"
     fi
 }
-trap cleanup EXIT
+register_cleanup_hook restore_path
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -106,7 +99,7 @@ fi
 # ── Set up a mock docker on PATH for the runtime tests ────────────────────
 
 MOCK_BIN_DIR=$(mktemp -d)
-TEMP_DIRS+=("$MOCK_BIN_DIR")
+register_temp_dir "$MOCK_BIN_DIR"
 ORIG_PATH_SAVE="$PATH"
 export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
 

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -22,23 +22,16 @@ TESTS=0
 
 # ─── Helpers ──────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
+# Cleanup of temp directories + PATH restore via the shared helper
+# (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 ORIG_PATH_SAVE=""
-
-cleanup() {
-    set +eu
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
+restore_path() {
     if [[ -n "$ORIG_PATH_SAVE" ]]; then
         export PATH="$ORIG_PATH_SAVE"
     fi
 }
-trap cleanup EXIT
+register_cleanup_hook restore_path
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -57,7 +50,7 @@ fail() {
 # Reset PATH/env for each scenario (mock_gh writes a fresh gh script).
 ORIG_PATH_SAVE="$PATH"
 MOCK_BIN_DIR=$(mktemp -d)
-TEMP_DIRS+=("$MOCK_BIN_DIR")
+register_temp_dir "$MOCK_BIN_DIR"
 export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
 
 # Path to the mock gh script that test cases overwrite.

--- a/scripts/tests/test_cleanup_worktree_review_log_mirror.sh
+++ b/scripts/tests/test_cleanup_worktree_review_log_mirror.sh
@@ -23,21 +23,13 @@ TESTS=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
-cleanup_temps() {
-    set +e
-    for d in "${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}"; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
-}
-trap cleanup_temps EXIT
+# Cleanup of temp directories on exit via the shared helper (see #4343).
+. "$REPO_ROOT/scripts/tests/_temp_cleanup_helpers.sh"
 
 make_temp_dir() {
     local dir
     dir=$(mktemp -d)
-    TEMP_DIRS+=("$dir")
+    register_temp_dir "$dir"
     echo "$dir"
 }
 

--- a/scripts/tests/test_notify_telegram_exit_codes.sh
+++ b/scripts/tests/test_notify_telegram_exit_codes.sh
@@ -30,19 +30,8 @@ TESTS=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
-
-cleanup() {
-    set +eu
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
-}
-trap cleanup EXIT
+# Cleanup of temp directories on exit via the shared helper (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -66,7 +55,7 @@ fail() {
 make_stub_bin() {
     local bindir
     bindir=$(mktemp -d)
-    TEMP_DIRS+=("$bindir")
+    register_temp_dir "$bindir"
 
     cat > "$bindir/aws" <<'AWS_STUB'
 #!/usr/bin/env bash

--- a/scripts/tests/test_preflight_branch_fresh.sh
+++ b/scripts/tests/test_preflight_branch_fresh.sh
@@ -27,21 +27,16 @@ WRAPPER="$SCRIPT_DIR/preflight-branch-fresh.sh"
 FAILURES=0
 TESTS=0
 
-TEMP_DIRS=()
+# Cleanup of temp directories + cd-restore via the shared helper
+# (see #4343). We register the cd hook BEFORE any register_temp_dir
+# call so the rm-phase finds itself outside any temp dir before
+# trying to rm-rf it.
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 ORIG_PWD=$(pwd)
-
-cleanup() {
-    set +eu
+restore_pwd() {
     cd "$ORIG_PWD" || true
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
 }
-trap cleanup EXIT
+register_cleanup_hook restore_pwd
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -72,7 +67,7 @@ fi
 make_test_repo_fresh() {
     local pair_dir
     pair_dir=$(mktemp -d)
-    TEMP_DIRS+=("$pair_dir")
+    register_temp_dir "$pair_dir"
 
     # Bootstrap the upstream.
     git init --quiet --initial-branch=main "$pair_dir/upstream"
@@ -112,7 +107,7 @@ make_test_repo_behind() {
     # as its origin.
     local push_clone
     push_clone=$(mktemp -d)
-    TEMP_DIRS+=("$push_clone")
+    register_temp_dir "$push_clone"
     git clone --quiet "$pair_dir/remote.git" "$push_clone/push" > /dev/null
     (
         cd "$push_clone/push"

--- a/scripts/tests/test_temp_cleanup_helpers.sh
+++ b/scripts/tests/test_temp_cleanup_helpers.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# test_temp_cleanup_helpers.sh — Regression test for issue #4343.
+#
+# Exercises scripts/tests/_temp_cleanup_helpers.sh — the shared
+# EXIT-trap cleanup helper that the migration in #4343 swaps in for
+# the hand-rolled ``TEMP_DIRS=() / cleanup() / trap cleanup EXIT``
+# boilerplate across ~12+ shell test fixtures.
+#
+# What this verifies:
+#
+#   AC1 — Helper sources cleanly and exposes ``register_temp_dir`` +
+#         ``register_temp_file`` as functions.
+#   AC2 — Sourcing the helper installs an EXIT trap eagerly at
+#         source time. This is the eager-install contract: the trap
+#         must be installed in the shell that sources the helper, not
+#         deferred until a register_* call (which might happen inside
+#         a command-substitution subshell, leaving the parent shell
+#         with no trap). See the helper's "When the trap is installed"
+#         header comment for the full rationale.
+#   AC3 — ``register_temp_dir`` rm-rfs registered directories on EXIT
+#         even when the array contains zero, one, or many entries.
+#   AC4 — ``register_temp_file`` rm-fs registered files on EXIT.
+#   AC5 — Mixed registrations (dirs + files) clean up correctly in
+#         the same trap.
+#   AC6 — Bash 3.2 compatibility — the iteration form must be the
+#         guarded ``${arr[@]+...}`` idiom, not the naive
+#         ``"${arr[@]}"`` which trips bash 3.2 + ``set -u`` on an
+#         empty array.
+#   AC7 — Idempotent re-sourcing preserves registrations rather than
+#         resetting the arrays.
+#   AC8 — Argument validation: each helper rejects 0 or 2+ arguments,
+#         and rejects an empty path argument, with exit/return code 2.
+#
+# Test strategy
+# -------------
+# Each scenario spawns a child bash process that sources the helper,
+# registers some paths, and exits. The parent then verifies the paths
+# no longer exist (cleanup happened) and the child exited cleanly.
+#
+# The "lazy trap install" check (AC2) inspects ``trap -p EXIT`` from
+# inside a child shell that has sourced the helper but not called any
+# register_* function — the output should be empty.
+#
+# Usage:
+#   scripts/tests/test_temp_cleanup_helpers.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+
+FAILURES=0
+TESTS=0
+
+# This test fixture itself uses the helper it is testing, to confirm
+# the helper is usable in real test code. Its own scratch directory is
+# registered for cleanup. (This is a self-host smoke — the AC tests
+# below spawn fresh child shells so the helper's behavior is validated
+# in isolation, not just via this fixture's own usage.)
+. "$HELPER"
+
+SELF_TMP=$(mktemp -d)
+register_temp_dir "$SELF_TMP"
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: helper exists ───────────────────────────────────────────
+if [[ ! -f "$HELPER" ]]; then
+    echo "FAIL: $HELPER does not exist" >&2
+    exit 1
+fi
+
+# ── AC1: helper sources cleanly and exposes the two functions ────────────
+out=$(bash -c "set -uo pipefail; . '$HELPER'; \
+declare -F register_temp_dir > /dev/null && \
+declare -F register_temp_file > /dev/null && \
+echo OK" 2>&1) || true
+if [[ "$out" == "OK" ]]; then
+    pass "AC1: helper sources and exposes register_temp_dir + register_temp_file"
+else
+    fail "AC1: helper does not expose both functions" "got: $out"
+fi
+
+# ── AC2: eager trap install — sourcing installs an EXIT trap now ─────────
+# ``trap -p EXIT`` after sourcing must show our cleanup function. We
+# match against the function name rather than a fixed string so a
+# refactor of the trap printf format (bash version drift) does not
+# break the assertion.
+out=$(bash -c "set -uo pipefail; . '$HELPER'; trap -p EXIT" 2>&1) || true
+if [[ "$out" == *"_temp_cleanup_helpers__cleanup"* ]]; then
+    pass "AC2: sourcing the helper eagerly installs the EXIT trap"
+else
+    fail "AC2: helper did not install EXIT trap at source time" "got: $out"
+fi
+
+# AC2b — eager-install means a register_* call made inside a command-
+# substitution subshell (e.g. ``bindir=$(make_stub_bin)``) does NOT
+# trip the dir-removed-before-test-uses-it footgun the lazy-install
+# design had. With lazy install, the FIRST register_* inside ``$()``
+# would install the trap in that subshell only; when the subshell
+# exited, its trap would fire and rm the dir, breaking the parent
+# test that just captured the path. With eager install at source
+# time, the parent shell has the trap already; the subshell does not
+# inherit it (POSIX bash semantics for command substitution), so the
+# subshell's exit does NOT trigger any cleanup, and the directory
+# survives for the parent test to use. This is the bug that surfaced
+# during the #4343 migration of test_notify_telegram_exit_codes.sh —
+# locking it in via a regression test.
+PROBE_OUT=$(mktemp)
+register_temp_file "$PROBE_OUT"
+bash -c "set -uo pipefail; . '$HELPER'; \
+mk_subshell() { local d; d=\$(mktemp -d); register_temp_dir \"\$d\"; echo \"\$d\"; }; \
+got=\$(mk_subshell); \
+test -d \"\$got\" && echo 'SUBSHELL_DID_NOT_REMOVE' > '$PROBE_OUT'" || {
+    fail "AC2b: child shell exited non-zero"
+}
+if grep -q SUBSHELL_DID_NOT_REMOVE "$PROBE_OUT"; then
+    pass "AC2b: register inside \$() does not remove dir via subshell trap"
+else
+    fail "AC2b: dir registered in subshell was removed before parent could use it" \
+         "(would break the bindir=\$(make_stub_bin) pattern — eager install regressed?)"
+fi
+
+# ── AC3: register_temp_dir cleans up registered directories ───────────────
+
+# Empty-registration path: ensure the trap fires cleanly even when
+# only one register call is made on an otherwise-empty array.
+SCRATCH=$(mktemp -d)
+register_temp_dir "$SCRATCH"
+PATH_FILE="$SCRATCH/paths.txt"
+
+bash -c "set -uo pipefail; . '$HELPER'; \
+d1=\$(mktemp -d); register_temp_dir \"\$d1\"; \
+echo \"\$d1\" > '$PATH_FILE'" || {
+    fail "AC3: child shell exited non-zero with single registration"
+}
+
+if [[ -s "$PATH_FILE" ]]; then
+    d1=$(head -1 "$PATH_FILE")
+    if [[ -d "$d1" ]]; then
+        fail "AC3: directory $d1 still exists after child exit"
+    else
+        pass "AC3: single registered directory removed on exit"
+    fi
+else
+    fail "AC3: paths.txt empty — child did not record path"
+fi
+
+# Multi-registration path: register 5 dirs, all should be removed.
+PATH_FILE2="$SCRATCH/paths2.txt"
+bash -c "set -uo pipefail; . '$HELPER'; \
+for i in 1 2 3 4 5; do \
+    d=\$(mktemp -d); \
+    register_temp_dir \"\$d\"; \
+    echo \"\$d\" >> '$PATH_FILE2'; \
+done" || {
+    fail "AC3: child shell exited non-zero with multi-registration"
+}
+
+if [[ -s "$PATH_FILE2" ]]; then
+    all_gone=true
+    while IFS= read -r d; do
+        if [[ -d "$d" ]]; then
+            all_gone=false
+            fail "AC3: directory $d still exists after child exit"
+        fi
+    done < "$PATH_FILE2"
+    if $all_gone; then
+        pass "AC3: 5 registered directories all removed on exit"
+    fi
+else
+    fail "AC3: paths2.txt empty — child did not record paths"
+fi
+
+# ── AC4: register_temp_file cleans up registered files ────────────────────
+PATH_FILE3="$SCRATCH/paths3.txt"
+bash -c "set -uo pipefail; . '$HELPER'; \
+for i in 1 2 3; do \
+    f=\$(mktemp); \
+    register_temp_file \"\$f\"; \
+    echo \"\$f\" >> '$PATH_FILE3'; \
+done" || {
+    fail "AC4: child shell exited non-zero with file registration"
+}
+
+if [[ -s "$PATH_FILE3" ]]; then
+    all_gone=true
+    while IFS= read -r f; do
+        if [[ -e "$f" ]]; then
+            all_gone=false
+            fail "AC4: file $f still exists after child exit"
+        fi
+    done < "$PATH_FILE3"
+    if $all_gone; then
+        pass "AC4: registered files all removed on exit"
+    fi
+else
+    fail "AC4: paths3.txt empty — child did not record paths"
+fi
+
+# ── AC5: mixed dir + file registrations clean up together ─────────────────
+PATH_FILE4="$SCRATCH/paths4.txt"
+bash -c "set -uo pipefail; . '$HELPER'; \
+d=\$(mktemp -d); register_temp_dir \"\$d\"; \
+f=\$(mktemp); register_temp_file \"\$f\"; \
+echo \"DIR \$d\" >> '$PATH_FILE4'; \
+echo \"FILE \$f\" >> '$PATH_FILE4'" || {
+    fail "AC5: child shell exited non-zero with mixed registration"
+}
+
+if [[ -s "$PATH_FILE4" ]]; then
+    all_gone=true
+    while IFS= read -r line; do
+        kind="${line%% *}"
+        path="${line#* }"
+        case "$kind" in
+            DIR)  [[ -d "$path" ]] && { all_gone=false; fail "AC5: dir $path still exists"; } ;;
+            FILE) [[ -e "$path" ]] && { all_gone=false; fail "AC5: file $path still exists"; } ;;
+        esac
+    done < "$PATH_FILE4"
+    if $all_gone; then
+        pass "AC5: mixed dir+file registrations cleaned up together"
+    fi
+else
+    fail "AC5: paths4.txt empty — child did not record paths"
+fi
+
+# ── AC6: bash 3.2 + set -u empty-array iteration safety ───────────────────
+# The helper itself sets up the empty array ``_TEMP_CLEANUP_HELPERS__DIRS=()``
+# and iterates it via ``${arr[@]+...}`` in the trap body. This iteration
+# shape is what the issue's verify command checks. We assert the
+# repo-wide check passes on the tests/ directory after the helper landed.
+out=$("$SCRIPT_DIR/check-bash-set-u-empty-array.sh" "$SCRIPT_DIR/tests/" 2>&1) || {
+    fail "AC6: check-bash-set-u-empty-array.sh failed on scripts/tests/" "$out"
+}
+if [[ "$out" == *"all clean"* ]]; then
+    pass "AC6: scripts/tests/ passes check-bash-set-u-empty-array.sh"
+fi
+
+# AC6b: also run the check in syntax-check mode against the helper file
+# itself. ``bash -n`` validates parsing (catches ``${arr[@]+...}``-form
+# typos); the empty-array check above validates semantics.
+if bash -n "$HELPER" 2>/dev/null; then
+    pass "AC6b: helper passes bash -n syntax check"
+else
+    fail "AC6b: helper failed bash -n syntax check"
+fi
+
+# ── AC7: idempotent re-sourcing preserves registrations ───────────────────
+# A test which sources both this helper and another helper that also
+# sources this one should not lose its registrations on the second
+# source. We verify by sourcing twice in the same shell, registering
+# in between, and ensuring the array still has the entry after the
+# second source.
+out=$(bash -c "set -uo pipefail; \
+. '$HELPER'; \
+d=\$(mktemp -d); \
+register_temp_dir \"\$d\"; \
+. '$HELPER'; \
+echo \"COUNT=\${#_TEMP_CLEANUP_HELPERS__DIRS[@]}\"" 2>&1) || true
+if [[ "$out" == "COUNT=1" ]]; then
+    pass "AC7: re-sourcing preserves registrations"
+else
+    fail "AC7: re-sourcing reset registrations" "got: $out"
+fi
+
+# ── AC8: argument validation ──────────────────────────────────────────────
+
+# 8a — register_temp_dir with no arg returns 2.
+# Use ``exit \$?`` after the call so the child shell propagates the
+# function's return code as its own exit code (without ``set -e``,
+# the default is to keep going and exit with 0). We don't enable
+# ``set -e`` here because the helper's ``return 2`` is exactly the
+# return-code form ``set -e`` would not intercept on a ``[[ ]]``
+# guard inside the function — propagating via ``exit \$?`` on the
+# next line is the simplest way to surface the function's return
+# code without relying on ``set -e`` semantics.
+code=0
+bash -c ". '$HELPER'; register_temp_dir; exit \$?" >/dev/null 2>&1 || code=$?
+if [[ "$code" -eq 2 ]]; then
+    pass "AC8a: register_temp_dir with no arg returns 2"
+else
+    fail "AC8a: register_temp_dir with no arg" "expected return 2, got $code"
+fi
+
+# 8b — register_temp_dir with empty string returns 2.
+code=0
+bash -c ". '$HELPER'; register_temp_dir ''; exit \$?" >/dev/null 2>&1 || code=$?
+if [[ "$code" -eq 2 ]]; then
+    pass "AC8b: register_temp_dir with empty path returns 2"
+else
+    fail "AC8b: register_temp_dir with empty path" "expected return 2, got $code"
+fi
+
+# 8c — register_temp_dir with two args returns 2.
+code=0
+bash -c ". '$HELPER'; register_temp_dir a b; exit \$?" >/dev/null 2>&1 || code=$?
+if [[ "$code" -eq 2 ]]; then
+    pass "AC8c: register_temp_dir with two args returns 2"
+else
+    fail "AC8c: register_temp_dir with two args" "expected return 2, got $code"
+fi
+
+# 8d — register_temp_file with no arg returns 2.
+code=0
+bash -c ". '$HELPER'; register_temp_file; exit \$?" >/dev/null 2>&1 || code=$?
+if [[ "$code" -eq 2 ]]; then
+    pass "AC8d: register_temp_file with no arg returns 2"
+else
+    fail "AC8d: register_temp_file with no arg" "expected return 2, got $code"
+fi
+
+# ── AC9: cleanup hook fires on exit, BEFORE the rm phase ──────────────────
+# We register a hook that writes a marker file and then registers the
+# parent directory for cleanup. The hook must run while the dir still
+# exists; after the trap finishes, the dir is gone.
+HOOK_TMP=$(mktemp -d)
+register_temp_dir "$HOOK_TMP"
+HOOK_OUT="$HOOK_TMP/hook.out"
+bash -c "set -uo pipefail; . '$HELPER'; \
+d=\$(mktemp -d); \
+register_temp_dir \"\$d\"; \
+mark_hook() { echo \"\$d\" > '$HOOK_OUT'; test -d \"\$d\" && echo 'DIR_PRESENT' >> '$HOOK_OUT'; }; \
+register_cleanup_hook mark_hook; \
+exit 0" || {
+    fail "AC9: child shell with hook exited non-zero"
+}
+if [[ -s "$HOOK_OUT" ]]; then
+    if grep -q DIR_PRESENT "$HOOK_OUT"; then
+        recorded_dir=$(head -1 "$HOOK_OUT")
+        if [[ -d "$recorded_dir" ]]; then
+            fail "AC9: registered dir $recorded_dir was not removed after trap"
+        else
+            pass "AC9: hook ran before rm phase, dir removed afterwards"
+        fi
+    else
+        fail "AC9: hook ran but DIR_PRESENT marker missing"
+    fi
+else
+    fail "AC9: hook did not run (HOOK_OUT empty)"
+fi
+
+# AC9b — multiple hooks fire in registration order.
+HOOK_OUT2="$HOOK_TMP/hook2.out"
+bash -c "set -uo pipefail; . '$HELPER'; \
+h1() { echo 1 >> '$HOOK_OUT2'; }; \
+h2() { echo 2 >> '$HOOK_OUT2'; }; \
+h3() { echo 3 >> '$HOOK_OUT2'; }; \
+register_cleanup_hook h1; \
+register_cleanup_hook h2; \
+register_cleanup_hook h3" || {
+    fail "AC9b: child shell with multi-hook exited non-zero"
+}
+if [[ -s "$HOOK_OUT2" ]]; then
+    expected=$'1\n2\n3'
+    actual=$(cat "$HOOK_OUT2")
+    if [[ "$actual" == "$expected" ]]; then
+        pass "AC9b: hooks run in registration order"
+    else
+        fail "AC9b: hooks ran out of order" "expected '$expected', got '$actual'"
+    fi
+else
+    fail "AC9b: no hook output (HOOK_OUT2 empty)"
+fi
+
+# AC9c — register_cleanup_hook arg validation.
+code=0
+bash -c ". '$HELPER'; register_cleanup_hook; exit \$?" >/dev/null 2>&1 || code=$?
+if [[ "$code" -eq 2 ]]; then
+    pass "AC9c: register_cleanup_hook with no arg returns 2"
+else
+    fail "AC9c: register_cleanup_hook with no arg" "expected return 2, got $code"
+fi
+
+code=0
+bash -c ". '$HELPER'; register_cleanup_hook ''; exit \$?" >/dev/null 2>&1 || code=$?
+if [[ "$code" -eq 2 ]]; then
+    pass "AC9d: register_cleanup_hook with empty arg returns 2"
+else
+    fail "AC9d: register_cleanup_hook with empty arg" "expected return 2, got $code"
+fi
+
+# AC9e — failing hook does not abort the rm phase.
+HOOK_OUT3="$HOOK_TMP/hook3.out"
+bash -c "set -uo pipefail; . '$HELPER'; \
+d=\$(mktemp -d); \
+echo \"\$d\" > '$HOOK_OUT3'; \
+register_temp_dir \"\$d\"; \
+broken_hook() { return 1; }; \
+register_cleanup_hook broken_hook" || {
+    fail "AC9e: child shell with broken hook exited non-zero"
+}
+if [[ -s "$HOOK_OUT3" ]]; then
+    recorded_dir=$(head -1 "$HOOK_OUT3")
+    if [[ -d "$recorded_dir" ]]; then
+        fail "AC9e: dir $recorded_dir survived a failing hook (rm phase aborted)"
+    else
+        pass "AC9e: failing hook does not abort rm phase"
+    fi
+else
+    fail "AC9e: HOOK_OUT3 empty"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "========================================="
+echo "Tests run: $TESTS"
+echo "Failures:  $FAILURES"
+echo "========================================="
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_unblock_issue.sh
+++ b/scripts/tests/test_unblock_issue.sh
@@ -27,23 +27,16 @@ TESTS=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
+# Cleanup of temp directories + PATH restore via the shared helper
+# (see #4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
 ORIG_PATH_SAVE=""
-
-cleanup() {
-    set +eu
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
+restore_path() {
     if [[ -n "$ORIG_PATH_SAVE" ]]; then
         export PATH="$ORIG_PATH_SAVE"
     fi
 }
-trap cleanup EXIT
+register_cleanup_hook restore_path
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -106,7 +99,7 @@ fi
 # ── Set up a mock gh CLI on PATH for the remaining tests ──────────────────
 
 MOCK_BIN_DIR=$(mktemp -d)
-TEMP_DIRS+=("$MOCK_BIN_DIR")
+register_temp_dir "$MOCK_BIN_DIR"
 ORIG_PATH_SAVE="$PATH"
 export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
 

--- a/scripts/tests/test_verify_pr_in_deployed_sha.sh
+++ b/scripts/tests/test_verify_pr_in_deployed_sha.sh
@@ -29,21 +29,15 @@ TESTS=0
 
 # ── Helpers ────────────────────────────────────────────────────────────────
 
-TEMP_DIRS=()
+# Cleanup of temp directories + PATH restore via the shared helper
+# (see #4343). PATH is captured here at module-load time and the
+# restore_path hook fires before the rm-phase of the trap.
+. "$REPO_ROOT/scripts/tests/_temp_cleanup_helpers.sh"
 ORIG_PATH_SAVE="$PATH"
-
-cleanup() {
-    set +eu
-    # ``${TEMP_DIRS[@]+...}`` guards empty-array iteration under
-    # bash 3.2 + set -u (see #4336).
-    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
-        if [[ -n "$d" && -d "$d" ]]; then
-            rm -rf "$d"
-        fi
-    done
+restore_path() {
     export PATH="$ORIG_PATH_SAVE"
 }
-trap cleanup EXIT
+register_cleanup_hook restore_path
 
 pass() {
     TESTS=$((TESTS + 1))
@@ -62,7 +56,7 @@ fail() {
 make_temp_dir() {
     local dir
     dir=$(mktemp -d)
-    TEMP_DIRS+=("$dir")
+    register_temp_dir "$dir"
     echo "$dir"
 }
 


### PR DESCRIPTION
## Summary

Adds `scripts/tests/_temp_cleanup_helpers.sh` as a sourceable shell helper
that bakes the bash-3.2-safe EXIT-trap cleanup pattern into one place
(`register_temp_dir` / `register_temp_file` / `register_cleanup_hook`).
Migrates 12 shell test fixtures off the hand-rolled boilerplate; tests
keep working unchanged. Adds `test_temp_cleanup_helpers.sh` (19 cases)
to lock in the helper's contract — including the eager-install design
that prevents the `bindir=$(make_stub_bin)` subshell-register footgun.

Closes #4343

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (test-only shell helper + migration)
