### PR TITLE
fix(reingest): register _SCRAPER_REGISTRY under _SPLIT_REGISTRY_ALIASES (#4386)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -2288,11 +2288,15 @@ _SCRAPER_CLASS_BY_ID: dict[str, type] = {
     "ca-la-tentatives-appellate": LAAppellateTentativeRulingsScraper,
 }
 
-# Extra scraper_ids under which this module's ``_split_rulings`` /
-# ``_llm_extract_rulings`` should be registered.  Required so audit / drain
-# scripts that key on ``documents.scraper_id`` resolve the splitter on
-# rebuild-path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``,
-# which emits ``rebuild-ca-los_angeles`` instead of the live ``ca-la-...`` id).
+# Extra scraper_ids under which this module's ``_SCRAPER_REGISTRY`` (#4386),
+# ``_split_rulings`` (#4331), and ``_llm_extract_rulings`` (#4331) should be
+# registered.  Required so audit / drain / reingest scripts that key on
+# ``documents.scraper_id`` resolve the scraper class and splitter on rebuild-
+# path rows (rows reconstructed from S3 by ``scripts/rebuild_db.py``, which
+# emits ``rebuild-ca-los_angeles`` instead of the live ``ca-la-...`` id).
 # Both civil and appellate share this rebuild id since they're produced from
-# the same county slug.  See #4331.
+# the same county slug.  See #4331 (split-registry aliasing) and #4386
+# (scraper-class registry aliasing — without it, ``_reparse_document``
+# returned ``None`` for the scraper class, ``parse_document`` was never
+# called, and the LA rebuild path silently dropped its judge_id resolution).
 _SPLIT_REGISTRY_ALIASES: list[str] = ["rebuild-ca-los_angeles"]

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -4084,6 +4084,12 @@ class TestScraperRegistryAutoDiscovery:
         Multi-scraper modules (those exporting ``_SCRAPER_CLASS_BY_ID`` with
         multiple ``default_config_<suffix>`` factories) contribute one expected
         scraper_id per factory (#2599).
+
+        Modules exporting ``_SPLIT_REGISTRY_ALIASES`` also contribute one
+        expected entry per alias — these are the rebuild-path scraper_ids
+        emitted by ``scripts/rebuild_db.py`` and the loader registers them
+        under the canonical scraper class so ``_reparse_document`` can call
+        ``parse_document`` on rebuild rows (#4386).
         """
         import inspect
         import pkgutil
@@ -4121,6 +4127,10 @@ class TestScraperRegistryAutoDiscovery:
                     _name == "default_config" or _name.startswith("default_config_")
                 ) and obj.__module__ == mod.__name__:
                     expected_ids.add(obj().scraper_id)
+            # Include _SPLIT_REGISTRY_ALIASES entries — the loader registers
+            # the scraper class under each alias too (#4386).
+            for alias in getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or []:
+                expected_ids.add(alias)
 
         reingest._load_scraper_registry()
         assert expected_ids == set(reingest._SCRAPER_REGISTRY.keys())
@@ -4352,11 +4362,18 @@ class TestReparsePdfDocuments:
             )
 
     def test_registry_keys_match_default_config_scraper_id(self) -> None:
-        """Each registry key should match a ``default_config*()`` factory's scraper_id.
+        """Each registry key should match a ``default_config*()`` factory's scraper_id
+        or one of the module's declared ``_SPLIT_REGISTRY_ALIASES``.
 
         Multi-scraper modules (#2599) expose multiple factories; walk them all
         and verify that every registered ``scraper_id`` is produced by some
         ``default_config*()`` factory in the class's module.
+
+        Aliases declared via ``_SPLIT_REGISTRY_ALIASES`` (#4386) are also
+        valid keys — the loader registers the canonical scraper class under
+        each alias so ``_reparse_document`` can call ``parse_document`` on
+        rebuild-path rows.  An alias key is valid iff the alias appears in
+        the registered class's module's ``_SPLIT_REGISTRY_ALIASES``.
         """
         import importlib
         import inspect
@@ -4370,9 +4387,11 @@ class TestReparsePdfDocuments:
                     _name == "default_config" or _name.startswith("default_config_")
                 ) and obj.__module__ == mod.__name__:
                     factory_ids.add(obj().scraper_id)
-            assert scraper_id in factory_ids, (
+            alias_ids: set[str] = set(getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or [])
+            assert scraper_id in (factory_ids | alias_ids), (
                 f"scraper_id {scraper_id!r} not produced by any default_config* "
-                f"factory in {mod.__name__}"
+                f"factory in {mod.__name__} (factories produce {sorted(factory_ids)}, "
+                f"aliases declare {sorted(alias_ids)})"
             )
 
     def test_idempotent_load(self) -> None:

--- a/packages/scraper-framework/tests/test_reingest_registry.py
+++ b/packages/scraper-framework/tests/test_reingest_registry.py
@@ -122,7 +122,10 @@ def _get_all_scraper_ids() -> dict[str, str]:
     """Return {scraper_id: module_path} for every known scraper module.
 
     Multi-scraper modules contribute one entry per ``default_config*``
-    factory (#2599).
+    factory (#2599).  Modules that export ``_SPLIT_REGISTRY_ALIASES`` also
+    contribute one entry per alias (#4386 — the rebuild-path scraper_id
+    must resolve to the same scraper class as the canonical id so
+    ``_reparse_document`` can call ``parse_document`` on rebuild rows).
     """
     result: dict[str, str] = {}
     seen_modules: set[str] = set()
@@ -134,6 +137,12 @@ def _get_all_scraper_ids() -> dict[str, str]:
         for factory in _discover_config_factories(mod):
             config = factory()
             result[config.scraper_id] = module_path
+        # Include _SPLIT_REGISTRY_ALIASES entries — these are registered
+        # in ``_SCRAPER_REGISTRY`` by the loader (#4386), so they must
+        # appear in the expected set or the coverage check below would
+        # flag them as "extra unknown ids".
+        for alias in getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or []:
+            result[alias] = module_path
     return result
 
 
@@ -156,12 +165,35 @@ class TestScraperRegistryNonEmpty:
         )
 
     def test_registry_has_all_known_scrapers(self) -> None:
-        """The registry must contain an entry for every discovered scraper module."""
+        """The registry must contain an entry for every discovered scraper module.
+
+        Counts both canonical scraper_ids (one per registered class) and
+        ``_SPLIT_REGISTRY_ALIASES`` entries (one per alias per multi-class
+        module — both LA classes share the same alias, so the alias adds
+        one entry total even though the module has two classes).
+        """
         reingest._SCRAPER_REGISTRY.clear()
         reingest._load_scraper_registry()
-        assert len(reingest._SCRAPER_REGISTRY) == len(_SCRAPER_MODULES), (
+        # Canonical entries: one per (module, class) tuple in _SCRAPER_MODULES.
+        canonical_count = len(_SCRAPER_MODULES)
+        # Alias entries: each module's _SPLIT_REGISTRY_ALIASES register the
+        # *same* alias key across all its classes, so the alias contributes
+        # only one entry per module per alias (the second class's
+        # ``_SCRAPER_REGISTRY[alias] = scraper_cls`` overwrites the first
+        # under the same key).
+        alias_count = 0
+        seen_modules: set[str] = set()
+        for module_path, _class_name in _SCRAPER_MODULES:
+            if module_path in seen_modules:
+                continue
+            seen_modules.add(module_path)
+            mod = _load_module(module_path)
+            alias_count += len(getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or [])
+        expected_count = canonical_count + alias_count
+        assert len(reingest._SCRAPER_REGISTRY) == expected_count, (
             f"Registry has {len(reingest._SCRAPER_REGISTRY)} entries but "
-            f"auto-discovery found {len(_SCRAPER_MODULES)} scraper modules"
+            f"auto-discovery found {canonical_count} scraper modules and "
+            f"{alias_count} alias entries (total expected {expected_count})"
         )
 
     def test_discovery_found_scrapers(self) -> None:
@@ -176,7 +208,15 @@ class TestRegistryKeysMatchDefaultConfig:
     """Every registered key must match a ``default_config*`` factory's scraper_id."""
 
     def test_all_keys_match_default_config_scraper_id(self) -> None:
-        """Each key must equal some ``default_config*()`` factory's scraper_id."""
+        """Each key must equal a ``default_config*()`` factory's scraper_id or a declared alias.
+
+        Aliases come from a module's ``_SPLIT_REGISTRY_ALIASES`` and resolve
+        the rebuild-path scraper_ids emitted by ``scripts/rebuild_db.py``
+        to the canonical scraper class (#4386).  An alias entry is valid
+        iff the alias appears in the same module's ``_SPLIT_REGISTRY_ALIASES``
+        as the registered class — guards against accidental cross-module
+        alias bleeding.
+        """
         reingest._SCRAPER_REGISTRY.clear()
         reingest._load_scraper_registry()
 
@@ -189,11 +229,14 @@ class TestRegistryKeysMatchDefaultConfig:
             # for single-scraper modules this is one id; for multi-scraper
             # modules (#2599) it's one per factory.
             factory_ids = {f().scraper_id for f in _discover_config_factories(mod)}
+            # Alias scraper_ids declared by this module (#4386).
+            alias_ids = set(getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or [])
 
-            assert registry_key in factory_ids, (
+            assert registry_key in (factory_ids | alias_ids), (
                 f"Registry key {registry_key!r} does not match any "
-                f"default_config*().scraper_id in {module_name} "
-                f"(module offers {sorted(factory_ids)})"
+                f"default_config*().scraper_id or _SPLIT_REGISTRY_ALIASES "
+                f"in {module_name} (module offers {sorted(factory_ids)}, "
+                f"aliases {sorted(alias_ids)})"
             )
 
 

--- a/packages/scraper-framework/tests/test_split_registry.py
+++ b/packages/scraper-framework/tests/test_split_registry.py
@@ -1,30 +1,40 @@
-"""Regression tests for the splitter alias mechanism (#4331).
+"""Regression tests for the splitter alias mechanism (#4331, #4386).
 
 The discovery loop in ``scripts/reingest_from_s3.py:_load_scraper_registry``
 walks every court module that exposes ``default_config()`` and registers its
-``_split_rulings`` / ``_llm_extract_rulings`` callables in the ``_SPLIT_REGISTRY``
-/ ``_LLM_SPLIT_REGISTRY`` dicts under the canonical ``scraper_id``.  These
-tests verify that any module exporting an additional ``_SPLIT_REGISTRY_ALIASES``
-list also registers the same callables under each alias scraper_id.
+scraper class plus its ``_split_rulings`` / ``_llm_extract_rulings`` callables
+in the ``_SCRAPER_REGISTRY`` / ``_SPLIT_REGISTRY`` / ``_LLM_SPLIT_REGISTRY``
+dicts under the canonical ``scraper_id``.  These tests verify that any module
+exporting an additional ``_SPLIT_REGISTRY_ALIASES`` list also registers the
+scraper class and the same callables under each alias scraper_id.
 
 Why aliases are needed.  ``scripts/rebuild_db.py`` reconstructs rows from S3
 by emitting a synthetic ``rebuild-{state}-{county}`` scraper_id (rather than
 the live ``ca-{abbrev}-...`` id).  Audit and drain scripts that key on
 ``documents.scraper_id`` look up ``_SPLIT_REGISTRY[scraper_id]`` directly —
 without an alias entry, every rebuild-path row silently no-ops because the
-canonical scraper_id never matches.  Issue #4331 documents the failure mode:
-21 SC ``all_same_case_title_cluster`` rows were stuck on the rebuild path
-because ``ca-sc-tentatives-civil`` was registered but ``rebuild-ca-santa_clara``
-was not.
+canonical scraper_id never matches.  Issue #4331 documents the failure mode
+for the split registries: 21 SC ``all_same_case_title_cluster`` rows were
+stuck on the rebuild path because ``ca-sc-tentatives-civil`` was registered
+but ``rebuild-ca-santa_clara`` was not.
+
+Issue #4386 extends the contract to ``_SCRAPER_REGISTRY``: when
+``_reparse_document`` looks up the scraper class for a rebuild-path row, the
+absence of an alias entry made it return ``None``, ``parse_document`` was
+never called, and ``extracted["ruling_text"]`` kept its raw HTML — which
+``check_no_html_in_ruling_text`` then rejected, skipping the DB write and the
+judge resolver chain (root-caused for LA dept-25 in
+``docs/investigations/la-dept-25-html-in-ruling-text-2026-05.md``).
 
 This test file enforces the contract that:
 
 1. Every module declaring ``_SPLIT_REGISTRY_ALIASES`` registers each alias.
-2. Each alias resolves to the SAME callable as the canonical scraper_id
-   (so the splitter behaviour is identical regardless of which id surfaces).
+2. Each alias resolves to the SAME callable / class as the canonical
+   scraper_id (so splitter and parse-document behaviour is identical
+   regardless of which id surfaces).
 3. Every county that has a splitter has a matching ``rebuild-ca-<county>``
-   alias — so a future scraper_id rename can't silently break splitter
-   resolution on rebuild rows.
+   alias — so a future scraper_id rename can't silently break splitter or
+   scraper-class resolution on rebuild rows.
 """
 
 from __future__ import annotations
@@ -149,6 +159,51 @@ class TestAliasesPlumbedIntoRegistry:
                     f"audit / drain on rebuild rows silently no-ops."
                 )
 
+    def test_every_alias_registers_scraper_class(self) -> None:
+        """Every alias must resolve to a registered scraper class (#4386).
+
+        This is the ``_SCRAPER_REGISTRY`` companion to the split-registry
+        checks above.  ``_reparse_document`` looks up the scraper class via
+        ``_SCRAPER_REGISTRY.get(scraper_id)``; if the rebuild-path alias is
+        missing, the lookup returns ``None``, ``parse_document`` is never
+        called, and ``extracted["ruling_text"]`` keeps the raw HTML page —
+        which ``check_no_html_in_ruling_text`` rejects, skipping the DB
+        write and the judge resolver chain (LA dept-25 reproducer in
+        ``docs/investigations/la-dept-25-html-in-ruling-text-2026-05.md``).
+        """
+        self._reload_registries()
+        for mod in _discover_modules_with_aliases():
+            canonical_ids = _canonical_scraper_ids(mod)
+            if not canonical_ids:
+                # Module declares aliases but exports no default_config —
+                # nothing to register a scraper class against.
+                continue
+            for canonical_id in canonical_ids:
+                canonical_cls = reingest._SCRAPER_REGISTRY.get(canonical_id)
+                assert canonical_cls is not None, (
+                    f"Canonical scraper_id {canonical_id!r} from "
+                    f"{mod.__name__} did not register a scraper class in "
+                    f"_SCRAPER_REGISTRY."
+                )
+            for alias in mod._SPLIT_REGISTRY_ALIASES:
+                alias_cls = reingest._SCRAPER_REGISTRY.get(alias)
+                assert alias_cls is not None, (
+                    f"Alias scraper_id {alias!r} declared by {mod.__name__} "
+                    f"did not register a scraper class in _SCRAPER_REGISTRY. "
+                    f"This is the #4386 failure mode — _reparse_document "
+                    f"will fall through and leave raw HTML in ruling_text."
+                )
+                # Sanity: the alias should map to one of the module's
+                # registered classes (it cannot map to the wrong module's
+                # class because aliases are scoped to a single module in
+                # _load_scraper_registry).
+                assert alias_cls in {reingest._SCRAPER_REGISTRY[cid] for cid in canonical_ids}, (
+                    f"Alias scraper_id {alias!r} declared by {mod.__name__} "
+                    f"resolves to {alias_cls!r}, which is not one of the "
+                    f"module's canonical classes "
+                    f"{[reingest._SCRAPER_REGISTRY[cid] for cid in canonical_ids]!r}."
+                )
+
     def test_every_alias_registers_llm_split_fn_when_canonical_does(self) -> None:
         """If a module's canonical scraper_id has an LLM splitter, every alias must too."""
         self._reload_registries()
@@ -197,6 +252,58 @@ class TestSantaClaraReproducerSatisfied:
         assert reingest._SPLIT_REGISTRY["rebuild-ca-santa_clara"] is sc_tentatives._split_rulings, (
             "rebuild-ca-santa_clara resolves to a function but not the SC "
             "splitter — alias plumbing crossed wires."
+        )
+
+
+class TestLosAngelesReproducerSatisfied:
+    """Direct regression for the #4386 reproducer (LA dept-25 HTML-in-ruling_text)."""
+
+    def test_rebuild_ca_los_angeles_resolves_to_la_scraper_class(self) -> None:
+        """``_SCRAPER_REGISTRY['rebuild-ca-los_angeles']`` must resolve to LA's class.
+
+        This is the literal failure mode from #4386: LA's dept-25
+        rebuild-path rows carried ``scraper_id='rebuild-ca-los_angeles'``,
+        ``_reparse_document`` looked up ``_SCRAPER_REGISTRY`` with that
+        key, got ``None``, and ``parse_document`` was never called — so
+        ``extracted["ruling_text"]`` kept its raw HTML, the deterministic
+        validator rejected it, and the DB write (and judge resolution)
+        was skipped.
+
+        Root-cause writeup:
+        ``docs/investigations/la-dept-25-html-in-ruling-text-2026-05.md``.
+        """
+        reingest._SCRAPER_REGISTRY.clear()
+        reingest._SPLIT_REGISTRY.clear()
+        reingest._LLM_SPLIT_REGISTRY.clear()
+        reingest._load_scraper_registry()
+
+        assert "rebuild-ca-los_angeles" in reingest._SCRAPER_REGISTRY, (
+            "rebuild-ca-los_angeles not registered in _SCRAPER_REGISTRY — "
+            "_reparse_document will return None for the scraper class, "
+            "parse_document will never be called, and ruling_text will "
+            "stay as raw HTML (#4386)."
+        )
+
+        from courts.ca import la_tentatives  # type: ignore[import-not-found]
+
+        # Both LA scrapers (civil + appellate) share this rebuild id.
+        # The discovery loop iterates ``_SCRAPER_CLASS_BY_ID`` in dict
+        # insertion order (civil then appellate), so the alias entry
+        # ends up pointing at the *last* registered class — appellate.
+        # Either is correct for satisfying the AC ("does NOT start with
+        # <html"): both expose ``parse_document`` and call into
+        # ``_split_rulings`` to narrow per-case.  We assert the alias
+        # resolves to one of the module's classes rather than pinning
+        # to a specific one — pinning would make the test brittle to
+        # an unrelated _SCRAPER_CLASS_BY_ID reorder.
+        alias_cls = reingest._SCRAPER_REGISTRY["rebuild-ca-los_angeles"]
+        assert alias_cls in (
+            la_tentatives.LATentativeRulingsScraper,
+            la_tentatives.LAAppellateTentativeRulingsScraper,
+        ), (
+            f"rebuild-ca-los_angeles resolves to {alias_cls!r}, which is "
+            f"not one of LA's registered scraper classes — alias plumbing "
+            f"crossed wires (#4386)."
         )
 
 
@@ -334,3 +441,38 @@ class TestAliasContractIsolated:
             "alias mechanism may have inadvertently broken canonical "
             "registration for modules without _SPLIT_REGISTRY_ALIASES."
         )
+
+    def test_alias_registers_in_scraper_registry(self) -> None:
+        """A module with _SPLIT_REGISTRY_ALIASES must also register its scraper class
+        under each alias in ``_SCRAPER_REGISTRY`` (#4386).
+
+        Mirrors ``test_alias_registers_in_split_registry`` for the
+        scraper-class registry.  Uses a real reload of the production
+        loader against a known-aliased module (sd_calendar) rather than a
+        synthetic ``types.ModuleType`` because ``_SCRAPER_REGISTRY``
+        registration depends on the discovery loop's ``default_config()``
+        + ``_SCRAPER_CLASS_BY_ID`` resolution path, which is harder to
+        fake than the bare ``getattr(_split_rulings)`` lookup.
+        """
+        reingest._SCRAPER_REGISTRY.clear()
+        reingest._SPLIT_REGISTRY.clear()
+        reingest._LLM_SPLIT_REGISTRY.clear()
+        reingest._load_scraper_registry()
+
+        # SD is the simplest end-to-end witness: one canonical
+        # scraper_id, one alias.
+        from courts.ca import sd_calendar  # type: ignore[import-not-found]
+
+        canonical_id = sd_calendar.default_config().scraper_id
+        canonical_cls = reingest._SCRAPER_REGISTRY.get(canonical_id)
+        assert canonical_cls is not None, (
+            f"sd_calendar canonical scraper_id {canonical_id!r} did not "
+            f"register a scraper class — discovery loop is broken."
+        )
+
+        for alias in sd_calendar._SPLIT_REGISTRY_ALIASES:
+            assert reingest._SCRAPER_REGISTRY.get(alias) is canonical_cls, (
+                f"sd_calendar alias {alias!r} did not register the same "
+                f"scraper class as the canonical id {canonical_id!r} — "
+                f"#4386 alias plumbing is wrong."
+            )

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -391,6 +391,20 @@ def _load_scraper_registry() -> None:
             # canonical scraper_id only.
             split_aliases: list[str] = getattr(mod, "_SPLIT_REGISTRY_ALIASES", []) or []
 
+            # Register the scraper class under each alias too.  Without
+            # this, ``_reparse_document`` (line ~1123) fails to resolve
+            # rebuild-path rows to a class, ``parse_document`` is never
+            # called, and ``extracted["ruling_text"]`` keeps the raw HTML
+            # — which ``check_no_html_in_ruling_text`` then rejects,
+            # skipping the DB write and the judge resolver chain.  The
+            # split / llm-split registries already honored aliases
+            # (below); aliasing the scraper-class registry closes the
+            # gap so future counties that define
+            # ``_SPLIT_REGISTRY_ALIASES`` get the same upgrade for free
+            # (#4386).
+            for alias in split_aliases:
+                _SCRAPER_REGISTRY[alias] = scraper_cls
+
             # Register split function if the module exports one.
             # Convention: a module-level ``_split_rulings`` callable
             # indicates that the scraper produces multi-ruling documents
@@ -1225,13 +1239,23 @@ def _reparse_document(
     # ------------------------------------------------------------------
     # San Diego direct narrowing (#2311, #2381)
     # ------------------------------------------------------------------
-    # San Diego calendar pages contain 30+ cases per HTML file.  When a
-    # document has no registered scraper class (e.g. scraper_id
-    # "rebuild-ca-san_diego" from rebuild_db.py), ``parse_document`` is
-    # never called and ``extracted["ruling_text"]`` remains the full raw
-    # HTML page (~50KB).  We narrow directly here so the stored
-    # ruling_text becomes the plain-text excerpt for the specific case,
-    # independent of whether LLM extraction runs below.
+    # San Diego calendar pages contain 30+ cases per HTML file.
+    # Historically, when a document had no registered scraper class
+    # (e.g. scraper_id "rebuild-ca-san_diego" from rebuild_db.py),
+    # ``parse_document`` was never called and ``extracted["ruling_text"]``
+    # remained the full raw HTML page (~50KB).
+    #
+    # As of #4386, ``_load_scraper_registry`` registers
+    # ``_SCRAPER_REGISTRY`` under each ``_SPLIT_REGISTRY_ALIASES`` entry
+    # too, so rebuild-path scraper_ids now resolve to the canonical
+    # scraper class and ``parse_document`` IS called.  This narrowing
+    # block is kept as belt-and-suspenders defense for any SD document
+    # whose scraper class still happens to be unregistered (e.g. a
+    # synthetic future scraper_id outside the alias list, or an
+    # initialization failure that left the registry partially loaded).
+    # We narrow directly here so the stored ruling_text becomes the
+    # plain-text excerpt for the specific case, independent of whether
+    # LLM extraction runs below.
     sd_case_num = extracted.get("case_number")
     if (
         sd_case_num


### PR DESCRIPTION
## Summary

Extends `scripts/reingest_from_s3.py:_load_scraper_registry` to register the scraper class under each `_SPLIT_REGISTRY_ALIASES` entry, mirroring what `_SPLIT_REGISTRY` and `_LLM_SPLIT_REGISTRY` already do. Closes the gap that caused LA dept-25 documents to retain raw HTML in `ruling_text` and fail the deterministic validator (root-caused in #4382). Benefits all 7 CA counties that declare aliases (cc, fresno, la, riverside, sc, sd, sf).

Closes #4386

## Test plan

### Automated checks
- [x] Lint passes (ruff check, all 5 modified files)
- [x] Format check passes (ruff format --check, all 5 modified files)
- [x] Tests pass (full scraper-framework suite: 7610 passed, 3 skipped, 97% coverage)
- [x] Regression-test contract: 3 new tests confirmed to FAIL without the production fix and PASS with it (`test_every_alias_registers_scraper_class`, `test_rebuild_ca_los_angeles_resolves_to_la_scraper_class`, `test_alias_registers_in_scraper_registry`)
- [x] CI green

### Post-deploy verification
- [x] Reingest LA dept-25 on dev: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "Los Angeles" --department-in 25 --no-llm` (126 docs, 126 updated, 0 failed, 16.9s)
- [x] Confirm reingest logs show no `no_html_in_ruling_text` failures for dept-25 documents (CloudWatch Insights: 0 occurrences in run window)
- [x] Confirm dept-25 NULL judge count dropped (119 → 62, 48% reduction; see issue evidence comment for residual-NULL caveat)
- [x] Verification evidence posted on issue
