### PR TITLE
feat(ci): guard against logging.basicConfig + extra= regressions (#4376)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1562,6 +1562,27 @@ jobs:
         run: scripts/check-oneshot-imports.sh
 
   # ---------------------------------------------------------------
+  # Logger configuration guard: scripts/*.py must not pair
+  # ``logging.basicConfig`` with ``extra=`` kwargs unless they also
+  # call ``configure_structlog`` (#4376). The combination silently
+  # drops every ``extra=`` field from CloudWatch output because the
+  # basicConfig format string does not reference the LogRecord's
+  # extra dict — see #4368 for the production post-deploy
+  # verification incident that motivated this guard. The step name
+  # below intentionally avoids quoting the forbidden token (per
+  # docs/agent/code-standards.md §Hygiene-check CI steps and
+  # #2541/#2542).
+  # ---------------------------------------------------------------
+  no-basicconfig-with-extra-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scripts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce structlog routing in scripts that emit logger extras
+        run: scripts/check-no-basicconfig-with-extra.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot repo-path guard: flag scripts that use REPO_ROOT
   # without a validated fallback for when the repo is unavailable (#1277)
   # ---------------------------------------------------------------
@@ -1970,7 +1991,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check, fix-block-coverage-complete-check, ci-guards-skip-list-coverage-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, redos-pattern-check, split-ruling-propagation-check, cleanup-step-continue-on-error-check, parse-document-reingest-safety-check, tests-use-reingest-helper-check, hardcoded-models-check, terraform-empty-resource-check, terraform-ecs-entrypoint-check, hardcoded-colors-check, bare-shadcn-accent-check, docs-tailwind-drift-check, llm-json-loads-check, llm-paths-symmetry-check, case-type-fallback-parity-check, oneshot-imports-check, no-basicconfig-with-extra-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, test-statuscode-assertions-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, workflow-paths-filter-coverage-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, no-graphql-instanceof-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, dispatcher-integration-tests, ci-passed-coverage-check, placeholder-gates-check, repo-walk-exclusions-canonical-check, dispatcher-terminal-statuses-check, dispatcher-dispatch-vocabulary-check, script-headers-check, filename-separator-hygiene-check, removed-exports-check, vitest-environment-deps-check, fix-block-coverage-complete-check, ci-guards-skip-list-coverage-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -56,6 +56,31 @@ The `archive/`, `eval/`, `tests/`, and `spotcheck/` subdirectories under `script
 
 **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
 
+#### Logger configuration
+
+Top-level `scripts/*.py` scripts that emit logger calls with `extra=` kwargs MUST configure logging via `configure_structlog`, not `logging.basicConfig`. The basicConfig idiom — `logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s")` — silently drops every `extra=` field from the LogRecord because the format string only references `%(asctime)s`, `%(levelname)s`, and `%(message)s`. Issue #4368 documented the production incident: a backfill script's `extra=` fields disappeared from CloudWatch Logs Insights, and the post-deploy verification that depended on those fields silently passed.
+
+The canonical pattern is:
+
+```python
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Module docstring."""
+from __future__ import annotations
+
+import logging
+
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
+logger = logging.getLogger(__name__)
+```
+
+`configure_structlog(json=True, stdlib_bridge=True)` routes stdlib `logging.getLogger(__name__)` calls through structlog's ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its extras as one event per line. The `stdlib_bridge=True` flag is the load-bearing piece — without it, `extra=` fields still drop because structlog and stdlib `logging` remain unwired.
+
+`scripts/drain_splitter_carry_forward_clusters.py` (PR #4368) is the reference implementation. PR #4373 migrated the other 13 affected `scripts/*.py` files. The `no-basicconfig-with-extra-check` CI job (`scripts/check-no-basicconfig-with-extra.sh`, #4376) enforces the contract: it AST-walks every top-level `scripts/*.py` and fails CI when a file calls `logging.basicConfig(...)` AND passes `extra=` to a logger method AND does NOT also call `configure_structlog(...)`. Files that call both `basicConfig` and `configure_structlog` are accepted — the contributor has been deliberate about routing.
+
 ## TypeScript (API, frontend)
 
 - Strict mode always.

--- a/docs/dx/check-script-fix-block-coverage.md
+++ b/docs/dx/check-script-fix-block-coverage.md
@@ -76,6 +76,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 35 | `scripts/check-migration-files.sh` | self-diagnosing (Fix block) | **Upgraded #4346:** emits a `Fix:` block with concrete `git mv N_*.sql <expected>_*.sql` rename suggestions for naming-pattern, duplicate-number, and gap errors. Prior shape only printed the violation. |
 | 36 | `scripts/check-migration-number-collision.sh` | wrapper (delegates to helper) | Wrapper for `check-migration-number-collision.py` whose `format_collision()` already emits a 5-step Remediation block. |
 | 37 | `scripts/check-no-api-github-fetch.sh` | self-diagnosing (Fix block) | Emits the `gh` CLI replacement. |
+| 37a | `scripts/check-no-basicconfig-with-extra.sh` | self-diagnosing (Fix block) | AST-walks every top-level `scripts/*.py` and flags files that call `logging.basicConfig(...)` AND pass `extra=` to a logger method AND do NOT also call `configure_structlog(...)`. Catches the #4368 bug class — `basicConfig(format="%(asctime)s %(levelname)-8s %(message)s")` silently drops every `extra=` field from CloudWatch output. Emits a `Fix:` block naming the canonical `from framework.logging import configure_structlog` + `configure_structlog(json=True, stdlib_bridge=True)` replacement and citing `scripts/drain_splitter_carry_forward_clusters.py` (PR #4368) as the reference implementation. Wired by `no-basicconfig-with-extra-check` in `.github/workflows/ci.yml` (gated on `detect-changes.outputs.scripts == 'true'`). Tracking: #4376 (this guard), #4368 (root-cause incident), #4373 (bulk migration of pre-existing affected scripts). |
 | 38 | `scripts/check-no-duplicate-stubs.sh` | self-diagnosing (Fix block) | Emits "remove the duplicate" guidance with file:line pairs. |
 | 39 | `scripts/check-no-ecs-wait-services-stable.sh` | self-diagnosing (Fix block) | Emits the `wait-for-deploy.sh` replacement. |
 | 40 | `scripts/check-no-git-repo-root-anchor.sh` | self-diagnosing (Fix block) | Emits the `git -C "$REPO_ROOT"` replacement. |
@@ -123,6 +124,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 76 | `scripts/check-transition-dispatch-vocabulary.sh` | self-diagnosing (Fix block) | Emits the canonical-vocabulary list. |
 | 77 | `scripts/check-vitest-environment-deps.sh` | self-diagnosing (Fix block) | Emits the `npm install` invocation. |
 | 78 | `scripts/check-workflow-paths-filter-coverage.sh` | wrapper (delegates to helper) | Wrapper for `check-workflow-paths-filter-coverage.py`. |
+| 78a | `scripts/check_no_basicconfig_with_extra.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:logging.basicConfig + extra= at line(s) ...` per violating file; wrapper sh adds the `Fix:` block naming the canonical `configure_structlog(json=True, stdlib_bridge=True)` replacement. Tracking: #4376. |
 | 79 | `scripts/check_no_redos_pattern.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:<pattern>` per violation; wrapper sh adds the Fix-options block. |
 | 80 | `scripts/check_parse_document_reingest_safety.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:<label>` per violation; wrapper sh adds the required-marker block. |
 | 81 | `scripts/check_split_ruling_fields_propagated.py` | self-diagnosing (Fix block) | Reference upgrade from PR #4345 — emits per-violation Fix block with the `_DATACLASS_SCOPE` patch literal. |
@@ -132,7 +134,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 
 ## Summary
 
-- Total guards: 93 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50b `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379; #50a `check-no-tmp-oneshot-file-path-derivation.py` added by #4381).
+- Total guards: 95 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50b `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379; #50a `check-no-tmp-oneshot-file-path-derivation.py` added by #4381; #37a `check-no-basicconfig-with-extra.sh` + #78a `check_no_basicconfig_with_extra.py` added by #4376).
 - Already self-diagnosing (Fix block or actionable text) before #4346: 71.
 - Wrappers (delegate to helper): 18.
 - Operational health probes: 5.

--- a/scripts/check-no-basicconfig-with-extra.sh
+++ b/scripts/check-no-basicconfig-with-extra.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# check-no-basicconfig-with-extra.sh — Forbid ``logging.basicConfig`` +
+# ``extra=`` co-occurrence in scripts/*.py without ``configure_structlog``.
+#
+# Background — the silent extra= field drop
+# ─────────────────────────────────────────
+# ``logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s")``
+# is the canonical Python stdlib idiom for one-line console logging.
+# The format string looks reasonable, but it silently drops every
+# ``extra=`` field passed to ``logger.<level>(...)`` calls because the
+# format only references ``%(asctime)s``, ``%(levelname)s``, and
+# ``%(message)s`` — nothing that surfaces the LogRecord's extra dict.
+# Issue #4368 documented the production incident: a backfill script's
+# ``extra=`` fields disappeared from CloudWatch Logs Insights, and the
+# post-deploy verification that depended on those fields silently passed.
+#
+# The fix is ``configure_structlog(json=True, stdlib_bridge=True)``
+# from ``packages/scraper-framework/src/framework/logging.py`` — it
+# routes stdlib ``logging.getLogger(__name__)`` calls through
+# structlog's ProcessorFormatter + ExtraAdder, JSON-encoding the
+# LogRecord plus its extras as one event per line.  PR #4368 fixed
+# ``scripts/drain_splitter_carry_forward_clusters.py``; #4373 migrated
+# the other 13 affected scripts.  This guard prevents the bug from
+# re-accruing as ``scripts/*.py`` expands.
+#
+# What this guard scans
+# ─────────────────────
+# Every top-level ``scripts/*.py`` file — i.e. files matching the glob
+# ``scripts/*.py`` (no recursion).  Subdirectories under ``scripts/``
+# (``scripts/archive/``, ``scripts/dispatcher/``, ``scripts/dispatcher_v3/``,
+# ``scripts/spotcheck/``, ``scripts/oneoff/``, ``scripts/one_off/``,
+# ``scripts/tests/``) are out of scope:
+#
+#   - ``scripts/archive/`` and ``scripts/oneoff/`` / ``scripts/one_off/``
+#     are deprecated one-offs, kept for posterity.
+#   - ``scripts/dispatcher/`` and ``scripts/dispatcher_v3/`` are library
+#     modules whose entrypoints live in the daemon binary; they
+#     compose a logger but do not own the global configuration.
+#   - ``scripts/spotcheck/`` and ``scripts/tests/`` are likewise scoped
+#     to a different runtime (cron / pytest).
+#
+# A file is flagged when ALL of the following hold:
+#
+#   1. The file calls ``logging.basicConfig(...)`` (also via
+#      ``from logging import basicConfig`` then ``basicConfig(...)``).
+#   2. The file passes ``extra=...`` as a keyword argument to at least
+#      one logger method call (``logger.info(...)``, etc.).
+#   3. The file does NOT call ``configure_structlog(...)`` anywhere.
+#
+# Issue #4376.  Parent: #4368.
+#
+# Usage
+# ─────
+#
+#   scripts/check-no-basicconfig-with-extra.sh        # scan scripts/*.py
+#   scripts/check-no-basicconfig-with-extra.sh [path] # scan a specific file or directory
+#
+# Exit codes
+# ──────────
+#
+#   0 — No violations found.
+#   1 — At least one file calls basicConfig + extra= without
+#       configure_structlog.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ─── Determine scan targets ──────────────────────────────────────────
+# With no argument: scan top-level scripts/*.py only (the production
+# scope per the issue).
+# With an argument: scan that path (file or directory) — used by tests.
+py_files=()
+if [[ $# -eq 0 ]]; then
+    while IFS= read -r found; do
+        py_files+=("$found")
+    done < <(find "$REPO_ROOT/scripts" -maxdepth 1 -type f -name '*.py' | LC_ALL=C sort)
+else
+    target="$1"
+    if [[ -f "$target" && "$target" == *.py ]]; then
+        py_files+=("$target")
+    elif [[ -d "$target" ]]; then
+        # When given a directory, scan only the top level by default.
+        # This mirrors the production scope and keeps the test fixture
+        # behaviour consistent.
+        while IFS= read -r found; do
+            py_files+=("$found")
+        done < <(find "$target" -maxdepth 1 -type f -name '*.py' | LC_ALL=C sort)
+    fi
+fi
+
+# Empty file list → no violations possible.
+if [[ ${#py_files[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+# ─── Run the AST scanner ─────────────────────────────────────────────
+# The Python scanner emits one line per violation in the form:
+#   <path>:<lineno>:<snippet>
+python_output="$(python3 "$REPO_ROOT/scripts/check_no_basicconfig_with_extra.py" "${py_files[@]}")"
+
+# ─── Report violations ───────────────────────────────────────────────
+if [[ -z "${python_output// /}" ]]; then
+    exit 0
+fi
+
+violations=0
+echo "ERROR: Found Python script(s) calling basicConfig + extra= without configure_structlog."
+echo ""
+echo "  The combination silently drops every extra= field from CloudWatch"
+echo "  output because the basicConfig format string does not reference the"
+echo "  LogRecord's extra dict.  See issue #4368 for the production"
+echo "  post-deploy verification incident that motivated the migration."
+echo ""
+echo "  Fix: replace the basicConfig call with configure_structlog from"
+echo "  framework.logging.  The canonical pattern is:"
+echo ""
+echo "      from framework.logging import configure_structlog  # noqa: E402"
+echo "      configure_structlog(json=True, stdlib_bridge=True)"
+echo "      logger = logging.getLogger(__name__)"
+echo ""
+echo "  See scripts/drain_splitter_carry_forward_clusters.py for the"
+echo "  reference implementation (PR #4368) and #4373 for the bulk"
+echo "  migration of the other 13 affected scripts."
+echo ""
+echo "  Violating file(s):"
+echo ""
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    echo "    $entry"
+    violations=$((violations + 1))
+done <<< "$python_output"
+
+if (( violations > 0 )); then
+    echo ""
+    echo "  Found $violations file(s) with basicConfig + extra= and no configure_structlog."
+    exit 1
+fi
+
+exit 0

--- a/scripts/check_no_basicconfig_with_extra.py
+++ b/scripts/check_no_basicconfig_with_extra.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check_no_basicconfig_with_extra.py — AST scanner for the
+``logging.basicConfig`` + ``extra=`` anti-pattern.
+
+Driven by ``scripts/check-no-basicconfig-with-extra.sh``.  See that
+wrapper for the full motivation and CI integration story (issue #4376).
+
+Background — the silent extra= field drop
+-----------------------------------------
+
+``logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s")``
+is the canonical Python stdlib idiom for one-line console logging.  The
+format string looks reasonable, but it silently drops every ``extra=``
+field passed to ``logger.<level>(...)`` calls because the format only
+references ``%(asctime)s``, ``%(levelname)s``, and ``%(message)s`` —
+nothing that surfaces the LogRecord's extra dict.  Issue #4368
+documented the production incident: a backfill script's ``extra=``
+fields disappeared from CloudWatch Logs Insights, and the post-deploy
+verification that depended on those fields silently passed.
+
+The fix is ``configure_structlog(json=True, stdlib_bridge=True)`` from
+``packages/scraper-framework/src/framework/logging.py`` — it routes
+stdlib ``logging.getLogger(__name__)`` calls through structlog's
+ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+extras as one event per line.  PR #4368 fixed
+``scripts/drain_splitter_carry_forward_clusters.py``; #4373 migrated
+the other 13 affected scripts.  This guard prevents the bug from
+re-accruing as ``scripts/*.py`` expands.
+
+What is flagged
+---------------
+
+A Python source file is flagged when ALL of the following hold:
+
+  1. The file calls ``logging.basicConfig(...)`` (also via
+     ``from logging import basicConfig`` then ``basicConfig(...)``).
+  2. The file passes ``extra=...`` as a keyword argument to at least
+     one logger method call (``logger.info(...)``, ``log.warning(...)``,
+     ``LOGGER.error(...)``, etc.) — any attribute call whose attribute
+     name is one of ``debug``, ``info``, ``warning``, ``warn``,
+     ``error``, ``critical``, ``exception``, or ``log``, with an
+     ``extra=`` keyword.
+  3. The file does NOT call ``configure_structlog(...)`` anywhere.
+     Calling ``configure_structlog`` in the same file means the
+     structlog config supersedes basicConfig (or the two are at least
+     present, and the operator has been deliberate about routing
+     extras through).
+
+The AST-based check correctly distinguishes call sites from comment
+references and docstrings — many post-#4373 scripts mention
+``logging.basicConfig`` in their migration-history comment but only
+*call* ``configure_structlog``, so they pass cleanly.
+
+What is NOT flagged
+-------------------
+
+  - Files with ``basicConfig(...)`` but no ``extra=`` calls — the bug
+    is latent.  #4373 migrated these defensively; the guard does not
+    re-flag them.  (Catching the latent shape too is appealing but
+    out of scope per the issue body — the primary class of regression
+    we want to prevent is *new* ``extra=`` calls layered onto existing
+    ``basicConfig`` configs.)
+  - Files that call both ``basicConfig`` AND ``configure_structlog``.
+    Order matters at runtime (the last config wins), but if a file
+    has been deliberate enough to call both, we trust that the
+    contributor has the structlog routing they want.
+  - Files outside the scan scope (the wrapper restricts to
+    ``scripts/*.py`` top-level by default; pass a custom path for
+    tests).
+
+Usage
+-----
+
+    python3 scripts/check_no_basicconfig_with_extra.py [PATH ...]
+
+Each PATH is a ``.py`` file.  The wrapper script discovers the paths.
+
+Exit codes
+----------
+
+  0 — Always.  The wrapper turns the printed-violations stream into a
+       non-zero exit.  Splitting the responsibility keeps this script's
+       output stream the single source of truth for tests and the
+       wrapper alike.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# ─── Logger-method names ──────────────────────────────────────────────
+# Every logger call attribute we recognise.  Matches the standard
+# ``logging.Logger`` API plus the lowercase aliases.  We accept any
+# variable name on the receiving end (``logger``, ``log``, ``LOGGER``,
+# ``self.log``, etc.) — the AST walk does not need to resolve the
+# variable, it just needs to spot ``<anything>.<method>(extra=...)``.
+_LOGGER_METHODS = frozenset(
+    {
+        "debug",
+        "info",
+        "warning",
+        "warn",
+        "error",
+        "critical",
+        "exception",
+        "log",
+    }
+)
+
+
+def _is_basicconfig_call(node: ast.Call) -> bool:
+    """Return True if ``node`` is a ``logging.basicConfig(...)`` call.
+
+    Recognises both forms:
+
+        logging.basicConfig(...)
+        basicConfig(...)             # after ``from logging import basicConfig``
+    """
+    func = node.func
+    # logging.basicConfig(...)
+    if isinstance(func, ast.Attribute):
+        if (
+            func.attr == "basicConfig"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "logging"
+        ):
+            return True
+    # basicConfig(...)  — caller did `from logging import basicConfig`
+    if isinstance(func, ast.Name) and func.id == "basicConfig":
+        return True
+    return False
+
+
+def _is_configure_structlog_call(node: ast.Call) -> bool:
+    """Return True if ``node`` is a ``configure_structlog(...)`` call.
+
+    Recognises both forms:
+
+        configure_structlog(...)
+        framework.logging.configure_structlog(...)
+        anything.configure_structlog(...)
+
+    The check is intentionally permissive — any callable whose final
+    attribute or bare name is ``configure_structlog`` counts as the
+    structlog opt-in, since there is no other function with that name
+    in the codebase.
+    """
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "configure_structlog":
+        return True
+    if isinstance(func, ast.Name) and func.id == "configure_structlog":
+        return True
+    return False
+
+
+def _is_logger_call_with_extra(node: ast.Call) -> bool:
+    """Return True if ``node`` is a logger method call with ``extra=`` kwarg.
+
+    Matches any attribute call whose attribute name is in
+    ``_LOGGER_METHODS`` AND has at least one keyword named ``extra``.
+    The receiver name is not constrained — ``logger.info(extra=...)``,
+    ``log.warning(extra=...)``, ``self.LOGGER.error(extra=...)``, and
+    ``getLogger(__name__).debug(extra=...)`` all match.
+    """
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr not in _LOGGER_METHODS:
+        return False
+    for kw in node.keywords:
+        if kw.arg == "extra":
+            return True
+    return False
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    """Return a list of (lineno, snippet) tuples — one per violation.
+
+    A file with no violations returns an empty list.
+
+    Each violation is reported once at the line of the
+    ``logging.basicConfig(...)`` call, with a snippet naming the
+    co-occurring ``extra=`` line numbers so the operator can find both
+    halves of the bug at a glance.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Not valid Python — skip.  May be a fixture or template.
+        return []
+
+    basicconfig_lines: list[int] = []
+    configure_structlog_lines: list[int] = []
+    extra_call_lines: list[int] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _is_basicconfig_call(node):
+            basicconfig_lines.append(node.lineno)
+        elif _is_configure_structlog_call(node):
+            configure_structlog_lines.append(node.lineno)
+        elif _is_logger_call_with_extra(node):
+            extra_call_lines.append(node.lineno)
+
+    # No basicConfig OR no extra= → no violation.
+    if not basicconfig_lines or not extra_call_lines:
+        return []
+
+    # Has configure_structlog → operator opted into structlog routing,
+    # trust the deliberate config.
+    if configure_structlog_lines:
+        return []
+
+    # All three conditions hold — flag the file.  Report at the first
+    # basicConfig call line; show the first two extra= line numbers in
+    # the snippet so the human reading the CI log can jump to both
+    # halves of the anti-pattern.
+    first_bc = basicconfig_lines[0]
+    extra_preview = ",".join(str(n) for n in extra_call_lines[:2])
+    if len(extra_call_lines) > 2:
+        extra_preview += f",... ({len(extra_call_lines)} total)"
+    snippet = f"logging.basicConfig + extra= at line(s) {extra_preview} (no configure_structlog)"
+    return [(first_bc, snippet)]
+
+
+def main(argv: list[str]) -> int:
+    """Print one ``<path>:<lineno>:<snippet>`` line per violation."""
+    paths = [Path(p) for p in argv[1:]]
+    for path in paths:
+        for lineno, snippet in scan_file(path):
+            print(f"{path}:{lineno}:{snippet}")
+    # Exit 0 unconditionally — the wrapper script aggregates and exits 1
+    # on non-empty output.  See module docstring.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_check_no_basicconfig_with_extra.sh
+++ b/scripts/tests/test_check_no_basicconfig_with_extra.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# test_check_no_basicconfig_with_extra.sh — Tests for
+# check-no-basicconfig-with-extra.sh.
+#
+# Issue #4376.  The guard forbids ``logging.basicConfig`` +
+# ``extra=`` co-occurrence in scripts/*.py files that do not also
+# call ``configure_structlog``.  The combination silently drops every
+# ``extra=`` field from CloudWatch output (see #4368).
+#
+# Tests below build temp .py files in TMPDIR_TEST and point the guard
+# at that directory, mirroring the test_check_no_redos_pattern.sh
+# pattern.
+#
+# Usage:
+#   scripts/tests/test_check_no_basicconfig_with_extra.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-basicconfig-with-extra.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: The exact #4368 anti-pattern is caught ──────────────────────
+# logging.basicConfig + logger.info(..., extra={...}) + no configure_structlog.
+create_test_file "antipattern.py" 'import logging
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def run():
+    logger.info("processed", extra={"s3_key": "ca/foo/raw/abc.pdf"})
+'
+assert_fails "Exact #4368 anti-pattern (basicConfig + extra= + no configure_structlog) is caught"
+reset_tmpdir
+
+# ─── Test 2: One-line bad form is caught ─────────────────────────────────
+create_test_file "oneline.py" 'import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+logger.warning("oops", extra={"k": "v"})
+'
+assert_fails "One-line basicConfig + extra= is caught"
+reset_tmpdir
+
+# ─── Test 3: configure_structlog present → passes ────────────────────────
+# The post-#4368 fix shape — basicConfig is gone, replaced with
+# configure_structlog.
+create_test_file "fixed.py" 'import logging
+from framework.logging import configure_structlog
+
+configure_structlog(json=True, stdlib_bridge=True)
+logger = logging.getLogger(__name__)
+
+
+def run():
+    logger.info("processed", extra={"s3_key": "ca/foo/raw/abc.pdf"})
+'
+assert_passes "configure_structlog (no basicConfig) passes"
+reset_tmpdir
+
+# ─── Test 4: Both basicConfig AND configure_structlog → passes ───────────
+# If a contributor has been deliberate enough to call both, we trust
+# them — the structlog config supersedes basicConfig at runtime.
+create_test_file "both.py" 'import logging
+from framework.logging import configure_structlog
+
+logging.basicConfig(level=logging.INFO)
+configure_structlog(json=True, stdlib_bridge=True)
+logger = logging.getLogger(__name__)
+logger.info("processed", extra={"k": "v"})
+'
+assert_passes "basicConfig AND configure_structlog (deliberate config) passes"
+reset_tmpdir
+
+# ─── Test 5: basicConfig but no extra= calls → passes ────────────────────
+# The bug class is latent, not active.  The guard does not flag this
+# defensively-migrated shape (#4373 covered the latent shape; this
+# guard is for new regressions that pair extra= with basicConfig).
+create_test_file "latent.py" 'import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def run():
+    logger.info("no extras here")
+'
+assert_passes "basicConfig with no extra= calls is not flagged (latent shape)"
+reset_tmpdir
+
+# ─── Test 6: extra= without basicConfig → passes ─────────────────────────
+# A library module that uses logger.info(..., extra=...) but does not
+# own the global config is fine — the entrypoint calls
+# configure_structlog elsewhere.
+create_test_file "library.py" 'import logging
+
+logger = logging.getLogger(__name__)
+
+
+def emit(key: str) -> None:
+    logger.info("processed", extra={"key": key})
+'
+assert_passes "extra= calls without basicConfig (library module) pass"
+reset_tmpdir
+
+# ─── Test 7: Comment-only references do not trip the AST check ───────────
+# Many post-#4373 scripts retain a comment like "# Use configure_structlog
+# so any extra= ... — the previous logging.basicConfig format dropped..."
+# AST inspection ignores comments, so the comment alone must not flag.
+create_test_file "comment_only.py" '"""A migrated script.
+
+The previous logging.basicConfig format string silently dropped every
+extra= field — see #4368.
+"""
+import logging
+from framework.logging import configure_structlog
+
+configure_structlog(json=True, stdlib_bridge=True)
+logger = logging.getLogger(__name__)
+logger.info("processed", extra={"k": "v"})
+'
+assert_passes "Comment/docstring references to basicConfig and extra= do not flag"
+reset_tmpdir
+
+# ─── Test 8: from logging import basicConfig → still detected ────────────
+# Caller imported the function directly; the AST walk still recognises
+# the bare ``basicConfig(...)`` name.
+create_test_file "bare_import.py" 'import logging
+from logging import basicConfig
+
+basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+logger.info("processed", extra={"k": "v"})
+'
+assert_fails "from logging import basicConfig + bare basicConfig() is caught"
+reset_tmpdir
+
+# ─── Test 9: log.warning() (not logger.warning) is detected ──────────────
+# We accept any receiver name — "log", "logger", "LOGGER", "self.log"
+# all pass the attribute-name match.
+create_test_file "alt_receiver.py" 'import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+log = logging.getLogger("my-module")
+log.warning("oops", extra={"k": "v"})
+'
+assert_fails "Alternative receiver name (log.warning instead of logger.warning) is caught"
+reset_tmpdir
+
+# ─── Test 10: logger.exception() with extra= is detected ─────────────────
+create_test_file "exception.py" 'import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+try:
+    raise RuntimeError("boom")
+except RuntimeError:
+    logger.exception("failed", extra={"k": "v"})
+'
+assert_fails "logger.exception with extra= is caught"
+reset_tmpdir
+
+# ─── Test 11: logger.log(level, msg, extra=...) is detected ──────────────
+create_test_file "log_method.py" 'import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+logger.log(logging.INFO, "processed", extra={"k": "v"})
+'
+assert_fails "logger.log(level, msg, extra=) is caught"
+reset_tmpdir
+
+# ─── Test 12: Empty file passes ──────────────────────────────────────────
+create_test_file "empty.py" ''
+assert_passes "Empty .py file passes"
+reset_tmpdir
+
+# ─── Test 13: Pure `pass` stub passes ────────────────────────────────────
+create_test_file "stub.py" 'pass
+'
+assert_passes "Pure stub .py file passes"
+reset_tmpdir
+
+# ─── Test 14: Syntactically broken Python is skipped silently ────────────
+create_test_file "broken.py" 'import logging
+def broken(:  # syntax error
+    pass
+'
+assert_passes "Syntactically broken Python is skipped silently"
+reset_tmpdir
+
+# ─── Test 15: extra= as positional dict (not kwarg) is NOT flagged ───────
+# logger.info("msg", extra) is illegal anyway (signature mismatch);
+# the heuristic only matches the kwarg form, which is the only shape
+# that compiles and ships.
+create_test_file "positional.py" 'import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+extra = {"k": "v"}
+logger.info("msg")  # no extra= kwarg
+logger.info("msg2 %r", extra)  # extra is positional, not kwarg
+'
+assert_passes "extra used as variable name (not kwarg) is not flagged"
+reset_tmpdir
+
+# ─── Test 16: Multiple extra= calls report once per file ─────────────────
+# The Python scanner emits one entry per *file*, not per call site —
+# the wrapper aggregates and the violation count is the file count.
+create_test_file "multi_extras.py" 'import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+logger.info("a", extra={"k": 1})
+logger.warning("b", extra={"k": 2})
+logger.error("c", extra={"k": 3})
+'
+assert_fails "File with multiple extra= calls is flagged once"
+reset_tmpdir
+
+# ─── Test 17: The guard emits a Fix block in stderr ──────────────────────
+# Per the Fix-block contract (docs/agent/code-standards.md
+# §Hygiene-check guards: Fix-block contract), the guard must emit a
+# copy-pasteable Fix block on the violation path.  Build a violating
+# fixture and assert the Fix block content shows up.
+create_test_file "fixblock.py" 'import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+logger.info("oops", extra={"k": "v"})
+'
+TESTS=$((TESTS + 1))
+err_out=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1 || true)
+if printf '%s' "$err_out" | grep -q '^[[:space:]]*Fix:' \
+   && printf '%s' "$err_out" | grep -q 'configure_structlog' \
+   && printf '%s' "$err_out" | grep -q 'framework.logging'; then
+    echo "PASS: error output emits a Fix: block naming configure_structlog and framework.logging"
+else
+    echo "FAIL: error output did not emit the expected Fix: block"
+    echo "  output was:"
+    printf '%s\n' "$err_out" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
+
+# ─── Test 18: file:lineno is named in the violation report ───────────────
+create_test_file "src/named.py" 'import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+logger = logging.getLogger(__name__)
+logger.info("oops", extra={"k": "v"})
+'
+TESTS=$((TESTS + 1))
+output=$("$CHECK_SCRIPT" "$TMPDIR_TEST/src" 2>&1 || true)
+if printf '%s' "$output" | grep -qE 'src/named\.py:[0-9]+:.*basicConfig'; then
+    echo "PASS: error output names file:line of violation"
+else
+    echo "FAIL: error output did not include file:line for violation"
+    echo "  output was:"
+    printf '%s\n' "$output" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
+
+# ─── Test 19: Direct file-path argument works ────────────────────────────
+TESTS=$((TESTS + 1))
+single_file="$TMPDIR_TEST/single.py"
+mkdir -p "$TMPDIR_TEST"
+printf 'import logging\nlogging.basicConfig(level=logging.INFO, format="%%(asctime)s %%(message)s")\nlogger = logging.getLogger(__name__)\nlogger.info("oops", extra={"k": "v"})\n' \
+    > "$single_file"
+if "$CHECK_SCRIPT" "$single_file" > /dev/null 2>&1; then
+    echo "FAIL: Direct .py file path argument detects violations (expected failure, got success)"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: Direct .py file path argument detects violations"
+fi
+reset_tmpdir
+
+# ─── Test 20: scripts/*.py production scope passes on origin/main ────────
+# AC verify line: ``scripts/check-no-basicconfig-with-extra.sh`` (no
+# args) exits 0 against the worktree's scripts/*.py.  This duplicates
+# the AC's verify command into the test suite so a regression that
+# adds the anti-pattern to a real script is caught at PR time, not
+# at CI time.
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: production scope (scripts/*.py) passes on this worktree"
+else
+    echo "FAIL: production scope (scripts/*.py) does NOT pass on this worktree"
+    echo "  output was:"
+    "$CHECK_SCRIPT" 2>&1 | sed 's/^/    /' || true
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 21: No self-match on ci.yml step name ──────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the forbidden token.  See
+# docs/agent/code-standards.md §Hygiene-check CI steps and #2541/#2542.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-basicconfig-with-extra.sh" "py"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a CI hygiene guard (`scripts/check-no-basicconfig-with-extra.{sh,py}`) that AST-walks every top-level `scripts/*.py` and fails CI when a file pairs `logging.basicConfig(...)` with `logger.<level>(..., extra=...)` calls WITHOUT also calling `configure_structlog(...)` — the silent-extras-drop bug class fixed by #4368 / #4373. The guard is wired into `.github/workflows/ci.yml` as `no-basicconfig-with-extra-check`, gated on `scripts/**` changes. Documented under a new "Logger configuration" sub-section in `docs/agent/code-standards.md` and indexed in `docs/dx/check-script-fix-block-coverage.md`.

Closes #4376.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `no-basicconfig-with-extra-check` job passes against the post-#4368/#4373 tree
- [x] `scripts-tests` (auto-discovered) runs `test_check_no_basicconfig_with_extra.sh` and reports 21/21 passing

### Post-deploy verification
- [x] N/A — no deployed component (CI workflow + hygiene guard + docs only)
