### PR TITLE
feat(ingestion): seed derived.judges from court_directory_snapshots (#4370)

### DIFF
--- a/packages/scraper-framework/src/framework/court_directory.py
+++ b/packages/scraper-framework/src/framework/court_directory.py
@@ -174,11 +174,33 @@ class CourtDirectory(abc.ABC):
 
         clear_roster_cache()
 
+        # Seed derived.judges from the just-inserted snapshot so that the
+        # single-word surname expansion helper (#4297) has multi-word
+        # canonical-name candidates to expand against.  Best-effort — a
+        # seed failure must not roll back the snapshot insert that
+        # already committed.  See #4370.
+        from ingestion.judge_seed import seed_judges_from_directory_snapshots
+
+        try:
+            seed_stats = seed_judges_from_directory_snapshots(self._conn, only_court_id=court_id)
+            self._conn.commit()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception(
+                "Judge seed from snapshot failed — continuing",
+                court_id=court_id,
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            seed_stats = {"inserted": 0}
+
         logger.info(
             "Saved directory snapshot",
             court_id=court_id,
             departments=len(mapping),
             content_hash=content_hash[:12],
+            judges_seeded=seed_stats.get("inserted", 0),
         )
         return True
 

--- a/packages/scraper-framework/src/ingestion/judge_seed.py
+++ b/packages/scraper-framework/src/ingestion/judge_seed.py
@@ -1,0 +1,251 @@
+"""Seed ``derived.judges`` from ``derived.court_directory_snapshots`` (#4370).
+
+Background
+----------
+LA County tentative-ruling HTML uses a ``JUDGE/DEPT: <Surname>/<dept>``
+form-layout header that genuinely carries only the surname.  Issue #4297
+landed a single-word surname-expansion helper in
+:func:`ingestion.db._expand_single_word_judge_surname` that maps a
+single-word surname to a canonical judge name by:
+
+1. Looking the department up in ``derived.court_directory_snapshots``
+   for the hearing-date-effective canonical name, and
+2. Falling back to a surname-suffix search against ``derived.judges``
+   when (1) misses.
+
+The fallback in (2) only works when the canonical-name **already
+exists** in ``derived.judges``.  But in practice, judges who only ever
+appear in tentative rulings as a bare surname never get created in
+``derived.judges`` — :func:`_looks_like_valid_judge_name` (db.py:760)
+rejects single-word names from creating new judge rows (a defensive
+guard against truncated/garbage entries).  So the helper has nothing
+to expand against, and rulings continue to store ``judge_id = NULL``.
+
+This module breaks the chicken-and-egg by seeding ``derived.judges``
+from the canonical mapping in ``court_directory_snapshots``.  The
+snapshot mapping is authoritative — entries like
+``{"25": "Karine Mkrtchyan"}`` come from the LA judicial-officer
+directory scrape — so seeding from it is safe.
+
+Behaviour
+---------
+- INSERT-only (idempotent).  Never UPDATEs an existing row, never
+  removes rows.  Uses ``ON CONFLICT (canonical_name, court_id) DO
+  NOTHING`` against the constraint defined in migration #10.
+- Skips entries that fail :func:`_looks_like_valid_judge_name` (e.g.
+  empty strings, single-word values, garbage).  These should never
+  appear in a directory mapping but we defend in depth.
+- Resolves the snapshot's text ``court_id`` (e.g. ``"ca_los_angeles"``)
+  to the ``derived.courts.id`` UUID via ``court_code`` (with the
+  ``_`` -> ``-`` translation that mirrors
+  :func:`resolve_judge_from_department`).
+- Reads the **latest** snapshot per ``court_id``.  Historical snapshots
+  are not read here — they would already have produced a seed when they
+  were the latest, and re-reading them only re-confirms current state.
+
+Wired into:
+
+- :func:`framework.court_directory.CourtDirectory.save_snapshot` after
+  every new-snapshot insert, so each daily directory refresh seeds new
+  judges for its court.
+- :mod:`scripts.seed_judges_from_directory_snapshots` for the
+  retroactive backfill across all courts.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_court_uuid(
+    conn: psycopg.Connection,
+    snapshot_court_id: str,
+) -> str | None:
+    """Resolve a snapshot's text ``court_id`` to ``derived.courts.id`` UUID.
+
+    Snapshots use ``court_id`` strings like ``"ca_los_angeles"`` while
+    ``derived.courts.court_code`` uses the dashed form ``"ca-los-angeles"``.
+    Mirrors the conversion in :func:`resolve_judge_from_department`.
+
+    Returns ``None`` if no court row matches (rare — would mean a snapshot
+    for a court that has been removed from the courts table).
+    """
+    court_code = snapshot_court_id.replace("_", "-")
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM courts WHERE court_code = %s LIMIT 1",
+            (court_code,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        return None
+    return str(row[0])
+
+
+def _latest_snapshots(
+    conn: psycopg.Connection,
+    *,
+    only_court_id: str | None = None,
+) -> list[tuple[str, dict[str, str]]]:
+    """Return ``[(snapshot_court_id, mapping), ...]`` for the latest
+    snapshot of each court.
+
+    When ``only_court_id`` is provided, restricts the result to that one
+    court (used by :meth:`CourtDirectory.save_snapshot` after inserting
+    a new snapshot for a single court).
+    """
+    with conn.cursor() as cur:
+        if only_court_id is not None:
+            cur.execute(
+                """
+                SELECT court_id, mapping
+                FROM court_directory_snapshots
+                WHERE court_id = %s
+                ORDER BY captured_at DESC
+                LIMIT 1
+                """,
+                (only_court_id,),
+            )
+        else:
+            # DISTINCT ON (court_id) returns the latest row per court_id
+            # given the ORDER BY.
+            cur.execute(
+                """
+                SELECT DISTINCT ON (court_id) court_id, mapping
+                FROM court_directory_snapshots
+                ORDER BY court_id, captured_at DESC
+                """
+            )
+        rows = cur.fetchall()
+
+    out: list[tuple[str, dict[str, str]]] = []
+    for court_id, mapping in rows:
+        if isinstance(mapping, dict):
+            parsed = mapping
+        else:
+            try:
+                parsed = json.loads(mapping)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "seed_judges_from_directory_snapshots: skipping court %r — "
+                    "could not parse mapping JSON",
+                    court_id,
+                )
+                continue
+        out.append((court_id, parsed))
+    return out
+
+
+def seed_judges_from_directory_snapshots(
+    conn: psycopg.Connection,
+    *,
+    only_court_id: str | None = None,
+) -> dict[str, int]:
+    """Seed ``derived.judges`` from the latest court_directory_snapshot
+    of each court.
+
+    INSERT-only and idempotent.  For each canonical judge name in each
+    snapshot's ``mapping`` values, INSERTs a row into ``derived.judges``
+    with ``ON CONFLICT (canonical_name, court_id) DO NOTHING``.  Names
+    that fail :func:`_looks_like_valid_judge_name` are skipped with a
+    debug log.
+
+    Parameters
+    ----------
+    conn : psycopg.Connection
+        Database connection.  The caller is responsible for committing
+        the transaction.
+    only_court_id : str | None
+        When set, restricts the seed to a single ``court_id`` (the
+        snapshot's text id, e.g. ``"ca_los_angeles"``).  Used by
+        :meth:`CourtDirectory.save_snapshot` after a single-court insert.
+        When ``None``, seeds across the latest snapshot of every court.
+
+    Returns
+    -------
+    dict[str, int]
+        Stats: ``{"courts": N, "candidates": N, "inserted": N,
+        "skipped_existing": N, "skipped_invalid": N, "skipped_no_court": N}``.
+        - ``courts``: number of courts whose snapshots were processed.
+        - ``candidates``: number of unique (court_id, canonical_name) pairs
+          considered for insertion.
+        - ``inserted``: number of new judge rows actually inserted.
+        - ``skipped_existing``: candidates that were already present.
+        - ``skipped_invalid``: names that failed the validity guard.
+        - ``skipped_no_court``: snapshots whose ``court_id`` did not
+          resolve to a row in ``derived.courts``.
+    """
+    # Lazy import to avoid circular dependency with ingestion.db.
+    from ingestion.db import _looks_like_valid_judge_name
+
+    stats = {
+        "courts": 0,
+        "candidates": 0,
+        "inserted": 0,
+        "skipped_existing": 0,
+        "skipped_invalid": 0,
+        "skipped_no_court": 0,
+    }
+
+    snapshots = _latest_snapshots(conn, only_court_id=only_court_id)
+
+    for snapshot_court_id, mapping in snapshots:
+        stats["courts"] += 1
+        court_uuid = _resolve_court_uuid(conn, snapshot_court_id)
+        if court_uuid is None:
+            stats["skipped_no_court"] += 1
+            logger.warning(
+                "seed_judges_from_directory_snapshots: no derived.courts row "
+                "for snapshot court_id=%r — skipping",
+                snapshot_court_id,
+            )
+            continue
+
+        # Canonical names in the mapping values.  Use a set so that
+        # multiple departments assigned to the same judge produce one
+        # candidate, not N.
+        unique_names = {name for name in mapping.values() if name}
+
+        for name in unique_names:
+            stats["candidates"] += 1
+            if not _looks_like_valid_judge_name(name):
+                stats["skipped_invalid"] += 1
+                logger.debug(
+                    "seed_judges_from_directory_snapshots: skipping invalid name %r for court %r",
+                    name,
+                    snapshot_court_id,
+                )
+                continue
+
+            with conn.cursor() as cur:
+                # ON CONFLICT DO NOTHING relies on migration #10's
+                # UNIQUE (canonical_name, court_id) constraint.  We
+                # check rowcount instead of using RETURNING because
+                # ON CONFLICT DO NOTHING with RETURNING returns no row
+                # on conflict — rowcount is the simpler path.
+                cur.execute(
+                    """
+                    INSERT INTO judges (canonical_name, court_id)
+                    VALUES (%s, %s::uuid)
+                    ON CONFLICT (canonical_name, court_id) DO NOTHING
+                    """,
+                    (name, court_uuid),
+                )
+                if cur.rowcount > 0:
+                    stats["inserted"] += 1
+                    logger.info(
+                        "seed_judges_from_directory_snapshots: inserted judge %r for court %r",
+                        name,
+                        snapshot_court_id,
+                    )
+                else:
+                    stats["skipped_existing"] += 1
+
+    return stats

--- a/packages/scraper-framework/tests/courts/test_sc_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sc_tentatives.py
@@ -733,13 +733,18 @@ class TestSantaClaraCourtDirectory:
 
         directory.fetch_and_snapshot(COURT_ID)
 
-        db.commit.assert_called_once()
+        # Two commits: snapshot insert + seed-judges follow-up (#4370).
+        assert db.commit.call_count == 2
         cursor = db.cursor.return_value.__enter__.return_value
         calls = cursor.execute.call_args_list
-        # First call: dedup SELECT, second call: INSERT
-        assert len(calls) == 2
-        insert_sql = calls[1].args[0]
-        assert "INSERT INTO court_directory_snapshots" in insert_sql
+        # The seeder issues additional SELECTs against
+        # court_directory_snapshots and courts (and possibly INSERTs into
+        # judges) after the snapshot insert, so we no longer assert a
+        # fixed call count — just the snapshot INSERT shape.
+        snapshot_inserts = [
+            c for c in calls if "INSERT INTO court_directory_snapshots" in c.args[0]
+        ]
+        assert len(snapshot_inserts) == 1
 
     @respx.mock
     def test_fetch_and_snapshot_dedup_skips_insert(self) -> None:

--- a/packages/scraper-framework/tests/ingestion/test_judge_seed.py
+++ b/packages/scraper-framework/tests/ingestion/test_judge_seed.py
@@ -1,0 +1,417 @@
+"""Tests for ``ingestion.judge_seed.seed_judges_from_directory_snapshots`` (#4370).
+
+The helper exists to break the chicken-and-egg between #4297's
+single-word surname-expansion helper and the
+``_looks_like_valid_judge_name`` rejection guard:
+
+- ``_looks_like_valid_judge_name`` rejects single-word names from
+  creating new judge rows (defense against truncated/garbage entries).
+- So a judge who only ever appears in tentative rulings as a bare
+  surname never enters ``derived.judges``.
+- So #4297's surname-suffix lookup has nothing to expand against.
+
+This module seeds ``derived.judges`` from the canonical mapping in
+``derived.court_directory_snapshots`` so #4297's helper has multi-word
+candidates available.
+
+Coverage matrix:
+  - Happy path: latest snapshot per court is read, valid names are
+    inserted, stats are accurate.
+  - Idempotency: ON CONFLICT DO NOTHING means a second run with the
+    same data is a no-op (zero inserts, same skipped_existing count).
+  - Invalid-name guard: single-word values, empty strings, garbage are
+    rejected and counted as skipped_invalid.
+  - Snapshot court_id -> derived.courts.id translation: ``ca_los_angeles``
+    resolves to the court UUID for ``court_code = ca-los-angeles``.
+  - Missing court row: snapshot for a court that has no derived.courts
+    row is skipped, counted as skipped_no_court.
+  - Single-court mode: only_court_id restricts the query.
+  - Deduplication: when multiple departments map to the same canonical
+    name, only one INSERT is attempted (one candidate counted).
+  - Mapping JSON parse failure: skipped without raising.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from ingestion.judge_seed import seed_judges_from_directory_snapshots
+
+
+def _make_mock_conn() -> tuple[MagicMock, MagicMock]:
+    """Create a mock psycopg connection with cursor context manager."""
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cur
+
+
+class TestHappyPath:
+    """Latest snapshot is read, valid names are inserted, stats are accurate."""
+
+    def test_inserts_unique_canonical_names_from_la_snapshot(self) -> None:
+        """LA snapshot with three departments produces three INSERTs when none
+        of those judges already exist."""
+        mock_conn, mock_cur = _make_mock_conn()
+
+        # fetchall: latest snapshots query -> one LA row
+        # fetchone: court UUID lookup for ca_los_angeles -> one row
+        # rowcount: each INSERT returns 1 (newly inserted)
+        mock_cur.fetchall.return_value = [
+            (
+                "ca_los_angeles",
+                {
+                    "1": "Karine Mkrtchyan",
+                    "25": "Jonathan H. Eisenman",
+                    "62": "Maureen Duffy-Lewis",
+                },
+            )
+        ]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+        mock_cur.rowcount = 1
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["courts"] == 1
+        assert stats["candidates"] == 3
+        assert stats["inserted"] == 3
+        assert stats["skipped_existing"] == 0
+        assert stats["skipped_invalid"] == 0
+        assert stats["skipped_no_court"] == 0
+
+    def test_inserts_use_judges_table_with_on_conflict_do_nothing(self) -> None:
+        """The INSERT must use ON CONFLICT DO NOTHING (idempotent)."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [("ca_los_angeles", {"1": "Alice Smith"})]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+        mock_cur.rowcount = 1
+
+        seed_judges_from_directory_snapshots(mock_conn)
+
+        # Find the INSERT call.
+        insert_calls = [
+            c for c in mock_cur.execute.call_args_list if "INSERT INTO judges" in c.args[0]
+        ]
+        assert len(insert_calls) == 1
+        sql = insert_calls[0].args[0]
+        assert "ON CONFLICT (canonical_name, court_id) DO NOTHING" in sql
+        # No UPDATE clause — INSERT-only per AC #2.
+        assert "DO UPDATE" not in sql
+        assert "UPDATE judges" not in sql
+
+    def test_passes_correct_canonical_name_and_court_uuid_to_insert(self) -> None:
+        """Insert parameters are (canonical_name, court_uuid)."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [("ca_los_angeles", {"25": "Karine Mkrtchyan"})]
+        mock_cur.fetchone.return_value = ("la-uuid",)
+        mock_cur.rowcount = 1
+
+        seed_judges_from_directory_snapshots(mock_conn)
+
+        insert_calls = [
+            c for c in mock_cur.execute.call_args_list if "INSERT INTO judges" in c.args[0]
+        ]
+        assert insert_calls[0].args[1] == ("Karine Mkrtchyan", "la-uuid")
+
+
+class TestIdempotency:
+    """Re-running on the same snapshot should not double-insert.
+
+    AC #2: "unit test seeds a snapshot, runs the helper twice, asserts
+    second run is a no-op (no duplicate inserts, no UPDATE statements
+    issued)."
+    """
+
+    def test_second_run_is_no_op_when_judges_already_exist(self) -> None:
+        """When ON CONFLICT fires (rowcount=0), candidates count toward
+        skipped_existing instead of inserted."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            (
+                "ca_los_angeles",
+                {"1": "Alice Smith", "2": "Bob Jones"},
+            )
+        ]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+        # ON CONFLICT DO NOTHING -> rowcount = 0 for already-present rows.
+        mock_cur.rowcount = 0
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["candidates"] == 2
+        assert stats["inserted"] == 0
+        assert stats["skipped_existing"] == 2
+
+    def test_running_twice_produces_zero_inserts_on_second_call(self) -> None:
+        """Run the helper twice on the same connection.  First call:
+        rowcount=1 (newly inserted).  Second call: rowcount=0 (ON CONFLICT
+        fired).  Total: 2 inserted in run 1, 0 inserted in run 2.
+
+        This exercises the full AC #2 scenario verbatim — "seeds a
+        snapshot, runs the helper twice, asserts second run is a no-op."
+        """
+        mock_conn, mock_cur = _make_mock_conn()
+        # The two queries the seeder makes are identical across runs;
+        # only rowcount differs (mock-controlled below).
+        mock_cur.fetchall.return_value = [
+            (
+                "ca_los_angeles",
+                {"1": "Alice Smith", "2": "Bob Jones"},
+            )
+        ]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+
+        # Run 1 — inserts both judges.
+        mock_cur.rowcount = 1
+        stats_first = seed_judges_from_directory_snapshots(mock_conn)
+        assert stats_first["inserted"] == 2
+        assert stats_first["skipped_existing"] == 0
+
+        # Run 2 — ON CONFLICT fires for both, no rows inserted.
+        mock_cur.rowcount = 0
+        stats_second = seed_judges_from_directory_snapshots(mock_conn)
+        assert stats_second["inserted"] == 0
+        assert stats_second["skipped_existing"] == 2
+
+        # No UPDATE statements ever issued (neither run).
+        for c in mock_cur.execute.call_args_list:
+            sql_lower = c.args[0].lstrip().lower()
+            assert not sql_lower.startswith("update "), f"Helper issued UPDATE: {c.args[0]!r}"
+            assert "do update" not in sql_lower
+
+    def test_no_update_statements_issued(self) -> None:
+        """The helper must NEVER issue an UPDATE.  Only SELECT + INSERT."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [("ca_los_angeles", {"1": "Alice Smith"})]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+        mock_cur.rowcount = 0  # already exists
+
+        seed_judges_from_directory_snapshots(mock_conn)
+
+        # Inspect every SQL statement issued.
+        for c in mock_cur.execute.call_args_list:
+            sql = c.args[0]
+            # Trim leading whitespace to handle indented SQL strings.
+            sql_lower = sql.lstrip().lower()
+            # We allow the substring "update" inside "updated_at" but not at
+            # the start of a SQL statement.
+            assert not sql_lower.startswith("update "), (
+                f"Helper issued an UPDATE statement: {sql!r}"
+            )
+            assert "do update" not in sql_lower, f"Helper used ON CONFLICT DO UPDATE: {sql!r}"
+
+
+class TestInvalidNameGuard:
+    """Names that fail _looks_like_valid_judge_name are skipped."""
+
+    def test_single_word_name_skipped(self) -> None:
+        """A bare surname like 'Mkrtchyan' should be rejected — that's the
+        whole bug class we're trying to avoid creating."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            (
+                "ca_los_angeles",
+                {"1": "Mkrtchyan", "2": "Karine Mkrtchyan"},
+            )
+        ]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+        mock_cur.rowcount = 1
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["candidates"] == 2
+        assert stats["skipped_invalid"] == 1  # single-word "Mkrtchyan"
+        assert stats["inserted"] == 1  # "Karine Mkrtchyan"
+
+    def test_empty_string_skipped(self) -> None:
+        """Empty or whitespace-only mapping values are dropped before
+        the validity check via the truthiness filter, and any that slip
+        through are caught by the validity check."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            (
+                "ca_los_angeles",
+                {"1": "", "2": "Alice Smith"},
+            )
+        ]
+        mock_cur.fetchone.return_value = ("court-uuid-la",)
+        mock_cur.rowcount = 1
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        # Empty string is filtered by `if name` truthiness gate, so it
+        # never becomes a candidate.
+        assert stats["candidates"] == 1
+        assert stats["inserted"] == 1
+
+
+class TestCourtIdResolution:
+    """Snapshot court_id (text) resolves to derived.courts.id (uuid)."""
+
+    def test_snapshot_court_id_translated_to_court_code(self) -> None:
+        """ca_los_angeles -> court_code = ca-los-angeles."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [("ca_los_angeles", {"1": "Alice Smith"})]
+        mock_cur.fetchone.return_value = ("la-uuid",)
+        mock_cur.rowcount = 1
+
+        seed_judges_from_directory_snapshots(mock_conn)
+
+        # The court-lookup query must pass the dashed form.
+        court_lookup_calls = [
+            c for c in mock_cur.execute.call_args_list if "FROM courts" in c.args[0]
+        ]
+        assert len(court_lookup_calls) == 1
+        assert court_lookup_calls[0].args[1] == ("ca-los-angeles",)
+
+    def test_missing_court_row_counted_as_skipped_no_court(self) -> None:
+        """A snapshot whose court isn't in derived.courts should not crash."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [("ca_unknown_county", {"1": "Alice Smith"})]
+        # courts table returns no row.
+        mock_cur.fetchone.return_value = None
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["courts"] == 1
+        assert stats["skipped_no_court"] == 1
+        assert stats["candidates"] == 0  # never reached
+        assert stats["inserted"] == 0
+
+
+class TestSingleCourtMode:
+    """only_court_id restricts the query to a single court."""
+
+    def test_only_court_id_filters_query(self) -> None:
+        """The latest-snapshots query must filter by court_id when
+        only_court_id is set."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [("ca_los_angeles", {"1": "Alice Smith"})]
+        mock_cur.fetchone.return_value = ("la-uuid",)
+        mock_cur.rowcount = 1
+
+        seed_judges_from_directory_snapshots(mock_conn, only_court_id="ca_los_angeles")
+
+        snapshot_calls = [
+            c for c in mock_cur.execute.call_args_list if "court_directory_snapshots" in c.args[0]
+        ]
+        assert len(snapshot_calls) == 1
+        sql = snapshot_calls[0].args[0]
+        assert "WHERE court_id = %s" in sql
+        assert snapshot_calls[0].args[1] == ("ca_los_angeles",)
+
+    def test_default_uses_distinct_on_court_id(self) -> None:
+        """Without only_court_id, the query reads the latest row per court."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = []
+
+        seed_judges_from_directory_snapshots(mock_conn)
+
+        snapshot_calls = [
+            c for c in mock_cur.execute.call_args_list if "court_directory_snapshots" in c.args[0]
+        ]
+        assert len(snapshot_calls) == 1
+        sql = snapshot_calls[0].args[0]
+        assert "DISTINCT ON (court_id)" in sql
+
+
+class TestMappingDedup:
+    """Multiple departments mapped to the same judge produce one candidate."""
+
+    def test_same_judge_in_multiple_departments_inserted_once(self) -> None:
+        """Two departments with the same judge -> one candidate, one INSERT."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            (
+                "ca_los_angeles",
+                {"1": "Alice Smith", "2": "Alice Smith", "3": "Bob Jones"},
+            )
+        ]
+        mock_cur.fetchone.return_value = ("la-uuid",)
+        mock_cur.rowcount = 1
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["candidates"] == 2  # Alice + Bob, deduped
+        assert stats["inserted"] == 2
+
+        insert_calls = [
+            c for c in mock_cur.execute.call_args_list if "INSERT INTO judges" in c.args[0]
+        ]
+        assert len(insert_calls) == 2
+
+
+class TestMultipleCourts:
+    """Multiple courts in one run."""
+
+    def test_processes_all_courts(self) -> None:
+        """Two courts each contribute their judges."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            ("ca_los_angeles", {"1": "Alice Smith"}),
+            ("ca_orange", {"1": "Bob Jones"}),
+        ]
+        # courts lookups: la-uuid then orange-uuid
+        mock_cur.fetchone.side_effect = [
+            ("la-uuid",),
+            ("orange-uuid",),
+        ]
+        mock_cur.rowcount = 1
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["courts"] == 2
+        assert stats["candidates"] == 2
+        assert stats["inserted"] == 2
+
+
+class TestMappingJsonString:
+    """Mappings stored as JSON strings (legacy / non-jsonb path) are parsed."""
+
+    def test_string_mapping_parsed_as_json(self) -> None:
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            ("ca_los_angeles", json.dumps({"1": "Alice Smith"})),
+        ]
+        mock_cur.fetchone.return_value = ("la-uuid",)
+        mock_cur.rowcount = 1
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats["candidates"] == 1
+        assert stats["inserted"] == 1
+
+    def test_unparseable_mapping_skipped(self) -> None:
+        """Malformed JSON is logged + skipped, not raised."""
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = [
+            ("ca_los_angeles", "not valid json {"),
+        ]
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        # The court isn't even counted because _latest_snapshots filters it
+        # out before yielding.
+        assert stats["courts"] == 0
+        assert stats["candidates"] == 0
+
+
+class TestEmptySnapshots:
+    """Helper handles the empty snapshot table without raising."""
+
+    def test_no_snapshots_returns_zero_stats(self) -> None:
+        mock_conn, mock_cur = _make_mock_conn()
+        mock_cur.fetchall.return_value = []
+
+        stats = seed_judges_from_directory_snapshots(mock_conn)
+
+        assert stats == {
+            "courts": 0,
+            "candidates": 0,
+            "inserted": 0,
+            "skipped_existing": 0,
+            "skipped_invalid": 0,
+            "skipped_no_court": 0,
+        }

--- a/packages/scraper-framework/tests/test_court_directory.py
+++ b/packages/scraper-framework/tests/test_court_directory.py
@@ -155,13 +155,20 @@ class TestSaveSnapshot:
         result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
 
         assert result is True
-        directory._conn.commit.assert_called_once()
-        # Verify the INSERT was called
+        # Two commits expected: one for the snapshot insert, one for the
+        # seed-judges follow-up (#4370).  The seeder runs in its own
+        # transactional unit so a seed failure cannot roll back the
+        # snapshot insert that already committed.
+        assert directory._conn.commit.call_count == 2
+        # Verify the snapshot INSERT was issued.  The seeder adds further
+        # SELECTs against court_directory_snapshots and courts plus
+        # potential INSERT INTO judges; we only assert the snapshot path
+        # was exercised here.
         calls = cursor.execute.call_args_list
-        # First call is the dedup SELECT, second is the INSERT
-        assert len(calls) == 2
-        insert_sql = calls[1].args[0]
-        assert "INSERT INTO court_directory_snapshots" in insert_sql
+        snapshot_inserts = [
+            c for c in calls if "INSERT INTO court_directory_snapshots" in c.args[0]
+        ]
+        assert len(snapshot_inserts) == 1
 
     def test_skips_db_insert_when_duplicate(self, directory: _StubDirectory) -> None:
         """When content_hash matches the latest snapshot, skip the DB insert."""
@@ -182,7 +189,8 @@ class TestSaveSnapshot:
         result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
 
         assert result is True
-        directory._conn.commit.assert_called_once()
+        # Two commits: snapshot insert + seed-judges follow-up (#4370).
+        assert directory._conn.commit.call_count == 2
 
     def test_mapping_stored_as_sorted_json(self, directory: _StubDirectory) -> None:
         """The mapping should be stored as sorted JSON for consistency."""
@@ -191,8 +199,16 @@ class TestSaveSnapshot:
 
         directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
 
-        calls = cursor.execute.call_args_list
-        insert_params = calls[1].args[1]
+        # Find the snapshot INSERT specifically — the seed step (#4370)
+        # adds further SELECTs and possibly judge INSERTs after, so we
+        # cannot rely on a fixed call index.
+        snapshot_inserts = [
+            c
+            for c in cursor.execute.call_args_list
+            if "INSERT INTO court_directory_snapshots" in c.args[0]
+        ]
+        assert len(snapshot_inserts) == 1
+        insert_params = snapshot_inserts[0].args[1]
         # The mapping JSON is the 4th parameter (index 3)
         stored_json = insert_params[3]
         assert stored_json == json.dumps(MAPPING, sort_keys=True)
@@ -220,8 +236,15 @@ class TestSaveSnapshot:
 
         expected_hash = sha256_hex(RAW_HTML)
         expected_key = f"directories/{COURT_ID}/{expected_hash}.html"
-        calls = cursor.execute.call_args_list
-        insert_params = calls[1].args[1]
+        # Find the snapshot INSERT specifically — the seed step (#4370)
+        # adds further calls after this one.
+        snapshot_inserts = [
+            c
+            for c in cursor.execute.call_args_list
+            if "INSERT INTO court_directory_snapshots" in c.args[0]
+        ]
+        assert len(snapshot_inserts) == 1
+        insert_params = snapshot_inserts[0].args[1]
         # s3_key is the 3rd parameter (index 2)
         assert insert_params[2] == expected_key
 
@@ -240,7 +263,8 @@ class TestSaveSnapshot:
 
         assert result is True
         s3_client.put_object.assert_not_called()  # skip upload
-        directory._conn.commit.assert_called_once()  # still insert into DB
+        # Two commits: snapshot insert + seed-judges follow-up (#4370).
+        assert directory._conn.commit.call_count == 2
 
     def test_clears_roster_cache_on_new_snapshot(self, directory: _StubDirectory) -> None:
         """Saving a new snapshot should clear the roster name cache."""
@@ -279,6 +303,70 @@ class TestSaveSnapshot:
 
         # Clean up
         clear_roster_cache()
+
+    def test_seeds_judges_from_snapshot_after_insert(self, directory: _StubDirectory) -> None:
+        """After a new snapshot is inserted, judges are seeded from the
+        same DB connection (#4370).
+
+        AC #3: "Helper wired into the daily court-directory snapshot
+        refresh — integration test that runs the snapshot writer,
+        asserts new judges are inserted on the same DB transaction."
+        """
+        from unittest.mock import patch
+
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None  # not a duplicate
+
+        with patch("ingestion.judge_seed.seed_judges_from_directory_snapshots") as mock_seed:
+            mock_seed.return_value = {
+                "courts": 1,
+                "candidates": 2,
+                "inserted": 2,
+                "skipped_existing": 0,
+                "skipped_invalid": 0,
+                "skipped_no_court": 0,
+            }
+
+            result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+            assert result is True
+            # The seeder must be called with the same DB connection the
+            # snapshot was just written on, scoped to the just-inserted
+            # court_id.
+            mock_seed.assert_called_once_with(directory._conn, only_court_id=COURT_ID)
+
+    def test_skips_seed_when_snapshot_is_duplicate(self, directory: _StubDirectory) -> None:
+        """When the snapshot is a duplicate (no new DB row), the seeder is
+        not called — there's no new mapping to seed from."""
+        from unittest.mock import patch
+
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        # _is_duplicate sees the same content_hash -> duplicate.
+        cursor.fetchone.return_value = (sha256_hex(RAW_HTML),)
+
+        with patch("ingestion.judge_seed.seed_judges_from_directory_snapshots") as mock_seed:
+            result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+            assert result is False
+            mock_seed.assert_not_called()
+
+    def test_seed_failure_does_not_break_save_snapshot(self, directory: _StubDirectory) -> None:
+        """A seed failure must not roll back the snapshot insert that
+        already committed.  Best-effort, defensive — we never want a
+        seed-side bug to lose the directory snapshot."""
+        from unittest.mock import patch
+
+        cursor = directory._conn.cursor.return_value.__enter__.return_value
+        cursor.fetchone.return_value = None  # not a duplicate
+
+        with patch(
+            "ingestion.judge_seed.seed_judges_from_directory_snapshots",
+            side_effect=RuntimeError("simulated seed failure"),
+        ):
+            # Must not raise — the snapshot insert already happened.
+            result = directory.save_snapshot(RAW_HTML, MAPPING, COURT_ID)
+
+            assert result is True
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/seed_judges_from_directory_snapshots.py
+++ b/scripts/seed_judges_from_directory_snapshots.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Backfill ``derived.judges`` from ``derived.court_directory_snapshots`` (#4370).
+
+Reads the latest snapshot for every court in
+``derived.court_directory_snapshots`` and INSERTs any canonical judge
+name that isn't already in ``derived.judges``.  Idempotent — re-running
+is a no-op once all judges have been seeded.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- scripts/run-py.sh scripts/seed_judges_from_directory_snapshots.py
+
+Options:
+    --dry-run    Print the count of judges that would be inserted, then
+                 roll back the transaction without committing.
+    --court-id   Restrict the seed to a single snapshot court_id (e.g.
+                 ``ca_los_angeles``).  By default all courts are seeded.
+
+Why this exists
+---------------
+After #4297 landed the single-word JUDGE/DEPT surname-expansion helper,
+LA dept-25 rulings continued to store ``judge_id = NULL`` because
+``Karine Mkrtchyan`` did not exist in ``derived.judges`` — so the
+helper's surname-suffix lookup fell through to no-match.  This is a
+chicken-and-egg: judges who only ever appear in tentatives as a bare
+surname never get created in ``derived.judges``, because
+``_looks_like_valid_judge_name`` (db.py:760) rejects single-word names
+from creating new judge rows.
+
+``derived.court_directory_snapshots`` already carries the canonical
+mapping from the LA judicial-officer directory scrape — those names
+are authoritative.  This script seeds them into ``derived.judges`` so
+#4297's helper has expansion candidates.
+
+After this script runs against dev, re-run the targeted reingest from
+#4297's verification:
+
+    scripts/ecs-run-task.sh scripts/reingest_from_s3.py \\
+        -- --county "Los Angeles" --department-in 25 --no-llm
+
+and confirm dept-25 NULL count drops to ≤ ~5.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import psycopg
+
+from ingestion.judge_seed import seed_judges_from_directory_snapshots
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    dry_run: bool = False,
+    only_court_id: str | None = None,
+) -> dict[str, int]:
+    """Apply the seed and return stats."""
+    with psycopg.connect(dsn) as conn:
+        stats = seed_judges_from_directory_snapshots(conn, only_court_id=only_court_id)
+
+        if dry_run:
+            conn.rollback()
+            logger.info(
+                "DRY RUN: would insert %d judge row(s) "
+                "(courts=%d candidates=%d skipped_existing=%d "
+                "skipped_invalid=%d skipped_no_court=%d) [rolled back]",
+                stats["inserted"],
+                stats["courts"],
+                stats["candidates"],
+                stats["skipped_existing"],
+                stats["skipped_invalid"],
+                stats["skipped_no_court"],
+            )
+        else:
+            conn.commit()
+            logger.info(
+                "Committed: inserted %d judge row(s) "
+                "(courts=%d candidates=%d skipped_existing=%d "
+                "skipped_invalid=%d skipped_no_court=%d)",
+                stats["inserted"],
+                stats["courts"],
+                stats["candidates"],
+                stats["skipped_existing"],
+                stats["skipped_invalid"],
+                stats["skipped_no_court"],
+            )
+
+    return stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed derived.judges from court_directory_snapshots (#4370).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the count of judges that would be inserted, then "
+        "roll back without committing.",
+    )
+    parser.add_argument(
+        "--court-id",
+        default=None,
+        help="Restrict to a single snapshot court_id (e.g. ca_los_angeles). "
+        "Default: all courts.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    run_backfill(dsn, dry_run=args.dry_run, only_court_id=args.court_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Seed `derived.judges` from `derived.court_directory_snapshots` so #4297's single-word JUDGE/DEPT surname-expansion helper has multi-word canonical-name candidates to expand against. Breaks the chicken-and-egg where judges who only ever appear in tentative rulings as a bare surname (e.g. LA dept-25 `Mkrtchyan`) never enter `derived.judges` because `_looks_like_valid_judge_name` rejects single-word names — leaving #4297's surname-suffix lookup with nothing to match.

Closes #4370

## Approach

- New `packages/scraper-framework/src/ingestion/judge_seed.py` — `seed_judges_from_directory_snapshots(conn, *, only_court_id=None)`. INSERT-only via `ON CONFLICT (canonical_name, court_id) DO NOTHING` against the migration-#10 unique constraint. Skips names that fail `_looks_like_valid_judge_name`. Reads the latest snapshot per court (DISTINCT ON), or scopes to one court when `only_court_id` is set.
- Wired into `framework/court_directory.py:save_snapshot()` so each daily roster refresh seeds new judges from the just-inserted snapshot. Seed runs in its own try/except + commit so a seed failure cannot roll back the snapshot insert that already committed.
- One-off `scripts/seed_judges_from_directory_snapshots.py` for the retroactive backfill (closes the dept-25 NULL gap from #4297). `--dry-run` rolls back; `--court-id` scopes to one court.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (17 new unit tests for `judge_seed.py` at 100% coverage; 3 new integration tests in `test_court_directory.py` covering wiring, dedup-skip, and failure-isolation; existing 30 court_directory tests + 1 SC tentatives test updated for the new two-commit shape; full scraper-framework suite 7604 passed locally)
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh -- scripts/seed_judges_from_directory_snapshots.py` against dev (printed `Committed: inserted 518 judge row(s) (courts=11 candidates=723 skipped_existing=189 skipped_invalid=16 skipped_no_court=1)`)
- [x] Verify the LA directory's current dept-25 entry (`Jonathan H. Eisenman`) now appears in `derived.judges` via `dev-db-query.sh` — confirmed
- [ ] ~~Re-run the dept-25 reingest from #4297's verification and confirm NULL count drops to ≤ ~5~~ — blocked by pre-existing transcription bug (every dept-25 doc fails `no_html_in_ruling_text` validation, `Deterministic validation FAIL — skipping DB write`). Tracked as follow-up #4382. Seed itself is verified working; downstream blocker is unrelated to this PR.
- [x] Verification evidence posted on issue (see [#4370 comment](https://github.com/judgemind/judgemind/issues/4370#issuecomment-4410336359))
