### PR TITLE
fix(observability): migrate seed_judges_from_directory_snapshots.py to configure_structlog (#4399)

### DIFF
--- a/scripts/seed_judges_from_directory_snapshots.py
+++ b/scripts/seed_judges_from_directory_snapshots.py
@@ -55,10 +55,18 @@ import psycopg
 
 from ingestion.judge_seed import seed_judges_from_directory_snapshots
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+# Use ``configure_structlog`` so any ``extra=`` fields passed to logger calls
+# surface in CloudWatch Logs Insights output. ``stdlib_bridge=True`` routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder, JSON-encoding the LogRecord plus its
+# extras as one event per line. The previous ``logging.basicConfig`` format
+# string (``"%(asctime)s %(levelname)-8s %(message)s"``) silently dropped
+# every ``extra=`` field — see #4368 for the post-deploy verification
+# incident that motivated migrating every ``scripts/*.py`` to this pattern
+# (#4373).
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary

Replace `logging.basicConfig(...)` in `scripts/seed_judges_from_directory_snapshots.py` with `configure_structlog(json=True, stdlib_bridge=True)`, mirroring the post-#4368 and post-#4373 pattern. Closes the residual one-line replacement that #4373 deliberately left out of its 13-file scope.

Closes #4399

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — `# one-off: true` script that has not been invoked in production; the migration only matters when an agent later adds an `extra=` field. Verification is the AC's grep + the unchanged pre-existing test suite (no regressions). No deployed component to exercise.
- [x] Verification evidence posted on issue (see A.8)
