### PR TITLE
dx(audit): backfill check-script-fix-block-coverage.md + CI guard for drift (#4367)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1912,6 +1912,21 @@ jobs:
         run: scripts/check-dispatcher-image-versions.sh --build Dockerfile.dispatcher
 
   # ---------------------------------------------------------------
+  # Fix-block coverage guard: every executable scripts/check-*.{sh,py}
+  # hygiene guard must have a matching row in
+  # docs/dx/check-script-fix-block-coverage.md so the per-guard
+  # health-check inventory does not silently drift behind reality.
+  # See #4322 / #4345 / #4346 for the Fix-block contract this inventory
+  # tracks; #4367 for this guard.
+  # ---------------------------------------------------------------
+  fix-block-coverage-complete-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify every hygiene guard has a row in the inventory
+        run: scripts/check-fix-block-coverage-complete.sh
+
+  # ---------------------------------------------------------------
   # ci-passed coverage guard: assert every top-level job appears in
   # ci-passed.needs: so gaps like #3919 are caught before merge.
   # ---------------------------------------------------------------
@@ -1926,7 +1941,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check, fix-block-coverage-complete-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/dx/check-script-fix-block-coverage.md
+++ b/docs/dx/check-script-fix-block-coverage.md
@@ -59,6 +59,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 21 | `scripts/check-dispatcher-terminals-consistent.sh` | self-diagnosing (Fix block) | Emits canonical terminal list. |
 | 22 | `scripts/check-duplicate-functions.sh` | wrapper (delegates to helper) | Wrapper for `check-duplicate-functions.py`. |
 | 23 | `scripts/check-duplicate-pr.sh` | decision flow (no violation list) | Returns 0/1/2 with a single status line for callers (`/task` skill). No code violation. |
+| 23a | `scripts/check-fix-block-coverage-complete.sh` | self-diagnosing (Fix block) | Inventory-coverage guard: fails when a runnable hygiene guard exists in the tree without a matching row here. Emits per-violation `Fix:` block naming the doc, the verdict vocabulary, and the letter-suffix-row pattern. Mirrors `run-ci-guards.sh --list` discovery so .py companions are covered by their .sh wrapper's row. Tracking: #4367. |
 | 24 | `scripts/check-git-gh-retries.sh` | self-diagnosing (Fix block) | Emits the `git_with_retry` / `gh_with_retry` wrapper pattern. |
 | 25 | `scripts/check-graphql-nullability-drift.sh` | wrapper (delegates to helper) | Wrapper for `check-graphql-nullability-drift.py`. |
 | 26 | `scripts/check-graphql-queries.sh` | self-diagnosing (Fix block) | Emits the `mock` / `__typename` add suggestion. |
@@ -87,6 +88,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 48 | `scripts/check-no-redos-pattern.sh` | self-diagnosing (Fix block) | Emits "Fix options" with three patterns + `# noqa: redos-pattern` suppression. |
 | 49 | `scripts/check-no-test-database-url-fallback.sh` | self-diagnosing (Fix block) | Emits required-shape example. |
 | 50 | `scripts/check-no-test-leaked-worktrees.sh` | self-diagnosing (Fix block) | Emits cleanup-pattern recipe. |
+| 50a | `scripts/check-no-unbounded-timeouts.py` | self-diagnosing (Fix block) | Validates IO call sites under `scripts/dispatcher/` carry bounded timeouts (boto3, psycopg, requests, urllib3). Emits per-violation `Fix: add the missing kwarg, or annotate the call with ...` block. No `.sh` wrapper — invoked directly via `python3 scripts/check-no-unbounded-timeouts.py` from CI and pre-push. Tracking: #3353 (root cause), #4364/#4365 (pre-push wiring). |
 | 51 | `scripts/check-nullable-column-reads.sh` | wrapper (delegates to helper) | Wrapper for `check-nullable-column-reads.py`. |
 | 52 | `scripts/check-oneshot-imports.sh` | self-diagnosing (Fix block) | Emits "Fix: inline the helper" guidance. |
 | 53 | `scripts/check-oneshot-repo-paths.sh` | self-diagnosing (Fix block) | Emits the `Path(__file__).resolve().parent.parent` replacement. |
@@ -99,10 +101,14 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 60 | `scripts/check-repo-walk-exclusions-canonical.sh` | self-diagnosing (Fix block) | Emits "Required shape:" with literal `source preflight.sh` + iteration block. |
 | 61 | `scripts/check-scraper-image-shipped.sh` | self-diagnosing (Fix block) | Emits "Did you push the image to ECR?" recipe. |
 | 62 | `scripts/check-scraper-registry.sh` | wrapper (delegates to helper) | Wrapper for `check-scraper-registry.py`. |
+| 62a | `scripts/check-scraper-zero-record-runner.py` | operational health probe | Scheduled-cron ECS runner for the zero-record streak detector — wraps `check-scraper-zero-record-streak.py` and manages GitHub-issue lifecycle (open/comment/close) on breach. Fix is to investigate the scraper that triggered the alert — no source-code patch literal applies. Wired by `.github/workflows/scraper-zero-record-check.yml`. Tracking: #2620 / #2666. |
+| 62b | `scripts/check-scraper-zero-record-streak.py` | operational health probe | Scheduled-cron data-quality probe — queries `telemetry.scraper_runs` for consecutive zero-record streaks per scraper. Fires when any active scraper has been silently outputting no data for N runs. Fix is to investigate the scraper, not patch the check. Wired by `.github/workflows/scraper-zero-record-check.yml`. Tracking: #2620 / #2666. |
 | 63 | `scripts/check-script-headers.sh` | wrapper (delegates to helper) | Wrapper for `check-script-headers.py` which emits the `# one-off: true` / `# permanent: true` add-this guidance. |
 | 64 | `scripts/check-shard-coverage.sh` | self-diagnosing (Fix block) | Emits the `--shard-of-N` invocation hint. |
 | 65 | `scripts/check-shipped-pr.sh` | decision flow (no violation list) | Returns shipped/not-shipped verdict for callers. No code violation. |
+| 65a | `scripts/check-short-unsubstantive-rulings.py` | operational health probe | Scheduled-cron data-quality probe — counts per-county rulings with `char_length(ruling_text) < 200 AND motion_type IS NULL AND outcome IS NULL` over the last 7 days. Fires when any county exceeds the configured threshold (signal that extraction is silently dropping useful fields). Fix is to investigate the extraction pipeline for that county; no source-code patch literal applies. Wired by `.github/workflows/short-unsubstantive-ruling-check.yml`. Tracking: #2671. |
 | 66 | `scripts/check-split-ruling-fields-propagated.sh` | wrapper (delegates to helper) | Wrapper for `check_split_ruling_fields_propagated.py` whose `_suggest_scope_entry()` emits the canonical Fix block (the reference upgrade from PR #4345). |
+| 66a | `scripts/check-sql-columns.py` | self-diagnosing (Fix block) | Validates qualified (`alias.column`) and unqualified column references in Python SQL string literals against `packages/api/src/data-access/schema.sql`. Emits per-violation `Fix: check the table's column definitions in schema.sql.` block. No `.sh` wrapper — invoked directly via `python3 scripts/check-sql-columns.py` from CI (`sql-column-check` job). Tracking: #1929 (qualified-drift), #4271 (unqualified-drift). |
 | 67 | `scripts/check-sql-conflicts.sh` | wrapper (delegates to helper) | Wrapper for `check-sql-conflicts.py`. |
 | 68 | `scripts/check-subprocess-timeouts.sh` | self-diagnosing (Fix block) | Emits `timeout=N` argument suggestion. |
 | 69 | `scripts/check-task-recovery.sh` | decision flow (no violation list) | Emits per-phase resume hints — that IS the fix-guidance, not a violation list. |
@@ -124,10 +130,10 @@ first read of the failing CI job names the fix, copy-pasteable.
 
 ## Summary
 
-- Total guards: 85 (#31a `check-issue-verify-sql.py` added by #4358).
+- Total guards: 91 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50a `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367).
 - Already self-diagnosing (Fix block or actionable text) before #4346: 71.
 - Wrappers (delegate to helper): 18.
-- Operational health probes: 2.
+- Operational health probes: 5.
 - Decision flows: 4.
 - **Upgraded by #4346: 5** (#6 `check-bash-compat.sh`, #29 `check-hyphen-underscore-collision.sh`, #35 `check-migration-files.sh`, #71 `check_tf_ecs_entrypoint.py`, #72 `check_tf_empty_resource.py`).
 - No future upgrade currently warranted: the remaining "actionable text" guards (#8, #14, #16, #33, #57) have human-readable guidance that's already concrete enough; upgrading them to literal-patch shape would add noise relative to the friction they cause.
@@ -137,10 +143,16 @@ first read of the failing CI job names the fix, copy-pasteable.
 This survey was authored manually for the #4346 audit (2026-05-08). Future
 contributors:
 
-- When you add a new `scripts/check-*.{sh,py}` guard: append a row.
+- When you add a new `scripts/check-*.{sh,py}` guard: append a row. To
+  minimise renumbering churn use a letter-suffix row number at the
+  alphabetical insertion point (e.g. `23a`, `50a`, `66a`) — the
+  `scripts/check-fix-block-coverage-complete.sh` CI guard (#23a) fails
+  the build if you forget.
 - When you upgrade a guard's error output: update the Verdict and Notes.
 - When you delete a guard: remove the row.
 
 The audit's `/audit` skill (§1.9) counts top-level scripts via marker
 headers; this doc is a per-guard health check the audit can cross-reference
-against the count.
+against the count. The `scripts/check-fix-block-coverage-complete.sh` guard
+(wired into CI as `fix-block-coverage-complete-check`) catches drift at PR
+time — see #4367.

--- a/scripts/check-fix-block-coverage-complete.sh
+++ b/scripts/check-fix-block-coverage-complete.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# permanent: true
+# check-fix-block-coverage-complete.sh — Fail if any executable hygiene
+# guard under `scripts/check-*.{sh,py}` is missing a row in
+# `docs/dx/check-script-fix-block-coverage.md`.
+#
+# Why this check exists
+# ---------------------
+# `docs/dx/check-script-fix-block-coverage.md` is the per-guard health-check
+# inventory for the Fix-block contract introduced in #4322 / #4345 / #4346.
+# Without an automated guard, the doc silently drifts behind reality: a
+# guard ships, the row is forgotten, and "the doc is the canonical
+# inventory" stops being true. Issue #4367 motivated this check after the
+# same drift surfaced while wiring `check-no-unbounded-timeouts.py` into
+# pre-push (PR #4365).
+#
+# What gets flagged
+# -----------------
+# Any executable file matching `scripts/check-*.sh`, `scripts/check-*.py`,
+# or `scripts/check_*.py` whose basename does not appear in the inventory
+# table.
+#
+# Companion `.py` deduplication
+# -----------------------------
+# When both `scripts/check-foo.sh` AND `scripts/check-foo.py` exist, the
+# `.py` is treated as the implementation and the `.sh` as the canonical
+# wrapper — same convention `scripts/run-ci-guards.sh` uses. Documenting
+# the `.sh` row is sufficient; the `.py` companion does not need its own
+# row (the wrapper's Notes column already names it). This matches the
+# existing rows like #51 `check-nullable-column-reads.sh` "Wrapper for
+# `check-nullable-column-reads.py`".
+#
+# Opt-out marker (`# ci-guards: skip`)
+# ------------------------------------
+# Independent of this check. The marker only suppresses execution by the
+# umbrella runner — it does NOT exempt a guard from the inventory. New
+# guards must always carry a row in the inventory; the marker just lets
+# the umbrella skip running them when they require external context
+# (network, issue numbers, npm-installed deps, etc.).
+#
+# Usage
+# -----
+#   scripts/check-fix-block-coverage-complete.sh           # scan repo
+#
+# Exit codes
+# ----------
+#   0 — Every executable guard has a row in the inventory.
+#   1 — One or more guards are missing rows. Each missing guard is listed;
+#       a Fix block names the doc and the row insertion point.
+#   2 — Script error (doc missing, scripts/ dir not found, etc.).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_ROOT/scripts"
+DOC="$REPO_ROOT/docs/dx/check-script-fix-block-coverage.md"
+
+if [ ! -d "$SCRIPTS_DIR" ]; then
+    echo "ERROR: scripts/ dir not found: $SCRIPTS_DIR" >&2
+    exit 2
+fi
+
+if [ ! -f "$DOC" ]; then
+    echo "ERROR: inventory doc not found: $DOC" >&2
+    exit 2
+fi
+
+# Discover every executable check file: check-*.sh, check-*.py, check_*.py.
+# .py files invoked via `python3 …` from CI / pre-push do not require an
+# executable bit (CI canonical — see scripts/run-ci-guards.sh comments) so
+# we accept any regular file matching the glob. .sh files MUST be
+# executable — a non-executable .sh is dead, not a guard. We mirror that
+# semantic: only .sh files with +x get scanned; all .py files get scanned.
+discovered=()
+while IFS= read -r path; do
+    [ -n "$path" ] && discovered+=("$path")
+done < <(LC_ALL=C find "$SCRIPTS_DIR" -maxdepth 1 -type f \
+            \( -name 'check-*.sh' -o -name 'check-*.py' -o -name 'check_*.py' \) \
+         | LC_ALL=C sort)
+
+if [ "${#discovered[@]}" -eq 0 ]; then
+    echo "ERROR: no scripts/check-*.{sh,py} files found under $SCRIPTS_DIR" >&2
+    exit 2
+fi
+
+# Filter: keep .sh files only if executable; keep all .py files; drop the
+# umbrella self (we are not a guard).
+SELF_BASENAME="$(basename "${BASH_SOURCE[0]}")"
+keepers=()
+for path in "${discovered[@]}"; do
+    name="$(basename "$path")"
+    [ "$name" = "$SELF_BASENAME" ] && continue
+    case "$name" in
+        check-*.sh)
+            [ -x "$path" ] || continue
+            ;;
+        check-*.py|check_*.py)
+            ;;
+    esac
+    keepers+=("$name")
+done
+
+# Build the set of basenames present (for companion-pair dedup).
+declare -a basenames_present=()
+for name in "${keepers[@]}"; do
+    basenames_present+=("$name")
+done
+basename_present() {
+    local needle="$1"
+    local entry
+    for entry in "${basenames_present[@]}"; do
+        [ "$entry" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+# When both check-foo.sh and check-foo.py exist, drop the .py — the .sh
+# wrapper's row covers it. Only the hyphen-named pair is recognised; the
+# underscore-named .py files (check_split_…py, check_tf_…py, etc.) have
+# no .sh sibling and are documented in their own right.
+required=()
+for name in "${keepers[@]}"; do
+    case "$name" in
+        check-*.py)
+            stem="${name%.py}"
+            sh_companion="${stem}.sh"
+            if basename_present "$sh_companion"; then
+                continue  # covered by .sh wrapper's row
+            fi
+            ;;
+    esac
+    required+=("$name")
+done
+
+# Required basenames — these MUST appear in the inventory.
+required_sorted=$(printf '%s\n' "${required[@]}" | LC_ALL=C sort -u)
+
+# Extract the set of guard basenames documented in the inventory. The doc
+# references guards as "`scripts/check-foo.sh`" (or check_foo.py) inside
+# table rows — strip the path prefix for comparison.
+documented_basenames=$(grep -oE 'scripts/check[-_][a-zA-Z0-9_-]+\.(sh|py)' "$DOC" \
+                       | sed 's|^scripts/||' | LC_ALL=C sort -u)
+
+# Compute required-but-undocumented. Force LC_ALL=C on comm so the
+# byte-order comparison matches the byte-order sort used to build both
+# inputs above. Without this, locale-aware comm treats `-` and `_` as
+# equivalent collation classes and reports underscored-name guards
+# (`check_tf_ecs_entrypoint.py`, etc.) as missing even when they ARE
+# documented.
+missing=$(LC_ALL=C comm -23 \
+    <(printf '%s\n' "$required_sorted") \
+    <(printf '%s\n' "$documented_basenames"))
+
+if [ -n "$missing" ]; then
+    echo "FAIL: scripts/check-*.{sh,py} guard(s) missing from inventory:" >&2
+    echo "" >&2
+    while IFS= read -r name; do
+        [ -n "$name" ] && echo "  - scripts/$name" >&2
+    done <<< "$missing"
+    echo "" >&2
+    echo "Inventory: docs/dx/check-script-fix-block-coverage.md" >&2
+    echo "" >&2
+    echo "Fix: add a row to the survey table for each missing guard. Use the" >&2
+    echo "verdict vocabulary already in the doc:" >&2
+    echo "" >&2
+    echo "  | <N> | \`scripts/<guard>\` | <verdict> | <one-line note describing what the Fix block contains> |" >&2
+    echo "" >&2
+    echo "Verdict options: self-diagnosing (Fix block), self-diagnosing (actionable text)," >&2
+    echo "wrapper (delegates to helper), operational health probe, decision flow, NEEDS UPGRADE." >&2
+    echo "" >&2
+    echo "To minimise renumbering churn, use letter-suffix row numbers (e.g. \`50a\`)" >&2
+    echo "for the alphabetical insertion point — see the existing \`31a\` row for" >&2
+    echo "\`check-issue-verify-sql.py\`." >&2
+    echo "" >&2
+    echo "Note: the \`# ci-guards: skip\` opt-out marker only suppresses umbrella" >&2
+    echo "execution; it does NOT exempt a guard from the inventory. Even guards" >&2
+    echo "that opt out of the umbrella must carry a row here." >&2
+    exit 1
+fi
+
+echo "OK: every executable guard has a row in $DOC" >&2
+exit 0


### PR DESCRIPTION
## Summary

Backfill 6 missing rows in `docs/dx/check-script-fix-block-coverage.md` and add `scripts/check-fix-block-coverage-complete.sh` to fail at PR time when an executable hygiene guard ships without an inventory row. Wired as a new CI job (`fix-block-coverage-complete-check`) and into the `run-ci-guards.sh` umbrella so pre-push catches the drift class locally too.

Closes #4367

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only). Verified locally:
  - `scripts/check-fix-block-coverage-complete.sh` exits 0 against the worktree.
  - Drop-stub experiment: stub `scripts/check-zzz-coverage-probe.sh` with `# ci-guards: skip`, no doc row → check exits 1; add row → exits 0; remove stub + row → exits 0.
  - Pre-push hook ran the umbrella through 73 guards on the push that opened this PR; only the pre-existing `check-issue-verify-sql.py` umbrella-discovery bug failed (unrelated to this PR).
  - The new `fix-block-coverage-complete-check` CI job ran green on this PR's first push.
- [x] Verification evidence posted on issue (see A.8)
