### PR TITLE
fix(observability): migrate remaining scripts/*.py to configure_structlog (#4373)

### DIFF
--- a/scripts/audit_correctly_labeled_s3_orphans.py
+++ b/scripts/audit_correctly_labeled_s3_orphans.py
@@ -51,10 +51,18 @@ from typing import Iterator
 import boto3
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string (``"%(asctime)s %(levelname)-8s %(message)s"``) silently dropped
+# every ``extra=`` field — see #4368 for the post-deploy verification
+# incident that motivated migrating every ``scripts/*.py`` to this pattern
+# (#4373).
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/audit_field_completeness.py
+++ b/scripts/audit_field_completeness.py
@@ -32,10 +32,15 @@ import sys
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 AUDIT_QUERY = """

--- a/scripts/audit_llm_carry_forward.py
+++ b/scripts/audit_llm_carry_forward.py
@@ -88,10 +88,15 @@ def _load_psycopg() -> Any:
     return psycopg
 
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/audit_oc_ruling_integrity.py
+++ b/scripts/audit_oc_ruling_integrity.py
@@ -39,10 +39,15 @@ import sys
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/audit_s3_raw_mislabels.py
+++ b/scripts/audit_s3_raw_mislabels.py
@@ -35,12 +35,16 @@ import sys
 
 import boto3
 
+from framework.logging import configure_structlog
 from framework.s3_integrity import S3MislabelError, verify_key_matches_bytes
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")

--- a/scripts/audit_scraper_field_population.py
+++ b/scripts/audit_scraper_field_population.py
@@ -84,10 +84,15 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_bare_vs_case_titles.py
+++ b/scripts/backfill_bare_vs_case_titles.py
@@ -30,10 +30,15 @@ import sys
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_braner_canonical_typo_3858.py
+++ b/scripts/backfill_braner_canonical_typo_3858.py
@@ -28,10 +28,15 @@ import sys
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 _JUDGE_UUID = "bafa63e4-6a93-4d97-b00e-92e446857c7c"

--- a/scripts/backfill_repeated_title_cleanup.py
+++ b/scripts/backfill_repeated_title_cleanup.py
@@ -29,12 +29,16 @@ import sys
 
 import psycopg
 
+from framework.logging import configure_structlog
 from ingestion.extract import dedupe_repeated_title, strip_trailing_case_number
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-scraper-zero-record-runner.py
+++ b/scripts/check-scraper-zero-record-runner.py
@@ -47,10 +47,15 @@ from datetime import UTC, datetime
 from importlib import import_module
 from pathlib import Path
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -64,10 +64,15 @@ from typing import Any
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/check-short-unsubstantive-rulings.py
+++ b/scripts/check-short-unsubstantive-rulings.py
@@ -46,10 +46,15 @@ from typing import Any
 
 import psycopg
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -54,10 +54,15 @@ def _import_trend_storage():  # noqa: ANN202
     return _dq_trend_storage
 
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string silently dropped every ``extra=`` field — see #4368 / #4373.
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # Resolve repo root from scripts/ directory.

--- a/scripts/tests/test_audit_correctly_labeled_s3_orphans.py
+++ b/scripts/tests/test_audit_correctly_labeled_s3_orphans.py
@@ -10,8 +10,12 @@ Covers:
 - --json output schema is stable
 - fetch_db_s3_keys issues correct LIKE query
 
-The script imports boto3 and psycopg at module level; we mock them before
-importing to support CI environments without those packages installed.
+The script imports boto3, psycopg, structlog, and framework.logging at module
+level; we mock them before importing to support the CI scripts-tests (python)
+environment which only installs ``pytest pytest-xdist boto3 -e
+packages/judgemind-config``. Mirrors the post-#4368 pattern used in
+``test_drain_splitter_carry_forward_clusters.py`` /
+``test_backfill_split_supersede.py``. Migrated as part of #4373.
 """
 
 from __future__ import annotations
@@ -27,17 +31,28 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 # ---------------------------------------------------------------------------
-# Pre-import mocking — inject boto3 + psycopg mocks before the script loads.
+# Pre-import mocking — inject boto3, psycopg, structlog, and framework.logging
+# mocks before the script loads. The script's top-level
+# ``from framework.logging import configure_structlog`` would otherwise raise
+# ModuleNotFoundError in the lightweight CI scripts-tests (python) shard
+# (which only installs pytest, pytest-xdist, boto3, judgemind-config). See #4373.
 # ---------------------------------------------------------------------------
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 _mock_boto3 = MagicMock()
 _mock_psycopg = MagicMock()
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+_mock_framework = MagicMock()
+_mock_framework_logging = MagicMock()
 
 _modules_to_mock = {
     "boto3": _mock_boto3,
     "psycopg": _mock_psycopg,
+    "structlog": _mock_structlog,
+    "framework": _mock_framework,
+    "framework.logging": _mock_framework_logging,
 }
 
 _saved_modules: dict[str, object] = {}

--- a/scripts/tests/test_audit_llm_carry_forward.py
+++ b/scripts/tests/test_audit_llm_carry_forward.py
@@ -7,7 +7,11 @@ Covers the four carry-forward check primitives:
 - case_title_text_mismatch (no case_title party word in ruling_text)
 
 The script imports ``psycopg`` lazily inside ``run_audit``, so tests can
-import the module without a live DB connection.
+import the module without a live DB connection. The script also imports
+``framework.logging`` (which transitively imports ``structlog``) at module
+level since the #4373 migration; we pre-mock both in ``sys.modules`` so the
+lightweight CI scripts-tests (python) shard import works (it only installs
+pytest, pytest-xdist, boto3, judgemind-config).
 
 Cluster check 4 (all_same_case_title_cluster) is SQL-only and tested via
 ``run_audit`` integration tests using a mock psycopg connection.
@@ -19,9 +23,41 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+# ---------------------------------------------------------------------------
+# Pre-import mocking — inject structlog and framework.logging mocks before
+# the script loads. The script's top-level
+# ``from framework.logging import configure_structlog`` would otherwise raise
+# ModuleNotFoundError in the lightweight CI scripts-tests (python) shard.
+# See #4373.
+# ---------------------------------------------------------------------------
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+_mock_framework = MagicMock()
+_mock_framework_logging = MagicMock()
+
+_modules_to_mock = {
+    "structlog": _mock_structlog,
+    "framework": _mock_framework,
+    "framework.logging": _mock_framework_logging,
+}
+
+_saved_modules: dict[str, object] = {}
+for _mod_name, _mock_mod in _modules_to_mock.items():
+    if _mod_name in sys.modules:
+        _saved_modules[_mod_name] = sys.modules[_mod_name]
+    sys.modules[_mod_name] = _mock_mod
+
 import audit_llm_carry_forward as _script  # noqa: E402
+
+# Restore sys.modules to avoid polluting other test files.
+for _mod_name in list(_modules_to_mock.keys()):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
 
 _check_outcome_continue = _script._check_outcome_continue
 _check_motion_type_contradiction = _script._check_motion_type_contradiction

--- a/scripts/tests/test_audit_scraper_field_population.py
+++ b/scripts/tests/test_audit_scraper_field_population.py
@@ -11,7 +11,11 @@ Covers:
 - main() --dry-run --write-issue-body writes a non-empty file
 
 The script imports boto3 + psycopg lazily (only inside main's real run);
-tests can import the module without those deps.
+tests can import the module without those deps. The script also imports
+``framework.logging`` (which transitively imports ``structlog``) at module
+level since the #4373 migration; we pre-mock both in ``sys.modules`` so the
+lightweight CI scripts-tests (python) shard import works (it only installs
+pytest, pytest-xdist, boto3, judgemind-config).
 """
 
 from __future__ import annotations
@@ -24,9 +28,41 @@ from unittest.mock import MagicMock
 
 import pytest
 
+# ---------------------------------------------------------------------------
+# Pre-import mocking — inject structlog and framework.logging mocks before
+# the script loads. The script's top-level
+# ``from framework.logging import configure_structlog`` would otherwise raise
+# ModuleNotFoundError in the lightweight CI scripts-tests (python) shard.
+# See #4373.
+# ---------------------------------------------------------------------------
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+_mock_framework = MagicMock()
+_mock_framework_logging = MagicMock()
+
+_modules_to_mock = {
+    "structlog": _mock_structlog,
+    "framework": _mock_framework,
+    "framework.logging": _mock_framework_logging,
+}
+
+_saved_modules: dict[str, object] = {}
+for _mod_name, _mock_mod in _modules_to_mock.items():
+    if _mod_name in sys.modules:
+        _saved_modules[_mod_name] = sys.modules[_mod_name]
+    sys.modules[_mod_name] = _mock_mod
+
 import audit_scraper_field_population as _script  # noqa: E402
+
+# Restore sys.modules to avoid polluting other test files.
+for _mod_name in list(_modules_to_mock.keys()):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
 
 REGISTRY = _script.REGISTRY
 get_spec = _script.get_spec


### PR DESCRIPTION
## Summary

Migrate the 13 `scripts/*.py` files listed in #4373 from
`logging.basicConfig(format=...)` to `from framework.logging import
configure_structlog` + `configure_structlog(json=True, stdlib_bridge=True)`,
mirroring the post-#4368 pattern from
`scripts/drain_splitter_carry_forward_clusters.py`. The 3 corresponding
test files in `scripts/tests/` get the same pre-import `sys.modules`
mock pattern as `test_drain_splitter_carry_forward_clusters.py` so the
lightweight CI `scripts-tests (python)` shard import still works.

Defense-in-depth fix — none of the 13 currently pass `extra=` to logger
calls, so no CloudWatch fields are actively being dropped today. But the
moment any of them adds an `extra=` (during a future audit/backfill
enhancement), the field would silently disappear; migrating now means
the next agent on these scripts doesn't burn a ralph cycle re-discovering
#4368.

Closes #4373

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (scripts/* are run on demand via
      `scripts/ecs-run-task.sh` / GitHub Actions; this PR changes only
      logger configuration shape, not behavior — verified by running
      every migrated script through Python's import machinery in the
      scraper-framework venv and by running `scripts/tests/` in both
      the scraper-framework venv (1341 passed, 8 pre-existing failures
      excluded) and the lightweight CI-equivalent venv (134 passed for
      the 3 affected test files). The next time any of these scripts
      runs (next scheduled scraper-zero-record-runner, audit, backfill
      via `scripts/ecs-run-task.sh`), CloudWatch will start emitting
      JSON-encoded LogRecord events instead of the old space-padded
      `%(asctime)s %(levelname)-8s %(message)s` format — that change is
      observable in CloudWatch Logs Insights but doesn't require a
      deploy because the change ships when `main` is next pulled into
      the ingestion-worker / scraper image, and the AC verifies state
      via `grep` and `pytest`, not a service health probe.
- [x] Verification evidence already posted in the issue's Process Summary
      comment (https://github.com/judgemind/judgemind/issues/4373#issuecomment-4410588764).
