### PR TITLE
fix(dx): check-shipped-pr.sh skips PRs merged before the issue was filed (#4353)

### DIFF
--- a/scripts/_check_shipped_pr_extract_created_at.py
+++ b/scripts/_check_shipped_pr_extract_created_at.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_extract_created_at.py — Extract the `createdAt` field
+# from an issue JSON for scripts/check-shipped-pr.sh.
+#
+# Reads `gh issue view --json body,title,createdAt` JSON on stdin
+# (other fields are ignored). Prints the `createdAt` ISO-8601 timestamp
+# (e.g. `2026-05-08T19:41:29Z`) to stdout, or nothing if the field is
+# absent / null / malformed.
+#
+# venv: none
+# permanent: true
+#
+# Exit codes:
+#   0 — Always. The helper degrades gracefully: a missing or malformed
+#       `createdAt` is treated as "no date guard available" by the
+#       caller, which is fail-open (preserve pre-#4353 behavior). No
+#       exit-1 path because every recoverable input shape ends in
+#       "print empty string + return 0".
+#
+# Why this lives in its own helper rather than being merged into
+# _check_shipped_pr_extract_files.py: separation of concerns. The
+# extract_files helper emits N path lines on stdout (one per candidate
+# file); adding a sentinel-prefixed `createdAt:` line to the same stream
+# would force every consumer to learn the new format. A standalone
+# helper that emits a single bare timestamp is simpler to consume from
+# bash and can be unit-tested in isolation.
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        # Malformed JSON — fail open. The caller will skip the date
+        # guard entirely, preserving pre-#4353 behavior.
+        return 0
+
+    created_at = data.get("createdAt")
+    if isinstance(created_at, str) and created_at:
+        # GitHub returns ISO-8601 UTC with a trailing `Z`
+        # (e.g. `2026-05-08T19:41:29Z`). Lexicographic string comparison
+        # is correct for this format — the caller does not need to
+        # parse it into a datetime.
+        print(created_at)
+    # Otherwise: print nothing. The caller checks for empty string and
+    # skips the date guard.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_check_shipped_pr_overlap.py
+++ b/scripts/_check_shipped_pr_overlap.py
@@ -114,6 +114,20 @@ def main() -> int:
         # Merged onto a feature branch, not main.
         return 0
 
+    # Date-ordering guard (#4353). A PR that merged BEFORE the issue was
+    # filed cannot have shipped the issue's work — by definition. The
+    # check is a string comparison: GitHub timestamps are ISO-8601 UTC
+    # with a trailing `Z`, which is lexicographically sortable. When
+    # CHECK_SHIPPED_ISSUE_CREATED_AT is unset / empty (e.g. the caller
+    # could not extract it from the issue JSON), the guard is a no-op
+    # — preserving the pre-#4353 fail-open behavior so downstream tests
+    # whose mocks omit `createdAt` continue to work.
+    issue_created_at = os.environ.get("CHECK_SHIPPED_ISSUE_CREATED_AT", "")
+    if issue_created_at and merged_at < issue_created_at:
+        # PR merged before the issue existed — incidental file overlap,
+        # not a shipped match.
+        return 0
+
     candidate_csv = os.environ.get("CHECK_SHIPPED_CANDIDATE_FILES", "")
     candidates = [c for c in candidate_csv.split(",") if c]
     if not candidates:

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -82,7 +82,7 @@ fi
 # ─── Fetch issue body ──────────────────────────────────────────────────────
 
 issue_json=""
-if ! issue_json=$("$GH_BIN" issue view "$issue_num" --repo "$REPO" --json body,title 2>/dev/null); then
+if ! issue_json=$("$GH_BIN" issue view "$issue_num" --repo "$REPO" --json body,title,createdAt 2>/dev/null); then
     echo "error: failed to fetch issue #${issue_num} from ${REPO} (exit 2)" >&2
     exit 2
 fi
@@ -96,6 +96,18 @@ if ! candidate_files=$(printf '%s' "$issue_json" | python3 \
     echo "error: failed to extract candidate file paths from issue #${issue_num} (exit 2)" >&2
     exit 2
 fi
+
+# Extract the issue's createdAt timestamp for the date-ordering guard
+# (#4353). The helper exits 0 unconditionally and emits an empty string
+# when the field is absent / null / malformed, so the guard fails open
+# (no date check applied) when the data is unavailable. The downstream
+# overlap helper uses CHECK_SHIPPED_ISSUE_CREATED_AT to skip candidate
+# PRs whose `mergedAt` precedes the issue's `createdAt` — a PR that
+# merged before the issue existed cannot have shipped its work.
+issue_created_at=""
+issue_created_at=$(printf '%s' "$issue_json" | python3 \
+    "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_extract_created_at.py" \
+    2>/dev/null) || issue_created_at=""
 
 if [[ -z "$candidate_files" ]]; then
     echo "not-shipped: no candidate file paths in issue #${issue_num} body (exit 1)"
@@ -192,9 +204,14 @@ for pr_num in "${prs_array[@]}"; do
 
     # Compute overlap and merged-on-main check via Python helper.
     # The helper applies the threshold (≥1 added overlap OR ≥2 total
-    # overlap) and emits a tab-separated line on match, empty on miss.
+    # overlap), the date-ordering guard (#4353 — a PR that merged
+    # before the issue existed cannot have shipped its work), and
+    # emits a tab-separated line on match, empty on miss.
     overlap_result=""
-    if ! overlap_result=$(printf '%s' "$pr_json" | CHECK_SHIPPED_CANDIDATE_FILES="$candidate_files_csv" python3 \
+    if ! overlap_result=$(printf '%s' "$pr_json" | \
+        CHECK_SHIPPED_CANDIDATE_FILES="$candidate_files_csv" \
+        CHECK_SHIPPED_ISSUE_CREATED_AT="$issue_created_at" \
+        python3 \
         "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_overlap.py" \
         2>/dev/null); then
         continue

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -703,6 +703,142 @@ else
     fail "canonical placeholder PR (empty body) still reports shipped (regression #4327, AC2)" "exit=$exit_code output=$output"
 fi
 
+# ─── Test 18: PR merged BEFORE the issue was filed → exit 1 (#4353) ──────
+
+# Regression for #4353. Issue body cites scripts/foo.sh; a closed PR
+# *added* that file but `mergedAt` is 30 days before the issue's
+# `createdAt`. A PR that merged before the issue existed cannot have
+# shipped the issue's work — by definition. Pre-fix, file overlap on
+# the heavily-edited path was enough to clear the high-confidence
+# threshold and emit a `shipped:` line. Post-fix, the date-ordering
+# guard skips the candidate and the script reports not-shipped.
+#
+# Concrete case: issue #4353 (created 2026-05-08) hit a false positive
+# against PR #3268 (merged 2026-04-25) on `docs/agent/code-standards.md`
+# — flagged because the 1-file added overlap was the only signal the
+# script considered.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.", "title": "dx: add scripts/foo.sh", "createdAt": "2026-05-08T19:41:29Z"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Closes the widget loop (#3268)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-08T15:39:47Z", "number": 3268, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4353 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$output" == *"not-shipped:"* ]]; then
+    pass "exits 1 when candidate PR merged before the issue was filed (regression #4353)"
+else
+    fail "exits 1 when candidate PR merged before the issue was filed (regression #4353)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 19: missing createdAt → guard fails open, fall back to overlap ─
+
+# When the issue JSON lacks `createdAt` (e.g. an older mock or a gh CLI
+# version that doesn't expose the field for some reason), the date guard
+# must be a no-op so existing behavior is preserved. Same shape as
+# Test 18 but with `createdAt` omitted from the issue mock — the
+# candidate PR's `mergedAt` is irrelevant to the guard. Expect exit 0
+# (shipped) because the file-overlap threshold is cleared.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Closes the widget loop (#3268)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-04-08T15:39:47Z", "number": 3268, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4353 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* ]]; then
+    pass "guard fails open when issue createdAt is absent (regression #4353)"
+else
+    fail "guard fails open when issue createdAt is absent (regression #4353)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 20: PR merged AFTER the issue was filed → exit 0 (#4353) ───────
+
+# Sanity check — the date guard must NOT block legitimate post-issue
+# PRs. Issue created 2026-05-08; candidate PR merged 2026-05-09 (one
+# day after). File overlap clears the threshold; the date guard does
+# not fire. Expect exit 0 (shipped).
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh.", "title": "dx: add scripts/foo.sh", "createdAt": "2026-05-08T19:41:29Z"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Add foo (#4400)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0}], "mergedAt": "2026-05-09T00:00:00Z", "number": 4400, "title": "feat: add foo"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4353 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"4400"* ]]; then
+    pass "PR merged AFTER issue createdAt is still a valid shipped match (#4353 sanity)"
+else
+    fail "PR merged AFTER issue createdAt is still a valid shipped match (#4353 sanity)" "exit=$exit_code output=$output"
+fi
+
 # Restore PATH for cleanup
 export PATH="$ORIG_PATH_SAVE"
 


### PR DESCRIPTION
## Summary

Adds a date-ordering guard to `scripts/check-shipped-pr.sh`: candidate PRs whose `mergedAt` precedes the target issue's `createdAt` are now skipped. A PR that merged before the issue existed cannot have shipped the issue's work — by definition. Eliminates an entire false-positive class on heavily-edited shared docs (e.g. `docs/agent/code-standards.md`, where any new PR touching it became a phantom shipped match for every future issue mentioning the same path).

The guard lives in the existing `_check_shipped_pr_overlap.py` helper alongside the other eligibility gates (`mergedAt` non-null, `baseRefName == main`), and is fed via a new `CHECK_SHIPPED_ISSUE_CREATED_AT` env var. The wrapper extracts `createdAt` via a new tiny helper (`_check_shipped_pr_extract_created_at.py`) and degrades gracefully (no-op guard) when the field is missing — preserving pre-fix behavior for old test mocks.

Closes #4353

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (tooling-only change to operator-laptop / dispatcher-runtime scripts).
- [x] Verification evidence posted on issue (see A.8) — the live `scripts/check-shipped-pr.sh 4353` output is the canonical evidence.

## What changed

- `scripts/check-shipped-pr.sh` — fetch `createdAt` alongside `body,title`; thread it through to the overlap helper.
- `scripts/_check_shipped_pr_overlap.py` — third eligibility gate: skip candidate when `mergedAt < issue_created_at` (lexicographic on ISO-8601 UTC `Z`-suffixed strings; fail-open when env var unset).
- `scripts/_check_shipped_pr_extract_created_at.py` — new helper, mirrors the pattern of the other `_check_shipped_pr_*.py` helpers (stdin JSON in, single value out, exit 0 unconditionally).
- `scripts/tests/test_check_shipped_pr.sh` — 3 new regression tests (Test 18: PR merged 30d before issue → not-shipped; Test 19: createdAt absent → fail open; Test 20: PR merged AFTER issue → still shipped).

## Verification

Live behavior on the issue that triggered the work:
```
$ scripts/check-shipped-pr.sh 4353
not-shipped: no merged PR has ≥1 file overlap with issue #4353 (exit 1)
```
(Pre-fix: `shipped: PR #3268 merged to main with 1 file overlap(s) for issue #4353 (exit 0)`.)
