### PR TITLE
feat(dx): wait-for-ci.sh exits 3 on green-but-DIRTY (#4412)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -719,6 +719,8 @@ scripts/wait-for-ci.sh <PR-N>
 
 This polls the check-runs API with `filter=latest` (deduplicates re-runs) and exits 0 via either of two paths: (a) the canonical-merge-gate fast-path — `mergeable == MERGEABLE`, any `ci-passed` entry is `success`, no latest check has failed — fires immediately even if stale `in_progress` entries from a superseded CI run linger in the response (#4069); (b) the all-checks-complete fallback — `pending == 0`, `ci-passed` is `success`, no failures, `mergeStateStatus` is `CLEAN` or `UNSTABLE` — fires when CI legitimately drains to zero pending. Stdout names the path explicitly with `canonical merge gate green` or `all checks complete`. Exit 1 = failure, Exit 2 = timeout.
 
+**Exit 3 — REBASE_REQUIRED (#4412).** When CI is green (`ci-passed=success`, no latest failures) but `mergeStateStatus=DIRTY` (a concurrent merge landed on origin/main that conflicts with this PR's diff), `wait-for-ci.sh` exits 3 immediately on the first poll iteration where this is true rather than continuing to poll until timeout. There is no path forward by waiting — the agent must rebase before the PR can merge. On exit 3, follow the A.4 rebase recipe (`git fetch origin main && git rebase origin/main && git push --force-with-lease`), then re-enter the CI watch loop, incrementing the `ci-watch (N)` phase counter and re-emitting `awaiting_ci`. The exit-3 path is the rebase-fast-path equivalent of A.4's merge-conflict handling — both bottom out in the same rebase + force-push, but exit 3 surfaces the signal in <1s instead of the ~10 min the script previously burned re-logging `still waiting...` until timeout.
+
 For workflow-run-level watching (deploy workflows in §A.8), `gh run watch` stays as the fallback:
 
 ```

--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -903,6 +903,161 @@ LOG
     fi
 }
 
+# Test 15 (#4412): Exit 3 (REBASE_REQUIRED) when CI is green but
+# mergeStateStatus=DIRTY (a concurrent merge landed on origin/main that
+# conflicts with the PR's diff). The script must exit 3 within one polling
+# cycle rather than continuing to poll until timeout.
+test_rebase_required_exits_3_on_first_poll() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_all_success_response "$tmpdir/responses/01.json"
+
+    local output exit_code start_ts end_ts elapsed
+    exit_code=0
+    start_ts=$(date +%s)
+    # ci-passed=success, failures=0, mergeStateStatus=DIRTY. mergeable would be
+    # CONFLICTING in production; the mock returns whatever MERGEABLE_RESPONSE is
+    # set to. We pass UNKNOWN to prove the exit-3 path doesn't depend on the
+    # mergeable enum (DIRTY is the load-bearing signal).
+    output=$(MERGEABLE_RESPONSE=CONFLICTING MERGE_STATE_RESPONSE=DIRTY \
+        run_script "$tmpdir" 42 --poll-interval 5 --timeout-secs 60 2>&1) || exit_code=$?
+    end_ts=$(date +%s)
+    elapsed=$((end_ts - start_ts))
+
+    if [ "$exit_code" -eq 3 ]; then
+        pass "rebase_required: exits 3 on green-but-DIRTY"
+    else
+        fail "rebase_required: exits 3 on green-but-DIRTY" "exit=$exit_code output=$output"
+    fi
+
+    # AC#1: must exit within one polling cycle (well before --poll-interval).
+    if [ "$elapsed" -lt 5 ]; then
+        pass "rebase_required: exits in <5s (actual: ${elapsed}s) — one polling cycle"
+    else
+        fail "rebase_required: exits in <5s" "elapsed=${elapsed}s — must not wait for second poll"
+    fi
+
+    # AC#2: stdout/stderr names the action with the exact rebase command.
+    if echo "$output" | grep -q "mergeStateStatus=DIRTY"; then
+        pass "rebase_required: output names mergeStateStatus=DIRTY"
+    else
+        fail "rebase_required: output names mergeStateStatus=DIRTY" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "rebase required to merge"; then
+        pass "rebase_required: output names the required action"
+    else
+        fail "rebase_required: output names the required action" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "git fetch origin main && git rebase origin/main && git push --force-with-lease"; then
+        pass "rebase_required: output includes the literal rebase command"
+    else
+        fail "rebase_required: output includes the literal rebase command" "output=$output"
+    fi
+}
+
+# Test 16 (#4412): The exit-3 path must NOT fire when mergeStateStatus is
+# CLEAN or UNSTABLE — those go through the existing exit-0 paths. Defense in
+# depth against a future refactor that mis-orders the branch chain.
+test_rebase_required_does_not_fire_on_clean_or_unstable() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_all_success_response "$tmpdir/responses/01.json"
+
+    local exit_code
+    exit_code=0
+    MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=CLEAN \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 30 >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "rebase_required_no_misfire_clean: CLEAN exits 0, not 3"
+    else
+        fail "rebase_required_no_misfire_clean: CLEAN exits 0, not 3" "exit=$exit_code"
+    fi
+
+    # Re-run with UNSTABLE.
+    local tmpdir2
+    tmpdir2=$(make_temp_dir)
+    write_all_success_response "$tmpdir2/responses/01.json"
+    exit_code=0
+    MERGEABLE_RESPONSE=MERGEABLE MERGE_STATE_RESPONSE=UNSTABLE \
+        run_script "$tmpdir2" 42 --poll-interval 0 --timeout-secs 30 >/dev/null 2>&1 || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "rebase_required_no_misfire_unstable: UNSTABLE exits 0, not 3"
+    else
+        fail "rebase_required_no_misfire_unstable: UNSTABLE exits 0, not 3" "exit=$exit_code"
+    fi
+}
+
+# Test 17 (#4412): Failure short-circuits the exit-3 path. If a check has
+# conclusion=failure AND mergeStateStatus=DIRTY, exit 1 (failure) wins over
+# exit 3 (rebase) — the agent must fix the failure before considering rebase.
+test_rebase_required_does_not_fire_when_failure_present() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_failure_response "$tmpdir/responses/01.json" "web-tests"
+
+    local exit_code output
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=CONFLICTING MERGE_STATE_RESPONSE=DIRTY \
+        run_script "$tmpdir" 42 --poll-interval 0 --timeout-secs 30 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 1 ]; then
+        pass "rebase_required_no_misfire_failure: exits 1 (not 3) when a check failed"
+    else
+        fail "rebase_required_no_misfire_failure: exits 1 (not 3) when a check failed" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "rebase required to merge"; then
+        fail "rebase_required_no_misfire_failure: must NOT log the rebase action when a check failed" "output=$output"
+    else
+        pass "rebase_required_no_misfire_failure: rebase action correctly suppressed by failure"
+    fi
+}
+
+# Test 18 (#4412): The exit-3 path must NOT fire while ci-passed is still
+# in_progress, even if mergeStateStatus=DIRTY. We can't tell the agent to
+# rebase based on a partial CI signal — they may still need to wait for a
+# real failure to surface. Times out (exit 2) instead.
+test_rebase_required_does_not_fire_while_ci_passed_in_progress() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_in_progress_ci_passed_response "$tmpdir/responses/01.json"
+
+    local exit_code output
+    exit_code=0
+    output=$(MERGEABLE_RESPONSE=CONFLICTING MERGE_STATE_RESPONSE=DIRTY \
+        run_script "$tmpdir" 42 --poll-interval 1 --timeout-secs 2 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 2 ]; then
+        pass "rebase_required_no_misfire_ci_in_progress: times out (exit 2), does not exit 3"
+    else
+        fail "rebase_required_no_misfire_ci_in_progress: times out (exit 2), does not exit 3" "exit=$exit_code output=$output"
+    fi
+}
+
+# Test 19 (#4412): --help output must list exit code 3 alongside 0/1/2.
+test_help_documents_exit_3() {
+    local output exit_code
+    exit_code=0
+    output=$("$SCRIPT_UNDER_TEST" --help 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        pass "help_documents_exit_3: --help exits 0"
+    else
+        fail "help_documents_exit_3: --help exits 0" "exit=$exit_code"
+    fi
+
+    # Must mention exit 3 / REBASE_REQUIRED.
+    if echo "$output" | grep -qE 'REBASE_REQUIRED|^\s*3 —|^\s*3 -'; then
+        pass "help_documents_exit_3: --help output names exit code 3"
+    else
+        fail "help_documents_exit_3: --help output names exit code 3" "output=$output"
+    fi
+}
+
 # Test 14 (#4148): --no-auto-rerun must disable the classifier path entirely
 # even when a flake pattern is present in the job log.
 test_no_auto_rerun_flag_disables_classifier() {
@@ -1071,6 +1226,11 @@ test_flake_telemetry_aggregatable
 test_cancelled_non_required_does_not_block_merge_gate
 test_cancelled_falls_through_to_all_checks_complete
 test_real_failure_with_cancelled_still_exits_1
+test_rebase_required_exits_3_on_first_poll
+test_rebase_required_does_not_fire_on_clean_or_unstable
+test_rebase_required_does_not_fire_when_failure_present
+test_rebase_required_does_not_fire_while_ci_passed_in_progress
+test_help_documents_exit_3
 
 echo ""
 echo "────────────────────────────────────────────"

--- a/scripts/wait-for-ci.sh
+++ b/scripts/wait-for-ci.sh
@@ -90,6 +90,14 @@
 #       the matched pattern with `flake detected: <label>`). A second
 #       flake on the same run exits 1 — see #4148.
 #   2 — Timeout: --timeout-secs elapsed without reaching a terminal state.
+#   3 — REBASE_REQUIRED (#4412): CI is green (`ci-passed=success`, no latest
+#       failures) but `mergeStateStatus=DIRTY` — a concurrent merge landed on
+#       origin/main that conflicts with this PR's diff. There is no path
+#       forward by waiting; the agent must rebase before re-entering the CI
+#       watch. Exits 3 immediately on the first poll iteration where the
+#       condition is met. Stdout names the action with the literal command:
+#       `mergeStateStatus=DIRTY — rebase required to merge.
+#        Run: git fetch origin main && git rebase origin/main && git push --force-with-lease.`
 #
 # ── Flake telemetry (#4163) ──────────────────────────────────────────────────
 #
@@ -146,7 +154,7 @@ print_help() {
     grep '^#   --' "$0" | sed 's/^# //'
     echo ""
     grep '^# Exit codes:' "$0" | sed 's/^# //'
-    grep '^#   [012]' "$0" | sed 's/^# //'
+    grep '^#   [0123]' "$0" | sed 's/^# //'
 }
 
 while [ $# -gt 0 ]; do
@@ -425,6 +433,29 @@ EOF
     # `any` form returns a single boolean string.
     CI_PASSED_SUCCESS=$(echo "$CHECK_RUNS_JSON" | jq -r '[.[] | select(.name == "ci-passed")] | any(.conclusion == "success")')
     CI_PASSED_CONCLUSION=$(echo "$CHECK_RUNS_JSON" | jq -r '[.[] | select(.name == "ci-passed") | .conclusion] | (.[0] // "")')
+
+    # ── Rebase-required fast-path (#4412) ────────────────────────────────────
+    # When CI is green (ci-passed=success, no latest failures) but
+    # mergeStateStatus is DIRTY, a concurrent merge landed on origin/main that
+    # conflicts with the PR's diff. There is no path forward by polling — the
+    # agent must rebase before re-entering the CI watch. Exit 3 immediately
+    # on the first poll iteration where this is true so the caller can pivot
+    # to the rebase + force-push path documented in `.claude/skills/task/SKILL.md`
+    # §A.5.
+    #
+    # Checked BEFORE the canonical-merge-gate fast-path because mergeable will
+    # be CONFLICTING (not MERGEABLE) when mergeStateStatus=DIRTY, so the gate
+    # cannot fire on this state — but we want to surface the rebase signal
+    # promptly rather than fall through to the all-checks-complete path which
+    # would log "still waiting" repeatedly until timeout.
+    if [ "$CI_PASSED_SUCCESS" = "true" ] && [ "$FAILED_COUNT" -eq 0 ]; then
+        MERGE_STATE_FOR_DIRTY=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json mergeStateStatus -q .mergeStateStatus 2>/dev/null || echo "UNKNOWN")
+        if [ "$MERGE_STATE_FOR_DIRTY" = "DIRTY" ]; then
+            echo ""
+            echo "[${ELAPSED}s] mergeStateStatus=DIRTY — rebase required to merge. Run: git fetch origin main && git rebase origin/main && git push --force-with-lease."
+            exit 3
+        fi
+    fi
 
     # ── Canonical-merge-gate fast-path (#4069, #4407) ────────────────────────
     # Mirrors `docs/agent/code-standards.md` §"Interpreting mergeStateStatus


### PR DESCRIPTION
## Summary

Adds exit code 3 (`REBASE_REQUIRED`) to `scripts/wait-for-ci.sh`. When CI is green (`ci-passed=success`, no latest failures) but `mergeStateStatus=DIRTY`, the script exits 3 immediately on the first poll iteration with the literal rebase command, instead of polling until timeout (~10 min). The exit-3 path is the rebase-fast-path equivalent of the A.4 merge-conflict handling in `/task` SKILL.md.

Closes #4412

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (66/66 `scripts/tests/test_wait_for_ci.sh` locally, including 5 new tests)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling script + SKILL.md only). Functional verification in-band: this PR's first CI watch hit green-but-DIRTY (concurrent merge of #4407 dirtied the diff) and `wait-for-ci.sh` exited 3 in 94s with `mergeStateStatus=DIRTY — rebase required to merge. Run: git fetch origin main && git rebase origin/main && git push --force-with-lease.` exactly as designed. After rebase + force-push, the canonical merge gate fired green at 126s. The new exit-3 path replaced what would previously have been ~10 min of `still waiting...` log spam.
