### PR TITLE
docs(investigation): close LA dept-25 NULL-judge investigation chain (#4397)

### DIFF
--- a/docs/investigations/la-dept-25-html-in-ruling-text-2026-05.md
+++ b/docs/investigations/la-dept-25-html-in-ruling-text-2026-05.md
@@ -1,9 +1,9 @@
 # LA dept-25 "raw HTML in ruling_text" reingest failure — 2026-05
 
-**Issue:** #4382
-**Status:** Root-cause identified; hypothesis in original issue body falsified.
-**Worktree:** `agent-ad2cacb6c1bcfd80c`
-**Date:** 2026-05-08
+**Issue:** #4382 (parent), #4386 (registry-loader fix), #4397 (residual-NULL follow-up)
+**Status:** Closed end-to-end. #4386 fix landed in PR #4394 (119 → 62 NULL); #4397 follow-up identified the residual 62 as a chronological resolver-chain race; a second `--no-llm` reingest after the in-band judge auto-create dropped the count to **0/120**. See §"Residual NULLs after #4386 (2026-05-09)" below.
+**Worktree:** `agent-ad2cacb6c1bcfd80c` (#4382), `agent-aa2d6e145af885f85` (#4397)
+**Date:** 2026-05-08 (initial); 2026-05-09 (#4397 update)
 
 ## TL;DR
 
@@ -218,3 +218,55 @@ After re-reading the affected source files, the docstrings below contain claims 
 - `packages/scraper-framework/src/validation/deterministic.py:161-181` (the `check_no_html_in_ruling_text` docstring) — accurate; the rule fires correctly on the input it sees. The bug is upstream (raw HTML being fed to it), not in the rule.
 
 No follow-up issue is needed for docstring updates — the relevant edits are all part of the fix PR's natural scope and tracked under follow-up #1 above.
+
+---
+
+## Residual NULLs after #4386 (2026-05-09) — investigation #4397
+
+After PR #4394 landed and the dept-25 reingest re-ran, NULL `judge_id` count for LA dept-25 dropped from **119 → 62**. Issue #4397 was filed to investigate the residual 62. The four hypothesis classes in #4397's body (alias-map gap, alternate-format regex, missing judge_directory rows, LLM-only recoverable) all turned out to be **falsified** — the actual root cause is a different, fifth class.
+
+### Root cause: chronological resolver-chain race during reingest
+
+Every one of the 62 residual NULLs contains "Mkrtchyan" in `ruling_text`, and 57 of 62 carry the per-case `JUDGE/DEPT: Mkrtchyan/25` form-layout header that PR #4394 wired through. The expansion path at `scripts/reingest_from_s3.py:3138` (`_expand_single_word_judge_surname`) and the resolver at `packages/scraper-framework/src/ingestion/db.py:1212-1346` are wired correctly. The bug is that `_expand_single_word_judge_surname` Step 4 (suffix search at `db.py:1296-1311`) can only resolve "Mkrtchyan" when **`derived.judges` already contains a row whose `canonical_name` ends in "Mkrtchyan"** — and during the post-#4394 reingest, that row didn't exist yet for the first 62 documents in cursor order.
+
+#### Evidence chain
+
+1. **All 62 NULL rows mention Mkrtchyan** (per `tmp/null_classification.sql` — 62/62 contain the substring; 57/62 carry the JUDGE/DEPT header; 0 contain "Eisenman", the directory-snapshot-mapped judge for dept 25).
+2. **`Karine Mkrtchyan` was created in `derived.judges` at `2026-05-08 23:43:42.179284`.** No earlier row exists.
+   ```
+   id: cc47f872-2c55-43fb-8e72-301e8bf69f88, canonical_name: 'Karine Mkrtchyan',
+   created_at: 2026-05-08 23:43:42.179284+00:00, court county: 'Los Angeles'
+   ```
+3. **The 62 NULL rows all committed BEFORE the judge was created.** updated_at range: `23:43:32.079 → 23:43:42.161` — all before `23:43:42.179`.
+4. **The 45 successfully-resolved Mkrtchyan rows all committed AFTER.** updated_at range: `23:43:42.179 → 23:43:48.838`. The first resolved row's updated_at exactly matches the judge's `created_at` (sub-second).
+5. **The judge was auto-created by `resolve_judge` Step 4** (`db.py:1685-1700`) when processing the FIRST document whose `parse_document` strategy 3 (`extract_judge_name` → LA ALL-CAPS regex `_JUDGE_NAME_PATTERNS[7]` at `extract.py:927-937`) extracted the full name "KARINE MKRTCHYAN" from the boilerplate page text `*** The Judicial Officer Presiding in Department 25 is JUDGE KARINE MKRTCHYAN ***`. That page (document_id `4443de74-c6b8-58e5-bef3-b1292c4d2d01`, `ruling_id abfb96e8-f6e7-47b1-b047-cb4e37e9e4fa`, ruling_text length 1629 — pure boilerplate) is the only doc in the corpus whose `parse_document` returned the full name as the doc-level `judge_name`. All other dept-25 docs match strategy 1 (`_JUDGE_DEPT_RE`) first and produce the surname-only "Mkrtchyan".
+6. **The full-name-bearing boilerplate doc happens to fall LATER in the FETCH cursor order** (`(captured_at, id) ASC`) than the 62 surname-only docs. So the 62 hit the resolver before "Karine Mkrtchyan" was a row in `derived.judges`; their `_expand_single_word_judge_surname` Step 4 SQL `LOWER(canonical_name) LIKE '% mkrtchyan'` returned 0 rows; the function returned `None`; `judge_name` stayed "Mkrtchyan"; `resolve_judge` rejected the single-word name (`db.py:1457-1463`); `judge_id` stayed NULL.
+7. **A second `--no-llm` reingest after the judge was auto-created in pass 1 dropped the residual NULLs from 62 to 0.** Verified 2026-05-09: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county "Los Angeles" --department-in 25 --no-llm` processed 120 docs in 15.5 s with `total_failed: 0`. Post-run distribution:
+   ```json
+   [{"total":120,"null_judge":0,"resolved_judge":120,"starts_with_html":0,"starts_with_plain":120}]
+   [{"canonical_name":"Karine Mkrtchyan","n_rulings":107},
+    {"canonical_name":"Jonathan H. Eisenman","n_rulings":7},
+    {"canonical_name":"Latrice A. G. Byrdsong","n_rulings":6}]
+   ```
+   This is the closure of the original #4297 → #4370 → #4382 → #4386 → #4397 chain. End-to-end: 119 NULL → 62 NULL (PR #4394 landed) → 0 NULL (second reingest after in-band judge auto-create).
+
+#### Why the four hypotheses in #4397's body were all wrong
+
+| #4397 hypothesis | Why falsified |
+|---|---|
+| 1. Single-word surname with no LA alias entry — "`_LA_SURNAME_TO_FULL` only has aliases for surnames the LA county directory already knows" | There is no `_LA_SURNAME_TO_FULL` map in the codebase. The expansion is purely DB-driven via `_expand_single_word_judge_surname` (`db.py:1212`) which queries `derived.judges` directly. The surname IS resolvable once "Karine Mkrtchyan" is in `derived.judges`. |
+| 2. Alternate-format pages — "longer header `*** The Judicial Officer Presiding in Department 25 is JUDGE KARINE MKRTCHYAN ***` may not match the regex" | The LA ALL-CAPS regex (`_JUDGE_NAME_PATTERNS[7]` at `extract.py:927-937`) DOES match this header — verified with the worktree's `tmp/test_la_allcaps_regex.py`. In fact, this is precisely the regex that auto-created the judge during pass 1. |
+| 3. Missing judge_directory rows — "the directory snapshot for LA dept 25 hasn't been refreshed" | The latest LA snapshot (id 429, captured 2026-05-08 13:30) maps dept 25 → "Jonathan H. Eisenman". This is consistent with LA's public directory and is correct from the directory's perspective; the snapshot is not stale. The disagreement between the snapshot (Eisenman) and the actual day-of-bench rulings (Mkrtchyan) is by design — `_expand_single_word_judge_surname` Step 4 explicitly handles this case via the suffix search. |
+| 4. Reingest scope — "`--no-llm` was used; LLM extraction would recover them" | Falsified by hypothesis 7's evidence: a second `--no-llm` reingest closed all 62. LLM extraction is not required. |
+
+### Actionable follow-ups
+
+The chronological-race class of bug is structural: **any new judge whose first per-document appearance is in surname-only docs that fall earlier in the FETCH cursor than the doc that triggers the auto-create is at risk of staying NULL on the first reingest pass.** It will recur whenever a county adds a new judge whose name matches this pattern (single-word surname header + a separate full-name boilerplate page).
+
+Two follow-ups close the loop:
+
+1. **`feat(reingest): two-pass resolver to remove the chronological-race class`** (priority/p2, area/ingestion). Add a pre-pass to `scripts/reingest_from_s3.py` that walks the cursor once to discover all candidate full judge names (via `parse_document` + `extract_judge_name`) without writing rulings, upserts them into `derived.judges`, then runs the existing pass to write rulings. Eliminates the ordering dependency entirely. The same problem exists for any single-word LA pattern (other surnames will hit it the next time a new dept gets a new judge), so a structural fix is preferred over per-judge mitigations.
+2. **`fix(reingest): document the second-reingest-pass closure pattern in the surname-expansion docstring`** (priority/p3, area/docs). Update the docstring at `db.py:1212-1267` to note that Step 4 only resolves surnames once a judge with the matching canonical_name has been created — so a single reingest pass can leave residual NULLs if the cursor order processes surname-only docs before the full-name doc that triggers the auto-create. Until follow-up #1 lands, a second reingest pass closes the gap.
+
+The same "second reingest" pattern works for any LA dept whose new presiding judge first appears with a single-word JUDGE/DEPT header and is later seeded by a full-name boilerplate. No surgical SQL is needed; the rebuild path (`scripts/rebuild_db.py --county "Los Angeles"`) followed by two reingest passes always converges.
+


### PR DESCRIPTION
## Summary

Investigation #4397 — root-causes the residual 62 NULL `judge_id` rows for LA dept-25 after PR #4394 (#4386 fix). Updates the existing investigation doc with the §"Residual NULLs after #4386 (2026-05-09)" section. End-to-end NULL trajectory closed: 119 → 62 (PR #4394) → **0/120** (second `--no-llm` reingest 2026-05-09).

The root cause is a **chronological resolver-chain race during a single reingest pass**: surname-only docs (carrying `JUDGE/DEPT: Mkrtchyan/25`) commit with NULL `judge_id` when they precede in the FETCH cursor the boilerplate-header doc whose full-name extraction triggers `resolve_judge`'s in-band judge auto-create. All four hypothesis classes named in #4397's body are falsified. Two follow-ups filed for the structural fix (#4408) and docstring update (#4409).

Closes #4397

## Test plan

### Automated checks
- [x] Markdown links (`scripts/check-markdown-links.sh`) — 105 files, no broken links
- [x] Lint passes (no Python/TS code touched)
- [x] CI green

### Post-deploy verification
- [x] Verified on dev: `scripts/dev-db-query.sh` returns `null_judge: 0` for the LA dept-25 corpus after a second `--no-llm` reingest pass (full evidence in #4397 close comment)
- [x] Verification evidence posted on issue (closing comment with reingest log + pre/post NULL counts + per-judge resolution distribution)
