### PR TITLE
feat(dx): emit per-guard Fix block in check-fix-block-coverage-complete (#4405)

### DIFF
--- a/docs/dx/check-script-fix-block-coverage.md
+++ b/docs/dx/check-script-fix-block-coverage.md
@@ -124,6 +124,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 76 | `scripts/check-transition-dispatch-vocabulary.sh` | self-diagnosing (Fix block) | Emits the canonical-vocabulary list. |
 | 77 | `scripts/check-vitest-environment-deps.sh` | self-diagnosing (Fix block) | Emits the `npm install` invocation. |
 | 78 | `scripts/check-workflow-paths-filter-coverage.sh` | wrapper (delegates to helper) | Wrapper for `check-workflow-paths-filter-coverage.py`. |
+| 78b | `scripts/check_fix_block_coverage_complete.py` | self-diagnosing (Fix block) | Per-guard Fix-block formatter for `check-fix-block-coverage-complete.sh` (#23a). Parses the inventory in this file, computes the alphabetical insertion point + letter-suffix row number for each missing guard, and emits a copy-pasteable row template plus the new `Total guards: N` count. Invoked from the wrapper when the diff produces a non-empty missing list. Tracking: #4405 (this guard), #4376 (parent retro). |
 | 78a | `scripts/check_no_basicconfig_with_extra.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:logging.basicConfig + extra= at line(s) ...` per violating file; wrapper sh adds the `Fix:` block naming the canonical `configure_structlog(json=True, stdlib_bridge=True)` replacement. Tracking: #4376. |
 | 79 | `scripts/check_no_redos_pattern.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:<pattern>` per violation; wrapper sh adds the Fix-options block. |
 | 80 | `scripts/check_parse_document_reingest_safety.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:<label>` per violation; wrapper sh adds the required-marker block. |
@@ -134,7 +135,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 
 ## Summary
 
-- Total guards: 95 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50b `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379; #50a `check-no-tmp-oneshot-file-path-derivation.py` added by #4381; #37a `check-no-basicconfig-with-extra.sh` + #78a `check_no_basicconfig_with_extra.py` added by #4376).
+- Total guards: 96 (#31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50b `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379; #50a `check-no-tmp-oneshot-file-path-derivation.py` added by #4381; #37a `check-no-basicconfig-with-extra.sh` + #78a `check_no_basicconfig_with_extra.py` added by #4376; #78b `check_fix_block_coverage_complete.py` added by #4405).
 - Already self-diagnosing (Fix block or actionable text) before #4346: 71.
 - Wrappers (delegate to helper): 18.
 - Operational health probes: 5.

--- a/scripts/check-fix-block-coverage-complete.sh
+++ b/scripts/check-fix-block-coverage-complete.sh
@@ -52,8 +52,12 @@
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SCRIPTS_DIR="$REPO_ROOT/scripts"
-DOC="$REPO_ROOT/docs/dx/check-script-fix-block-coverage.md"
+# Test-override hooks (issue #4405). Production paths are derived from
+# $REPO_ROOT; tests in scripts/tests/ point these at a synthesized
+# directory + inventory so the per-guard Fix-block contract can be
+# exercised end-to-end without touching the real tree. Unset in CI.
+SCRIPTS_DIR="${SCRIPTS_DIR_OVERRIDE:-$REPO_ROOT/scripts}"
+DOC="${DOC_OVERRIDE:-$REPO_ROOT/docs/dx/check-script-fix-block-coverage.md}"
 
 if [ ! -d "$SCRIPTS_DIR" ]; then
     echo "ERROR: scripts/ dir not found: $SCRIPTS_DIR" >&2
@@ -160,17 +164,34 @@ if [ -n "$missing" ]; then
     echo "" >&2
     echo "Inventory: docs/dx/check-script-fix-block-coverage.md" >&2
     echo "" >&2
-    echo "Fix: add a row to the survey table for each missing guard. Use the" >&2
-    echo "verdict vocabulary already in the doc:" >&2
-    echo "" >&2
-    echo "  | <N> | \`scripts/<guard>\` | <verdict> | <one-line note describing what the Fix block contains> |" >&2
-    echo "" >&2
-    echo "Verdict options: self-diagnosing (Fix block), self-diagnosing (actionable text)," >&2
-    echo "wrapper (delegates to helper), operational health probe, decision flow, NEEDS UPGRADE." >&2
-    echo "" >&2
-    echo "To minimise renumbering churn, use letter-suffix row numbers (e.g. \`50a\`)" >&2
-    echo "for the alphabetical insertion point — see the existing \`31a\` row for" >&2
-    echo "\`check-issue-verify-sql.py\`." >&2
+    # Per-guard Fix blocks (issue #4405) — name the exact letter-suffix
+    # row number, a copy-pasteable row template with <guard> already
+    # filled in, and the new "Total guards: N" count. Implemented in
+    # scripts/check_fix_block_coverage_complete.py for testability.
+    missing_args=()
+    while IFS= read -r name; do
+        [ -n "$name" ] && missing_args+=("$name")
+    done <<< "$missing"
+    if ! python3 "$REPO_ROOT/scripts/check_fix_block_coverage_complete.py" \
+            --doc "$DOC" \
+            "${missing_args[@]}"; then
+        # Helper failed — fall through to the generic Fix block so CI
+        # operators still get actionable guidance even if the per-guard
+        # formatter regresses.
+        echo "(Per-guard Fix-block formatter exited non-zero — falling back to generic Fix block.)" >&2
+        echo "" >&2
+        echo "Fix: add a row to the survey table for each missing guard. Use the" >&2
+        echo "verdict vocabulary already in the doc:" >&2
+        echo "" >&2
+        echo "  | <N> | \`scripts/<guard>\` | <verdict> | <one-line note describing what the Fix block contains> |" >&2
+        echo "" >&2
+        echo "Verdict options: self-diagnosing (Fix block), self-diagnosing (actionable text)," >&2
+        echo "wrapper (delegates to helper), operational health probe, decision flow, NEEDS UPGRADE." >&2
+        echo "" >&2
+        echo "To minimise renumbering churn, use letter-suffix row numbers (e.g. \`50a\`)" >&2
+        echo "for the alphabetical insertion point — see the existing \`31a\` row for" >&2
+        echo "\`check-issue-verify-sql.py\`." >&2
+    fi
     echo "" >&2
     echo "Note: the \`# ci-guards: skip\` opt-out marker only suppresses umbrella" >&2
     echo "execution; it does NOT exempt a guard from the inventory. Even guards" >&2

--- a/scripts/check_fix_block_coverage_complete.py
+++ b/scripts/check_fix_block_coverage_complete.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check_fix_block_coverage_complete.py — Per-guard Fix-block formatter.
+
+Driven by ``scripts/check-fix-block-coverage-complete.sh``.  When the
+shell guard discovers that one or more executable hygiene guards under
+``scripts/check-*.{sh,py}`` are missing from the inventory at
+``docs/dx/check-script-fix-block-coverage.md``, the wrapper invokes this
+module to emit a per-guard Fix block that names:
+
+  - The exact letter-suffix row number for the alphabetical insertion
+    point (e.g. ``Insert at row #37a, between #37 ... and #38 ...``).
+  - A copy-pasteable row template with ``<guard>`` already filled in.
+  - The new ``Total guards: N`` count for the Summary section.
+
+Design — why a separate Python module
+-------------------------------------
+
+Computing the alphabetical insertion + letter-suffix increment + new
+total in shell is awkward and bug-prone.  Pulling the logic into a small
+Python module keeps the wrapper script's discovery + diff path simple
+and fast (the common case is "everything is documented, exit 0"), and
+makes the formatter unit-testable from
+``scripts/tests/test_check_fix_block_coverage_complete.py``.
+
+Issue #4405 / parent #4376.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# The inventory uses LC_ALL=C byte sort.  ASCII byte values:
+#   '-' (0x2D) < '_' (0x5F)
+# So the existing rows fall into two natural lexicographic groups:
+#   1. hyphen-named (`check-*.sh` and hyphen-named `.py` files)
+#   2. underscore-named (`check_*.py`)
+# A Python ``str`` comparison reproduces this byte-order convention
+# directly — no ``locale`` setup needed.
+
+# Row format inside the survey table:
+#   | 23a | `scripts/check-fix-block-coverage-complete.sh` | <verdict> | ... |
+_ROW_RE = re.compile(
+    r"^\|\s*(?P<rn>[0-9]+[a-z]?)\s*\|\s*`scripts/(?P<name>check[-_a-zA-Z0-9_]+\.(?:sh|py))`"
+)
+
+# Total-guards summary line:
+#   - Total guards: 95 (#31a `check-issue-verify-sql.py` ...
+_TOTAL_RE = re.compile(r"^-?\s*Total guards:\s*(?P<n>[0-9]+)\b")
+
+
+@dataclass(frozen=True)
+class InventoryRow:
+    """One row from the survey table.
+
+    Attributes
+    ----------
+    rownum:
+        Row number string as it appears in the table — may carry a
+        single lowercase letter suffix (``"23"``, ``"23a"``, ``"50b"``).
+    basename:
+        Guard basename, e.g. ``"check-fix-block-coverage-complete.sh"``.
+    """
+
+    rownum: str
+    basename: str
+
+    @property
+    def base_number(self) -> int:
+        """Numeric prefix of the rownum (``23a`` → ``23``)."""
+
+        m = re.match(r"^([0-9]+)", self.rownum)
+        assert m is not None, (
+            f"InventoryRow.rownum has no numeric prefix: {self.rownum!r}"
+        )
+        return int(m.group(1))
+
+    @property
+    def letter_suffix(self) -> str:
+        """The letter suffix, or empty string (``23a`` → ``"a"``, ``23`` → ``""``)."""
+
+        return self.rownum[len(str(self.base_number)) :]
+
+
+@dataclass(frozen=True)
+class InsertionResult:
+    """Computed insertion point for a missing guard.
+
+    Attributes
+    ----------
+    new_rownum:
+        The row number to assign the new guard. For start-of-list inserts
+        (no prior peer), this is a marker like ``"(before #11)"`` so the
+        operator picks a number manually.
+    prior:
+        The alphabetically-prior peer row, or ``None`` if the new guard
+        sorts before every existing row.
+    next_:
+        The alphabetically-next peer row, or ``None`` if the new guard
+        sorts after every existing row.
+    """
+
+    new_rownum: str
+    prior: InventoryRow | None
+    next_: InventoryRow | None
+
+
+def parse_inventory(doc_path: Path) -> list[InventoryRow]:
+    """Read ``doc_path`` and return inventory rows in document order.
+
+    Lines outside the survey table are ignored.  The parser is whitespace
+    tolerant — leading/trailing spaces inside table cells are trimmed.
+    """
+
+    rows: list[InventoryRow] = []
+    with doc_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            m = _ROW_RE.match(line)
+            if m is None:
+                continue
+            rows.append(InventoryRow(rownum=m.group("rn"), basename=m.group("name")))
+    return rows
+
+
+def parse_total_guards(doc_path: Path) -> int | None:
+    """Return the integer from the ``Total guards: N`` line, or ``None``."""
+
+    with doc_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            stripped = line.lstrip()
+            m = _TOTAL_RE.match(stripped)
+            if m is not None:
+                return int(m.group("n"))
+    return None
+
+
+def compute_insertion(new_basename: str, rows: list[InventoryRow]) -> InsertionResult:
+    """Compute the alphabetical insertion point + letter-suffix for ``new_basename``.
+
+    Algorithm:
+
+    1. Find the alphabetical position by byte-comparing ``new_basename``
+       against the existing ``rows`` (already in document order, which
+       matches the LC_ALL=C byte-sort order the inventory enforces).
+    2. The "prior peer" is the row immediately before the insertion
+       position.  The "next peer" is the row at the insertion position.
+    3. Letter suffix for the new row:
+        - If no prior peer: special-case marker ``(before #<next>.rownum)``.
+        - Else: take the prior's ``base_number``; find every existing row
+          with that ``base_number`` (including the prior itself); pick
+          the next available lowercase letter ('a', 'b', ...). When the
+          prior has no letter suffix, the first available letter is
+          ``a`` (so we get ``23 → 23a``).  When ``a`` is taken, ``b``,
+          and so on.
+    """
+
+    # Walk in document order.  ``i`` is the first index whose basename
+    # sorts AFTER ``new_basename`` — that is the insertion position.
+    i = 0
+    while i < len(rows) and rows[i].basename < new_basename:
+        i += 1
+
+    prior = rows[i - 1] if i > 0 else None
+    next_ = rows[i] if i < len(rows) else None
+
+    if prior is None:
+        assert next_ is not None, "compute_insertion called against empty inventory"
+        return InsertionResult(
+            new_rownum=f"(before #{next_.rownum})", prior=prior, next_=next_
+        )
+
+    base = prior.base_number
+    taken_letters = {
+        r.letter_suffix for r in rows if r.base_number == base and r.letter_suffix
+    }
+    for code in range(ord("a"), ord("z") + 1):
+        candidate = chr(code)
+        if candidate not in taken_letters:
+            return InsertionResult(
+                new_rownum=f"{base}{candidate}", prior=prior, next_=next_
+            )
+
+    # Pathological — every letter a..z is taken at this base. Fall back
+    # to a marker so the operator picks a non-conflicting rownum manually.
+    return InsertionResult(
+        new_rownum=f"(after #{prior.rownum})", prior=prior, next_=next_
+    )
+
+
+def format_fix_block(
+    new_basename: str,
+    result: InsertionResult,
+    *,
+    total_guards: int,
+    n_missing: int,
+) -> str:
+    """Format the per-guard Fix block.
+
+    ``n_missing`` is the total number of missing guards in this run; it
+    drives the ``Total guards: <new-count>`` line so each per-guard block
+    advertises the correct final count rather than current+1.
+    """
+
+    new_total = total_guards + n_missing
+    rownum = result.new_rownum
+
+    if result.prior is None and result.next_ is not None:
+        # Start-of-list edge case.
+        location_line = (
+            f"Insert at row {rownum}, "
+            f"before #{result.next_.rownum} `{result.next_.basename}`."
+        )
+    elif result.next_ is None and result.prior is not None:
+        # End-of-list edge case.
+        location_line = (
+            f"Insert at row #{rownum}, "
+            f"after #{result.prior.rownum} `{result.prior.basename}`."
+        )
+    elif result.prior is not None and result.next_ is not None:
+        location_line = (
+            f"Insert at row #{rownum}, "
+            f"between #{result.prior.rownum} `{result.prior.basename}` "
+            f"and #{result.next_.rownum} `{result.next_.basename}`."
+        )
+    else:  # pragma: no cover — empty-inventory path is rejected upstream
+        location_line = f"Insert at row #{rownum} (inventory empty)."
+
+    template_rownum = rownum.lstrip("(").rstrip(")")
+    # The template strips the "(before/after ...)" wrapper for the literal
+    # patch — operators paste this verbatim into the table.
+    if template_rownum.startswith("before #") or template_rownum.startswith("after #"):
+        # Pathological / start-of-list — use the prior/next rownum as a hint.
+        if result.next_ is not None:
+            template_rownum = f"{result.next_.base_number}_NEW"
+        else:
+            template_rownum = "1"
+
+    template_line = f"| {template_rownum} | `scripts/{new_basename}` | <verdict> | <one-line note> |"
+
+    return (
+        f"Fix for `scripts/{new_basename}`:\n"
+        f"  {location_line}\n"
+        f"  Row template (paste into the survey table):\n"
+        f"    {template_line}\n"
+        f"  Update the Summary section's count: Total guards: {new_total}\n"
+        f"  Verdict options: self-diagnosing (Fix block), self-diagnosing (actionable text),\n"
+        f"  wrapper (delegates to helper), operational health probe, decision flow, NEEDS UPGRADE.\n"
+    )
+
+
+# ─── CLI ────────────────────────────────────────────────────────────────
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Emit per-guard Fix blocks for missing hygiene guards. "
+            "Driven by check-fix-block-coverage-complete.sh."
+        )
+    )
+    parser.add_argument(
+        "--doc",
+        type=Path,
+        required=True,
+        help="Path to docs/dx/check-script-fix-block-coverage.md.",
+    )
+    parser.add_argument(
+        "missing",
+        nargs="+",
+        help="One or more basenames of missing guards (e.g. check-foo.sh).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    if not args.doc.is_file():
+        print(f"ERROR: inventory doc not found: {args.doc}", file=sys.stderr)
+        return 2
+
+    rows = parse_inventory(args.doc)
+    if not rows:
+        print(
+            f"ERROR: no inventory rows parsed from {args.doc}",
+            file=sys.stderr,
+        )
+        return 2
+
+    total = parse_total_guards(args.doc)
+    if total is None:
+        # Fall back to the row count — the Summary section may be missing
+        # in synthetic fixtures.  Not a fatal error.
+        total = len(rows)
+
+    n_missing = len(args.missing)
+    for basename in args.missing:
+        result = compute_insertion(basename, rows)
+        block = format_fix_block(
+            basename, result, total_guards=total, n_missing=n_missing
+        )
+        print(block, file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_fix_block_coverage_complete.py
+++ b/scripts/tests/test_check_fix_block_coverage_complete.py
@@ -1,0 +1,307 @@
+"""Tests for ``scripts.check_fix_block_coverage_complete`` — the per-guard
+Fix-block formatter for ``check-fix-block-coverage-complete.sh`` (issue
+#4405).
+
+The helper computes alphabetical insertion points for missing hygiene
+guards against the existing inventory rows in
+``docs/dx/check-script-fix-block-coverage.md`` and emits a copy-pasteable
+Fix block per missing guard naming the exact letter-suffix row number,
+a row template with ``<guard>`` already filled in, and the new
+``Total guards: N`` count for the Summary section.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from check_fix_block_coverage_complete import (
+    InventoryRow,
+    compute_insertion,
+    format_fix_block,
+    parse_inventory,
+)
+
+
+# ─── Inventory parsing ────────────────────────────────────────────────────
+
+
+def write_inventory(tmp_path: Path, rows: list[tuple[str, str]]) -> Path:
+    """Write a minimal inventory doc with ``rows`` and return the path.
+
+    Each row is ``(rownum, basename)``.  The doc reproduces the
+    "## Survey", "## Summary" section structure expected by the parser
+    (Total-guards line included so the new-total computation has
+    something to read).
+    """
+
+    body_rows = "\n".join(
+        f"| {rn} | `scripts/{name}` | self-diagnosing (Fix block) | Note. |"
+        for rn, name in rows
+    )
+    doc = (
+        "# Hygiene-Guard Fix-Block Coverage\n"
+        "\n"
+        "## Survey\n"
+        "\n"
+        "| # | Guard | Verdict | Notes |\n"
+        "|---|-------|---------|-------|\n"
+        f"{body_rows}\n"
+        "\n"
+        "## Summary\n"
+        "\n"
+        f"- Total guards: {len(rows)} (synthetic).\n"
+    )
+    path = tmp_path / "check-script-fix-block-coverage.md"
+    path.write_text(doc)
+    return path
+
+
+def test_parse_inventory_extracts_rownum_and_basename(tmp_path: Path) -> None:
+    """Parser returns rows in document order with rownum + basename."""
+
+    doc = write_inventory(
+        tmp_path,
+        [
+            ("1", "check-api-keys.sh"),
+            ("11", "check-ci-job-skipped.sh"),
+            ("11a", "check-ci-guards-skip-list-coverage.sh"),
+            ("23", "check-duplicate-pr.sh"),
+            ("23a", "check-fix-block-coverage-complete.sh"),
+            ("84", "check_tf_empty_resource.py"),
+        ],
+    )
+    rows = parse_inventory(doc)
+
+    assert [(r.rownum, r.basename) for r in rows] == [
+        ("1", "check-api-keys.sh"),
+        ("11", "check-ci-job-skipped.sh"),
+        ("11a", "check-ci-guards-skip-list-coverage.sh"),
+        ("23", "check-duplicate-pr.sh"),
+        ("23a", "check-fix-block-coverage-complete.sh"),
+        ("84", "check_tf_empty_resource.py"),
+    ]
+
+
+def test_parse_inventory_total_count(tmp_path: Path) -> None:
+    """Parser returns the count from the ``Total guards:`` summary line."""
+
+    doc = write_inventory(
+        tmp_path,
+        [
+            ("1", "check-api-keys.sh"),
+            ("2", "check-apollo-keyfields.sh"),
+        ],
+    )
+    rows = parse_inventory(doc)
+    assert len(rows) == 2
+
+
+# ─── Insertion-point computation ──────────────────────────────────────────
+
+
+@pytest.fixture
+def sample_rows() -> list[InventoryRow]:
+    """A minimal but representative slice of the production inventory."""
+
+    return [
+        InventoryRow("11", "check-ci-job-skipped.sh"),
+        InventoryRow("11a", "check-ci-guards-skip-list-coverage.sh"),
+        InventoryRow("12", "check-ci-passed-coverage.sh"),
+        InventoryRow("23", "check-duplicate-pr.sh"),
+        InventoryRow("23a", "check-fix-block-coverage-complete.sh"),
+        InventoryRow("24", "check-git-gh-retries.sh"),
+        InventoryRow("37", "check-no-api-github-fetch.sh"),
+        InventoryRow("38", "check-no-duplicate-stubs.sh"),
+        InventoryRow("78", "check-workflow-paths-filter-coverage.sh"),
+        InventoryRow("78a", "check_no_basicconfig_with_extra.py"),
+        InventoryRow("79", "check_no_redos_pattern.py"),
+        InventoryRow("84", "check_tf_empty_resource.py"),
+    ]
+
+
+def test_compute_insertion_between_two_existing_rows(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """A new ``check-no-basicconfig-with-extra.sh`` slots between #37 and #38."""
+
+    result = compute_insertion("check-no-basicconfig-with-extra.sh", sample_rows)
+
+    assert result.new_rownum == "37a"
+    assert result.prior is not None
+    assert result.prior.basename == "check-no-api-github-fetch.sh"
+    assert result.prior.rownum == "37"
+    assert result.next_ is not None
+    assert result.next_.basename == "check-no-duplicate-stubs.sh"
+
+
+def test_compute_insertion_picks_next_letter_when_a_taken(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """When ``23a`` already exists, a new row at that position uses ``23b``."""
+
+    # ``check-foo-bar.sh`` slots between row 23a (check-fix-block-...) and
+    # row 24 (check-git-gh-retries.sh) — alphabetically:
+    #   check-fix-block-coverage-complete.sh < check-foo-bar.sh < check-git-gh-retries.sh
+    # The prior peer is 23a, so the next available letter on base 23 is ``b``.
+    result = compute_insertion("check-foo-bar.sh", sample_rows)
+
+    assert result.new_rownum == "23b"
+    assert result.prior is not None
+    assert result.prior.basename == "check-fix-block-coverage-complete.sh"
+    assert result.prior.rownum == "23a"
+
+
+def test_compute_insertion_underscore_py_in_underscore_section(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """Underscore-named ``.py`` files placed between underscore peers."""
+
+    # ``check_other.py`` slots between row 79 and row 84 — alphabetically:
+    #   check_no_redos_pattern.py < check_other.py < check_tf_empty_resource.py
+    result = compute_insertion("check_other.py", sample_rows)
+
+    assert result.new_rownum == "79a"
+    assert result.prior is not None
+    assert result.prior.basename == "check_no_redos_pattern.py"
+    assert result.next_ is not None
+    assert result.next_.basename == "check_tf_empty_resource.py"
+
+
+def test_compute_insertion_at_alphabetical_start(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """A guard that sorts before every existing row gets letter-suffix on row 1's number."""
+
+    # ``check-aaa.sh`` sorts before the first row (`check-ci-job-skipped.sh`).
+    # The expected insertion: prior is None, suggest the guard becomes a new
+    # row at the start. We use the special-case suffix on the first row's
+    # number minus 1, but since no row 0 exists, the convention is to use
+    # ``1`` itself with a leading-letter suffix — but for simplicity the
+    # implementation falls back to "Insert before row #11" with no
+    # letter-suffix derivation (start-of-list edge case).
+    result = compute_insertion("check-aaa.sh", sample_rows)
+
+    assert result.prior is None
+    assert result.next_ is not None
+    assert result.next_.basename == "check-ci-job-skipped.sh"
+    # Edge case: the implementation surfaces this as a special "before-first"
+    # marker so the operator knows to renumber manually or pick a low rownum.
+    assert result.new_rownum.startswith("(before #")
+
+
+def test_compute_insertion_at_alphabetical_end(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """A guard that sorts after every existing row gets letter-suffix on the last row's number."""
+
+    result = compute_insertion("check_zzz_last.py", sample_rows)
+
+    assert result.next_ is None
+    assert result.prior is not None
+    assert result.prior.basename == "check_tf_empty_resource.py"
+    assert result.new_rownum == "84a"
+
+
+# ─── Fix-block formatting ─────────────────────────────────────────────────
+
+
+def test_format_fix_block_names_specific_row_and_template(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """Fix block names the exact letter-suffix row + a copy-pasteable row template."""
+
+    result = compute_insertion("check-no-basicconfig-with-extra.sh", sample_rows)
+    block = format_fix_block(
+        "check-no-basicconfig-with-extra.sh", result, total_guards=12, n_missing=1
+    )
+
+    # Specific row number named.
+    assert "Insert at row #37a" in block
+    # Both surrounding peers named with their row numbers.
+    assert "#37 `check-no-api-github-fetch.sh`" in block
+    assert "#38 `check-no-duplicate-stubs.sh`" in block
+    # Copy-pasteable row template with <guard> filled in.
+    assert (
+        "| 37a | `scripts/check-no-basicconfig-with-extra.sh` | <verdict> | <one-line note> |"
+        in block
+    )
+
+
+def test_format_fix_block_includes_total_guards_with_new_count(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """Fix block reminds the contributor to update Total guards: N with the actual count."""
+
+    result = compute_insertion("check-no-basicconfig-with-extra.sh", sample_rows)
+    # Suppose inventory currently has 12 guards and we're adding 1.
+    block = format_fix_block(
+        "check-no-basicconfig-with-extra.sh", result, total_guards=12, n_missing=1
+    )
+
+    # The new total is 12 + 1 = 13.  Block must name the literal new count.
+    assert "Total guards: 13" in block
+
+
+def test_format_fix_block_at_end_uses_last_row_letter_suffix(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """At-end placement uses ``<last-rownum>a`` (e.g. 84a)."""
+
+    result = compute_insertion("check_zzz_last.py", sample_rows)
+    block = format_fix_block("check_zzz_last.py", result, total_guards=12, n_missing=1)
+
+    assert "Insert at row #84a" in block
+    assert "after #84 `check_tf_empty_resource.py`" in block
+    assert (
+        "| 84a | `scripts/check_zzz_last.py` | <verdict> | <one-line note> |" in block
+    )
+
+
+def test_format_fix_block_picks_next_letter_when_a_taken(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """Letter suffix increments past existing peers (23 + 23a → 23b)."""
+
+    result = compute_insertion("check-foo-bar.sh", sample_rows)
+    block = format_fix_block("check-foo-bar.sh", result, total_guards=12, n_missing=1)
+
+    assert "Insert at row #23b" in block
+    assert "| 23b | `scripts/check-foo-bar.sh` | <verdict> | <one-line note> |" in block
+
+
+def test_format_fix_block_sums_n_missing_in_total(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """When two guards are missing, each per-guard block names total + 2."""
+
+    result = compute_insertion("check-foo-bar.sh", sample_rows)
+    block = format_fix_block("check-foo-bar.sh", result, total_guards=12, n_missing=2)
+
+    # 12 + 2 = 14 — the new total accounts for ALL missing guards.
+    assert "Total guards: 14" in block
+
+
+# ─── Live inventory smoke test ────────────────────────────────────────────
+
+
+def test_live_inventory_parses(tmp_path: Path) -> None:
+    """Parser handles the production ``docs/dx/check-script-fix-block-coverage.md``.
+
+    Smoke test against the real file shipped with the repo. Catches a parser
+    that accidentally over-fits the synthetic fixture format.
+    """
+
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    live_doc = repo_root / "docs" / "dx" / "check-script-fix-block-coverage.md"
+    if not live_doc.is_file():
+        pytest.skip(f"Live inventory not found at {live_doc}")
+
+    rows = parse_inventory(live_doc)
+
+    assert len(rows) >= 80
+    # Spot-check a few well-known rows that are unlikely to renumber.
+    basenames = {r.basename for r in rows}
+    assert "check-api-keys.sh" in basenames
+    assert "check-fix-block-coverage-complete.sh" in basenames

--- a/scripts/tests/test_check_fix_block_coverage_complete.sh
+++ b/scripts/tests/test_check_fix_block_coverage_complete.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# test_check_fix_block_coverage_complete.sh — end-to-end test for the
+# per-guard Fix-block contract added in issue #4405.
+#
+# The Python helper has its own unit tests at
+# scripts/tests/test_check_fix_block_coverage_complete.py.  This shell
+# test runs the wrapper script (`scripts/check-fix-block-coverage-complete.sh`)
+# against a synthesized scripts/ directory + inventory doc so the
+# verify-line scenario in #4405 — "introduce a synthetic
+# scripts/check-foo-bar.sh, run the meta-check, and confirm the stderr
+# Fix block names a specific row number" — is asserted at the wrapper
+# layer.  Catches a future regression where the wrapper drops the
+# python3 invocation, mis-passes args, or restores the old generic Fix
+# block.
+#
+# Usage
+# -----
+#   scripts/tests/test_check_fix_block_coverage_complete.sh
+#
+# Exit codes
+# ----------
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="$REPO_ROOT/scripts/check-fix-block-coverage-complete.sh"
+HELPER="$REPO_ROOT/scripts/check_fix_block_coverage_complete.py"
+
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+write_synth_inventory() {
+    # write_synth_inventory <doc-path> — write a minimal inventory with
+    # rows 11/11a/12, 23/23a/24, 37/38, 78/78a/79 — the same scaffolding
+    # the unit tests use.  Total guards line set to 12.
+    local doc="$1"
+    cat > "$doc" <<'EOF'
+# Hygiene-Guard Fix-Block Coverage
+
+## Survey
+
+| # | Guard | Verdict | Notes |
+|---|-------|---------|-------|
+| 11 | `scripts/check-ci-job-skipped.sh` | self-diagnosing (Fix block) | Note. |
+| 11a | `scripts/check-ci-guards-skip-list-coverage.sh` | self-diagnosing (Fix block) | Note. |
+| 12 | `scripts/check-ci-passed-coverage.sh` | self-diagnosing (Fix block) | Note. |
+| 23 | `scripts/check-duplicate-pr.sh` | self-diagnosing (Fix block) | Note. |
+| 23a | `scripts/check-fix-block-coverage-complete.sh` | self-diagnosing (Fix block) | Note. |
+| 24 | `scripts/check-git-gh-retries.sh` | self-diagnosing (Fix block) | Note. |
+| 37 | `scripts/check-no-api-github-fetch.sh` | self-diagnosing (Fix block) | Note. |
+| 38 | `scripts/check-no-duplicate-stubs.sh` | self-diagnosing (Fix block) | Note. |
+| 78 | `scripts/check-workflow-paths-filter-coverage.sh` | self-diagnosing (Fix block) | Note. |
+| 78a | `scripts/check_no_basicconfig_with_extra.py` | self-diagnosing (Fix block) | Note. |
+| 79 | `scripts/check_no_redos_pattern.py` | self-diagnosing (Fix block) | Note. |
+| 84 | `scripts/check_tf_empty_resource.py` | self-diagnosing (Fix block) | Note. |
+
+## Summary
+
+- Total guards: 12 (synthetic).
+EOF
+}
+
+write_synth_guard() {
+    # write_synth_guard <scripts-dir> <basename>
+    local scripts_dir="$1" name="$2"
+    local path="$scripts_dir/$name"
+    cat > "$path" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$path"
+}
+
+# ─── Test 1: Wrapper is happy when every guard is documented ─────────────
+
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/scripts"
+write_synth_inventory "$TMPDIR_TEST/inventory.md"
+
+# Stage a guard for every row in the synthetic inventory so the wrapper
+# sees a clean diff. The dedup logic only flags hyphen-named .py files
+# whose .sh sibling is missing — none here.
+for name in \
+    check-ci-job-skipped.sh \
+    check-ci-guards-skip-list-coverage.sh \
+    check-ci-passed-coverage.sh \
+    check-duplicate-pr.sh \
+    check-fix-block-coverage-complete.sh \
+    check-git-gh-retries.sh \
+    check-no-api-github-fetch.sh \
+    check-no-duplicate-stubs.sh \
+    check-workflow-paths-filter-coverage.sh; do
+    write_synth_guard "$TMPDIR_TEST/scripts" "$name"
+done
+# Hyphen-named .py files in the underscore range — staged without .sh
+# siblings so the dedup logic keeps them.  Must NOT be flagged because
+# they're already in the inventory.
+for name in \
+    check_no_basicconfig_with_extra.py \
+    check_no_redos_pattern.py \
+    check_tf_empty_resource.py; do
+    cat > "$TMPDIR_TEST/scripts/$name" <<'EOF'
+#!/usr/bin/env python3
+EOF
+done
+
+TESTS=$((TESTS + 1))
+last_stderr=$(mktemp)
+SCRIPTS_DIR_OVERRIDE="$TMPDIR_TEST/scripts" \
+    DOC_OVERRIDE="$TMPDIR_TEST/inventory.md" \
+    "$WRAPPER" 2> "$last_stderr"
+rc=$?
+if [[ $rc -eq 0 ]]; then
+    echo "PASS: Test 1 — clean inventory exits 0"
+else
+    echo "FAIL: Test 1 — expected exit 0, got $rc"
+    cat "$last_stderr"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_stderr"
+
+# ─── Test 2: Synthetic check-foo-bar.sh — issue #4405's verify line ──────
+
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/scripts"
+write_synth_inventory "$TMPDIR_TEST/inventory.md"
+for name in \
+    check-ci-job-skipped.sh \
+    check-ci-guards-skip-list-coverage.sh \
+    check-ci-passed-coverage.sh \
+    check-duplicate-pr.sh \
+    check-fix-block-coverage-complete.sh \
+    check-git-gh-retries.sh \
+    check-no-api-github-fetch.sh \
+    check-no-duplicate-stubs.sh \
+    check-workflow-paths-filter-coverage.sh; do
+    write_synth_guard "$TMPDIR_TEST/scripts" "$name"
+done
+for name in \
+    check_no_basicconfig_with_extra.py \
+    check_no_redos_pattern.py \
+    check_tf_empty_resource.py; do
+    cat > "$TMPDIR_TEST/scripts/$name" <<'EOF'
+#!/usr/bin/env python3
+EOF
+done
+
+# Add the synthetic guard the issue's verify line specifies.
+write_synth_guard "$TMPDIR_TEST/scripts" "check-foo-bar.sh"
+
+TESTS=$((TESTS + 1))
+last_stderr=$(mktemp)
+set +e
+SCRIPTS_DIR_OVERRIDE="$TMPDIR_TEST/scripts" \
+    DOC_OVERRIDE="$TMPDIR_TEST/inventory.md" \
+    "$WRAPPER" 2> "$last_stderr"
+rc=$?
+set -e
+
+# Expected: exit 1 + stderr names a specific row number + a row template
+# with <guard> filled in + the new Total guards: 13 line.
+#
+# `check-foo-bar.sh` slots between #23a (`check-fix-block-coverage-complete.sh`)
+# and #24 (`check-git-gh-retries.sh`) — alphabetically:
+#   check-fix-block-coverage-complete.sh < check-foo-bar.sh < check-git-gh-retries.sh
+# Prior peer is row 23a, base 23, taken letters {a} → next is `b`.
+if [[ $rc -eq 1 ]] \
+    && grep -q "Insert at row #23b" "$last_stderr" \
+    && grep -q "between #23a \`check-fix-block-coverage-complete.sh\` and #24 \`check-git-gh-retries.sh\`" "$last_stderr" \
+    && grep -q "| 23b | \`scripts/check-foo-bar.sh\` | <verdict> | <one-line note> |" "$last_stderr" \
+    && grep -q "Total guards: 13" "$last_stderr"; then
+    echo "PASS: Test 2 — synthetic check-foo-bar.sh produces #23b row + template + new total"
+else
+    echo "FAIL: Test 2 — Fix block did not name #23b + row template + Total guards: 13"
+    echo "  rc: $rc"
+    echo "  stderr:"
+    cat "$last_stderr" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_stderr"
+
+# ─── Test 3: Two missing guards both get individual Fix blocks ───────────
+
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/scripts"
+write_synth_inventory "$TMPDIR_TEST/inventory.md"
+for name in \
+    check-ci-job-skipped.sh \
+    check-ci-guards-skip-list-coverage.sh \
+    check-ci-passed-coverage.sh \
+    check-duplicate-pr.sh \
+    check-fix-block-coverage-complete.sh \
+    check-git-gh-retries.sh \
+    check-no-api-github-fetch.sh \
+    check-no-duplicate-stubs.sh \
+    check-workflow-paths-filter-coverage.sh; do
+    write_synth_guard "$TMPDIR_TEST/scripts" "$name"
+done
+for name in \
+    check_no_basicconfig_with_extra.py \
+    check_no_redos_pattern.py \
+    check_tf_empty_resource.py; do
+    cat > "$TMPDIR_TEST/scripts/$name" <<'EOF'
+#!/usr/bin/env python3
+EOF
+done
+write_synth_guard "$TMPDIR_TEST/scripts" "check-foo-bar.sh"
+write_synth_guard "$TMPDIR_TEST/scripts" "check-zzz-trailing.sh"
+
+TESTS=$((TESTS + 1))
+last_stderr=$(mktemp)
+set +e
+SCRIPTS_DIR_OVERRIDE="$TMPDIR_TEST/scripts" \
+    DOC_OVERRIDE="$TMPDIR_TEST/inventory.md" \
+    "$WRAPPER" 2> "$last_stderr"
+rc=$?
+set -e
+
+# Two missing guards: total should be 12 + 2 = 14.
+# check-foo-bar.sh → row 23b (between 23a and 24).
+# check-zzz-trailing.sh sorts after every existing hyphen-named row but
+# before every underscore-named row. The last hyphen row in the synthetic
+# inventory is #78 (check-workflow-paths-filter-coverage.sh).  Its
+# letter-sibling slots (78a) is taken by check_no_basicconfig_with_extra.py,
+# so check-zzz-trailing.sh slots at 78b.  But wait — alphabetically
+# check-zzz-* < check_no_* (hyphen < underscore), so prior is row 78
+# (no taken letters at base 78 in the prior set up to and including the
+# prior position) — actually check_no_basicconfig_with_extra.py is at
+# 78a, so taken_letters at base=78 includes {a} and the next free letter
+# is `b`. Result: row #78b.
+if [[ $rc -eq 1 ]] \
+    && grep -q "Insert at row #23b" "$last_stderr" \
+    && grep -q "Insert at row #78b" "$last_stderr" \
+    && grep -q "Total guards: 14" "$last_stderr"; then
+    echo "PASS: Test 3 — two missing guards produce two distinct Fix blocks + new total: 14"
+else
+    echo "FAIL: Test 3 — Fix output did not name #23b + #78b + Total guards: 14"
+    echo "  rc: $rc"
+    echo "  stderr:"
+    cat "$last_stderr" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_stderr"
+
+# ─── Test 4: Live wrapper passes against the real inventory ──────────────
+# Defensive — production inventory is in sync with production guards;
+# the wrapper must exit 0 when invoked with no overrides.
+
+TESTS=$((TESTS + 1))
+if "$WRAPPER" > /dev/null 2>&1; then
+    echo "PASS: Test 4 — live wrapper exits 0 against the real inventory"
+else
+    echo "FAIL: Test 4 — live wrapper failed (real inventory out of sync?)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 5: Helper module is discoverable via python3 invocation ────────
+# The wrapper invokes `python3 $REPO_ROOT/scripts/check_fix_block_coverage_complete.py`.
+# Sanity check that --help works as a smoke for the helper being on disk
+# and importable.
+
+TESTS=$((TESTS + 1))
+if python3 "$HELPER" --help > /dev/null 2>&1; then
+    echo "PASS: Test 5 — helper module --help works"
+else
+    echo "FAIL: Test 5 — helper module not importable / --help failed"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Replace the generic Fix block in `scripts/check-fix-block-coverage-complete.sh` with a per-guard variant that names the exact letter-suffix row number, a copy-pasteable row template with `<guard>` already filled in, and the new `Total guards: N` count for the Summary section. Closes the loop in zero discretionary work for every future hygiene-guard contributor.

The new helper `scripts/check_fix_block_coverage_complete.py` is unit-tested (13 cases) and exercised end-to-end through a new shell integration test. The wrapper itself gains `SCRIPTS_DIR_OVERRIDE` / `DOC_OVERRIDE` env hooks so the integration test can run against a synthesized inventory.

Closes #4405.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/CI tooling only)
