### PR TITLE
fix(scripts): resolve split_ids path under ECS oneshot (#4374)

### DIFF
--- a/scripts/drain_splitter_carry_forward_clusters.py
+++ b/scripts/drain_splitter_carry_forward_clusters.py
@@ -96,6 +96,18 @@ psycopg: Any = None
 
 # Make the scraper-framework src importable when running standalone (not
 # via ``packages/scraper-framework/.venv/bin/python3``).
+#
+# Path resolution gotcha — see #4374. The ``Path(__file__).resolve().parent.parent``
+# anchor only points at the repo root on the developer-laptop layout
+# (``<repo>/scripts/drain_splitter_carry_forward_clusters.py``). When the
+# script is executed via ``scripts/ecs-run-task.sh``, it is uploaded to
+# ``/tmp/_oneshot_script`` and ``__file__`` resolves there, so
+# ``parent.parent`` collapses to ``/`` and ``_SCRAPER_SRC`` wrongly becomes
+# ``/packages/scraper-framework/src``. The ``_load_split_ids_module``
+# fallback list below covers every shipping layout (developer laptop, ECS
+# oneshot via ``/app/src``, image-baked under ``/app/packages/...``); this
+# variable is kept solely for the dev-laptop ``sys.path`` insertion below
+# and as the *first* candidate in that fallback list.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 _SCRAPER_SRC = _REPO_ROOT / "packages" / "scraper-framework" / "src"
 if str(_SCRAPER_SRC) not in sys.path:
@@ -112,6 +124,17 @@ if str(_SCRAPER_SRC) not in sys.path:
 _ECS_SCRIPTS_DIR = Path("/app/scripts")
 if _ECS_SCRIPTS_DIR.is_dir() and str(_ECS_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_ECS_SCRIPTS_DIR))
+
+# In the in-image layout, the scraper-framework ``src/`` tree is copied to
+# ``/app/src/`` (Dockerfile line 34: ``COPY packages/scraper-framework/src/
+# ./src/`` after ``WORKDIR /app``). The pip install at line 35 also makes
+# the ``ingestion`` package importable from site-packages, but
+# ``_load_split_ids_module`` deliberately bypasses ``ingestion/__init__.py``
+# (which transitively imports ``ingestion.worker`` → psycopg, structlog),
+# so it needs a direct file-spec path to the module. The candidate-path
+# fallback list inside ``_load_split_ids_module`` includes ``/app/src/`` to
+# pick up split_ids.py from the in-image layout. See #4374.
+_ECS_APP_SRC = Path("/app/src")
 
 # Always include the directory the file lives in (for the developer-laptop
 # pytest path where __file__ is in scripts/) — Python normally adds this
@@ -366,6 +389,58 @@ _UPSERT_PARENT_SQL = """
 """
 
 
+def _split_ids_candidate_paths() -> list[Path]:
+    """Return the ordered list of candidate filesystem paths for
+    ``ingestion/split_ids.py``.
+
+    The first existing path is used by ``_load_split_ids_module``. The
+    list covers every shipping layout the script runs in:
+
+      1. ``_SCRAPER_SRC / ingestion / split_ids.py`` — the developer-laptop
+         + CI ``scripts-tests`` path. Resolves correctly when ``__file__``
+         lives in ``<repo>/scripts/`` so ``parent.parent`` is the repo root.
+      2. ``/app/src/ingestion/split_ids.py`` — the in-image path written by
+         the scraper-framework Dockerfile (``WORKDIR /app`` + ``COPY
+         packages/scraper-framework/src/ ./src/``). This is the path that
+         exists when the script runs via ``scripts/ecs-run-task.sh``,
+         because the oneshot uploads the script to ``/tmp/_oneshot_script``
+         where ``parent.parent`` collapses to ``/`` (#4374 root cause).
+      3. ``/app/packages/scraper-framework/src/ingestion/split_ids.py`` —
+         legacy / defense-in-depth path for any future image layout that
+         keeps the package directory under ``/app/packages/``. The current
+         Dockerfile flattens to ``/app/src/`` but a future build that
+         reverts to a per-package layout would land here.
+
+    Implemented as a function (not a module-level constant) so tests can
+    monkeypatch ``_SCRAPER_SRC`` to simulate the ECS-oneshot collapse and
+    exercise the fallback list. See #4374.
+    """
+    return [
+        _SCRAPER_SRC / "ingestion" / "split_ids.py",
+        _ECS_APP_SRC / "ingestion" / "split_ids.py",
+        Path("/app/packages/scraper-framework/src/ingestion/split_ids.py"),
+    ]
+
+
+def _resolve_split_ids_path() -> Path:
+    """Return the first existing candidate path from
+    ``_split_ids_candidate_paths``.
+
+    Raises ``RuntimeError`` listing every candidate that was tried if none
+    of them resolve to an existing file — this surfaces a self-diagnosing
+    error message instead of the original bare ``[Errno 2] No such file or
+    directory: '/packages/scraper-framework/src/ingestion/split_ids.py'``
+    that #4374 had to puzzle out from. See #4374.
+    """
+    candidates = _split_ids_candidate_paths()
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    tried = ", ".join(str(c) for c in candidates)
+    msg = f"Could not locate ingestion/split_ids.py in any known layout. Tried: {tried}"
+    raise RuntimeError(msg)
+
+
 def _load_split_ids_module() -> Any:
     """Load ``ingestion.split_ids`` directly from its file path.
 
@@ -376,6 +451,10 @@ def _load_split_ids_module() -> Any:
     file-spec API gives us the two pure-Python helpers we need
     (``derive_parent_document_id``, ``is_split_child_id``) without the
     transitive dependency cost.
+
+    The path lookup walks ``_split_ids_candidate_paths()`` and uses the
+    first existing file — see that function's docstring for why a
+    multi-layout fallback is required (#4374).
     """
     import importlib.util
 
@@ -383,7 +462,7 @@ def _load_split_ids_module() -> Any:
     if cached is not None:
         return cached
 
-    path = _SCRAPER_SRC / "ingestion" / "split_ids.py"
+    path = _resolve_split_ids_path()
     spec = importlib.util.spec_from_file_location("_drain_split_ids", str(path))
     if spec is None or spec.loader is None:  # pragma: no cover - defensive
         msg = f"Could not load split_ids module from {path}"

--- a/scripts/tests/test_drain_splitter_carry_forward_clusters.py
+++ b/scripts/tests/test_drain_splitter_carry_forward_clusters.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import sys
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -496,6 +497,152 @@ class TestRestoreParentForCluster:
         split_ids = _script._load_split_ids_module()
         expected = split_ids.derive_parent_document_id("parent-real-hash")
         assert _script.compute_parent_doc_id("parent-real-hash") == expected
+
+
+# ---------------------------------------------------------------------------
+# split_ids path resolution (#4374)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitIdsPathResolution:
+    """Regression tests for #4374 — when the script runs via
+    ``scripts/ecs-run-task.sh``, ``__file__`` is ``/tmp/_oneshot_script``
+    so the original ``Path(__file__).resolve().parent.parent`` collapses to
+    ``/`` and ``_SCRAPER_SRC`` wrongly becomes
+    ``/packages/scraper-framework/src``. The previous implementation passed
+    that bogus path straight to ``importlib.util.spec_from_file_location``
+    and crashed every cluster's ``Restore transaction failed`` branch with
+    ``[Errno 2] No such file or directory:
+    '/packages/scraper-framework/src/ingestion/split_ids.py'``.
+
+    The fix is the candidate-path fallback list in
+    ``_split_ids_candidate_paths`` — try the dev-laptop path first, then
+    the in-image ``/app/src`` path that the scraper-framework Dockerfile
+    actually writes the source tree to.
+    """
+
+    def test_candidate_paths_include_ecs_layouts(self) -> None:
+        # The fallback list must cover the ECS oneshot layouts, otherwise
+        # #4374 is back. Specifically, ``/app/src`` is where the
+        # scraper-framework Dockerfile copies the package source (line 34:
+        # ``COPY packages/scraper-framework/src/ ./src/``).
+        candidates = _script._split_ids_candidate_paths()
+        candidate_strs = [str(c) for c in candidates]
+        # Dev-laptop path (still first — exercised by every other test in
+        # this file via the existing ``_load_split_ids_module`` call).
+        assert any(
+            "packages/scraper-framework/src/ingestion/split_ids.py" in c
+            for c in candidate_strs
+        )
+        # ECS in-image flattened layout — the actual fix for #4374.
+        assert "/app/src/ingestion/split_ids.py" in candidate_strs
+        # Defense-in-depth path for any future image layout that keeps the
+        # per-package directory.
+        assert (
+            "/app/packages/scraper-framework/src/ingestion/split_ids.py"
+            in candidate_strs
+        )
+
+    def test_resolve_picks_first_existing_candidate(self, tmp_path: Any) -> None:
+        # When multiple candidates exist, ``_resolve_split_ids_path`` picks
+        # the FIRST matching one (dev-laptop > ECS app-src > legacy app
+        # path). Simulate by monkeypatching the candidate list to a
+        # tmp-path that does exist.
+        candidate_a = tmp_path / "first" / "split_ids.py"
+        candidate_a.parent.mkdir(parents=True)
+        candidate_a.write_text("# fake")
+        candidate_b = tmp_path / "second" / "split_ids.py"
+        candidate_b.parent.mkdir(parents=True)
+        candidate_b.write_text("# also fake")
+        with patch.object(
+            _script,
+            "_split_ids_candidate_paths",
+            return_value=[candidate_a, candidate_b],
+        ):
+            assert _script._resolve_split_ids_path() == candidate_a
+
+    def test_resolve_falls_through_to_second_candidate_when_first_missing(
+        self, tmp_path: Any
+    ) -> None:
+        # The bug: when the first candidate (dev-laptop ``_SCRAPER_SRC``)
+        # collapses to ``/packages/...`` because ``__file__`` is
+        # ``/tmp/_oneshot_script``, that file does NOT exist, and the
+        # resolver MUST fall through to the next candidate (the
+        # ``/app/src`` in-image path) instead of crashing. This is exactly
+        # the path-resolution regression #4374 reports.
+        missing = tmp_path / "does-not-exist" / "split_ids.py"
+        present = tmp_path / "present" / "split_ids.py"
+        present.parent.mkdir(parents=True)
+        present.write_text("# real-enough")
+        with patch.object(
+            _script,
+            "_split_ids_candidate_paths",
+            return_value=[missing, present],
+        ):
+            assert _script._resolve_split_ids_path() == present
+
+    def test_resolve_raises_self_diagnosing_error_when_all_missing(
+        self, tmp_path: Any
+    ) -> None:
+        # If every candidate is missing — should never happen in practice
+        # but guards against a future Dockerfile change that drops every
+        # known layout — the error message lists every candidate that was
+        # tried, instead of the original bare ``[Errno 2]`` from inside
+        # ``importlib.util.spec_from_file_location``. This makes the
+        # failure self-diagnosing per
+        # ``feedback_instrument_before_guess_validated.md``.
+        missing_a = tmp_path / "a" / "split_ids.py"
+        missing_b = tmp_path / "b" / "split_ids.py"
+        with patch.object(
+            _script,
+            "_split_ids_candidate_paths",
+            return_value=[missing_a, missing_b],
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                _script._resolve_split_ids_path()
+        msg = str(excinfo.value)
+        # The error must list every tried candidate so an operator can
+        # diagnose without re-reading the source.
+        assert str(missing_a) in msg
+        assert str(missing_b) in msg
+        assert "Could not locate" in msg
+
+    def test_load_succeeds_in_simulated_ecs_oneshot_layout(self, tmp_path: Any) -> None:
+        # Reproduce the #4374 failure mode end-to-end: when
+        # ``_SCRAPER_SRC`` would collapse to ``/packages/scraper-framework/src``
+        # (the exact path in the production error message), the loader
+        # MUST still find ``split_ids.py`` via the
+        # ``/app/src/ingestion/split_ids.py`` candidate. We simulate by:
+        #   1. Pointing ``_SCRAPER_SRC`` at a non-existent path
+        #      mirroring the ``__file__ = /tmp/_oneshot_script`` collapse.
+        #   2. Pointing the ``/app/src`` fallback at a tmp-path that
+        #      contains a real (minimal) ``split_ids.py``.
+        # Without the fix, this test fails because
+        # ``_load_split_ids_module`` would only ever try the bogus
+        # ``_SCRAPER_SRC`` path.
+        fake_oneshot_root = Path("/packages/scraper-framework/src")
+        # ``fake_oneshot_root / "ingestion" / "split_ids.py"`` won't exist
+        # on any real filesystem (root is not writable here, by design).
+        ecs_app_src = tmp_path / "app-src"
+        (ecs_app_src / "ingestion").mkdir(parents=True)
+        # Minimal split_ids stand-in — the loader should be able to
+        # ``exec_module`` it without errors.
+        (ecs_app_src / "ingestion" / "split_ids.py").write_text(
+            "MARKER = 'loaded-from-ecs-app-src'\n"
+        )
+
+        # Reset the cached module so the next call re-runs path resolution.
+        _script._load_split_ids_module._cached = None  # type: ignore[attr-defined]
+        try:
+            with (
+                patch.object(_script, "_SCRAPER_SRC", fake_oneshot_root),
+                patch.object(_script, "_ECS_APP_SRC", ecs_app_src),
+            ):
+                module = _script._load_split_ids_module()
+            assert module.MARKER == "loaded-from-ecs-app-src"
+        finally:
+            # Restore the cache so subsequent tests don't see our stub.
+            _script._load_split_ids_module._cached = None  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the path-resolution bug in `scripts/drain_splitter_carry_forward_clusters.py` that caused every cluster's `Restore transaction failed` branch to fail with `[Errno 2] No such file or directory: '/packages/scraper-framework/src/ingestion/split_ids.py'` when the script runs via `scripts/ecs-run-task.sh`.

Root cause: `_SCRAPER_SRC = Path(__file__).resolve().parent.parent / "packages" / "scraper-framework" / "src"` collapses to `/packages/scraper-framework/src` when `__file__` is `/tmp/_oneshot_script` (the path the ECS oneshot uploads to). `_load_split_ids_module()` then passed that bogus path verbatim to `importlib.util.spec_from_file_location`. The fix replaces the single-path lookup with a candidate-path fallback list (`_split_ids_candidate_paths` + `_resolve_split_ids_path`) that tries dev-laptop -> in-image `/app/src` -> defense-in-depth `/app/packages/...`, and emits a self-diagnosing `RuntimeError` listing every path tried when none resolve.

Closes #4374

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh scripts/drain_splitter_carry_forward_clusters.py -- --county "Santa Clara" --dry-run --no-reingest` against dev and confirm CloudWatch shows no `Restore transaction failed for cluster` errors with `error: "[Errno 2] No such file or directory: '/packages/scraper-framework/src/ingestion/split_ids.py'"`. `clusters_skipped` should reflect only legitimate skips (`skip_no_split` / `skip_single_title`).
- [x] Verification evidence posted on issue (see A.8)
