### PR TITLE
fix(dispatcher): _ci_rollup_state treats CANCELLED as non-blocking (#4414)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1132,10 +1132,13 @@ def _extract_failing_jobs(pr_status: dict) -> list[dict]:
     """Mirror DispatcherDaemon._extract_failing_jobs (pre-log-tail).
 
     Returns up to ``FIX_CI_MAX_FAILING_JOBS`` entries.
+
+    ``CANCELLED`` is intentionally excluded (#4414) — it is
+    non-blocking per the canonical merge gate and not a failure to
+    fix. Matches ``DispatcherDaemon._extract_failing_jobs``.
     """
     failure_conclusions = {
         "FAILURE",
-        "CANCELLED",
         "TIMED_OUT",
         "ACTION_REQUIRED",
         "STARTUP_FAILURE",
@@ -4341,14 +4344,21 @@ classify_pr_rollup() {
                         else "pending" end
                   else
                       # CheckRun (default) — the pre-#3200 code path.
+                      # CANCELLED is non-blocking (#4414): typical Vercel
+                      # ``concurrency: cancel-in-progress`` cancels surface
+                      # here when a newer push supersedes a deploy. Treat
+                      # as skip-equivalent ("ok"), matching
+                      # phase_transitions._CI_CANCELLED_CONCLUSIONS and
+                      # scripts/wait-for-ci.sh (#4407).
                       (.status // "" | ascii_upcase) as $st
                       | (.conclusion // "" | ascii_upcase) as $co
                       | if $st == "COMPLETED" then
-                            if ($co == "FAILURE" or $co == "CANCELLED"
-                                or $co == "TIMED_OUT" or $co == "ACTION_REQUIRED"
+                            if ($co == "FAILURE" or $co == "TIMED_OUT"
+                                or $co == "ACTION_REQUIRED"
                                 or $co == "STARTUP_FAILURE") then "red"
                             elif ($co == "SUCCESS" or $co == "SKIPPED"
-                                  or $co == "NEUTRAL" or $co == "STALE") then "ok"
+                                  or $co == "NEUTRAL" or $co == "STALE"
+                                  or $co == "CANCELLED") then "ok"
                             else "red" end
                         else "pending" end
                   end]) as $outcomes

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -15369,10 +15369,12 @@ class DispatcherDaemon:
         * **Green** (all SUCCESS/SKIPPED + ``mergeable=MERGEABLE`` +
           ``mergeStateStatus=CLEAN``) — merge with squash, transition
           ``phase='awaiting_deploy'``.
-        * **Red** (any FAILURE/CANCELLED/TIMED_OUT/ACTION_REQUIRED) —
-          spawn ``/task-v2-fix-ci``. Verdict PATCHED applies the patch
-          + pushes + stays in awaiting_ci with ``retries_used++``.
-          Verdicts BLOCKED / max-retries-exceeded mark failed.
+        * **Red** (any FAILURE/TIMED_OUT/ACTION_REQUIRED/STARTUP_FAILURE)
+          — spawn ``/task-v2-fix-ci``. Verdict PATCHED applies the
+          patch + pushes + stays in awaiting_ci with
+          ``retries_used++``. Verdicts BLOCKED / max-retries-exceeded
+          mark failed. ``CANCELLED`` is non-blocking (#4414) and does
+          NOT route here.
         """
         agent_id = agent["agent_id"]
         pr_number = agent["pr_number"]
@@ -16433,10 +16435,13 @@ class DispatcherDaemon:
         dicts — the daemon fills ``log_tail`` later via
         ``_fetch_job_log_tail``. Capped at ``FIX_CI_MAX_FAILING_JOBS``
         to bound the payload size handed to fix-ci.
+
+        ``CANCELLED`` is intentionally excluded (#4414) — it is
+        non-blocking per :data:`phase_transitions._CI_CANCELLED_CONCLUSIONS`
+        and not a failure to fix.
         """
         failure_conclusions = {
             "FAILURE",
-            "CANCELLED",
             "TIMED_OUT",
             "ACTION_REQUIRED",
             "STARTUP_FAILURE",

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -995,8 +995,9 @@ def transition_from_awaiting_ci(
     * **Red / conflict** (``mergeStateStatus=DIRTY`` or
       ``mergeable=CONFLICTING``) — advance to ``fix_conflict``
       (#3431; code-side rebase required).
-    * **Red / CI failure** (any FAILURE/CANCELLED/TIMED_OUT/
-      ACTION_REQUIRED) — advance to ``fix_ci``.
+    * **Red / CI failure** (any FAILURE/TIMED_OUT/ACTION_REQUIRED/
+      STARTUP_FAILURE) — advance to ``fix_ci``. ``CANCELLED`` is
+      non-blocking (#4414) and does NOT route here.
     """
     state = _ci_rollup_state(pr_status)
     if state == "green":
@@ -1260,15 +1261,30 @@ def transition_from_retro(retro_succeeded: bool) -> PhaseTransition:
 # ---------------------------------------------------------------------------
 
 #: Check-run conclusions that count as red.
+#:
+#: ``CANCELLED`` is intentionally NOT in this set (#4414) — it
+#: classifies as non-blocking via :data:`_CI_CANCELLED_CONCLUSIONS`
+#: below. The canonical merge gate documented in
+#: ``docs/agent/code-standards.md`` §"Interpreting mergeStateStatus
+#: (UNSTABLE-but-green)" allows non-required ``CANCELLED`` checks
+#: (typical Vercel ``concurrency: cancel-in-progress`` pattern)
+#: without blocking merge. Same fix as #4407 / PR #4411 for
+#: ``scripts/wait-for-ci.sh``.
 _CI_FAILURE_CONCLUSIONS: frozenset[str] = frozenset(
     {
         "FAILURE",
-        "CANCELLED",
         "TIMED_OUT",
         "ACTION_REQUIRED",
         "STARTUP_FAILURE",
     }
 )
+
+#: Check-run conclusions that count as cancelled — non-blocking,
+#: skip-equivalent for the rollup classification (#4414). Vercel /
+#: smoke-test ``concurrency: cancel-in-progress`` cancels surface
+#: here when a newer push supersedes a deploy; treating them as red
+#: would loop the daemon into ``fix_ci`` on already-mergeable PRs.
+_CI_CANCELLED_CONCLUSIONS: frozenset[str] = frozenset({"CANCELLED"})
 
 #: Check-run conclusions that count as green.
 _CI_SUCCESS_CONCLUSIONS: frozenset[str] = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
@@ -1303,9 +1319,11 @@ def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
     Rules (short-circuit ordering):
 
     1. If any check has a RED outcome (CheckRun conclusion in
-       FAILURE / CANCELLED / TIMED_OUT / ACTION_REQUIRED /
-       STARTUP_FAILURE, or StatusContext state in FAILURE / ERROR)
-       → red.
+       FAILURE / TIMED_OUT / ACTION_REQUIRED / STARTUP_FAILURE, or
+       StatusContext state in FAILURE / ERROR) → red. ``CANCELLED``
+       is NOT red — see :data:`_CI_CANCELLED_CONCLUSIONS` and
+       #4414 (typical Vercel ``concurrency: cancel-in-progress``
+       cancels are non-blocking).
     2. If any check is not yet complete (CheckRun status
        in_progress / queued / pending, or StatusContext state
        EXPECTED / PENDING) → pending.
@@ -1347,6 +1365,11 @@ def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
             if conclusion in _CI_FAILURE_CONCLUSIONS:
                 return "red"
             if conclusion in _CI_SUCCESS_CONCLUSIONS:
+                continue
+            if conclusion in _CI_CANCELLED_CONCLUSIONS:
+                # #4414 — Vercel ``concurrency: cancel-in-progress``
+                # and similar cancels are non-blocking; treat as
+                # skip-equivalent for the rollup classification.
                 continue
             # COMPLETED with an unrecognized conclusion — treat as
             # red rather than silently green.

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -382,7 +382,7 @@ class TestExtractFailingJobs:
             "statusCheckRollup": [
                 {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
                 {"status": "COMPLETED", "conclusion": "FAILURE", "name": "tests"},
-                {"status": "COMPLETED", "conclusion": "CANCELLED", "name": "build"},
+                {"status": "COMPLETED", "conclusion": "TIMED_OUT", "name": "build"},
             ]
         }
         failing = daemon.DispatcherDaemon._extract_failing_jobs(status)
@@ -390,6 +390,24 @@ class TestExtractFailingJobs:
         assert "tests" in names
         assert "build" in names
         assert "lint" not in names
+
+    def test_excludes_cancelled(self) -> None:
+        """#4414 — ``CANCELLED`` is non-blocking, not a failure to fix.
+
+        Vercel ``concurrency: cancel-in-progress`` cancels surface as
+        ``CANCELLED`` in the rollup; treating them as failures fed the
+        daemon into ``fix_ci`` retries on already-mergeable PRs.
+        """
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "FAILURE", "name": "tests"},
+                {"status": "COMPLETED", "conclusion": "CANCELLED", "name": "deploy"},
+            ]
+        }
+        failing = daemon.DispatcherDaemon._extract_failing_jobs(status)
+        names = [f["name"] for f in failing]
+        assert "tests" in names
+        assert "deploy" not in names
 
     def test_caps_at_max(self) -> None:
         status = {

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -324,13 +324,70 @@ class TestTransitionFromAwaitingCi:
         assert result.action == pt.TransitionAction.ADVANCE
         assert result.next_phase == pt.PHASE_FIX_CI
 
-    def test_cancelled_counts_as_red(self) -> None:
+    def test_cancelled_does_not_block_merge_gate(self) -> None:
+        """#4414 — ``CANCELLED`` is non-blocking (skip-equivalent).
+
+        Replaces the pre-#4414 ``test_cancelled_counts_as_red``: a
+        rollup with a single ``CANCELLED`` entry plus the canonical
+        green merge gate (``mergeable=MERGEABLE`` +
+        ``mergeStateStatus=CLEAN``) routes to ``merge``, not
+        ``fix_ci``. Matches ``scripts/wait-for-ci.sh`` after #4407 /
+        PR #4411 and the canonical gate documented in
+        ``docs/agent/code-standards.md`` §"Interpreting
+        mergeStateStatus (UNSTABLE-but-green)".
+        """
         status = self._make_status(
             [
                 {"status": "COMPLETED", "conclusion": "CANCELLED", "name": "test"},
             ]
         )
         result = pt.transition_from_awaiting_ci(status)
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_MERGE
+
+    def test_cancelled_with_green_ci_passed_returns_green(self) -> None:
+        """#4414 AC#1 — Vercel concurrency-cancel wedge.
+
+        The canonical wedge: a PR with one ``CANCELLED`` non-required
+        entry (e.g. ``Check major pages``) AND ``ci-passed: SUCCESS``
+        AND ``mergeable=MERGEABLE`` AND ``mergeStateStatus=CLEAN``
+        must classify as ``green`` from ``_ci_rollup_state``
+        (previously returned ``red`` and looped the daemon into
+        ``fix_ci`` until retry-cap exhaustion).
+        """
+        status = self._make_status(
+            [
+                {
+                    "status": "COMPLETED",
+                    "conclusion": "CANCELLED",
+                    "name": "Check major pages",
+                },
+                {
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "name": "ci-passed",
+                },
+            ]
+        )
+        assert pt._ci_rollup_state(status) == "green"
+
+    def test_real_failure_with_cancelled_still_routes_to_fix_ci(self) -> None:
+        """#4414 AC#3 — real failures still classify as red.
+
+        Defense-in-depth: a rollup with one ``CANCELLED`` AND one
+        real ``FAILURE`` must still route to ``fix_ci``. Splitting
+        ``CANCELLED`` out of ``_CI_FAILURE_CONCLUSIONS`` must not
+        accidentally suppress real failures that happen to
+        co-occur.
+        """
+        status = self._make_status(
+            [
+                {"status": "COMPLETED", "conclusion": "CANCELLED", "name": "deploy"},
+                {"status": "COMPLETED", "conclusion": "FAILURE", "name": "test"},
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.action == pt.TransitionAction.ADVANCE
         assert result.next_phase == pt.PHASE_FIX_CI
 
     def test_timed_out_counts_as_red(self) -> None:

--- a/scripts/worker-status.sh
+++ b/scripts/worker-status.sh
@@ -105,12 +105,20 @@ while read -r worker_num branch worker_path; do
         ci_json=$(gh pr view "$pr_number" --repo judgemind/judgemind \
             --json statusCheckRollup 2>/dev/null || echo "{}")
 
-        # Determine overall CI status from individual check conclusions
+        # Determine overall CI status from individual check conclusions.
+        # CANCELLED is intentionally NOT counted as failure (#4414):
+        # typical Vercel ``concurrency: cancel-in-progress`` cancels
+        # surface there when a newer push supersedes a deploy, and the
+        # canonical merge gate documented in
+        # docs/agent/code-standards.md §"Interpreting mergeStateStatus"
+        # treats them as non-blocking. Matches
+        # phase_transitions._CI_CANCELLED_CONCLUSIONS and
+        # scripts/wait-for-ci.sh (#4407).
         ci_status=$(echo "$ci_json" | awk '
             BEGIN { has_checks = 0; has_pending = 0; has_failure = 0 }
             /"conclusion"/ || /"status"/ {
                 has_checks = 1
-                if (/"FAILURE"/ || /"ERROR"/ || /"TIMED_OUT"/ || /"CANCELLED"/) has_failure = 1
+                if (/"FAILURE"/ || /"ERROR"/ || /"TIMED_OUT"/) has_failure = 1
                 if (/"PENDING"/ || /"IN_PROGRESS"/ || /"QUEUED"/) has_pending = 1
             }
             END {


### PR DESCRIPTION
## Summary

Splits `CANCELLED` out of the dispatcher's CI-failure conclusion sets so it classifies as non-blocking (skip-equivalent) — same fix as #4407 / PR #4411 for `scripts/wait-for-ci.sh`. Aligns four duplicated copies of the rule (`phase_transitions._CI_FAILURE_CONCLUSIONS`, `daemon._extract_failing_jobs`, the inline jq classifier and python mirror in `agent-runner-entrypoint.sh`, and `worker-status.sh`'s awk regex) so a Vercel `concurrency: cancel-in-progress` cancel no longer routes daemon-driven agents into `fix_ci` retries on already-mergeable PRs.

Closes #4414

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `scripts/verify-pr-in-deployed-sha.sh 4415` confirms distance=0 (deploy-dispatcher run 25588008786 succeeded against merge SHA `a487e74`).
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/4414#issuecomment-4411007549).
