### PR TITLE
fix(ingestion): expand single-word JUDGE/DEPT surname to canonical name (#4297)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1209,6 +1209,143 @@ def resolve_judge_from_department(
     return None
 
 
+def _expand_single_word_judge_surname(
+    conn: psycopg.Connection,
+    court_id: str,
+    surname: str,
+    department: str,
+    hearing_date: date | None = None,
+) -> str | None:
+    """Expand a single-word judge surname to a canonical full name (#4297).
+
+    Background
+    ----------
+    LA County tentative-ruling HTML uses a ``JUDGE/DEPT: <Surname>/<dept>``
+    form-layout header that genuinely carries only the surname (e.g.
+    ``Mkrtchyan/25``).  Without expansion, ``resolve_judge`` rejects the
+    single-word value via ``_looks_like_valid_judge_name`` and the ruling
+    stores ``judge_id = NULL`` (#4297 root cause).
+
+    Lookup chain
+    ------------
+    1. Reject if ``surname`` is not a single-word value (caller usually
+       gates on this, but defend in depth — return ``None``).
+    2. Query ``court_directory_snapshots`` for the hearing-date-effective
+       canonical name ``C(D, t)`` for ``department`` (mirrors
+       :func:`resolve_judge_from_department`).
+    3. If ``C(D, t)`` exists and its last word matches ``surname``
+       case-insensitively, return ``C(D, t)`` — the directory and the
+       document agree (happy path).
+    4. Otherwise, search ``judges`` for any judge at ``court_id`` whose
+       ``canonical_name`` ends in ``surname`` (last-word match,
+       case-insensitive).  Return the canonical name when exactly one
+       judge matches; return ``None`` for zero or multiple matches
+       (ambiguous — caller falls back to the existing rejection
+       behavior).
+    5. On any DB error, log and return ``None`` (best-effort, never
+       raise — the caller's ``resolve_judge`` path is the authority).
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Database connection.
+    court_id : str
+        The court UUID (from the ``courts`` table).
+    surname : str
+        The single-word surname extracted by the scraper.
+    department : str
+        The department string (used to look up the directory snapshot).
+    hearing_date : date | None
+        The hearing date for historical snapshot selection.  When
+        ``None``, the most recent snapshot is used.
+
+    Returns
+    -------
+    str | None
+        The expanded canonical judge name, or ``None`` when no
+        unambiguous expansion is available.
+    """
+    # Step 1: defensive guard — surname must be a single-word value.
+    if not surname or not surname.strip():
+        return None
+    surname_clean = surname.strip()
+    if len(surname_clean.split()) != 1:
+        return None
+    surname_lower = surname_clean.lower()
+
+    try:
+        # Step 2: directory snapshot lookup for the department.
+        directory_canonical = resolve_judge_from_department(
+            conn, court_id, department, hearing_date=hearing_date
+        )
+
+        # Step 3: directory canonical exists and surname matches → happy path.
+        if directory_canonical:
+            directory_words = directory_canonical.strip().split()
+            if directory_words:
+                directory_last = directory_words[-1].lower()
+                if directory_last == surname_lower:
+                    logger.debug(
+                        "_expand_single_word_judge_surname: directory match for %r/%s -> %r",
+                        surname_clean,
+                        department,
+                        directory_canonical,
+                    )
+                    return directory_canonical
+
+        # Step 4: search judges by surname suffix at the same court.
+        # Use LOWER + suffix match so we don't depend on any particular
+        # canonical_name casing.  ``%% <surname>`` matches names with at
+        # least one preceding word (i.e. real first+last names, not bare
+        # single-word entries that may already exist).
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT canonical_name
+                FROM judges
+                WHERE court_id = %s::uuid
+                  AND LOWER(canonical_name) LIKE %s
+                """,
+                (court_id, f"% {surname_lower}"),
+            )
+            rows = cur.fetchall()
+
+        if len(rows) == 1:
+            expanded = rows[0][0]
+            logger.info(
+                "_expand_single_word_judge_surname: surname suffix match %r/%s -> %r",
+                surname_clean,
+                department,
+                expanded,
+            )
+            return expanded
+
+        if len(rows) > 1:
+            logger.debug(
+                "_expand_single_word_judge_surname: ambiguous surname %r/%s "
+                "(%d candidates) — preserving single-word",
+                surname_clean,
+                department,
+                len(rows),
+            )
+            return None
+
+        # Zero matches.
+        logger.debug(
+            "_expand_single_word_judge_surname: no judge match for surname %r/%s",
+            surname_clean,
+            department,
+        )
+        return None
+    except Exception:  # pragma: no cover - defensive logging
+        logger.exception(
+            "_expand_single_word_judge_surname: DB error for surname=%r dept=%s",
+            surname_clean,
+            department,
+        )
+        return None
+
+
 def _maybe_arbitrate(
     cur: psycopg.Cursor,
     judge_id: str,

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -58,6 +58,8 @@ from validation.issue_filer import file_validation_issue
 
 from .case_type_resolver import resolve_case_type
 from .db import (
+    _expand_single_word_judge_surname,
+    _looks_like_valid_judge_name,
     batch_upsert_parties,
     delete_stale_split_children,
     insert_document_and_ruling,
@@ -3393,6 +3395,43 @@ class IngestionWorker:
                         "case_title": effective_title,
                     },
                 )
+
+            # 2c. LA County single-word JUDGE/DEPT surname expansion (#4297).
+            #
+            # LA tentative-ruling HTML uses a ``JUDGE/DEPT: <Surname>/<dept>``
+            # form-layout header that genuinely carries only the surname.
+            # ``resolve_judge`` rejects single-word names via
+            # ``_looks_like_valid_judge_name`` (defensive guard against
+            # truncated/garbage entries), so without expansion the ruling
+            # stores ``judge_id = NULL``.  Expand via the directory snapshot
+            # / ``judges`` surname-suffix lookup chain before resolving.
+            if (
+                judge_name
+                and not _looks_like_valid_judge_name(judge_name)
+                and len(judge_name.strip().split()) == 1
+                and department
+                and state == "CA"
+                and county == "Los Angeles"
+            ):
+                expanded = _expand_single_word_judge_surname(
+                    conn,
+                    court_id,
+                    judge_name,
+                    department,
+                    hearing_date=hearing_dt,
+                )
+                if expanded:
+                    logger.info(
+                        "Expanded single-word JUDGE/DEPT surname",
+                        extra={
+                            "document_id": document_id,
+                            "department": department,
+                            "original_surname": judge_name,
+                            "expanded_judge_name": expanded,
+                        },
+                    )
+                    judge_name = expanded
+                    extraction_methods["judge_name"] = "single_word_surname_expansion"
 
             # 3. Resolve judge name to canonical judge record
             judge_id: str | None = None

--- a/packages/scraper-framework/tests/ingestion/test_single_word_surname_expansion.py
+++ b/packages/scraper-framework/tests/ingestion/test_single_word_surname_expansion.py
@@ -1,0 +1,221 @@
+"""Tests for ``_expand_single_word_judge_surname`` (#4297).
+
+The helper exists because LA tentative-ruling HTML uses a
+``JUDGE/DEPT: <Surname>/<dept>`` form-layout header that genuinely carries
+only the surname.  ``resolve_judge`` rejects single-word names via
+``_looks_like_valid_judge_name`` (defensive guard), so without expansion
+the ruling stores ``judge_id = NULL``.
+
+Coverage matrix:
+  - Directory-snapshot match (happy path) — surname matches the directory
+    canonical name's last word -> return canonical name.
+  - Directory mismatch + exactly one judges-table match -> expand.
+  - Directory mismatch + zero judges-table matches -> return None
+    (caller falls back to current single-word-rejected NULL).
+  - Directory mismatch + multiple judges-table matches -> return None
+    (ambiguous).
+  - No directory snapshot at all + exactly one judges-table match ->
+    expand (the surname-suffix lookup still runs).
+  - Defensive guards: empty / whitespace / multi-word input -> None.
+  - DB error -> swallowed, returns None.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock
+
+from ingestion.db import _expand_single_word_judge_surname
+
+
+def _make_mock_conn() -> tuple[MagicMock, MagicMock]:
+    """Create a mock psycopg connection with cursor context manager."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cur
+
+
+class TestSingleWordGuard:
+    """Defensive guards against non-single-word inputs."""
+
+    def test_empty_string_returns_none(self) -> None:
+        mock_conn, _ = _make_mock_conn()
+        result = _expand_single_word_judge_surname(
+            mock_conn, "court-uuid", "", "25", hearing_date=date(2026, 5, 1)
+        )
+        assert result is None
+
+    def test_whitespace_only_returns_none(self) -> None:
+        mock_conn, _ = _make_mock_conn()
+        result = _expand_single_word_judge_surname(
+            mock_conn, "court-uuid", "   ", "25", hearing_date=date(2026, 5, 1)
+        )
+        assert result is None
+
+    def test_multi_word_input_returns_none(self) -> None:
+        """A two-word input is not a single-word surname — the helper
+        is scoped to the JUDGE/DEPT bug class only."""
+        mock_conn, _ = _make_mock_conn()
+        result = _expand_single_word_judge_surname(
+            mock_conn,
+            "court-uuid",
+            "Karine Mkrtchyan",
+            "25",
+            hearing_date=date(2026, 5, 1),
+        )
+        assert result is None
+
+
+class TestDirectoryMatch:
+    """Happy path: directory snapshot canonical surname matches input."""
+
+    def test_directory_surname_matches_input(self) -> None:
+        """Directory says ``Karine Mkrtchyan`` for dept 25; input is
+        ``Mkrtchyan``.  Last-word match → return ``Karine Mkrtchyan``."""
+        mock_conn, mock_cur = _make_mock_conn()
+
+        # Step 2 inside resolve_judge_from_department:
+        #   - SELECT court_code FROM courts -> ('ca-los-angeles',)
+        #   - SELECT mapping FROM court_directory_snapshots -> ({"25": "Karine Mkrtchyan"},)
+        # Step 4 (judges fallback) is NOT reached because directory matches.
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),
+            ({"25": "Karine Mkrtchyan"},),
+        ]
+
+        result = _expand_single_word_judge_surname(
+            mock_conn,
+            "court-uuid-la",
+            "Mkrtchyan",
+            "25",
+            hearing_date=date(2026, 5, 1),
+        )
+
+        assert result == "Karine Mkrtchyan"
+
+    def test_directory_match_case_insensitive(self) -> None:
+        """Directory canonical may be in any case; surname compare is lower."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),
+            ({"25": "KARINE MKRTCHYAN"},),
+        ]
+
+        result = _expand_single_word_judge_surname(mock_conn, "court-uuid-la", "mkrtchyan", "25")
+
+        assert result == "KARINE MKRTCHYAN"
+
+
+class TestDirectoryMismatchSingleJudgesMatch:
+    """Mismatch path with exactly one judges-table match."""
+
+    def test_exactly_one_judge_match_expands(self) -> None:
+        """Directory says Byrdsong for dept 25 (primary assignment).  The
+        document says Mkrtchyan.  judges has exactly one ``... Mkrtchyan``
+        at this court → expand to that canonical name."""
+        mock_conn, mock_cur = _make_mock_conn()
+
+        # Step 2:
+        #   - court_code lookup -> ('ca-los-angeles',)
+        #   - snapshot mapping -> ({"25": "Latrice A. G. Byrdsong"},)
+        # Step 4:
+        #   - judges suffix lookup -> [("Karine Mkrtchyan",)]
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),
+            ({"25": "Latrice A. G. Byrdsong"},),
+        ]
+        mock_cur.fetchall.side_effect = [
+            [("Karine Mkrtchyan",)],
+        ]
+
+        result = _expand_single_word_judge_surname(
+            mock_conn,
+            "court-uuid-la",
+            "Mkrtchyan",
+            "25",
+            hearing_date=date(2026, 5, 1),
+        )
+
+        assert result == "Karine Mkrtchyan"
+
+
+class TestDirectoryMismatchZeroOrMultipleMatches:
+    """Mismatch path with zero or multiple judges-table matches."""
+
+    def test_zero_judge_matches_returns_none(self) -> None:
+        """Directory says different surname; no judge with this surname at
+        this court → None (caller falls back to current NULL behavior)."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),
+            ({"25": "Latrice A. G. Byrdsong"},),
+        ]
+        mock_cur.fetchall.side_effect = [[]]
+
+        result = _expand_single_word_judge_surname(mock_conn, "court-uuid-la", "Mkrtchyan", "25")
+
+        assert result is None
+
+    def test_multiple_judge_matches_returns_none(self) -> None:
+        """Two judges with the same surname at the same court → ambiguous,
+        return None."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),
+            ({"25": "Latrice A. G. Byrdsong"},),
+        ]
+        mock_cur.fetchall.side_effect = [
+            [("Karine Mkrtchyan",), ("Other Mkrtchyan",)],
+        ]
+
+        result = _expand_single_word_judge_surname(mock_conn, "court-uuid-la", "Mkrtchyan", "25")
+
+        assert result is None
+
+
+class TestNoDirectorySnapshot:
+    """When the directory snapshot is missing entirely, the surname-suffix
+    lookup still runs and can expand if exactly one match exists."""
+
+    def test_no_snapshot_falls_through_to_judges_lookup(self) -> None:
+        """No court_directory_snapshots row at all — but exactly one judge
+        in the judges table matches the surname suffix → expand."""
+        mock_conn, mock_cur = _make_mock_conn()
+
+        # resolve_judge_from_department fetchone sequence:
+        #   - court_code lookup -> ('ca-los-angeles',)
+        #   - hearing_date snapshot lookup -> None (no snapshot)
+        #   - earliest snapshot fallback -> None
+        # then helper Step 4 judges suffix lookup
+        mock_cur.fetchone.side_effect = [
+            ("ca-los-angeles",),
+            None,
+            None,
+        ]
+        mock_cur.fetchall.side_effect = [
+            [("Karine Mkrtchyan",)],
+        ]
+
+        result = _expand_single_word_judge_surname(
+            mock_conn,
+            "court-uuid-la",
+            "Mkrtchyan",
+            "25",
+            hearing_date=date(2026, 5, 1),
+        )
+
+        assert result == "Karine Mkrtchyan"
+
+
+class TestDbError:
+    """DB errors are swallowed — the helper is best-effort."""
+
+    def test_db_error_returns_none(self) -> None:
+        mock_conn = MagicMock()
+        mock_conn.cursor.side_effect = RuntimeError("connection lost")
+
+        result = _expand_single_word_judge_surname(mock_conn, "court-uuid", "Mkrtchyan", "25")
+
+        assert result is None

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -2749,6 +2749,226 @@ def test_roster_dept_lookup_skipped_when_judge_already_set(
 
 
 # ---------------------------------------------------------------------------
+# LA single-word JUDGE/DEPT surname expansion (#4297)
+# ---------------------------------------------------------------------------
+
+
+@patch(
+    "ingestion.worker._expand_single_word_judge_surname",
+    return_value="Karine Mkrtchyan",
+)
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-mkrtchyan")
+@patch("ingestion.worker.psycopg")
+def test_la_single_word_surname_expanded_before_resolve_judge(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_expand: MagicMock,
+) -> None:
+    """LA dept-25 single-word ``Mkrtchyan`` is expanded before resolve_judge (#4297).
+
+    Regression test for the JUDGE/DEPT form-layout bug: when
+    ``judge_name`` is a single-word surname that ``_looks_like_valid_judge_name``
+    rejects, the worker calls ``_expand_single_word_judge_surname`` to look
+    up the canonical full name from the directory snapshot / judges table
+    before calling ``resolve_judge``.  Without this expansion,
+    ``resolve_judge`` rejects the single-word value and the ruling stores
+    ``judge_id = NULL`` (#4297).
+    """
+    worker, _os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (DB write section)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document: RETURNING is_new = True
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name="Mkrtchyan",  # single-word surname from JUDGE/DEPT header
+        department="25",
+        state="CA",
+        county="Los Angeles",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    # The expansion helper should have been called with the single-word surname
+    mock_expand.assert_called_once()
+    expand_args = mock_expand.call_args
+    # positional args: (conn, court_id, surname, department); hearing_date is kwarg
+    assert expand_args[0][2] == "Mkrtchyan"
+    assert expand_args[0][3] == "25"
+
+    # resolve_judge should have been called with the EXPANDED canonical name,
+    # not the original single-word surname.
+    mock_resolve_judge.assert_called_once()
+    assert mock_resolve_judge.call_args[0][1] == "Karine Mkrtchyan"
+
+
+@patch(
+    "ingestion.worker._expand_single_word_judge_surname",
+    return_value=None,
+)
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_la_single_word_surname_unexpanded_falls_through_to_resolve_judge(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_expand: MagicMock,
+) -> None:
+    """When expansion is ambiguous (returns None), resolve_judge sees the original surname.
+
+    The current ``resolve_judge`` will reject the single-word value and
+    return None, leaving ``judge_id = NULL``.  This test confirms the
+    expansion path does not silently swallow names — it explicitly returns
+    None and the worker hands the original to resolve_judge.
+    """
+    worker, _os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (DB write section)
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name="Mkrtchyan",
+        department="25",
+        state="CA",
+        county="Los Angeles",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    mock_expand.assert_called_once()
+    # resolve_judge sees the original surname (which it will reject internally)
+    mock_resolve_judge.assert_called_once()
+    assert mock_resolve_judge.call_args[0][1] == "Mkrtchyan"
+
+
+@patch(
+    "ingestion.worker._expand_single_word_judge_surname",
+    return_value="Karine Mkrtchyan",
+)
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_la_expansion_skipped_for_non_la_county(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_expand: MagicMock,
+) -> None:
+    """The expansion is gated to LA only — other counties do NOT call the helper."""
+    worker, _os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name="Mkrtchyan",
+        department="25",
+        state="CA",
+        county="San Diego",  # NOT Los Angeles
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    mock_expand.assert_not_called()
+
+
+@patch(
+    "ingestion.worker._expand_single_word_judge_surname",
+    return_value="Karine Mkrtchyan",
+)
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_la_expansion_skipped_for_multi_word_judge_name(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_expand: MagicMock,
+) -> None:
+    """Multi-word judge names are NOT routed through the expansion helper.
+
+    The helper only addresses the single-word JUDGE/DEPT form-layout bug.
+    Multi-word names that fail ``_looks_like_valid_judge_name`` for other
+    reasons (truncated last word, no-vowel surname) are different bugs
+    and should not be silently re-resolved via this path.
+    """
+    worker, _os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name="Karine Mkrtchyan",  # multi-word, valid — short-circuits
+        department="25",
+        state="CA",
+        county="Los Angeles",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    # Expansion is gated to single-word inputs that fail validation.
+    mock_expand.assert_not_called()
+
+
+@patch(
+    "ingestion.worker._expand_single_word_judge_surname",
+    return_value="Karine Mkrtchyan",
+)
+@patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
+@patch("ingestion.worker.psycopg")
+def test_la_expansion_skipped_when_department_missing(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+    mock_expand: MagicMock,
+) -> None:
+    """When department is missing, expansion cannot proceed (no directory key)."""
+    worker, _os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court
+        ("case-uuid-1",),  # upsert_case
+        (True,),  # insert_document
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        judge_name="Mkrtchyan",
+        department=None,  # gate condition fails
+        state="CA",
+        county="Los Angeles",
+        _llm_extracted=True,
+        _split_processed=True,
+    )
+    worker.process_event(event)
+
+    mock_expand.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # PDF binary preprocessing in process_event
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -2474,6 +2474,73 @@ class TestReingestBatchDBWrites:
         # hearing_date is None but ruling should still be inserted (#2215)
         assert call_kwargs["hearing_date"] is None
 
+    @patch("reingest_from_s3.batch_upsert_parties")
+    @patch("reingest_from_s3.upsert_case_judge")
+    @patch(
+        "reingest_from_s3._expand_single_word_judge_surname",
+        return_value="Karine Mkrtchyan",
+    )
+    @patch("reingest_from_s3.resolve_judge")
+    @patch("reingest_from_s3.insert_document_and_ruling")
+    @patch("reingest_from_s3.upsert_case")
+    @patch("reingest_from_s3._reparse_document")
+    @patch("reingest_from_s3._fetch_s3_content")
+    def test_la_single_word_surname_expanded_in_reingest(
+        self,
+        mock_fetch_s3: MagicMock,
+        mock_reparse: MagicMock,
+        mock_upsert_case: MagicMock,
+        mock_insert_doc_and_ruling: MagicMock,
+        mock_resolve_judge: MagicMock,
+        mock_expand: MagicMock,
+        mock_upsert_cj: MagicMock,
+        mock_batch_parties: MagicMock,
+    ) -> None:
+        """Reingest mirror of the worker LA single-word JUDGE/DEPT expansion (#4297).
+
+        When the regex/extraction pipeline produces a single-word surname
+        (``Mkrtchyan``) for an LA dept-25 ruling, the reingest path must
+        call ``_expand_single_word_judge_surname`` and pass the expanded
+        canonical name to ``resolve_judge`` — mirroring the worker fix so
+        rebuilds produce consistent output.
+        """
+        row = _make_document_row()
+        conn = _mock_conn_with_rows([row])
+
+        mock_fetch_s3.return_value = b"<html>text</html>"
+        mock_reparse.return_value = {
+            "ruling_text": "Some LA dept-25 ruling text.",
+            "case_number": "23STCV01234",
+            "case_title": "Smith v. Jones",
+            "judge_name": "Mkrtchyan",  # single-word surname from JUDGE/DEPT
+            "outcome": "granted",
+            "motion_type": "msj",
+            "department": "25",
+            "parties": [],
+            "hearing_date": _HEARING_DATE,
+        }
+        mock_upsert_case.return_value = "case-id"
+        mock_resolve_judge.return_value = "judge-id"
+
+        reingest.reingest_batch(
+            conn,
+            MagicMock(),
+            batch_size=10,
+            cursor=_DEFAULT_CURSOR,
+            filters="",
+            filter_params=[],
+        )
+
+        # Expansion helper called with the single-word surname.
+        mock_expand.assert_called_once()
+        # positional args: (conn, court_id_str, surname, department); hearing_date kwarg
+        assert mock_expand.call_args[0][2] == "Mkrtchyan"
+        assert mock_expand.call_args[0][3] == "25"
+
+        # resolve_judge sees the EXPANDED canonical name.
+        mock_resolve_judge.assert_called_once()
+        assert mock_resolve_judge.call_args[0][1] == "Karine Mkrtchyan"
+
 
 # ---------------------------------------------------------------------------
 # reingest_batch tests — per-document commits

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -206,6 +206,8 @@ from framework.models import CapturedDocument, ContentFormat, ScraperConfig  # n
 from ingestion.db import (  # noqa: E402
     batch_upsert_parties,
     insert_document_and_ruling,
+    _expand_single_word_judge_surname,
+    _looks_like_valid_judge_name,
     resolve_judge,
     resolve_judge_from_department,
     upsert_case,
@@ -3064,6 +3066,40 @@ def reingest_batch(
                                 judge_name=judge_name,
                                 county=doc_meta.get("county"),
                             )
+                    # LA County single-word JUDGE/DEPT surname expansion
+                    # (#4297).  Mirrors the worker's expansion path so
+                    # rebuilds produce consistent output.  Only fires for
+                    # LA + single-word surname + department-set + name
+                    # rejected by ``_looks_like_valid_judge_name``.
+                    if (
+                        judge_name
+                        and not _looks_like_valid_judge_name(judge_name)
+                        and len(judge_name.strip().split()) == 1
+                        and extracted.get("department")
+                        and doc_meta.get("state", "").upper() == "CA"
+                        and doc_meta.get("county") == "Los Angeles"
+                    ):
+                        hearing_dt_for_expand = extracted.get("hearing_date")
+                        expanded = _expand_single_word_judge_surname(
+                            conn,
+                            court_id_str,
+                            judge_name,
+                            extracted["department"],
+                            hearing_date=hearing_dt_for_expand,
+                        )
+                        if expanded:
+                            logger.info(
+                                "Expanded single-word JUDGE/DEPT surname (reingest)",
+                                department=extracted["department"],
+                                original_surname=judge_name,
+                                expanded_judge_name=expanded,
+                                county=doc_meta.get("county"),
+                            )
+                            judge_name = expanded
+                            extracted["extraction_methods"]["judge_name"] = (
+                                "single_word_surname_expansion"
+                            )
+
                     judge_id = None
                     if judge_name:
                         judge_id = resolve_judge(conn, judge_name, court_id_str)


### PR DESCRIPTION
## Summary

Adds `_expand_single_word_judge_surname` to `ingestion/db.py` and wires it into both the live worker (`IngestionWorker.process_event`) and the rebuild path (`scripts/reingest_from_s3.py`). The helper consults the LA judicial-officer directory snapshot first, then falls back to a `derived.judges` last-word suffix lookup (exactly-one match expands, otherwise None). Without this expansion, LA dept-25 rulings whose HTML carries only a `JUDGE/DEPT: <Surname>/<dept>` form-layout header hit `resolve_judge`'s single-word rejection guard and store `judge_id = NULL` — this fix expands `Mkrtchyan` to `Karine Mkrtchyan` (or whichever judge unambiguously matches at the same court) before resolution.

Closes #4297

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (7585 passed, 3 skipped, 0 failures)
- [x] CI green

### Post-deploy verification
- [x] Deploy run #25579901593 SUCCESS for merge SHA `413e7cb`. Worker started clean on dev. Targeted reingest of 126 LA dept-25 docs ran on the deployed image (4.54s, 0 errors). See verification evidence comment on #4297 for AC #4 status — code working correctly; data outcome blocked on `Karine Mkrtchyan` not existing in `derived.judges` (separate follow-up issue to be filed in retro).
- [x] Verification evidence posted on issue (see A.8)
