### PR TITLE
fix(dx): wait-for-ci.sh treats CANCELLED as non-blocking (#4407)

### DIFF
--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -223,6 +223,43 @@ write_failure_response() {
 JSON
 }
 
+# Write a check-runs response that mirrors the #4407 wedge: one `cancelled`
+# non-required check (e.g. Vercel `Check major pages` cancelled by
+# `concurrency: cancel-in-progress`) alongside a green `ci-passed`. The
+# canonical merge gate considers this safe to merge — `wait-for-ci.sh` must
+# exit 0 via the fast-path within one poll, NOT exit 1 treating CANCELLED
+# as a hard failure.
+write_cancelled_with_success_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",              "status": "completed", "conclusion": "success",   "details_url": "https://example.com/lint"},
+    {"name": "unit-tests",        "status": "completed", "conclusion": "success",   "details_url": "https://example.com/unit"},
+    {"name": "ci-passed",         "status": "completed", "conclusion": "success",   "details_url": "https://example.com/ci"},
+    {"name": "Check major pages", "status": "completed", "conclusion": "cancelled", "details_url": "https://example.com/check-major-pages"}
+  ]
+}
+JSON
+}
+
+# Write a check-runs response that pairs a `cancelled` non-required check
+# with a real `failure`. The script must still exit 1 — the cancelled count
+# is non-blocking, but a real failure on the SAME SHA still trips the
+# early-failure branch. Defense-in-depth for #4407.
+write_cancelled_plus_real_failure_response() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "check_runs": [
+    {"name": "lint",              "status": "completed", "conclusion": "success",   "details_url": "https://example.com/lint"},
+    {"name": "unit-tests",        "status": "completed", "conclusion": "failure",   "details_url": "https://example.com/unit"},
+    {"name": "Check major pages", "status": "completed", "conclusion": "cancelled", "details_url": "https://example.com/check-major-pages"}
+  ]
+}
+JSON
+}
+
 # Write a check-runs response with one failed check whose details_url uses
 # the canonical GitHub Actions URL format. This is what production check-runs
 # actually emit and is required for the auto-rerun classifier path (#4148)
@@ -898,6 +935,121 @@ LOG
     fi
 }
 
+# Test 15 (#4407 AC#1): canonical merge gate fast-path with one CANCELLED
+# non-required check. This is the canonical wedge filed by the issue —
+# `Check major pages` got cancelled by Vercel's `concurrency:
+# cancel-in-progress`, but `ci-passed` is success and `mergeable` is
+# MERGEABLE. The script must exit 0 via the canonical fast-path within ~30s
+# AND must NOT print `ERROR: ... check(s) failed`.
+test_cancelled_non_required_does_not_block_merge_gate() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_cancelled_with_success_response "$tmpdir/responses/01.json"
+
+    local output exit_code start_ts end_ts elapsed
+    exit_code=0
+    start_ts=$(date +%s)
+    output=$(MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=UNSTABLE \
+        run_script "$tmpdir" 4406 --poll-interval 1 --timeout-secs 30 2>&1) || exit_code=$?
+    end_ts=$(date +%s)
+    elapsed=$((end_ts - start_ts))
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "cancelled_non_required: exits 0 even when one check is CANCELLED"
+    else
+        fail "cancelled_non_required: exits 0 even when one check is CANCELLED" "exit=$exit_code output=$output"
+    fi
+
+    if [ "$elapsed" -lt 10 ]; then
+        pass "cancelled_non_required: exits in <10s (actual: ${elapsed}s)"
+    else
+        fail "cancelled_non_required: exits in <10s" "elapsed=${elapsed}s — fast-path must not stall on cancelled checks"
+    fi
+
+    if echo "$output" | grep -q "canonical merge gate green"; then
+        pass "cancelled_non_required: stdout contains 'canonical merge gate green'"
+    else
+        fail "cancelled_non_required: stdout contains 'canonical merge gate green'" "output=$output"
+    fi
+
+    # The bug from #4407 — output should NOT contain `ERROR: 1 check(s) failed`.
+    if echo "$output" | grep -qE "ERROR: [0-9]+ check\(s\) failed"; then
+        fail "cancelled_non_required: must NOT print ERROR for CANCELLED-only state" "output=$output"
+    else
+        pass "cancelled_non_required: does not falsely report a failure"
+    fi
+
+    # Per-poll status line must reflect the new cancelled= field so callers
+    # reading the log can see the count was non-zero.
+    if echo "$output" | grep -qE "cancelled=[1-9]"; then
+        pass "cancelled_non_required: per-poll status line names cancelled count"
+    else
+        fail "cancelled_non_required: per-poll status line names cancelled count" "output=$output"
+    fi
+}
+
+# Test 16 (#4407 AC#1 fallback): cancelled-only state with mergeable=UNKNOWN
+# must still exit 0 via the all-checks-complete fallback path. This guards
+# against a regression where the fallback path stops firing because of the
+# new CANCELLED bookkeeping.
+test_cancelled_falls_through_to_all_checks_complete() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_cancelled_with_success_response "$tmpdir/responses/01.json"
+
+    local output exit_code
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=UNKNOWN MERGE_STATE_RESPONSE=UNSTABLE \
+        run_script "$tmpdir" 4406 --poll-interval 0 --timeout-secs 30 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "cancelled_all_checks_complete: exits 0 when mergeable=UNKNOWN but pending=0"
+    else
+        fail "cancelled_all_checks_complete: exits 0 when mergeable=UNKNOWN but pending=0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "all checks complete"; then
+        pass "cancelled_all_checks_complete: stdout contains 'all checks complete'"
+    else
+        fail "cancelled_all_checks_complete: stdout contains 'all checks complete'" "output=$output"
+    fi
+}
+
+# Test 17 (#4407 AC#2): real FAILURE checks still exit 1, even when a
+# CANCELLED check is also present. Splitting CANCELLED out of the failure
+# count must not let real failures slip through.
+test_real_failure_with_cancelled_still_exits_1() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_cancelled_plus_real_failure_response "$tmpdir/responses/01.json"
+
+    local output exit_code
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=DIRTY \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 30 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "real_failure_with_cancelled: exits 1 on real failure even with cancelled present"
+    else
+        fail "real_failure_with_cancelled: exits 1 on real failure even with cancelled present" "exit=$exit_code output=$output"
+    fi
+
+    # Output must mention the failed unit-tests check.
+    if echo "$output" | grep -q "unit-tests"; then
+        pass "real_failure_with_cancelled: output names the real failing check"
+    else
+        fail "real_failure_with_cancelled: output names the real failing check" "output=$output"
+    fi
+
+    # Output must NOT list `Check major pages` in the failure list — cancelled
+    # is no longer reported as a failure.
+    if echo "$output" | grep -qE "^\s+- Check major pages: conclusion=cancelled"; then
+        fail "real_failure_with_cancelled: cancelled checks must not be listed as failures" "output=$output"
+    else
+        pass "real_failure_with_cancelled: cancelled checks correctly excluded from failure list"
+    fi
+}
+
 # ── Run all tests ──────────────────────────────────────────────────────────
 
 test_happy_path
@@ -916,6 +1068,9 @@ test_real_failure_no_rerun
 test_no_auto_rerun_flag_disables_classifier
 test_flake_telemetry_emits_jsonl_line
 test_flake_telemetry_aggregatable
+test_cancelled_non_required_does_not_block_merge_gate
+test_cancelled_falls_through_to_all_checks_complete
+test_real_failure_with_cancelled_still_exits_1
 
 echo ""
 echo "────────────────────────────────────────────"

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -60,23 +60,35 @@
 #   0 — Success. Reached via one of two paths, in priority order:
 #       (a) **Canonical-merge-gate fast-path** (#4069): `mergeable == MERGEABLE`,
 #           any `ci-passed` entry in the filter=latest response has
-#           conclusion=success, and no latest check has conclusion=
-#           failure/timed_out/action_required/cancelled. Stdout names this
-#           path explicitly with the substring `canonical merge gate green`.
-#           This path exits immediately even if filter=latest still surfaces
-#           in_progress entries from a superseded CI run on the same SHA —
-#           the same gate documented in `docs/agent/code-standards.md`
-#           §"Interpreting mergeStateStatus (UNSTABLE-but-green)".
+#           conclusion=success, and no latest check has a hard-failure
+#           conclusion (failure, timed_out, action_required). Stdout names
+#           this path explicitly with the substring `canonical merge gate
+#           green`. This path exits immediately even if filter=latest still
+#           surfaces in_progress entries from a superseded CI run on the
+#           same SHA, or `cancelled` entries from a non-required check
+#           (e.g. Vercel's `Check major pages` `concurrency:
+#           cancel-in-progress` cancel) — the same gate documented in
+#           `docs/agent/code-standards.md` §"Interpreting mergeStateStatus
+#           (UNSTABLE-but-green)" (#4407).
 #       (b) **All-checks-complete path:** filter=latest shows pending=0,
-#           ci-passed=success, no failures, and mergeStateStatus is CLEAN or
-#           UNSTABLE. Stdout names this path with `all checks complete`.
-#   1 — Early failure: one or more checks have a failed conclusion. Prints the
-#       failed check names and their details_url. Before exiting, the failed
-#       jobs' logs are passed to `scripts/classify-ci-flake.sh`. If any
-#       classifies as a known flake AND no rerun has fired on this run yet,
-#       `gh run rerun <run-id> --failed` is invoked once and polling continues
-#       (path stdout names the matched pattern with `flake detected: <label>`).
-#       A second flake on the same run exits 1 — see #4148.
+#           ci-passed=success, no hard failures, and mergeStateStatus is
+#           CLEAN or UNSTABLE. `cancelled` checks count as terminal here —
+#           they do not block this path either. Stdout names this path with
+#           `all checks complete`.
+#   1 — Early failure: one or more checks have a hard failed conclusion
+#       (failure, timed_out, action_required). Prints the failed check
+#       names and their details_url. **`cancelled` is NOT a hard failure**
+#       — it routinely surfaces from Vercel / smoke-test
+#       `concurrency: cancel-in-progress` guards and from manual
+#       `gh run cancel` actions, neither of which reflects a real test
+#       failure (#4407). Cancelled entries are listed in the per-poll
+#       status line but never trigger exit 1.
+#       Before exiting, the failed jobs' logs are passed to
+#       `scripts/classify-ci-flake.sh`. If any classifies as a known flake
+#       AND no rerun has fired on this run yet, `gh run rerun <run-id>
+#       --failed` is invoked once and polling continues (path stdout names
+#       the matched pattern with `flake detected: <label>`). A second
+#       flake on the same run exits 1 — see #4148.
 #   2 — Timeout: --timeout-secs elapsed without reaching a terminal state.
 #
 # ── Flake telemetry (#4163) ──────────────────────────────────────────────────
@@ -290,18 +302,31 @@ while true; do
     CHECK_RUNS_JSON=$(gh api "repos/${REPO}/commits/${SHA}/check-runs?per_page=100&filter=latest" \
         | jq '.check_runs')
 
-    # Count pending, passed, and failed checks.
+    # Count pending, passed, failed (hard), and cancelled checks.
+    #
+    # `cancelled` is split out from `FAILED_COUNT` (#4407) because it is not a
+    # hard failure: Vercel and smoke-test workflows configure
+    # `concurrency: cancel-in-progress: true`, which cancels superseded check
+    # runs the moment a newer push/deploy starts. The cancel is intentional
+    # workflow behaviour, not a real test failure, and the canonical merge
+    # gate documented in `docs/agent/code-standards.md` §"Interpreting
+    # mergeStateStatus (UNSTABLE-but-green)" already permits non-required
+    # `cancelled` checks. Treating them as failures forced every /task agent
+    # to manually fall through to a separate `gh pr view` recipe on every
+    # Vercel-cancellation run; splitting the count closes that loop.
     PENDING_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status != "completed")] | length')
     PASSED_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status == "completed" and (.conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral"))] | length')
-    FAILED_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled"))] | length')
+    FAILED_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required"))] | length')
+    CANCELLED_COUNT=$(echo "$CHECK_RUNS_JSON" | jq '[.[] | select(.status == "completed" and .conclusion == "cancelled")] | length')
 
-    echo "[${ELAPSED}s] pending=${PENDING_COUNT} passed=${PASSED_COUNT} failed=${FAILED_COUNT}"
+    echo "[${ELAPSED}s] pending=${PENDING_COUNT} passed=${PASSED_COUNT} failed=${FAILED_COUNT} cancelled=${CANCELLED_COUNT}"
 
-    # Check for early failure: any check with a failed conclusion.
+    # Check for early failure: any check with a HARD failed conclusion. A
+    # cancelled-only state never trips this branch (#4407).
     if [ "$FAILED_COUNT" -gt 0 ]; then
         echo ""
         echo "ERROR: ${FAILED_COUNT} check(s) failed:" >&2
-        echo "$CHECK_RUNS_JSON" | jq -r '.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled")) | "  - \(.name): conclusion=\(.conclusion)  \(.details_url // "(no details url)")"' >&2
+        echo "$CHECK_RUNS_JSON" | jq -r '.[] | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")) | "  - \(.name): conclusion=\(.conclusion)  \(.details_url // "(no details url)")"' >&2
 
         # ── Known-flake auto-rerun (#4148) ────────────────────────────────
         # Before exiting 1, classify each failed job's log tail. If any
@@ -329,7 +354,7 @@ while true; do
             # validator forbids control chars).
             FAILED_DETAILS=$(echo "$CHECK_RUNS_JSON" | jq -r '
                 .[]
-                | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required" or .conclusion == "cancelled"))
+                | select(.status == "completed" and (.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required"))
                 | "\(.name // "")\t\(.details_url // "")"
             ')
 
@@ -401,35 +426,40 @@ EOF
     CI_PASSED_SUCCESS=$(echo "$CHECK_RUNS_JSON" | jq -r '[.[] | select(.name == "ci-passed")] | any(.conclusion == "success")')
     CI_PASSED_CONCLUSION=$(echo "$CHECK_RUNS_JSON" | jq -r '[.[] | select(.name == "ci-passed") | .conclusion] | (.[0] // "")')
 
-    # ── Canonical-merge-gate fast-path (#4069) ───────────────────────────────
+    # ── Canonical-merge-gate fast-path (#4069, #4407) ────────────────────────
     # Mirrors `docs/agent/code-standards.md` §"Interpreting mergeStateStatus
     # (UNSTABLE-but-green)" and the `/task` skill's §A.7 merge gate. When
     # `mergeable == MERGEABLE`, the required `ci-passed` check is success on
     # its latest run, and no latest check is a hard failure, the PR is safe
     # to merge regardless of any pending entries left over from a superseded
-    # CI run on the same SHA. Exit immediately so callers don't burn the full
-    # timeout watching phantom in_progress rows that will never complete.
+    # CI run on the same SHA OR `cancelled` entries from a non-required
+    # Vercel/smoke-test concurrency cancel (#4407). Exit immediately so
+    # callers don't burn the full timeout watching phantom in_progress rows
+    # that will never complete OR fall through to a hand-rolled `gh pr view`
+    # gate every time Vercel cancels a deploy.
     if [ "$CI_PASSED_SUCCESS" = "true" ] && [ "$FAILED_COUNT" -eq 0 ]; then
         MERGEABLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeable -q .mergeable 2>/dev/null || echo "UNKNOWN")
         if [ "$MERGEABLE" = "MERGEABLE" ]; then
             echo ""
-            echo "[${ELAPSED}s] canonical merge gate green — exiting (mergeable=MERGEABLE, ci-passed=success, failed=0; pending=${PENDING_COUNT} ignored as superseded)."
+            echo "[${ELAPSED}s] canonical merge gate green — exiting (mergeable=MERGEABLE, ci-passed=success, failed=0; pending=${PENDING_COUNT} ignored as superseded; cancelled=${CANCELLED_COUNT} ignored as non-required)."
             exit 0
         fi
     fi
 
     # ── Existing all-checks-complete path ────────────────────────────────────
-    # When pending=0, every check has a terminal conclusion. Combined with
-    # ci-passed=success and a CLEAN/UNSTABLE mergeStateStatus, this is the
-    # original safe-to-merge signal. Kept as a fallback for the case where
-    # `mergeable` cannot be resolved (UNKNOWN, API error) so the script still
-    # exits when CI legitimately drained to zero pending.
+    # When pending=0, every check has a terminal conclusion (success, skipped,
+    # neutral, or cancelled — cancelled counts as terminal here, see #4407).
+    # Combined with ci-passed=success, no hard failures, and a CLEAN/UNSTABLE
+    # mergeStateStatus, this is the original safe-to-merge signal. Kept as a
+    # fallback for the case where `mergeable` cannot be resolved (UNKNOWN,
+    # API error) so the script still exits when CI legitimately drained to
+    # zero pending.
     if [ "$CI_PASSED_SUCCESS" = "true" ] && [ "$FAILED_COUNT" -eq 0 ] && [ "$PENDING_COUNT" -eq 0 ]; then
         # Secondary guard: verify mergeStateStatus is CLEAN or UNSTABLE.
         MERGE_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus -q .mergeStateStatus)
         if [ "$MERGE_STATE" = "CLEAN" ] || [ "$MERGE_STATE" = "UNSTABLE" ]; then
             echo ""
-            echo "[${ELAPSED}s] all checks complete — CI passed (ci-passed=success, mergeStateStatus=${MERGE_STATE})."
+            echo "[${ELAPSED}s] all checks complete — CI passed (ci-passed=success, mergeStateStatus=${MERGE_STATE}, cancelled=${CANCELLED_COUNT} non-blocking)."
             exit 0
         else
             echo "  ci-passed=success but mergeStateStatus=${MERGE_STATE}, still waiting..."
@@ -440,7 +470,7 @@ EOF
     if [ "$NOW_TS" -ge "$DEADLINE" ]; then
         echo ""
         echo "ERROR: Timed out after ${TIMEOUT_SECS}s waiting for CI on PR #${PR_NUMBER}." >&2
-        echo "Last state: pending=${PENDING_COUNT} passed=${PASSED_COUNT} failed=${FAILED_COUNT}" >&2
+        echo "Last state: pending=${PENDING_COUNT} passed=${PASSED_COUNT} failed=${FAILED_COUNT} cancelled=${CANCELLED_COUNT}" >&2
         echo "ci-passed conclusion: ${CI_PASSED_CONCLUSION:-(not yet present)}" >&2
         exit 2
     fi


### PR DESCRIPTION
## Summary

Split `cancelled` out of `FAILED_COUNT` in `scripts/wait-for-ci.sh` so the canonical merge gate fast-path fires when the only non-success entries are `cancelled` non-required checks (typical Vercel `concurrency: cancel-in-progress` pattern). Real hard failures (`failure`, `timed_out`, `action_required`) still exit 1; only `cancelled` is reclassified as non-blocking, matching the gate documented in `docs/agent/code-standards.md` and `.claude/skills/task/SKILL.md` §A.7.

Three new regression tests cover the wedge from the issue body and the inverse case where a real failure must still exit 1 even with cancelled present. Full suite: 54/54 PASS.

Closes #4407

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI tooling script + its tests; runs locally and in CI shell-test shards, not deployed to any service)
- [x] Verification evidence posted on issue (see A.8)
