### PR TITLE
dx(ci-guards): meta-check for argument-required guards missing from SKIP_LIST (#4379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1927,6 +1927,21 @@ jobs:
         run: scripts/check-fix-block-coverage-complete.sh
 
   # ---------------------------------------------------------------
+  # CI-guards SKIP_LIST coverage: every argument-required hygiene guard
+  # under scripts/check-*.{sh,py} must be in run-ci-guards.sh's SKIP_LIST
+  # or carry a `# ci-guards: skip` marker. Without this, the umbrella
+  # crashes on blind invocation of guards that need --issue / --body-file
+  # / positional ${1:?} args. Two issues so far hit this footgun:
+  # #4332 (motivating retro) → #4372 (most recent recurrence). See #4379.
+  # ---------------------------------------------------------------
+  ci-guards-skip-list-coverage-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify every required-arg guard is covered by SKIP_LIST or marker
+        run: scripts/check-ci-guards-skip-list-coverage.sh
+
+  # ---------------------------------------------------------------
   # ci-passed coverage guard: assert every top-level job appears in
   # ci-passed.needs: so gaps like #3919 are caught before merge.
   # ---------------------------------------------------------------
@@ -1941,7 +1956,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check, fix-block-coverage-complete-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check, fix-block-coverage-complete-check, ci-guards-skip-list-coverage-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/dx/check-script-fix-block-coverage.md
+++ b/docs/dx/check-script-fix-block-coverage.md
@@ -47,6 +47,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 9 | `scripts/check-brand-md-tokens.sh` | self-diagnosing (Fix block) | Emits canonical token list. |
 | 10 | `scripts/check-case-type-fallback-parity.sh` | wrapper (delegates to helper) | Wrapper for `check-case-type-fallback-parity.py`. |
 | 11 | `scripts/check-ci-job-skipped.sh` | wrapper (delegates to helper) | Wrapper for `check-ci-job-skipped.py`. |
+| 11a | `scripts/check-ci-guards-skip-list-coverage.sh` | self-diagnosing (Fix block) | Meta-check guarding `run-ci-guards.sh`'s SKIP_LIST: fails when a guard with `argparse required=True` / `add_mutually_exclusive_group(required=True)` / shell `${1:?}` is missing from SKIP_LIST AND has no `# ci-guards: skip` marker. Emits per-violation `Fix:` block with both options (Option A: literal SKIP_LIST entry to paste; Option B: `# ci-guards: skip` marker). Tracking: #4379 (parent: #4332). |
 | 12 | `scripts/check-ci-passed-coverage.sh` | wrapper (delegates to helper) | Wrapper for `check-ci-passed-coverage.py`. |
 | 13 | `scripts/check-cleanup-step-continue-on-error.sh` | self-diagnosing (Fix block) | Inline Python emits "Add `continue-on-error: true` at the step level". |
 | 14 | `scripts/check-cloudwatch-alarm-docs.sh` | self-diagnosing (actionable text) | "Add a row to the §'CloudWatch Alarms' table with prefix, module, source metric, ...". Could be upgraded to emit a literal markdown-row patch. |
@@ -130,7 +131,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 
 ## Summary
 
-- Total guards: 91 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50a `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367).
+- Total guards: 92 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50a `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379).
 - Already self-diagnosing (Fix block or actionable text) before #4346: 71.
 - Wrappers (delegate to helper): 18.
 - Operational health probes: 5.

--- a/scripts/check-ci-guards-skip-list-coverage.py
+++ b/scripts/check-ci-guards-skip-list-coverage.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check-ci-guards-skip-list-coverage.py — Meta-check guarding the
+``scripts/run-ci-guards.sh`` umbrella against guards that take required
+arguments but are missing from the umbrella's ``SKIP_LIST`` (or the
+per-file ``# ci-guards: skip`` opt-out marker).
+
+Why this check exists
+---------------------
+``scripts/run-ci-guards.sh`` runs every executable ``scripts/check-*.sh``
+and ``scripts/check-*.py`` blind from the local working tree, with no
+arguments. Guards that *require* an argument (``--issue N``, positional
+``${1:?}``, etc.) crash on blind invocation, and the umbrella reports the
+crash as a failure even though the guard is fine when called from CI with
+the right args. Two issues so far have shipped a new argument-required
+guard and forgotten to add it to the umbrella's ``SKIP_LIST``: #4332
+(motivating retro) → #4372 (most recent recurrence). Each follow-up cost
+a full investigate-fix-CI-merge cycle.
+
+This check is the structural fix. It scans every ``scripts/check-*.{sh,py}``
+for hard-required argument signatures and fails when a hit is not covered
+by either:
+
+* the umbrella's ``SKIP_LIST`` (parsed live from
+  ``scripts/run-ci-guards.sh``), or
+* a top-level ``# ci-guards: skip`` opt-out marker (first 20 lines of the
+  file — same window the umbrella scans).
+
+What counts as "argument-required"
+----------------------------------
+**Python (argparse):**
+
+* ``required=True`` on an ``add_argument`` call (any line in the file).
+* ``add_mutually_exclusive_group(required=True)`` — at least one option
+  in the group must be supplied.
+
+**Shell:**
+
+* ``${1:?...}`` — strict-required positional (canonical pattern, used by
+  ``check-issue-author.sh`` and ``check-task-recovery.sh``).
+
+Patterns intentionally NOT flagged (would produce false positives):
+
+* ``${1:-}`` — defaulted positional. The script may or may not need an
+  argument; many legitimate guards take an optional flag here.
+* Environment-variable-required scripts (e.g. ``check-pr-title.sh`` reads
+  ``PR_TITLE`` / ``PR_BODY`` from the environment). These run without a
+  CLI arg but still need external context — they belong in ``SKIP_LIST``,
+  but this check does not detect them syntactically. The category is
+  small and stable; every member is already in the list.
+* ``argparse`` arguments without ``required=True``. argparse's default
+  is ``required=False``, so a missing optional flag is fine.
+
+CLI
+---
+::
+
+    scripts/check-ci-guards-skip-list-coverage.py            # scan repo
+    scripts/check-ci-guards-skip-list-coverage.py --scripts-dir DIR
+                                                             # scan a custom dir
+
+Exit codes
+----------
+* ``0`` — every argument-required guard is in ``SKIP_LIST`` or carries the
+  marker.
+* ``1`` — one or more argument-required guards are missing. A ``Fix:``
+  block names the offending file and the canonical remediation (add to
+  ``SKIP_LIST`` or add ``# ci-guards: skip`` marker).
+* ``2`` — script error (umbrella not found, scripts/ dir missing, etc.).
+
+Tracking: issue #4379 (parent: #4332).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────────────────────────────
+
+# Window size for the per-file ``# ci-guards: skip`` marker. Mirrors the
+# 20-line window in ``scripts/run-ci-guards.sh::has_opt_out_marker``.
+_MARKER_WINDOW_LINES: int = 20
+
+# Marker regex — matches a standalone top-level comment line. Whitespace
+# is tolerated. Mirrors the regex in ``run-ci-guards.sh``.
+_OPT_OUT_MARKER_RE = re.compile(r"^\s*#\s*ci-guards:\s*skip\s*$")
+
+# Python argparse: ``required=True`` anywhere in an ``add_argument`` or
+# ``add_mutually_exclusive_group`` call. We tolerate whitespace around
+# the ``=`` and accept a trailing ``,`` (signalling additional kwargs).
+# Matching is line-oriented because argparse calls in this repo span
+# at most a handful of lines and the kwarg lives on its own line in the
+# canonical style — see ``check-issue-verify-sql.py:608`` for the
+# reference shape.
+_PY_REQUIRED_TRUE_RE = re.compile(r"\brequired\s*=\s*True\b")
+
+# Python argparse: positional argument (no leading ``-``). Detection is
+# best-effort — argparse positionals are required by default unless
+# ``nargs="?"`` / ``"*"`` is given. We do NOT flag positionals here
+# because they would produce false positives on the many ``argparse``
+# scripts that accept ``"paths"`` with ``nargs="*"`` (zero or more —
+# blind invocation works fine). Stick to the explicit ``required=True``
+# signal.
+
+# Shell: ``${1:?...}`` — strict-required positional with custom error.
+# This is the canonical "first positional is required" pattern used by
+# ``check-issue-author.sh`` and ``check-task-recovery.sh``. Variants
+# like ``${1:?}`` (no message) are also matched.
+_SH_REQUIRED_POSITIONAL_RE = re.compile(r"\$\{1:\?")
+
+# SKIP_LIST extraction regex. Matches a ``"basename"`` literal inside the
+# ``SKIP_LIST=( … )`` array block in ``scripts/run-ci-guards.sh``. We
+# parse the live file rather than hard-coding the list so the meta-check
+# stays in sync as the SKIP_LIST evolves.
+_SKIP_LIST_BLOCK_RE = re.compile(
+    r"^\s*SKIP_LIST=\(\s*$(.*?)^\s*\)\s*$",
+    flags=re.MULTILINE | re.DOTALL,
+)
+_SKIP_LIST_ENTRY_RE = re.compile(r'"([^"]+)"')
+
+# Self-exempt: this check's own filename. Even though it has no required
+# args today (``--scripts-dir`` is optional), exclude it defensively so a
+# future change that adds a required arg can't loop the check on itself.
+_SELF_BASENAMES: frozenset[str] = frozenset(
+    {
+        "check-ci-guards-skip-list-coverage.py",
+        "check-ci-guards-skip-list-coverage.sh",
+    }
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Data helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def parse_skip_list(umbrella_path: Path) -> set[str]:
+    """Parse the ``SKIP_LIST=( ... )`` array out of run-ci-guards.sh.
+
+    Returns the set of basenames listed. Raises ``ValueError`` if the
+    block can't be located — this is a fail-loud signal that the umbrella
+    has been refactored in a way the meta-check doesn't recognise.
+    """
+
+    text = umbrella_path.read_text(encoding="utf-8")
+    block_match = _SKIP_LIST_BLOCK_RE.search(text)
+    if block_match is None:
+        raise ValueError(
+            f"Could not locate SKIP_LIST=( ... ) block in {umbrella_path}. "
+            "The umbrella may have been refactored — update "
+            "scripts/check-ci-guards-skip-list-coverage.py to match."
+        )
+    block_body = block_match.group(1)
+    return {m.group(1) for m in _SKIP_LIST_ENTRY_RE.finditer(block_body)}
+
+
+def has_opt_out_marker(path: Path, window: int = _MARKER_WINDOW_LINES) -> bool:
+    """Return True if ``# ci-guards: skip`` appears in the first ``window`` lines."""
+
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for i, line in enumerate(fh):
+                if i >= window:
+                    break
+                if _OPT_OUT_MARKER_RE.match(line):
+                    return True
+    except (OSError, UnicodeDecodeError):
+        return False
+    return False
+
+
+def has_python_required_arg(path: Path) -> bool:
+    """Return True if the file contains ``required=True`` on any line.
+
+    This catches both the ``add_argument(..., required=True, ...)`` and
+    ``add_mutually_exclusive_group(required=True)`` forms — both are
+    semantically "the user must supply this on the command line".
+
+    A line containing ``required=True`` inside a comment or docstring
+    technically also matches, but the regex is conservative enough that
+    the false-positive risk is negligible: the ``required=True`` token is
+    not a thing one writes in prose. The 100-line cap keeps the scan
+    cheap on the largest scripts in the tree.
+    """
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return bool(_PY_REQUIRED_TRUE_RE.search(text))
+
+
+def has_shell_required_positional(path: Path) -> bool:
+    """Return True if the shell script uses ``${1:?...}`` for the first arg.
+
+    We restrict to ``${1:?...}`` rather than scanning all ``${N:?...}``
+    because this is the canonical "first positional is required" idiom
+    in this repo, and matches the AC literally (positional ``$1`` /
+    ``${1:?}`` references with no default).
+    """
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+    return bool(_SH_REQUIRED_POSITIONAL_RE.search(text))
+
+
+def is_argument_required(path: Path) -> bool:
+    """Return True if the guard requires an argument to run blind.
+
+    Dispatches on file extension:
+      * ``.py`` → argparse ``required=True``.
+      * ``.sh`` → strict positional ``${1:?...}``.
+
+    Anything else returns False.
+    """
+
+    suffix = path.suffix.lower()
+    if suffix == ".py":
+        return has_python_required_arg(path)
+    if suffix == ".sh":
+        return has_shell_required_positional(path)
+    return False
+
+
+def discover_check_scripts(scripts_dir: Path) -> list[Path]:
+    """Return every ``scripts/check-*.{sh,py}`` file at the top level.
+
+    Excludes the meta-check itself (``_SELF_BASENAMES``).  Sorts the
+    output alphabetically for deterministic violation ordering.
+    """
+
+    candidates: list[Path] = []
+    for path in scripts_dir.iterdir():
+        if not path.is_file():
+            continue
+        if path.suffix not in {".sh", ".py"}:
+            continue
+        name = path.name
+        if not name.startswith("check-"):
+            continue
+        if name in _SELF_BASENAMES:
+            continue
+        candidates.append(path)
+    candidates.sort(key=lambda p: p.name)
+    return candidates
+
+
+def find_violations(
+    scripts_dir: Path,
+    skip_list: set[str],
+) -> list[Path]:
+    """Return guards that require an arg but are missing from the SKIP_LIST.
+
+    A guard is a violation iff ALL of:
+      * it requires a CLI argument to run blind, AND
+      * its basename is NOT in ``skip_list``, AND
+      * it does NOT carry the ``# ci-guards: skip`` opt-out marker.
+
+    The .sh-wrapper-companion logic from ``run-ci-guards.sh`` is NOT
+    applied here — if a ``.py`` companion has ``required=True`` it
+    would crash if the umbrella ever ran it (e.g. the .sh wrapper got
+    deleted). Defensive coverage keeps the meta-check robust against
+    future refactors.
+    """
+
+    violations: list[Path] = []
+    for path in discover_check_scripts(scripts_dir):
+        if not is_argument_required(path):
+            continue
+        if path.name in skip_list:
+            continue
+        if has_opt_out_marker(path):
+            continue
+        violations.append(path)
+    return violations
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CLI
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _format_fix_block(violations: list[Path]) -> str:
+    """Build the copy-pasteable Fix block for an error path.
+
+    The block names every violating guard plus the two remediation
+    options (add to SKIP_LIST, or add ``# ci-guards: skip`` marker).
+    The first option includes a literal SKIP_LIST entry the operator can
+    paste into ``scripts/run-ci-guards.sh``.
+    """
+
+    lines: list[str] = []
+    lines.append("Fix: each violating guard must be either added to the umbrella's")
+    lines.append("SKIP_LIST or carry a `# ci-guards: skip` marker. Pick the option")
+    lines.append("that matches what the guard does:")
+    lines.append("")
+    lines.append("  Option A — Add to SKIP_LIST (preferred for guards that need")
+    lines.append("  external context like an issue number, body file, or PR number).")
+    lines.append("  Edit scripts/run-ci-guards.sh and append a line to the SKIP_LIST")
+    lines.append("  array (~ line 119):")
+    lines.append("")
+    for path in violations:
+        lines.append(f'      "{path.name}"')
+    lines.append("")
+    lines.append("  Option B — Add the per-file opt-out marker. Add this line as a")
+    lines.append("  top-level comment in the first 20 lines of each violating file:")
+    lines.append("")
+    lines.append("      # ci-guards: skip")
+    lines.append("")
+    lines.append("  Use Option A when the guard is generic infrastructure (lives in")
+    lines.append("  scripts/ permanently and the requirement is intrinsic to its CLI).")
+    lines.append("  Use Option B for ad-hoc guards that depend on uncommon context")
+    lines.append("  (Docker, npm-install, packages/web/ deps, etc.).")
+    lines.append("")
+    lines.append("Reference: scripts/run-ci-guards.sh §SKIP_LIST entries (lines 37-66)")
+    lines.append("for the decision rubric. Tracking: #4379 (parent #4332).")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Meta-check: every argument-required scripts/check-*.{sh,py} "
+            "guard must be in run-ci-guards.sh's SKIP_LIST or carry the "
+            "`# ci-guards: skip` marker."
+        ),
+    )
+    parser.add_argument(
+        "--scripts-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory containing the check-*.{sh,py} guards "
+            "(default: scripts/ relative to this script's location)."
+        ),
+    )
+    parser.add_argument(
+        "--umbrella",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the umbrella runner whose SKIP_LIST array is parsed "
+            "(default: <scripts-dir>/run-ci-guards.sh)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.scripts_dir is None:
+        scripts_dir = Path(__file__).resolve().parent
+    else:
+        scripts_dir = args.scripts_dir.resolve()
+
+    if not scripts_dir.is_dir():
+        print(f"ERROR: scripts/ dir not found: {scripts_dir}", file=sys.stderr)
+        return 2
+
+    if args.umbrella is None:
+        umbrella_path = scripts_dir / "run-ci-guards.sh"
+    else:
+        umbrella_path = args.umbrella.resolve()
+
+    if not umbrella_path.is_file():
+        print(f"ERROR: umbrella not found: {umbrella_path}", file=sys.stderr)
+        return 2
+
+    try:
+        skip_list = parse_skip_list(umbrella_path)
+    except (OSError, ValueError) as exc:
+        print(
+            f"ERROR: failed to parse SKIP_LIST from {umbrella_path}: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    violations = find_violations(scripts_dir, skip_list)
+    if not violations:
+        return 0
+
+    print(
+        "FAIL: argument-required guard(s) missing from "
+        "scripts/run-ci-guards.sh SKIP_LIST:",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for path in violations:
+        print(f"  - {path.name}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(_format_fix_block(violations), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-ci-guards-skip-list-coverage.sh
+++ b/scripts/check-ci-guards-skip-list-coverage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# check-ci-guards-skip-list-coverage.sh — Thin wrapper around the
+# Python implementation. See check-ci-guards-skip-list-coverage.py for
+# the full behaviour description, exit codes, and Fix-block format.
+#
+# permanent: true
+#
+# Usage:
+#   scripts/check-ci-guards-skip-list-coverage.sh
+#   scripts/check-ci-guards-skip-list-coverage.sh --scripts-dir DIR
+#
+# Exit codes:
+#   0 — every argument-required guard is in SKIP_LIST or marked.
+#   1 — one or more argument-required guards are missing.
+#   2 — script error.
+#
+# Tracking: issue #4379 (parent: #4332).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-ci-guards-skip-list-coverage.py" "$@"

--- a/scripts/tests/test_check_ci_guards_skip_list_coverage.py
+++ b/scripts/tests/test_check_ci_guards_skip_list_coverage.py
@@ -1,0 +1,559 @@
+# venv: none
+"""Unit tests for check-ci-guards-skip-list-coverage.py (#4379).
+
+Three synthetic-fixture scenarios per the AC:
+  1. Passing — every required-arg guard is in SKIP_LIST or carries marker.
+  2. Failing — a required-arg guard is missing from SKIP_LIST AND has no
+     marker; the check must exit 1 and name the guard in the Fix block.
+  3. Marker-rescued — a required-arg guard is missing from SKIP_LIST but
+     carries the ``# ci-guards: skip`` marker; the check must exit 0.
+
+Plus end-to-end tests against the real ``scripts/`` tree:
+  * ``test_real_scripts_dir_passes`` — every actual argument-required guard
+    is covered. This is the regression gate for the #4372-class bug — if
+    a future PR ships a new required-arg guard without updating SKIP_LIST,
+    this test catches it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module (hyphenated filename — can't ``import`` directly).
+SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "check-ci-guards-skip-list-coverage.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "check_ci_guards_skip_list_coverage", SCRIPT_PATH
+)
+assert spec is not None and spec.loader is not None
+check_ci_guards = importlib.util.module_from_spec(spec)
+sys.modules["check_ci_guards_skip_list_coverage"] = check_ci_guards
+spec.loader.exec_module(check_ci_guards)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures: build a synthetic scripts/ tree with three guards
+# ---------------------------------------------------------------------------
+
+
+def _write_umbrella(tmp_path: Path, skip_list: list[str]) -> Path:
+    """Write a minimal scripts/run-ci-guards.sh whose SKIP_LIST mirrors the input.
+
+    The umbrella's actual logic doesn't run here — only the SKIP_LIST=( ... )
+    block is parsed by the meta-check. We emit just enough scaffolding for
+    the parser to find the array, plus the entries themselves.
+    """
+
+    entries = "\n".join(f'    "{name}"' for name in skip_list)
+    body = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        # synthetic test umbrella
+        # permanent: true
+        SKIP_LIST=(
+        {entries}
+        )
+        """
+    )
+    path = tmp_path / "run-ci-guards.sh"
+    path.write_text(body)
+    return path
+
+
+def _write_required_py_guard(tmp_path: Path, name: str, marker: bool = False) -> Path:
+    """Create a synthetic check-*.py guard with argparse required=True."""
+
+    marker_line = "# ci-guards: skip\n" if marker else ""
+    body = (
+        "#!/usr/bin/env python3\n"
+        "# venv: none\n"
+        "# permanent: true\n"
+        f"{marker_line}"
+        '"""Synthetic guard."""\n'
+        "import argparse\n"
+        "parser = argparse.ArgumentParser()\n"
+        'parser.add_argument("--issue", required=True)\n'
+        "args = parser.parse_args()\n"
+    )
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+def _write_required_sh_guard(tmp_path: Path, name: str, marker: bool = False) -> Path:
+    """Create a synthetic check-*.sh guard with ``${1:?...}``."""
+
+    marker_line = "# ci-guards: skip\n" if marker else ""
+    body = (
+        "#!/usr/bin/env bash\n"
+        "# permanent: true\n"
+        f"{marker_line}"
+        'ISSUE="${1:?Usage: synthetic-guard <issue>}"\n'
+        'echo "$ISSUE"\n'
+    )
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+def _write_optional_py_guard(tmp_path: Path, name: str) -> Path:
+    """Create a synthetic check-*.py guard with no required args."""
+
+    body = (
+        "#!/usr/bin/env python3\n"
+        "# venv: none\n"
+        "# permanent: true\n"
+        '"""Synthetic guard with optional args."""\n'
+        "import argparse\n"
+        "parser = argparse.ArgumentParser()\n"
+        'parser.add_argument("--maybe", default=None)\n'
+        "args = parser.parse_args()\n"
+    )
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+def _write_optional_sh_guard(tmp_path: Path, name: str) -> Path:
+    """Create a synthetic check-*.sh guard with defaulted positional."""
+
+    body = '#!/usr/bin/env bash\n# permanent: true\narg="${1:-default}"\necho "$arg"\n'
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# parse_skip_list
+# ---------------------------------------------------------------------------
+
+
+class TestParseSkipList:
+    def test_parses_entries(self, tmp_path: Path) -> None:
+        umbrella = _write_umbrella(
+            tmp_path,
+            ["check-foo.sh", "check-bar.py", "check-baz.sh"],
+        )
+        result = check_ci_guards.parse_skip_list(umbrella)
+        assert result == {"check-foo.sh", "check-bar.py", "check-baz.sh"}
+
+    def test_empty_list(self, tmp_path: Path) -> None:
+        umbrella = _write_umbrella(tmp_path, [])
+        result = check_ci_guards.parse_skip_list(umbrella)
+        assert result == set()
+
+    def test_missing_block_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "no-skip-list.sh"
+        path.write_text("#!/usr/bin/env bash\necho hi\n")
+        with pytest.raises(ValueError, match="Could not locate SKIP_LIST"):
+            check_ci_guards.parse_skip_list(path)
+
+
+# ---------------------------------------------------------------------------
+# Argument-required detection
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredArgDetection:
+    def test_python_required_true_flagged(self, tmp_path: Path) -> None:
+        path = _write_required_py_guard(tmp_path, "check-thing.py")
+        assert check_ci_guards.is_argument_required(path)
+
+    def test_python_optional_only_not_flagged(self, tmp_path: Path) -> None:
+        path = _write_optional_py_guard(tmp_path, "check-thing.py")
+        assert not check_ci_guards.is_argument_required(path)
+
+    def test_python_mutex_required_group_flagged(self, tmp_path: Path) -> None:
+        # Mirrors check-issue-verify-sql.py:608 — the canonical pattern.
+        body = (
+            "#!/usr/bin/env python3\n"
+            "import argparse\n"
+            "parser = argparse.ArgumentParser()\n"
+            "src = parser.add_mutually_exclusive_group(required=True)\n"
+            'src.add_argument("--issue", type=int)\n'
+            'src.add_argument("--body-file")\n'
+        )
+        path = tmp_path / "check-mutex.py"
+        path.write_text(body)
+        assert check_ci_guards.is_argument_required(path)
+
+    def test_shell_strict_positional_flagged(self, tmp_path: Path) -> None:
+        path = _write_required_sh_guard(tmp_path, "check-thing.sh")
+        assert check_ci_guards.is_argument_required(path)
+
+    def test_shell_strict_positional_no_message_flagged(self, tmp_path: Path) -> None:
+        # ``${1:?}`` (empty error message) is also a strict-required
+        # positional and must be detected.
+        body = '#!/usr/bin/env bash\n# permanent: true\nARG="${1:?}"\necho "$ARG"\n'
+        path = tmp_path / "check-bare.sh"
+        path.write_text(body)
+        assert check_ci_guards.is_argument_required(path)
+
+    def test_shell_defaulted_positional_not_flagged(self, tmp_path: Path) -> None:
+        path = _write_optional_sh_guard(tmp_path, "check-thing.sh")
+        assert not check_ci_guards.is_argument_required(path)
+
+    def test_unknown_extension_not_flagged(self, tmp_path: Path) -> None:
+        # The dispatcher only looks at .py / .sh — a hypothetical .rb
+        # would be skipped. (No-op in practice; defensive coverage.)
+        path = tmp_path / "check-thing.rb"
+        path.write_text("# pretend Ruby script\n")
+        assert not check_ci_guards.is_argument_required(path)
+
+
+# ---------------------------------------------------------------------------
+# has_opt_out_marker
+# ---------------------------------------------------------------------------
+
+
+class TestOptOutMarker:
+    def test_marker_present_top(self, tmp_path: Path) -> None:
+        path = tmp_path / "check-marked.sh"
+        path.write_text("#!/usr/bin/env bash\n# ci-guards: skip\necho hi\n")
+        assert check_ci_guards.has_opt_out_marker(path)
+
+    def test_marker_present_with_extra_spaces(self, tmp_path: Path) -> None:
+        path = tmp_path / "check-marked.sh"
+        path.write_text("#!/usr/bin/env bash\n#   ci-guards:   skip   \necho hi\n")
+        assert check_ci_guards.has_opt_out_marker(path)
+
+    def test_marker_absent(self, tmp_path: Path) -> None:
+        path = tmp_path / "check-bare.sh"
+        path.write_text("#!/usr/bin/env bash\necho hi\n")
+        assert not check_ci_guards.has_opt_out_marker(path)
+
+    def test_marker_beyond_window_not_found(self, tmp_path: Path) -> None:
+        # Push the marker past line 20 — must NOT be detected.
+        body = (
+            "#!/usr/bin/env bash\n"
+            + ("# filler\n" * 25)
+            + "# ci-guards: skip\n"
+            + "echo hi\n"
+        )
+        path = tmp_path / "check-far.sh"
+        path.write_text(body)
+        assert not check_ci_guards.has_opt_out_marker(path)
+
+
+# ---------------------------------------------------------------------------
+# Three-fixture AC scenarios (synthetic scripts/ tree)
+# ---------------------------------------------------------------------------
+
+
+class TestThreeFixtureScenarios:
+    """Per AC #2: seed three synthetic guards (passing, missing, marker-rescued)
+    and assert the correct verdict for each."""
+
+    def _build_tree(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Return (scripts_dir, umbrella_path)."""
+
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        # Passing: required-arg guard IS in SKIP_LIST.
+        _write_required_sh_guard(scripts_dir, "check-passing.sh")
+        # Failing: required-arg guard NOT in SKIP_LIST and NO marker.
+        _write_required_py_guard(scripts_dir, "check-missing.py", marker=False)
+        # Marker-rescued: required-arg guard NOT in SKIP_LIST but HAS marker.
+        _write_required_sh_guard(scripts_dir, "check-marker.sh", marker=True)
+        umbrella = _write_umbrella(scripts_dir, ["check-passing.sh"])
+        return scripts_dir, umbrella
+
+    def test_full_tree_reports_only_missing(self, tmp_path: Path) -> None:
+        scripts_dir, umbrella = self._build_tree(tmp_path)
+        skip_list = check_ci_guards.parse_skip_list(umbrella)
+        violations = check_ci_guards.find_violations(scripts_dir, skip_list)
+        names = sorted(p.name for p in violations)
+        assert names == ["check-missing.py"]
+
+    def test_passing_alone_no_violations(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_required_sh_guard(scripts_dir, "check-passing.sh")
+        umbrella = _write_umbrella(scripts_dir, ["check-passing.sh"])
+        skip_list = check_ci_guards.parse_skip_list(umbrella)
+        assert check_ci_guards.find_violations(scripts_dir, skip_list) == []
+
+    def test_marker_alone_no_violations(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_required_sh_guard(scripts_dir, "check-marker.sh", marker=True)
+        umbrella = _write_umbrella(scripts_dir, [])
+        skip_list = check_ci_guards.parse_skip_list(umbrella)
+        assert check_ci_guards.find_violations(scripts_dir, skip_list) == []
+
+    def test_missing_alone_one_violation(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_required_py_guard(scripts_dir, "check-missing.py", marker=False)
+        umbrella = _write_umbrella(scripts_dir, [])
+        skip_list = check_ci_guards.parse_skip_list(umbrella)
+        violations = check_ci_guards.find_violations(scripts_dir, skip_list)
+        assert [p.name for p in violations] == ["check-missing.py"]
+
+
+# ---------------------------------------------------------------------------
+# discover_check_scripts: exclusion + filtering
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverCheckScripts:
+    def test_self_excluded(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_required_py_guard(
+            scripts_dir, "check-ci-guards-skip-list-coverage.py", marker=False
+        )
+        _write_required_py_guard(scripts_dir, "check-other.py", marker=False)
+        names = sorted(
+            p.name for p in check_ci_guards.discover_check_scripts(scripts_dir)
+        )
+        assert names == ["check-other.py"]
+
+    def test_non_check_files_skipped(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "tool.py").write_text("# not a check\n")
+        (scripts_dir / "README.md").write_text("# docs\n")
+        _write_required_py_guard(scripts_dir, "check-real.py")
+        names = sorted(
+            p.name for p in check_ci_guards.discover_check_scripts(scripts_dir)
+        )
+        assert names == ["check-real.py"]
+
+    def test_subdir_files_skipped(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        sub = scripts_dir / "tests"
+        sub.mkdir()
+        (sub / "check-fake.py").write_text("# in subdir\n")
+        _write_required_py_guard(scripts_dir, "check-real.py")
+        names = sorted(
+            p.name for p in check_ci_guards.discover_check_scripts(scripts_dir)
+        )
+        assert names == ["check-real.py"]
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def _build_failing_tree(self, tmp_path: Path) -> Path:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_required_py_guard(scripts_dir, "check-missing.py", marker=False)
+        _write_umbrella(scripts_dir, [])
+        return scripts_dir
+
+    def test_cli_exits_zero_on_clean_tree(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_optional_py_guard(scripts_dir, "check-fine.py")
+        _write_umbrella(scripts_dir, [])
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(scripts_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_cli_exits_one_on_violation(self, tmp_path: Path) -> None:
+        scripts_dir = self._build_failing_tree(tmp_path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(scripts_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "check-missing.py" in result.stderr
+
+    def test_cli_emits_fix_block_on_violation(self, tmp_path: Path) -> None:
+        # AC: emit a copy-pasteable Fix: block per the §Hygiene-check
+        # guards Fix-block contract.
+        scripts_dir = self._build_failing_tree(tmp_path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(scripts_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        # Fix block markers — both options must be present.
+        assert re.search(r"^Fix:", result.stderr, flags=re.MULTILINE), (
+            f"Fix: line missing from stderr:\n{result.stderr}"
+        )
+        assert "Option A" in result.stderr
+        assert "Option B" in result.stderr
+        # The literal SKIP_LIST entry the operator would paste must
+        # name the violating guard.
+        assert '"check-missing.py"' in result.stderr
+        # The marker hint must include the literal opt-out comment.
+        assert "# ci-guards: skip" in result.stderr
+
+    def test_cli_exit_two_on_missing_umbrella(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        # No umbrella file — exit 2.
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(scripts_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 2
+        assert "umbrella not found" in result.stderr.lower()
+
+    def test_cli_exit_two_on_missing_scripts_dir(self, tmp_path: Path) -> None:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(tmp_path / "nope"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 2
+
+    def test_cli_default_scans_repo(self) -> None:
+        # No --scripts-dir → scans the real scripts/ directory the script
+        # lives in. The real repo state must be clean (every required-arg
+        # guard either in SKIP_LIST or marked).
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            "Real scripts/ has a required-arg guard missing from "
+            "run-ci-guards.sh's SKIP_LIST.\n" + result.stderr
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real scripts/ directory must pass.
+# ---------------------------------------------------------------------------
+
+
+class TestRealScriptsDir:
+    """The repo's actual scripts/ tree is the regression gate.
+
+    Per AC #5: this test would have caught #4372 before merge — when
+    ``check-issue-verify-sql.py`` shipped without a SKIP_LIST entry, this
+    test (and the CI guard) would have failed.
+    """
+
+    def test_real_scripts_dir_passes(self) -> None:
+        scripts_dir = SCRIPT_PATH.parent
+        umbrella = scripts_dir / "run-ci-guards.sh"
+        skip_list = check_ci_guards.parse_skip_list(umbrella)
+        violations = check_ci_guards.find_violations(scripts_dir, skip_list)
+        assert violations == [], (
+            "Required-arg guards missing from run-ci-guards.sh SKIP_LIST:\n"
+            + "\n".join(f"  {p.name}" for p in violations)
+        )
+
+    def test_real_scripts_dir_skip_list_parses(self) -> None:
+        # Sanity: the umbrella's SKIP_LIST is parseable. If the umbrella
+        # gets refactored out from under us, this fails loudly instead of
+        # silently dropping every guard from the check.
+        umbrella = SCRIPT_PATH.parent / "run-ci-guards.sh"
+        skip_list = check_ci_guards.parse_skip_list(umbrella)
+        # The list is non-empty (sanity — there are documented entries).
+        assert len(skip_list) > 0
+        # check-issue-verify-sql.py must be in the list (regression gate
+        # for #4372 — if a future refactor accidentally drops it, this
+        # test catches that).
+        assert "check-issue-verify-sql.py" in skip_list
+
+
+# ---------------------------------------------------------------------------
+# Regression simulation: AC #5 — without the #4372 fix, the check fails.
+# ---------------------------------------------------------------------------
+
+
+class TestPre4372Regression:
+    """AC #5: revert the #4372 SKIP_LIST entry locally and confirm exit 1.
+
+    We don't actually mutate the umbrella in the worktree — instead, we
+    pass a synthetic umbrella whose SKIP_LIST omits ``check-issue-verify-sql.py``
+    while pointing the check at the real scripts/ dir. This simulates the
+    pre-#4372 state exactly.
+    """
+
+    def test_pre_4372_state_fails(self, tmp_path: Path) -> None:
+        scripts_dir = SCRIPT_PATH.parent
+        real_umbrella = scripts_dir / "run-ci-guards.sh"
+        real_skip = check_ci_guards.parse_skip_list(real_umbrella)
+        # Drop the #4372 entry — this is the pre-#4372 SKIP_LIST.
+        broken_skip = real_skip - {"check-issue-verify-sql.py"}
+        # Build a synthetic umbrella with the broken list so we don't
+        # touch the working-tree umbrella.
+        broken_umbrella = _write_umbrella(tmp_path, sorted(broken_skip))
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(scripts_dir),
+                "--umbrella",
+                str(broken_umbrella),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1, (
+            "Expected meta-check to fail when check-issue-verify-sql.py is "
+            "missing from SKIP_LIST.\nstdout: "
+            + result.stdout
+            + "\nstderr: "
+            + result.stderr
+        )
+        assert "check-issue-verify-sql.py" in result.stderr
+
+    def test_post_4372_state_passes(self) -> None:
+        # The current real umbrella with the #4372 fix in place — the
+        # check must exit 0. (Same as test_real_scripts_dir_passes but
+        # framed as "the fix is in place.")
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Adds `scripts/check-ci-guards-skip-list-coverage.{sh,py}` — a meta-check
that fails CI when a `scripts/check-*.{sh,py}` guard takes hard-required
arguments (`argparse required=True` / mutex `required=True` group / shell
`${1:?}`) but is missing from `scripts/run-ci-guards.sh`'s `SKIP_LIST` AND
does not carry the `# ci-guards: skip` opt-out marker. Closes the
#4332 → #4372 regression class structurally — every future required-arg
guard either lands in `SKIP_LIST` or carries the marker before merge,
instead of triggering a manual follow-up PR after the umbrella crashes
locally.

Wired into `.github/workflows/ci.yml` as its own job (and into
`ci-passed.needs:`) and surfaces locally via `scripts/run-ci-guards.sh`
(the umbrella picks the new `.sh` up automatically because it has no
required args itself). Inventory row added at #11a in
`docs/dx/check-script-fix-block-coverage.md`.

Closes #4379

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (CI guard + local umbrella + tests only).

## Verification

- 31/31 tests pass: `PYTHONPATH=scripts python3 -m pytest scripts/tests/test_check_ci_guards_skip_list_coverage.py -v`
- AC #1: `scripts/check-ci-guards-skip-list-coverage.sh` exits 0 on the clean tree.
- AC #2: three synthetic-fixture scenarios covered by `TestThreeFixtureScenarios::test_full_tree_reports_only_missing` (passing + missing-no-marker + missing-with-marker → only the no-marker case is reported).
- AC #3: `grep -n check-ci-guards-skip-list-coverage .github/workflows/ci.yml` shows the job and the `ci-passed.needs:` entry.
- AC #4: `scripts/run-ci-guards.sh --list 2>&1 | grep check-ci-guards-skip-list-coverage` shows the new check under `RUN`.
- AC #5: `TestPre4372Regression::test_pre_4372_state_fails` passes a synthetic umbrella with the #4372 SKIP_LIST entry removed and asserts exit 1 with `check-issue-verify-sql.py` named in stderr; `test_post_4372_state_passes` asserts exit 0 against the live umbrella.
- Full umbrella green: `scripts/run-ci-guards.sh` reports "all 73 guard(s) passed."
