### PR TITLE
fix(dx): suppress check-shipped-pr.sh false-positives on Verify-line-only overlap (#4340)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -319,7 +319,12 @@ Exit codes:
 - **Exit 0 (`shipped:` line on stdout + JSON summary) — a closed PR merged onto `main` already shipped this issue's work.** Do NOT proceed to Step 4b / A.1 / ralph. Pivot to the verify-and-close decision below.
 - **Exit 2 (`error:` line on stderr) — check failed (gh unavailable, API error, etc.).** Fail-open: continue to Step 4b.
 
-The high-confidence threshold the script applies is **≥1 added overlap OR ≥2 total overlap** between the file paths in the issue body and the file paths the candidate PR landed (with the PR's `mergedAt` non-null and `baseRefName == main`). A single *modified*-file overlap is intentionally below the threshold — that case routinely fires on adjacent scripts the issue cites as references rather than load-bearing targets.
+The high-confidence threshold the script applies is **≥1 added overlap OR ≥2 total overlap on *target-context* candidate paths** (with the PR's `mergedAt` non-null and `baseRefName == main`). The extractor classifies issue-body file paths into two contexts:
+
+- **target-context** — paths in narrative prose / Proposal / AC text. These are the load-bearing locations the issue intends to change.
+- **search-context** — paths cited only inside `Verify:` lines, `grep` / `pytest` / `aws` / `curl` / `rg` invocations, or fenced shell-output blocks. These are search arguments, not change targets.
+
+Search-context overlaps never count toward the threshold by themselves (#4340 — fixes the false-positive where issue Verify lines list files purely as grep arguments). A single *modified*-file overlap is intentionally below the threshold — that case routinely fires on adjacent scripts the issue cites as references rather than load-bearing targets. The "added" classification uses the authoritative `changeType: "ADDED"` signal from `gh pr view --json files` (or `status: "added"` from the raw GitHub REST API), falling back to a `deletions == 0 && additions > 0` heuristic only when neither authoritative signal is present.
 
 ##### 4a.2.1 — Verify-and-close pivot (only runs on exit 0)
 

--- a/scripts/_check_shipped_pr_extract_files.py
+++ b/scripts/_check_shipped_pr_extract_files.py
@@ -2,9 +2,25 @@
 # _check_shipped_pr_extract_files.py — Extract candidate file paths from an
 # issue body for scripts/check-shipped-pr.sh.
 #
-# Reads JSON {"body": "...", "title": "..."} on stdin, prints unique candidate
-# file paths (one per line) to stdout. Pure stdlib — no external imports —
-# so it runs from any worktree without venv setup.
+# Reads JSON {"body": "...", "title": "..."} on stdin, prints one TAB-
+# separated line per unique candidate file path:
+#
+#     <path>\t<context>
+#
+# where ``<context>`` is one of:
+#   - ``target`` — narrative / Proposal / AC text. The path is a
+#     load-bearing target the issue intends to change.
+#   - ``search`` — appears only inside a ``Verify:`` line, a fenced
+#     code block containing a shell invocation (grep/pytest/aws/curl),
+#     or another search-context spot. The path is a search argument,
+#     not a change target.
+#
+# The bash glue in scripts/check-shipped-pr.sh splits on TAB to recover
+# both lists; the overlap helper applies a target-context-aware
+# threshold.
+#
+# Pure stdlib — no external imports — so it runs from any worktree
+# without venv setup.
 #
 # venv: none
 # permanent: true
@@ -15,6 +31,22 @@
 # the boundaries that terminate inline file references in markdown bodies.
 # A trailing punctuation strip removes `.`, `,`, `:`, `;` (sentence
 # punctuation that often follows an inline file reference).
+#
+# Search-context classifier (issue #4340):
+#   A line is a *search-context line* if it matches any of:
+#     - ``Verify:`` (case-insensitive, anywhere in the line)
+#     - a shell invocation verb followed by a space — ``grep ``,
+#       ``pytest ``, ``aws ``, ``curl ``, or ``ripgrep ``/``rg ``
+#   A line is also search-context if it falls inside a fenced code
+#   block (between triple backticks) AND the fenced block contains
+#   a shell-invocation verb anywhere in its body.
+#
+#   A path's classification is determined by ALL lines it appears in:
+#     - If the path appears at least once on a NON-search-context line,
+#       it is ``target``.
+#     - Otherwise it is ``search``.
+#   This precedence rule preserves the load-bearing intent of narrative
+#   prose even when the same path is also re-cited inside Verify lines.
 
 import json
 import re
@@ -31,40 +63,174 @@ PATH_REGEX = re.compile(r"(?:scripts/|packages/|docs/|infra/|\.github/)[^\s\]\)`
 # often follows an inline file reference but is not part of the path).
 TRAILING_STRIP = ".,:;"
 
+# Search-context detector. A line is search-context if it carries a
+# ``Verify:`` marker OR a shell-invocation verb followed by a space.
+# The verbs listed cover the conventional shapes the AC author uses to
+# write a re-run command (``Verify: pytest ...``, ``Verify: grep ...``,
+# ``Verify: aws ...``, ``Verify: curl ...``). The space after the verb
+# anchors the match to actual invocations and avoids false positives
+# on prose like "use grep when..." (which would otherwise match the
+# bare ``grep`` token).
+SEARCH_CONTEXT_LINE_REGEX = re.compile(
+    r"(?:Verify:|(?:^|\s)(?:grep|pytest|aws|curl|ripgrep|rg)\s)",
+    re.IGNORECASE,
+)
 
-def extract_files(body: str) -> list[str]:
-    """Return unique candidate file paths from `body` in first-seen order."""
-    if not body:
-        return []
-    seen: set[str] = set()
+# Fenced-code-block boundary marker (``` at the start of a line, possibly
+# preceded by indentation; with optional language label).
+FENCE_LINE_REGEX = re.compile(r"^\s*```")
+
+
+def _is_search_line(line: str) -> bool:
+    """True if ``line`` is a search-context line (Verify: / grep / pytest / aws / curl / rg)."""
+    return bool(SEARCH_CONTEXT_LINE_REGEX.search(line))
+
+
+def _classify_lines(body: str) -> list[bool]:
+    """Return a parallel list — one bool per line — flagging search-context lines.
+
+    A line is search-context if any of these hold:
+      - It directly matches ``SEARCH_CONTEXT_LINE_REGEX`` (Verify: /
+        grep / pytest / aws / curl / rg).
+      - It falls inside a fenced code block AND the fenced block
+        contains at least one shell-invocation verb anywhere in its
+        body. The fence boundaries themselves count as search-context
+        when the block qualifies.
+
+    Pre-pass over the body identifies fenced blocks and decides whether
+    each block carries shell invocations; second pass applies the per-
+    line classification using both the per-line regex and the fenced-
+    block flag.
+    """
+    lines = body.split("\n")
+    n = len(lines)
+    in_fence = [False] * n
+    fence_has_shell = [False] * n
+
+    # Identify fenced blocks (start/end indices) and whether each block
+    # contains a shell invocation.
+    open_idx: int | None = None
+    block_has_shell = False
+    for i, line in enumerate(lines):
+        if FENCE_LINE_REGEX.match(line):
+            if open_idx is None:
+                # Opening fence
+                open_idx = i
+                block_has_shell = False
+            else:
+                # Closing fence — record block flags
+                for j in range(open_idx, i + 1):
+                    in_fence[j] = True
+                    fence_has_shell[j] = block_has_shell
+                open_idx = None
+                block_has_shell = False
+            continue
+        if open_idx is not None and _is_search_line(line):
+            block_has_shell = True
+
+    # If a block was opened but never closed, treat the lines after it
+    # as out-of-block (defensive — malformed markdown shouldn't crash).
+
+    # Per-line search-context flag.
+    search_flags: list[bool] = []
+    for i, line in enumerate(lines):
+        if _is_search_line(line):
+            search_flags.append(True)
+        elif in_fence[i] and fence_has_shell[i]:
+            search_flags.append(True)
+        else:
+            search_flags.append(False)
+    return search_flags
+
+
+def _path_hits_per_line(line: str) -> list[str]:
+    """Return cleaned, filtered file paths cited in ``line``.
+
+    Applies the same trailing-punctuation strip + glob/short-path
+    filters as ``extract_files()``. Returned paths may include
+    duplicates — dedupe is the caller's responsibility.
+    """
     out: list[str] = []
-    for match in PATH_REGEX.finditer(body):
+    for match in PATH_REGEX.finditer(line):
         path = match.group(0)
         # Strip trailing punctuation
         while path and path[-1] in TRAILING_STRIP:
             path = path[:-1]
-        # Skip glob-y entries (`scripts/tests/*.sh`) — the commits API
-        # rejects globs and they would just produce 404s.
         if "*" in path or "?" in path:
             continue
-        # Skip directory references (paths ending in `/`). These are
-        # container references — the issue body cites them as the area
-        # where work happens, not as specific files the issue creates
-        # or modifies. Counting them as candidates produced false-
-        # positive `shipped:` matches against any PR that touched ANY
-        # file under the directory, because the overlap helper's
-        # directory-prefix matcher legitimately fires on the prefix.
-        # See #4219 for the worked examples (issues #4208, #4213).
         if path.endswith("/"):
             continue
-        # Skip suspiciously short hits (<6 chars after the root prefix)
-        # to suppress false positives like `docs/`. The shortest legit
-        # repo paths run ~10+ chars (e.g. "docs/A.md", "scripts/x.sh").
         if len(path) < 8:
             continue
-        if path not in seen:
-            seen.add(path)
-            out.append(path)
+        out.append(path)
+    return out
+
+
+def classify_files(body: str) -> tuple[list[str], list[str]]:
+    """Classify candidate file paths into (target_context, search_context).
+
+    Returns two ordered, deduped lists in first-seen order:
+      - ``target_context``: paths that appear at least once on a non-
+        search-context line. These are load-bearing targets the issue
+        intends to change.
+      - ``search_context``: paths that appear ONLY on search-context
+        lines (Verify: / grep / pytest / aws / curl / rg invocations,
+        or fenced code blocks containing such invocations). These are
+        search arguments, not change targets.
+
+    Precedence: a path appearing in BOTH narrative and a Verify line is
+    classified as ``target_context`` — the narrative reference is the
+    load-bearing intent.
+    """
+    if not body:
+        return [], []
+    search_line_flags = _classify_lines(body)
+    # path -> True if seen on at least one non-search line.
+    path_targety: dict[str, bool] = {}
+    # First-seen ordering (we want target_context and search_context in
+    # the order paths first appear in the body).
+    order: list[str] = []
+    for i, line in enumerate(body.split("\n")):
+        is_search = search_line_flags[i]
+        for path in _path_hits_per_line(line):
+            if path not in path_targety:
+                order.append(path)
+                path_targety[path] = not is_search
+            elif not is_search:
+                # Promote a previously-search-only path to target.
+                path_targety[path] = True
+    target_out: list[str] = []
+    search_out: list[str] = []
+    for path in order:
+        if path_targety[path]:
+            target_out.append(path)
+        else:
+            search_out.append(path)
+    return target_out, search_out
+
+
+def extract_files(body: str) -> list[str]:
+    """Return unique candidate file paths from ``body`` in first-seen order.
+
+    Legacy API — preserved for backward compatibility with callers that
+    don't care about target/search classification (e.g.
+    test_check_shipped_pr_extract_files.py's directory / glob / short-
+    path tests). Returns the union of target_context ∪ search_context
+    in first-seen order.
+    """
+    target, search = classify_files(body)
+    # Reconstruct first-seen order from the body so the legacy contract
+    # (paths in first-seen order) is preserved.
+    if not body:
+        return []
+    seen: set[str] = set()
+    out: list[str] = []
+    keep = set(target) | set(search)
+    for line in body.split("\n"):
+        for path in _path_hits_per_line(line):
+            if path in keep and path not in seen:
+                seen.add(path)
+                out.append(path)
     return out
 
 
@@ -76,10 +242,16 @@ def main() -> int:
     body = data.get("body") or ""
     title = data.get("title") or ""
     # Combine title + body for extraction (title rarely cites paths but
-    # cheap to include).
+    # cheap to include). Title is treated as narrative (target-context)
+    # — it never carries Verify: / grep / pytest invocations.
     combined = f"{title}\n{body}"
+    target, search = classify_files(combined)
+    target_set = set(target)
+    # Emit one line per path: <path>\t<context>. Preserve first-seen
+    # ordering from extract_files()'s legacy contract.
     for path in extract_files(combined):
-        print(path)
+        ctx = "target" if path in target_set else "search"
+        print(f"{path}\t{ctx}")
     return 0
 
 

--- a/scripts/_check_shipped_pr_overlap.py
+++ b/scripts/_check_shipped_pr_overlap.py
@@ -56,11 +56,29 @@ def compute_overlap(
         path = f.get("path")
         if not path:
             continue
-        # Either the explicit GitHub-API `status: "added"` field (when the
-        # caller passes raw API output) or the gh-CLI heuristic (deletions
-        # == 0 && additions > 0).
+        # Three possible signals for "this file was newly added by the PR":
+        #   1. ``status: "added"`` — raw GitHub REST API.
+        #   2. ``changeType: "ADDED"`` — gh CLI's ``--json files``
+        #      output (uppercased; equivalent to the REST API's ``status``).
+        #   3. ``deletions == 0 && additions > 0`` — fallback heuristic
+        #      for callers that pass neither of the above. This was the
+        #      pre-#4340 default but mis-classifies large pure-additive
+        #      *modifications* (e.g. PR #3552's
+        #      ``scripts/rebuild_db.py +120 -0`` is a modification but
+        #      reads as "added" to the heuristic). Only used when neither
+        #      authoritative signal is present.
         if f.get("status") == "added":
             added_paths.add(path)
+            continue
+        change_type = f.get("changeType")
+        if isinstance(change_type, str):
+            # When the authoritative signal is present, trust it
+            # exclusively — do NOT fall through to the deletions==0
+            # heuristic (which would re-add modified files with
+            # ``+N -0`` diffs, exactly the false-positive pattern that
+            # tripped the original #4340 bug against PR #3552).
+            if change_type.upper() == "ADDED":
+                added_paths.add(path)
             continue
         deletions = f.get("deletions")
         additions = f.get("additions")
@@ -133,19 +151,36 @@ def main() -> int:
     if not candidates:
         return 0
 
+    # Target-context candidate paths (#4340). The threshold below is
+    # applied AGAINST THIS SUBSET ONLY — search-context paths
+    # (Verify: / grep / pytest / aws / curl / rg invocation arguments)
+    # cannot trip a shipped match by themselves. When the env var is
+    # missing or empty the overlap helper falls back to treating ALL
+    # candidates as target-context — preserving pre-#4340 behavior so
+    # downstream callers that don't pass the new env var keep working.
+    target_csv = os.environ.get("CHECK_SHIPPED_TARGET_FILES")
+    if target_csv is None:
+        targets = candidates
+    else:
+        targets = [c for c in target_csv.split(",") if c]
+
     pr_files = data.get("files") or []
     overlap, added_overlap = compute_overlap(pr_files, candidates)
     if not overlap:
         return 0
 
-    # High-confidence threshold: at least one ADDED overlap (PR created a
-    # file the issue prescribed), OR ≥2 total overlaps. A single overlap
-    # on a *modified* file is too weak — it routinely fires on adjacent
-    # scripts that the issue cites as references rather than load-bearing
-    # targets (e.g. issue #4204 references scripts/check-duplicate-pr.sh
-    # only as the file it extends, and the PR that originally created
-    # that script then trips a 1-file-modified false positive).
-    if len(added_overlap) < 1 and len(overlap) < 2:
+    # High-confidence threshold (target-context-aware as of #4340):
+    #
+    #   ≥1 ADDED overlap on a target-context path
+    #   OR ≥2 total overlaps that are ALL on target-context paths
+    #
+    # Search-context overlaps (Verify-line-only file references) never
+    # count toward the threshold by themselves. The pre-#4340 rule —
+    # ≥1 added OR ≥2 total — is preserved over the target subset.
+    target_set = set(targets)
+    target_overlap = [p for p in overlap if p in target_set]
+    target_added_overlap = [p for p in added_overlap if p in target_set]
+    if len(target_added_overlap) < 1 and len(target_overlap) < 2:
         return 0
 
     # Output format: <count>\t<comma-separated-overlap>\t<comma-separated-added>

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -18,7 +18,12 @@
 #   1. Fetch the issue body via `gh issue view`.
 #   2. Extract candidate file paths from the body using a fixed regex
 #      that covers the four conventional repo roots
-#      (scripts/, packages/, docs/, infra/) plus `.github/`.
+#      (scripts/, packages/, docs/, infra/) plus `.github/`. Each path
+#      is classified as either *target-context* (narrative / Proposal /
+#      AC text — load-bearing change targets) or *search-context*
+#      (cited only inside Verify: / grep / pytest / aws / curl / rg
+#      invocations or fenced shell-output blocks — search arguments,
+#      not change targets). #4340.
 #   3. For each unique file path, query the commits API on `main` to find
 #      commits that touched it (`gh api /repos/.../commits?path=<file>`),
 #      and parse the squash-merge PR number from each commit headline
@@ -26,9 +31,15 @@
 #   4. For each candidate PR, fetch its merge metadata and changed files
 #      via `gh pr view --json mergedAt,baseRefName,files`. Drop the
 #      candidate if `mergedAt` is null or `baseRefName != main`.
-#   5. Compute overlap of the candidate PR's changed files vs the file
-#      paths extracted from the issue body. Treat ≥1 file overlap as a
-#      high-confidence shipped match.
+#   5. Compute overlap of the candidate PR's changed files vs the
+#      candidate paths. Apply the high-confidence threshold AGAINST THE
+#      TARGET-CONTEXT SUBSET ONLY — search-context overlaps don't trip
+#      a shipped match by themselves (#4340). Threshold: ≥1 added
+#      target-context overlap OR ≥2 total target-context overlaps. The
+#      "added" classification uses changeType:"ADDED" (or status:
+#      "added" from the raw GitHub REST API), falling back to a
+#      deletions==0 heuristic when neither authoritative signal is
+#      present.
 #   6. On match: print a `shipped:` line and a JSON summary to stdout,
 #      exit 0. On no match: print a `not-shipped:` line, exit 1. On
 #      error: print an `error:` line to stderr, exit 2.
@@ -88,14 +99,56 @@ if ! issue_json=$("$GH_BIN" issue view "$issue_num" --repo "$REPO" --json body,t
 fi
 
 # Extract candidate file paths from the issue body via Python (so the regex
-# dialect is portable across BSD vs GNU grep).
-candidate_files=""
-if ! candidate_files=$(printf '%s' "$issue_json" | python3 \
+# dialect is portable across BSD vs GNU grep). The helper emits one TAB-
+# separated line per path:  ``<path>\t<context>`` where ``<context>`` is
+# ``target`` (narrative / Proposal / AC text) or ``search`` (Verify: /
+# grep / pytest / aws / curl / rg invocations, or fenced shell blocks).
+# We split out:
+#   - ``candidate_lines`` — the raw output (path\tcontext per line)
+#   - ``candidate_files`` — column 1 only (paths), used for the per-file
+#       commits API query
+#   - ``target_files``    — paths classified as target-context, used by
+#       the overlap helper to apply the target-context-aware threshold
+#       (#4340 — Verify-line-only overlaps no longer trip false-positive
+#       shipped matches).
+candidate_lines=""
+if ! candidate_lines=$(printf '%s' "$issue_json" | python3 \
     "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_extract_files.py" \
     2>/dev/null); then
     echo "error: failed to extract candidate file paths from issue #${issue_num} (exit 2)" >&2
     exit 2
 fi
+
+# Split by TAB into (path, context). Defensive against legacy single-
+# column output (callers that test the helper without the new column
+# would emit just the path) — fall back to treating the whole line as
+# the path with context=target. Today's helper always emits the TAB-
+# separated form, but this keeps the bash glue robust to future helper
+# refactors that emit only paths.
+candidate_files=""
+target_files=""
+while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # Tab-split into path + context. If no tab, default to target.
+    path="${line%%$'\t'*}"
+    if [[ "$line" == *$'\t'* ]]; then
+        ctx="${line#*$'\t'}"
+    else
+        ctx="target"
+    fi
+    if [[ -z "$candidate_files" ]]; then
+        candidate_files="$path"
+    else
+        candidate_files="${candidate_files}"$'\n'"${path}"
+    fi
+    if [[ "$ctx" == "target" ]]; then
+        if [[ -z "$target_files" ]]; then
+            target_files="$path"
+        else
+            target_files="${target_files}"$'\n'"${path}"
+        fi
+    fi
+done <<< "$candidate_lines"
 
 # Extract the issue's createdAt timestamp for the date-ordering guard
 # (#4353). The helper exits 0 unconditionally and emits an empty string
@@ -172,6 +225,15 @@ best_added_list=""
 # overlap helper.
 candidate_files_csv=$(printf '%s' "$candidate_files" | tr '\n' ',' | sed 's/,$//')
 
+# Same conversion for target_files. The overlap helper applies a
+# target-context-aware threshold (#4340) — Verify-line-only overlaps
+# (where every overlap path is search-context) no longer trip false-
+# positive shipped matches.
+target_files_csv=""
+if [[ -n "$target_files" ]]; then
+    target_files_csv=$(printf '%s' "$target_files" | tr '\n' ',' | sed 's/,$//')
+fi
+
 # Iterate candidate PRs (comma-separated)
 IFS=',' read -ra prs_array <<< "$candidate_prs"
 for pr_num in "${prs_array[@]}"; do
@@ -210,6 +272,7 @@ for pr_num in "${prs_array[@]}"; do
     overlap_result=""
     if ! overlap_result=$(printf '%s' "$pr_json" | \
         CHECK_SHIPPED_CANDIDATE_FILES="$candidate_files_csv" \
+        CHECK_SHIPPED_TARGET_FILES="$target_files_csv" \
         CHECK_SHIPPED_ISSUE_CREATED_AT="$issue_created_at" \
         python3 \
         "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_overlap.py" \

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -832,6 +832,208 @@ else
     fail "PR merged AFTER issue createdAt is still a valid shipped match (#4353 sanity)" "exit=$exit_code output=$output"
 fi
 
+# ─── Test 21: Verify-line-only file overlap → exit 1 (#4340) ─────────────
+
+# Regression for #4340. Issue body cites three files only inside a
+# `Verify:` line — they're search arguments to grep, not load-bearing
+# targets. A merged PR happens to touch all three for unrelated reasons
+# (1 MODIFIED with deletions>0, 1 MODIFIED with deletions==0, 1
+# MODIFIED with deletions>0). Pre-fix: 1 added (heuristic-misclassified
+# "scripts/rebuild_db.py +120 -0" as added) → exit 0 false-positive
+# shipped match. Post-fix: those three are search-context only, the
+# only target-context candidate has no overlap, threshold fails → exit 1.
+#
+# Concrete case: issue #4331 (filed 2026-05-08) hit a false positive
+# against PR #3552 (merged 2026-04-27) — the PR body is the LLM-
+# enrichment retry plumbing, completely unrelated to the splitter alias
+# mechanism. The Verify line in #4331 cites
+#   `grep -n "..." packages/A.py packages/B.py scripts/C.py`
+# as a re-run convenience; PR #3552 happened to touch the three paths
+# for unrelated reasons.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "## Problem\n\nSomething is wrong.\n\n## Acceptance criteria\n\n- [ ] Splitter aliases registered.\n  Verify: `grep -n alias packages/scraper-framework/src/courts/ca/sc_tentatives.py packages/scraper-framework/src/ingestion/worker.py scripts/reingest_from_s3.py`", "title": "feat: register CA splitters under aliases", "createdAt": "2026-05-08T17:28:43Z"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        # Each candidate path returns the same incidental PR.
+        echo "fix(ingestion): add retry-on-transient (#3552)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            # PR #3552 — three modified files, all with deletions > 0.
+            # changeType: MODIFIED is the authoritative gh-CLI signal —
+            # post-fix the deletions==0 fallback no longer mis-classifies
+            # these as ADDED.
+            cat << 'JSON'
+{"baseRefName": "main", "body": "Closes #3549", "files": [{"path": "packages/scraper-framework/src/courts/ca/sc_tentatives.py", "additions": 50, "deletions": 5, "changeType": "MODIFIED"}, {"path": "packages/scraper-framework/src/ingestion/worker.py", "additions": 13, "deletions": 32, "changeType": "MODIFIED"}, {"path": "scripts/reingest_from_s3.py", "additions": 15, "deletions": 19, "changeType": "MODIFIED"}], "mergedAt": "2026-04-27T10:16:05Z", "number": 3552, "title": "fix(ingestion): add retry-on-transient and exit-on-exhaustion for LLM enrichment"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4331 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$output" == *"not-shipped:"* ]]; then
+    pass "exits 1 when overlap is ONLY on Verify-line search-context paths (regression #4340)"
+else
+    fail "exits 1 when overlap is ONLY on Verify-line search-context paths (regression #4340)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 22: pure-additive MODIFIED diff is not "added" (#4340 changeType) ─
+
+# Pre-#4340, the helper used a deletions==0 && additions>0 heuristic
+# to detect added files (since gh CLI didn't surface a status field in
+# older docs). That heuristic mis-classifies large *modifications* like
+# `scripts/rebuild_db.py +120 -0` as "added" — exactly the false-
+# positive pattern that tripped #4340. Post-fix the helper consults
+# changeType: "ADDED"/"MODIFIED" (the authoritative gh CLI signal) and
+# only falls back to deletions==0 when changeType is absent.
+#
+# Mock: a single MODIFIED file with `+200 -0` and `changeType: "MODIFIED"`.
+# Issue body cites the file in narrative (target-context). Pre-fix:
+# heuristic flags it as ADDED → 1 added overlap → shipped (false-
+# positive). Post-fix: changeType=MODIFIED authoritative → 0 added,
+# 1 total → fails threshold → not-shipped.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "Update scripts/big-mod.sh to add the new feature.", "title": "dx: extend big-mod"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "feat: add helper (#7000)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            # Pure-additive MODIFIED diff. changeType is authoritative
+            # — overrides the deletions==0 fallback.
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/big-mod.sh", "additions": 200, "deletions": 0, "changeType": "MODIFIED"}], "mergedAt": "2026-04-15T00:00:00Z", "number": 7000, "title": "feat: add helper"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4400 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$output" == *"not-shipped:"* ]]; then
+    pass "exits 1 when changeType:MODIFIED overrides deletions==0 heuristic (regression #4340)"
+else
+    fail "exits 1 when changeType:MODIFIED overrides deletions==0 heuristic (regression #4340)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 23: changeType:ADDED is the authoritative ADDED signal (#4340) ──
+
+# Sanity check — the changeType signal must NOT block legitimate adds.
+# Issue body cites a target-context file in narrative; PR adds it
+# (changeType: "ADDED"). Expect exit 0 (shipped).
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "Add scripts/new-helper.sh to validate widgets.", "title": "dx: add new-helper"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "feat: add helper (#8000)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/new-helper.sh", "additions": 100, "deletions": 0, "changeType": "ADDED"}], "mergedAt": "2026-04-15T00:00:00Z", "number": 8000, "title": "feat: add helper"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4500 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"8000"* ]]; then
+    pass "exits 0 when changeType:ADDED ratifies legitimate added-file overlap (regression #4340)"
+else
+    fail "exits 0 when changeType:ADDED ratifies legitimate added-file overlap (regression #4340)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 24: canonical #2831 ↔ PR #3229 still detected (#4340 AC3) ──────
+
+# AC3 of #4340: the fix must NOT regress the original #4204 use case —
+# genuine zombie issues (closed PRs that shipped the work without
+# `Closes #N`) are still detected. The canonical case from #2831 ↔ PR
+# #3229: PR title is `WIP: ralph output` (placeholder), body is empty
+# (no `Closes #N` keyword fired the auto-close), the PR added the file
+# named in the issue's narrative.
+#
+# This test mirrors the existing Test 17 (canonical placeholder PR
+# empty-body case) but uses the new authoritative changeType:"ADDED"
+# signal instead of relying on the deletions==0 heuristic — locks in
+# that the changeType fix doesn't regress this AC2 path.
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "WIP: ralph output (#3229)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "body": "", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0, "changeType": "ADDED"}], "mergedAt": "2026-04-24T00:00:00Z", "number": 3229, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3229"* ]]; then
+    pass "AC3: canonical #2831 ↔ PR #3229 still detected (regression #4340)"
+else
+    fail "AC3: canonical #2831 ↔ PR #3229 still detected (regression #4340)" "exit=$exit_code output=$output"
+fi
+
 # Restore PATH for cleanup
 export PATH="$ORIG_PATH_SAVE"
 

--- a/scripts/tests/test_check_shipped_pr_extract_files.py
+++ b/scripts/tests/test_check_shipped_pr_extract_files.py
@@ -160,3 +160,154 @@ def test_short_paths_excluded(extract_module):
     body = "See scripts/ and docs/ for more details."
     # All four are either too short or end in `/` — both filters drop them.
     assert extract_module.extract_files(body) == []
+
+
+# ─── Search-context vs target-context classification (issue #4340) ────
+
+
+def test_classify_files_separates_verify_line_paths(extract_module):
+    """Paths that appear ONLY inside a ``Verify:`` line are classified as
+    *search-context*, not *target-context*. The grep/pytest/aws verbs
+    inside the Verify line treat any cited paths as search arguments,
+    not as files the resolution must touch.
+
+    Regression for #4340. Issue #4331's Verify line is::
+
+        Verify: ``grep -n "..." packages/A.py packages/B.py scripts/C.py``
+
+    All three paths are search arguments to grep — not files the issue
+    resolution targets. PR #3552 happened to touch all three for
+    unrelated reasons (LLM retry plumbing) → false-positive shipped
+    match. Post-fix the classifier must tag those three as
+    ``search-context`` so the threshold helper can require ≥1
+    *target-context* overlap.
+    """
+    body = (
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] Splitter aliases registered.\n"
+        '  Verify: `grep -n "alias" packages/scraper-framework/src/courts/ca/sc_tentatives.py '
+        "packages/scraper-framework/src/ingestion/worker.py "
+        "scripts/reingest_from_s3.py`\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert target == []
+    assert sorted(search) == sorted(
+        [
+            "packages/scraper-framework/src/courts/ca/sc_tentatives.py",
+            "packages/scraper-framework/src/ingestion/worker.py",
+            "scripts/reingest_from_s3.py",
+        ]
+    )
+
+
+def test_classify_files_target_context_in_narrative(extract_module):
+    """Paths in narrative prose (Problem / Proposal / non-Verify AC text)
+    are *target-context* — they describe the load-bearing locations the
+    issue intends to change.
+    """
+    body = (
+        "## Proposal\n"
+        "\n"
+        "Update `scripts/check-shipped-pr.sh` to handle the verify-context case.\n"
+        "\n"
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] `scripts/check-shipped-pr.sh` no longer flags PR #3552.\n"
+        "  Verify: `bash scripts/tests/test_check_shipped_pr.sh` exits 0.\n"
+    )
+    target, search = extract_module.classify_files(body)
+    # The Verify line cites scripts/tests/test_check_shipped_pr.sh.
+    # Narrative cites scripts/check-shipped-pr.sh (twice — proposal + AC text).
+    assert "scripts/check-shipped-pr.sh" in target
+    assert "scripts/tests/test_check_shipped_pr.sh" in search
+    # No path appears in BOTH — once classified as search-context (Verify
+    # line), it stays there even if narrative also cites it. (See
+    # docstring on classify_files for the precedence rule.)
+    assert "scripts/check-shipped-pr.sh" not in search
+
+
+def test_classify_files_fenced_block_treated_as_search_context(extract_module):
+    """Paths inside fenced code blocks (``` ```) that contain shell
+    invocations (grep / pytest / aws / curl) are *search-context*, not
+    *target-context*. Issue bodies frequently paste shell-output blocks
+    naming files that are search arguments, not change targets.
+    """
+    body = (
+        "## Problem\n"
+        "\n"
+        "Found during /task pickup:\n"
+        "\n"
+        "```\n"
+        "$ grep -n widget scripts/run-foo.sh packages/api/src/index.ts\n"
+        "scripts/run-foo.sh:42: widget = make_widget()\n"
+        "```\n"
+        "\n"
+        "## Proposal\n"
+        "\n"
+        "Patch `scripts/render-widget.sh` to handle the new shape.\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert "scripts/render-widget.sh" in target
+    assert "scripts/run-foo.sh" in search
+    assert "packages/api/src/index.ts" in search
+    # No leakage in the other direction.
+    assert "scripts/render-widget.sh" not in search
+
+
+def test_classify_files_pytest_line_search_context(extract_module):
+    """``Verify: pytest <path>`` cites ``<path>`` as a test selector,
+    not as a file the resolution edits. Tag as search-context.
+    """
+    body = (
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] New behavior tested.\n"
+        "  Verify: `pytest packages/scraper-framework/tests/test_split_registry.py -v`\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert target == []
+    assert "packages/scraper-framework/tests/test_split_registry.py" in search
+
+
+def test_classify_files_extract_files_back_compat(extract_module):
+    """The legacy ``extract_files()`` API returns the union (search ∪
+    target) so callers that don't care about classification keep
+    working. Tests that lock in directory / glob / short-path filters
+    still pass against ``extract_files()``.
+    """
+    body = (
+        "Update `scripts/check-shipped-pr.sh`.\n"
+        "Verify: `grep -n widget scripts/run-foo.sh`.\n"
+    )
+    out = extract_module.extract_files(body)
+    # Both paths land in the union, regardless of context.
+    assert sorted(out) == sorted(["scripts/check-shipped-pr.sh", "scripts/run-foo.sh"])
+
+
+def test_classify_files_path_first_seen_in_verify_stays_search(extract_module):
+    """Precedence rule: a path is target-context only if it appears at
+    least once OUTSIDE a search-context line. A path cited only inside
+    Verify lines / shell-invocation fenced blocks is search-context
+    even if it appears multiple times.
+    """
+    body = (
+        "Verify: `grep packages/api/src/index.ts`\n"
+        "Verify: `pytest packages/api/src/index.ts`\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert target == []
+    assert search == ["packages/api/src/index.ts"]
+
+
+def test_classify_files_path_in_both_promotes_to_target(extract_module):
+    """If a path appears in BOTH narrative and a Verify line, it is
+    target-context — the narrative reference is the load-bearing
+    intent and the Verify line is just a re-run convenience."""
+    body = (
+        "Update `scripts/foo.sh` to handle the new format.\n"
+        "Verify: `bash scripts/foo.sh`.\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert target == ["scripts/foo.sh"]
+    assert search == []


### PR DESCRIPTION
## Summary

Two orthogonal fixes to suppress the `check-shipped-pr.sh` false-positive class observed during /task pickup of #4331 against PR #3552:

1. **Target-context vs search-context classifier** in the candidate-file extractor. Paths cited only inside `Verify:` lines, `grep`/`pytest`/`aws`/`curl`/`rg` invocations, or fenced shell-output blocks are tagged `search` (search arguments, not change targets). The high-confidence threshold (≥1 added OR ≥2 total) is applied against the target-context subset only.

2. **Authoritative `changeType` signal** in the overlap helper. The pre-existing `deletions == 0 && additions > 0` heuristic mis-classifies large pure-additive *modifications* (e.g. PR #3552's `scripts/rebuild_db.py +120 -0`) as ADDED. The helper now consults `changeType: "ADDED"` first, falling back to the deletions==0 heuristic only when neither authoritative signal is present.

Closes #4340

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (scripts/ tooling only; runs locally and in agent runners)
- [x] Verification evidence posted on issue (see A.8)
