### PR TITLE
fix(scraping): thread pdf_bytes through reingest+drain split paths (#4360)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives.py
@@ -251,7 +251,9 @@ class CCSplitRuling:
     parties: list[dict[str, str]] = dataclass_field(default_factory=list)
 
 
-def _llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
+def _llm_extract_rulings(
+    pdf_text: str, pdf_bytes: bytes | None = None
+) -> list[CCSplitRuling] | None:
     """Extract rulings from CC department PDF text using an LLM.
 
     Sends pdfplumber-extracted text to the LLM with the Contra Costa system
@@ -265,7 +267,13 @@ def _llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
     The name is deliberately ``_llm_extract_rulings`` (no ``_cc_`` prefix)
     so that ``scripts/reingest_from_s3.py`` discovers it via the
     ``_LLM_SPLIT_REGISTRY`` attribute-name scan (#2469).
+
+    The ``pdf_bytes`` parameter is part of the unified ``_LLM_SPLIT_REGISTRY``
+    contract introduced in #4360 (so SC's format-B bytes-based path can
+    receive raw bytes from registry callers). CC's LLM extractor operates
+    on text only and ignores ``pdf_bytes``.
     """
+    del pdf_bytes  # text-only LLM extractor; bytes ignored (contract symmetry)
     from ingestion.llm_providers import call_llm
 
     if not pdf_text or not pdf_text.strip():

--- a/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
@@ -420,7 +420,7 @@ def _normalize_outcome(raw: str) -> str:
     return raw.strip()
 
 
-def _split_rulings(text: str) -> list[SplitRuling]:
+def _split_rulings(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]:
     """Split PDF text containing multiple numbered rulings into SplitRuling objects.
 
     Fresno PDFs use numbered entries like:
@@ -434,7 +434,15 @@ def _split_rulings(text: str) -> list[SplitRuling]:
         To sustain ...
 
     Returns an empty list if no numbered entries are found.
+
+    The ``pdf_bytes`` parameter is part of the unified ``_SPLIT_REGISTRY``
+    contract ``(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]``
+    introduced in #4360 so SC's ``pdfplumber.extract_tables()``-based
+    format-B path can receive raw bytes from registry callers.  Fresno's
+    splitter is text-only and ignores ``pdf_bytes`` — the parameter exists
+    purely for signature symmetry across registered splitters.
     """
+    del pdf_bytes  # text-only splitter; bytes ignored (contract symmetry)
     matches = list(_RULING_ENTRY_RE.finditer(text))
     if not matches:
         return []

--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -560,7 +560,9 @@ def _rebuild_reversed_title_from_parties(
     return None
 
 
-def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
+def _llm_extract_rulings(
+    ruling_html: str, pdf_bytes: bytes | None = None
+) -> list[LASplitRuling] | None:
     """Extract rulings from LA department HTML using an LLM.
 
     Preprocesses the HTML to plain text, sends it to the LLM with a
@@ -570,7 +572,13 @@ def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
     Returns a list of ``LASplitRuling`` objects on success, or ``None``
     if the LLM call fails or the response cannot be parsed.  The caller
     should fall back to ``_split_cases_html()`` when ``None`` is returned.
+
+    The ``pdf_bytes`` parameter is part of the unified ``_LLM_SPLIT_REGISTRY``
+    contract introduced in #4360 (so SC's format-B bytes-based path can
+    receive raw bytes from registry callers). LA's LLM extractor operates
+    on HTML text only and ignores ``pdf_bytes``.
     """
+    del pdf_bytes  # text-only LLM extractor; bytes ignored (contract symmetry)
     from ingestion.llm_extract import preprocess_html
     from ingestion.llm_providers import call_llm
 
@@ -844,7 +852,7 @@ def _extract_judge_name_from_case_section(
     return None
 
 
-def _split_rulings(text: str) -> list[LASplitRuling]:
+def _split_rulings(text: str, pdf_bytes: bytes | None = None) -> list[LASplitRuling]:
     """Split an LA department page into per-case rulings using regex + HTML parsing.
 
     This is the non-LLM splitting path registered in ``_SPLIT_REGISTRY`` for
@@ -862,7 +870,14 @@ def _split_rulings(text: str) -> list[LASplitRuling]:
     fallback (#4282).
 
     Returns an empty list if no case sections are found.
+
+    The ``pdf_bytes`` parameter is part of the unified ``_SPLIT_REGISTRY``
+    contract introduced in #4360 (so SC's format-B path can receive raw
+    bytes from registry callers). LA's splitter operates on HTML text and
+    ignores ``pdf_bytes`` — the parameter exists purely for signature
+    symmetry across registered splitters.
     """
+    del pdf_bytes  # HTML-only splitter; bytes ignored (contract symmetry)
     case_htmls = _split_cases_html(text)
     if not case_htmls:
         return []

--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -276,7 +276,7 @@ def _extract_case_number_from_header(header: str) -> str | None:
     return m.group(0).upper() if m else None
 
 
-def _split_rulings(text: str) -> list[SplitRuling]:
+def _split_rulings(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]:
     """Split Riverside multi-ruling PDF text into per-entry ``SplitRuling`` objects.
 
     The page-1 preamble (Zoom call-in instructions, court reporter notice,
@@ -310,7 +310,14 @@ def _split_rulings(text: str) -> list[SplitRuling]:
     those fields via per-entry enrichment matches the Fresno fall-
     through path (#3599, AC4 of #3534) and preserves the behaviour the
     LLM was already producing on single-ruling PDFs.
+
+    The ``pdf_bytes`` parameter is part of the unified ``_SPLIT_REGISTRY``
+    contract introduced in #4360 (so SC's format-B path can receive raw
+    bytes from registry callers). Riverside's splitter is text-only and
+    ignores ``pdf_bytes`` — the parameter exists purely for signature
+    symmetry across registered splitters.
     """
+    del pdf_bytes  # text-only splitter; bytes ignored (contract symmetry)
     matches = list(_RULING_ENTRY_RE.finditer(text))
     if not matches:
         return []

--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -727,7 +727,7 @@ def is_sd_calendar_html(text: str | None) -> bool:
     return "CIVIL CALENDAR For" in head
 
 
-def _split_rulings(text: str) -> list[SDSplitRuling]:
+def _split_rulings(text: str, pdf_bytes: bytes | None = None) -> list[SDSplitRuling]:
     """Split a SD calendar HTML page into per-case rulings.
 
     Registered in :data:`scripts.reingest_from_s3._SPLIT_REGISTRY` under
@@ -744,7 +744,14 @@ def _split_rulings(text: str) -> list[SDSplitRuling]:
     Each returned ruling has a *focused* ``ruling_text`` built from that
     case's calendar row only — NEVER the full HTML.  This is what prevents
     50000-char raw-HTML dumps and cross-case contamination.
+
+    The ``pdf_bytes`` parameter is part of the unified ``_SPLIT_REGISTRY``
+    contract introduced in #4360 (so SC's format-B path can receive raw
+    bytes from registry callers). SD's splitter operates on HTML text and
+    ignores ``pdf_bytes`` — the parameter exists purely for signature
+    symmetry across registered splitters.
     """
+    del pdf_bytes  # HTML-only splitter; bytes ignored (contract symmetry)
     if not is_sd_calendar_html(text):
         return []
 

--- a/packages/scraper-framework/src/courts/ca/sf_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_tentatives.py
@@ -153,7 +153,7 @@ class SplitRuling:
         self.department = department
 
 
-def _split_rulings(text: str) -> list[SplitRuling]:
+def _split_rulings(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]:
     """Split SF family-law multi-ruling PDF text into per-entry ``SplitRuling`` objects.
 
     The page-1 / page-2 preamble (Tentative Ruling Instructions, Zoom
@@ -194,7 +194,14 @@ def _split_rulings(text: str) -> list[SplitRuling]:
     ``LlmExtractor`` populate those fields via per-entry enrichment
     matches the Riverside fall-through pattern (#3649) and preserves
     the behaviour the LLM was already producing on single-ruling PDFs.
+
+    The ``pdf_bytes`` parameter is part of the unified ``_SPLIT_REGISTRY``
+    contract introduced in #4360 (so SC's format-B path can receive raw
+    bytes from registry callers). SF's splitter is text-only and ignores
+    ``pdf_bytes`` — the parameter exists purely for signature symmetry
+    across registered splitters.
     """
+    del pdf_bytes  # text-only splitter; bytes ignored (contract symmetry)
     matches = list(_ENTRY_HEADER_RE.finditer(text))
     if not matches:
         return []

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -10807,8 +10807,8 @@ class TestLlmSplitRegistry:
 
         try:
             result = reingest._full_reparse_document(b"raw pdf", "test-llm-split", self._doc_meta())
-            # LLM split should have been called
-            mock_llm_split.assert_called_once_with("full pdf text")
+            # LLM split should have been called with pdf_bytes (#4360 contract).
+            mock_llm_split.assert_called_once_with("full pdf text", pdf_bytes=b"raw pdf")
             # Regex split should NOT have been called
             mock_regex_split.assert_not_called()
             # Ruling text should come from LLM (full analysis)
@@ -11417,10 +11417,10 @@ class TestLlmSplitExceptionFallback:
             result = reingest._full_reparse_document(
                 b"raw pdf", "test-llm-exception", self._doc_meta()
             )
-            # LLM was called but raised
-            mock_llm_split.assert_called_once_with("full pdf text")
-            # Regex fallback was called
-            mock_regex_split.assert_called_once_with("full pdf text")
+            # LLM was called but raised — must pass pdf_bytes (#4360 contract).
+            mock_llm_split.assert_called_once_with("full pdf text", pdf_bytes=b"raw pdf")
+            # Regex fallback was called — must also pass pdf_bytes.
+            mock_regex_split.assert_called_once_with("full pdf text", pdf_bytes=b"raw pdf")
             # Results come from regex
             assert len(result) == 2
             assert result[0]["ruling_text"] == "DENY MSJ."
@@ -11562,7 +11562,8 @@ class TestLlmOnlySplitRegistry:
 
         try:
             result = reingest._full_reparse_document(b"raw html", "test-llm-only", self._doc_meta())
-            mock_llm_split.assert_called_once_with("full html text")
+            # LLM split must receive pdf_bytes (#4360 contract).
+            mock_llm_split.assert_called_once_with("full html text", pdf_bytes=b"raw html")
             assert len(result) == 2
             assert result[0]["ruling_text"] == "First ruling text"
             assert result[1]["ruling_text"] == "Second ruling text"
@@ -13921,3 +13922,158 @@ class TestSplitChildGuardUntouched:
             "is_split_child_id guard signature changed — verify #4049 plumbing "
             "did not regress the DB-row multimodal mode."
         )
+
+
+class TestFullReparsePassesPdfBytesToSplitter:
+    """Regression coverage for #4360 — the ``_full_reparse_document`` split
+    paths MUST pass ``raw_content`` (the bytes already in scope) to both
+    ``split_fn`` and ``llm_split_fn`` so SC's bytes-aware format-B path
+    fires.  Without these bytes, SC dept-6 PDFs silently fall through to
+    the single-doc LLM reparse, leaving placeholder titles like
+    ``"Plaintiff v. FCA"`` on every entry (root-cause investigation
+    #4339; format-B parser shipped in #4348).
+    """
+
+    def _doc_meta(self, **overrides: Any) -> dict:
+        meta = {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Santa Clara",
+            "court_name": "Santa Clara Superior Court",
+            "source_url": "https://court.example.com/dept6.pdf",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "pdf",
+            "case_number": None,
+            "case_title": None,
+            "case_type": None,
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": "ca-santa-clara-tentatives-civil",
+            "s3_key": "ca/santa_clara/superior_court/raw/dept6.pdf",
+            "s3_bucket": "test-bucket",
+        }
+        meta.update(overrides)
+        return meta
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_split_fn_receives_pdf_bytes_kwarg(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """Bytes-only-aware ``split_fn`` returns multi-ruling output only when
+        invoked with ``pdf_bytes``.  This proves
+        ``_full_reparse_document`` threads ``raw_content`` through the
+        regex split path at the line that was previously
+        ``split_fn(text)`` (#4360).
+        """
+        from courts.ca.fresno_tentatives import SplitRuling
+
+        captured: dict[str, Any] = {}
+
+        def fake_split(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]:
+            captured["text"] = text
+            captured["pdf_bytes"] = pdf_bytes
+            if pdf_bytes is None:
+                return []  # mimics SC format A on dept-6 (returns empty)
+            # Mimic SC format B: 10 distinct case rows from the summary table.
+            return [
+                SplitRuling(
+                    i,
+                    f"24CV-{i:04d}",
+                    f"Ruling text {i}",
+                    f"Case Title {i}",
+                    None,
+                    None,
+                    None,
+                )
+                for i in range(1, 11)
+            ]
+
+        scraper_id = "ca-santa-clara-tentatives-civil"
+        reingest._SPLIT_REGISTRY[scraper_id] = fake_split
+        reingest._LLM_SPLIT_REGISTRY.pop(scraper_id, None)
+        reingest._SCRAPER_REGISTRY.pop(scraper_id, None)
+        mock_extract.return_value = "fake dept-6 pdf text"
+
+        try:
+            raw = b"%PDF-1.4 ...mock bytes..."
+            result = reingest._full_reparse_document(
+                raw,
+                scraper_id,
+                self._doc_meta(),
+            )
+            # The split function received ``pdf_bytes`` matching ``raw``.
+            assert captured["pdf_bytes"] == raw, (
+                "_full_reparse_document must thread raw_content into "
+                "split_fn(text, pdf_bytes=...) per #4360"
+            )
+            # >= 10 rulings exited the split path — that proves the
+            # multi-ruling code path ran instead of the single-doc
+            # fallback.  AC #4 of #4360 asks for >= 10.
+            assert len(result) >= 10, f"expected >= 10 split rulings; got {len(result)}"
+        finally:
+            reingest._SPLIT_REGISTRY.pop(scraper_id, None)
+
+    @patch.object(reingest, "_load_scraper_registry")
+    @patch.object(reingest, "_extract_text_from_content")
+    def test_llm_split_fn_receives_pdf_bytes_kwarg(
+        self,
+        mock_extract: MagicMock,
+        mock_registry: MagicMock,
+    ) -> None:
+        """The LLM-split call site must also pass ``pdf_bytes``.  Pre-#4360
+        it was ``llm_split_fn(text)`` — the unified contract requires the
+        bytes for symmetry with regex splitters.
+        """
+        from courts.ca.fresno_tentatives import SplitRuling
+
+        captured: dict[str, Any] = {}
+
+        def fake_llm_split(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling] | None:
+            captured["text"] = text
+            captured["pdf_bytes"] = pdf_bytes
+            # Return a non-None result so the regex fallback isn't invoked
+            # — we only care that pdf_bytes was passed to the LLM splitter.
+            return [
+                SplitRuling(
+                    1,
+                    "24CV-0001",
+                    "Ruling text 1",
+                    "Case Title 1",
+                    None,
+                    None,
+                    None,
+                ),
+                SplitRuling(
+                    2,
+                    "24CV-0002",
+                    "Ruling text 2",
+                    "Case Title 2",
+                    None,
+                    None,
+                    None,
+                ),
+            ]
+
+        scraper_id = "ca-santa-clara-tentatives-civil"
+        reingest._LLM_SPLIT_REGISTRY[scraper_id] = fake_llm_split
+        reingest._SPLIT_REGISTRY.pop(scraper_id, None)
+        reingest._SCRAPER_REGISTRY.pop(scraper_id, None)
+        mock_extract.return_value = "fake dept-6 pdf text"
+
+        try:
+            raw = b"%PDF-1.4 ...mock bytes..."
+            reingest._full_reparse_document(
+                raw,
+                scraper_id,
+                self._doc_meta(),
+            )
+            assert captured["pdf_bytes"] == raw, (
+                "_full_reparse_document must thread raw_content into "
+                "llm_split_fn(text, pdf_bytes=...) per #4360"
+            )
+        finally:
+            reingest._LLM_SPLIT_REGISTRY.pop(scraper_id, None)

--- a/scripts/drain_splitter_carry_forward_clusters.py
+++ b/scripts/drain_splitter_carry_forward_clusters.py
@@ -249,7 +249,7 @@ def plan_cluster_drain(
     cluster: Cluster,
     *,
     pdf_bytes: bytes,
-    split_fn: Callable[[str], list[Any]] | None,
+    split_fn: Callable[..., list[Any]] | None,
     extract_text_fn: Callable[[bytes], str],
 ) -> ClusterPlan:
     """Run the registered splitter to validate that draining will help.
@@ -259,7 +259,9 @@ def plan_cluster_drain(
         pdf_bytes: Raw bytes of the parent PDF (already fetched from S3).
         split_fn: The registered ``_split_rulings`` callable for the
             cluster's ``scraper_id``, or ``None`` if no splitter is
-            registered (in which case draining is a no-op).
+            registered (in which case draining is a no-op).  Conforms to
+            the unified ``_SPLIT_REGISTRY`` contract introduced in #4360:
+            ``(text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]``.
         extract_text_fn: Callable that turns PDF bytes into text. Tests
             stub this; production passes the same helper used by
             ``_full_reparse_document``.
@@ -271,7 +273,11 @@ def plan_cluster_drain(
         return ClusterPlan(status="skip_no_split", distinct_titles=0)
 
     text = extract_text_fn(pdf_bytes)
-    split_results = split_fn(text)
+    # Pass ``pdf_bytes`` to the registered splitter so bytes-aware paths
+    # (e.g. SC's format-B ``pdfplumber.extract_tables()``) can fire.
+    # Without this, dept-6 SC PDFs report ``skip_no_split`` because
+    # format A returns ``[]`` and format B can't run (#4360).
+    split_results = split_fn(text, pdf_bytes=pdf_bytes)
     if len(split_results) < 2:
         return ClusterPlan(status="skip_no_split", distinct_titles=len(split_results))
 
@@ -518,13 +524,17 @@ def restore_parent_for_cluster(
 # ---------------------------------------------------------------------------
 
 
-def resolve_split_fn(scraper_id: str) -> Callable[[str], list[Any]] | None:
+def resolve_split_fn(scraper_id: str) -> Callable[..., list[Any]] | None:
     """Return the registered ``_split_rulings`` callable for a scraper_id.
 
     Mirrors the lookup ``reingest_from_s3.py:1479`` does against its
     ``_SPLIT_REGISTRY``. We import that registry lazily so this module
     can be imported in a test environment without the scraper-framework
     venv (the test suite stubs this resolver out).
+
+    The returned callable conforms to the unified ``_SPLIT_REGISTRY``
+    contract (#4360): ``(text: str, pdf_bytes: bytes | None = None) ->
+    list[SplitRuling]``.
     """
     # Late import — reingest_from_s3 pulls in boto3, structlog, etc.,
     # which we don't want as test-time dependencies for the per-cluster
@@ -578,7 +588,7 @@ def run_drain(
     dsn: str,
     county: str | None,
     s3_fetcher: Callable[[str, str], bytes],
-    splitter_resolver: Callable[[str], Callable[[str], list[Any]] | None],
+    splitter_resolver: Callable[[str], Callable[..., list[Any]] | None],
     text_extractor: Callable[[bytes], str],
     dry_run: bool = False,
     limit: int | None = None,

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -245,19 +245,33 @@ logger = structlog.get_logger()
 _SCRAPER_REGISTRY: dict[str, type] = {}
 
 # Registry mapping scraper_id to a callable that splits raw PDF/document
-# content into multiple extracted-field dicts.  Only populated for scrapers
-# that produce multi-ruling documents (e.g. Riverside).  The callable
-# signature is:  (raw_content: bytes, doc_meta: dict) -> list[dict]
-# Each dict in the returned list has the same shape as _reparse_document()'s
-# return value plus a "ruling_index" key.
+# content into per-ruling SplitRuling-style records.  Only populated for
+# scrapers that produce multi-ruling documents (e.g. Riverside, SC).
+#
+# Unified registry contract (#4360):
+#   (text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]
+#
+# Every callable accepts the document text plus optionally the raw PDF
+# bytes.  The bytes argument exists for splitters that need a layout
+# engine (e.g. SC dept-6 format B uses ``pdfplumber.extract_tables()`` on
+# the original bytes).  Text-only splitters accept ``pdf_bytes`` for
+# signature symmetry and ignore it.  Callers (``_full_reparse_document``,
+# ``drain_splitter_carry_forward_clusters.plan_cluster_drain``) MUST
+# pass ``pdf_bytes`` so bytes-aware splitters can fire.
 _SPLIT_REGISTRY: dict[str, Any] = {}
 
 # Registry mapping scraper_id to an LLM-based split function.  These are
 # preferred over the regex-based _SPLIT_REGISTRY entries in full-reparse
 # mode because they use LLM prompts to extract ruling_text (which may have
-# been improved, e.g. #1948/#1959).  The callable signature is:
-#   (text: str) -> list[SplitRuling] | None
+# been improved, e.g. #1948/#1959).
+#
+# Unified registry contract (#4360):
+#   (text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling] | None
+#
 # Returns None on LLM failure, in which case the regex fallback is used.
+# Like ``_SPLIT_REGISTRY``, every callable accepts the optional
+# ``pdf_bytes`` for signature symmetry; today's CA LLM splitters operate
+# on text only and ignore the bytes.
 _LLM_SPLIT_REGISTRY: dict[str, Any] = {}
 
 
@@ -1535,9 +1549,16 @@ def _full_reparse_document(
     # see #1948/#1959).  Falls back to regex-based split on LLM failure.
     # Note: some scrapers (e.g. LA) only have an LLM splitter without a
     # regex fallback — previously these were skipped entirely (#2007).
+    # Unified _SPLIT_REGISTRY / _LLM_SPLIT_REGISTRY contract (#4360):
+    #   (text: str, pdf_bytes: bytes | None = None) -> list[SplitRuling]
+    # ``raw_content`` is the bytes already fetched from S3 at the top of
+    # this function — pass it through so bytes-aware splitters (e.g. SC's
+    # format-B pdfplumber.extract_tables() path) can fire.  Without these
+    # bytes, SC dept-6 PDFs silently fall through to the single-doc LLM
+    # reparse, leaving placeholder titles in place.
     if llm_split_fn is not None:
         try:
-            split_results = llm_split_fn(text)
+            split_results = llm_split_fn(text, pdf_bytes=raw_content)
         except Exception:
             logger.warning(
                 "LLM split raised exception, falling back to regex",
@@ -1553,7 +1574,7 @@ def _full_reparse_document(
                     document_id=doc_meta["document_id"],
                     scraper_id=scraper_id,
                 )
-                split_results = split_fn(text)
+                split_results = split_fn(text, pdf_bytes=raw_content)
             else:
                 logger.warning(
                     "LLM split failed and no regex fallback available",
@@ -1562,7 +1583,7 @@ def _full_reparse_document(
                 )
                 split_results = []
     else:
-        split_results = split_fn(text)
+        split_results = split_fn(text, pdf_bytes=raw_content)
 
     if len(split_results) <= 1:
         # Single ruling or no rulings — fall back to standard reparse

--- a/scripts/tests/test_drain_splitter_carry_forward_clusters.py
+++ b/scripts/tests/test_drain_splitter_carry_forward_clusters.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -221,6 +222,121 @@ class TestPlanClusterDrain:
             extract_text_fn=lambda b: "text",
         )
         assert plan.status == "skip_no_split"
+
+    def test_format_b_splitter_receives_pdf_bytes_kwarg(self) -> None:
+        """Regression test for #4360.
+
+        ``plan_cluster_drain`` MUST pass ``pdf_bytes`` to the registered
+        splitter so SC's bytes-aware format-B path can fire.  Pre-#4360
+        the call site was ``split_fn(text)`` and SC dept-6 PDFs reported
+        ``skip_no_split`` because format A returns ``[]`` and format B
+        couldn't run without bytes.
+
+        We stub a splitter that mimics SC's format-B behaviour: returns
+        ``[]`` when invoked with text only, returns >= 2 distinct-title
+        rulings when invoked with ``pdf_bytes``.  This proves the
+        plan_cluster_drain call site threads bytes through.
+        """
+        captured: dict[str, Any] = {}
+
+        def fake_split(text: str, pdf_bytes: bytes | None = None) -> list[Any]:
+            captured["text"] = text
+            captured["pdf_bytes"] = pdf_bytes
+            if pdf_bytes is None:
+                return []
+            sr_a = MagicMock()
+            sr_a.case_title = "Huynh vs Redis Labs"
+            sr_b = MagicMock()
+            sr_b.case_title = "Lee Casper v. Ford"
+            return [sr_a, sr_b]
+
+        cluster = _script.Cluster(
+            county="Santa Clara",
+            s3_key="ca/santa_clara/raw/dept6.pdf",
+            s3_bucket="abc-bucket",
+            scraper_id="ca-santa-clara-tentatives-civil",
+            case_title="Plaintiff v. FCA",
+            ruling_count=10,
+        )
+        plan = _script.plan_cluster_drain(
+            cluster,
+            pdf_bytes=b"%PDF-1.4 ...",
+            split_fn=fake_split,
+            extract_text_fn=lambda b: "fake dept-6 text",
+        )
+        # The bytes were threaded — splitter saw pdf_bytes != None and
+        # returned the multi-ruling result, so the plan is ready.
+        assert captured["pdf_bytes"] == b"%PDF-1.4 ..."
+        assert plan.status == "ready"
+        assert plan.distinct_titles == 2
+
+    def test_format_b_real_fixture_through_plan_cluster_drain(self) -> None:
+        """End-to-end regression test for #4360 using the real SC dept-6
+        fixture.  Wires ``plan_cluster_drain`` to the actual SC
+        ``_split_rulings`` callable and an extract_text_fn backed by
+        ``pdfplumber`` (via the scraper-framework helper) — proves the
+        format-B path returns >= 10 distinct titles when bytes flow
+        through.
+
+        Skipped when the scraper-framework venv isn't on ``sys.path`` —
+        this test runs from the scraper-framework venv during CI's
+        per-package pytest stage (it imports SC's ``_split_rulings`` and
+        ``extract_pdf_text`` helpers from the package source tree).
+        """
+        import pathlib
+
+        try:
+            from courts.ca.sc_tentatives import (  # type: ignore[import-not-found]
+                _split_rulings,
+                extract_pdf_text,
+            )
+        except ImportError:
+            import pytest
+
+            pytest.skip(
+                "scraper-framework imports not available; "
+                "test runs from packages/scraper-framework/.venv"
+            )
+
+        fixture_path = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "packages"
+            / "scraper-framework"
+            / "tests"
+            / "fixtures"
+            / "sc_dept6_tues.pdf"
+        )
+        if not fixture_path.exists():
+            import pytest
+
+            pytest.skip(f"SC dept-6 fixture not found at {fixture_path}")
+
+        pdf_bytes = fixture_path.read_bytes()
+
+        cluster = _script.Cluster(
+            county="Santa Clara",
+            s3_key="ca/santa_clara/superior_court/raw/dept6_tues.pdf",
+            s3_bucket="abc-bucket",
+            scraper_id="ca-santa-clara-tentatives-civil",
+            case_title="Plaintiff v. FCA",
+            ruling_count=10,
+        )
+
+        plan = _script.plan_cluster_drain(
+            cluster,
+            pdf_bytes=pdf_bytes,
+            split_fn=_split_rulings,
+            extract_text_fn=extract_pdf_text,
+        )
+        # The dept-6 summary table holds 10 distinct case rows.  Without
+        # the #4360 fix the plan was ``skip_no_split`` (format A returns
+        # 0 entries, format B can't run without bytes).
+        assert plan.status == "ready", (
+            f"expected status='ready' from real SC dept-6 fixture; got {plan.status}"
+        )
+        assert plan.distinct_titles >= 10, (
+            f"expected >= 10 distinct titles; got {plan.distinct_titles}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Unify the `_SPLIT_REGISTRY` / `_LLM_SPLIT_REGISTRY` callable contract to `(text: str, pdf_bytes: bytes | None = None)` and thread `pdf_bytes` through the four registry call sites in `scripts/reingest_from_s3.py:1540, 1556, 1565` and `scripts/drain_splitter_carry_forward_clusters.py:274`. Without these bytes, SC's bytes-aware format-B splitter (shipped in #4348) silently no-ops on every dept-6 PDF, leaving 21+ rulings with the hallucinated case_title `"Plaintiff v. FCA"` and blocking #4354's drain follow-up.

Closes #4360

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Format-B path verified on `sc_dept6_tues.pdf` fixture: pre-fix `_split_rulings(text)` returns 1 entry with 0 distinct titles; post-fix `_split_rulings(text, pdf_bytes=pdf_bytes)` returns 10 entries with 10 distinct titles. (See verification evidence comment.)
- [x] Verification evidence posted on issue (see A.8)
