### PR TITLE
feat(scraping): content-hash dedup in audit_llm_carry_forward cluster output (#4344)

### DIFF
--- a/scripts/audit_llm_carry_forward.py
+++ b/scripts/audit_llm_carry_forward.py
@@ -27,9 +27,20 @@ This script runs four carry-forward checks per CA county:
    ("v. plaintiff_name") do not appear in ``ruling_text``. Same shape as
    ``audit_oc_ruling_integrity.py`` but applied per-county.
 
-4. **all_same_case_title_cluster** — same ``documents.s3_key`` has multiple
-   rulings, all sharing identical ``case_title``. Strong indicator the LLM
-   applied page-1 case to every entry.
+4. **all_same_case_title_cluster** — multiple rulings within the same
+   county sharing identical ``case_title``, where the cluster output
+   reports both the distinct ``s3_key`` count and the distinct
+   ``content_hash`` count. Strong indicator the LLM applied page-1 case
+   to every entry.
+
+   Per-cluster output exposes ``distinct_blobs`` (count of unique
+   ``derived.documents.content_hash`` values spanning the cluster),
+   ``distinct_keys`` (count of unique ``s3_key`` values), and an
+   ``examples`` array deduplicated to one row per content_hash (#4344).
+   When ``keys > blobs`` the inflation factor is the
+   ``mislabeled-s3-writes-2026-04`` shape — one underlying PDF blob
+   stored under N different S3 keys; ``keys == blobs`` is a real
+   N-blob multi-PDF cluster.
 
 Counties with deterministic splitters wired in
 ``ingestion/worker.py`` (Riverside, Fresno, San Diego, LA) should produce
@@ -323,21 +334,36 @@ _RULING_QUERY = """
       {since_filter}
 """
 
-# Cluster query for check 4 — same s3_key (one source document) with
-# multiple rulings, all sharing identical case_title.
+# Cluster query for check 4 — multiple rulings sharing identical case_title
+# inside the same county.
 #
-# Single-case PDFs naturally have one (s3_key, case_title) tuple. Multi-case
-# PDFs split correctly produce multiple distinct case_titles per s3_key. The
+# Single-case PDFs naturally have one ruling per case_title. Multi-case PDFs
+# split correctly produce multiple distinct case_titles per source PDF. The
 # bug shape is multi-case PDFs that produced N>=2 rulings, all with the
 # SAME case_title — i.e. the LLM applied page 1's case to every entry.
+#
+# Why we group by ``case_title`` (not ``(s3_key, case_title)``): the
+# ``mislabeled-s3-writes-2026-04`` bug stores the same underlying PDF blob
+# under up to 15 different ``s3_key`` values (#4344). The pre-#4344 query
+# grouped by ``s3_key`` and inflated cluster counts 15× — investigators
+# reading the audit saw "21 SC clusters" when the underlying structural
+# defect was one PDF with 12 cases. Grouping by ``case_title`` and
+# aggregating ``distinct_blobs`` (count of distinct ``content_hash`` values
+# spanning the cluster) makes the inflation factor visible at audit time:
+# ``count: 30 (15 keys → 1 blob)`` vs ``count: 30 (15 keys → 15 blobs)``
+# tell completely different stories.
+#
+# We aggregate ``s3_key`` / ``content_hash`` / ``scraper_id`` as arrays so
+# the Python side can dedupe ``examples`` to one row per content_hash.
 
 _CLUSTER_QUERY = """
     SELECT
-        ct.county          AS county,
-        d.s3_key           AS s3_key,
-        d.scraper_id       AS scraper_id,
-        c.case_title       AS case_title,
-        COUNT(*)           AS ruling_count
+        ct.county                       AS county,
+        c.case_title                    AS case_title,
+        COUNT(*)                        AS ruling_count,
+        ARRAY_AGG(DISTINCT d.s3_key)        AS s3_keys,
+        ARRAY_AGG(DISTINCT d.content_hash)  AS content_hashes,
+        ARRAY_AGG(DISTINCT d.scraper_id)    AS scraper_ids
     FROM derived.rulings r
     JOIN derived.cases     c  ON c.id = r.case_id
     JOIN derived.courts    ct ON ct.id = r.court_id
@@ -347,7 +373,7 @@ _CLUSTER_QUERY = """
       {since_filter}
       AND c.case_title IS NOT NULL
       AND c.case_title <> ''
-    GROUP BY ct.county, d.s3_key, d.scraper_id, c.case_title
+    GROUP BY ct.county, c.case_title
     HAVING COUNT(*) >= 2
        AND COUNT(DISTINCT r.id) = COUNT(*)
 """
@@ -365,6 +391,50 @@ def _build_filters(county: str | None, since: str | None) -> tuple[str, str, lis
         since_filter = "AND r.posted_at >= %s"
         params.append(since)
     return county_filter, since_filter, params
+
+
+def _build_cluster_example(
+    *,
+    case_title: str | None,
+    ruling_count: int,
+    s3_keys: list[str],
+    content_hashes: list[str],
+    scraper_ids: list[str],
+) -> dict[str, Any]:
+    """Build a single cluster ``examples`` row with content-hash dedup.
+
+    Definition of done from #4344:
+
+    1. Each cluster output row exposes ``distinct_blobs`` (count of unique
+       content_hashes among the cluster's documents).
+    2. ``examples`` is capped to one row per content_hash so investigators
+       don't waste time downloading 15 copies of the same PDF.
+
+    The returned dict is one cluster row's worth of structured output —
+    callers cap the number of cluster rows separately via
+    ``limit_examples``.
+    """
+    distinct_blobs = len(content_hashes)
+    distinct_keys = len(s3_keys)
+    primary_content_hash = content_hashes[0] if content_hashes else None
+    primary_s3_key = s3_keys[0] if s3_keys else None
+    primary_scraper_id = scraper_ids[0] if scraper_ids else None
+
+    return {
+        "case_title": case_title,
+        "ruling_count": ruling_count,
+        "distinct_blobs": distinct_blobs,
+        "distinct_keys": distinct_keys,
+        # ``content_hash`` and ``s3_key`` keep their pre-#4344 names for
+        # downstream consumers; the ``s3_keys``/``content_hashes`` arrays
+        # carry the full set of distinct values when keys outnumber blobs.
+        "content_hash": primary_content_hash,
+        "s3_key": primary_s3_key,
+        "scraper_id": primary_scraper_id,
+        "s3_keys": list(s3_keys),
+        "content_hashes": list(content_hashes),
+        "scraper_ids": list(scraper_ids),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -472,16 +542,26 @@ def run_audit(
                             }
                         )
 
-            # Check 4 — same-s3_key + same-case_title clusters
+            # Check 4 — same case_title across rulings (content-hash aware)
+            #
+            # Each row covers one (county, case_title) pair, with
+            # array-aggregated s3_keys, content_hashes, and scraper_ids
+            # spanning the cluster (#4344). We expose ``distinct_blobs`` /
+            # ``distinct_keys`` so investigators can tell "real N-ruling
+            # cluster" from "1-blob cluster amplified by S3 mislabeling."
             cur.execute(cluster_sql, params)
             for row in cur.fetchall():
                 (
                     county_name,
-                    s3_key,
-                    scraper_id,
                     case_title,
                     ruling_count,
+                    s3_keys_raw,
+                    content_hashes_raw,
+                    scraper_ids_raw,
                 ) = row
+                s3_keys = [k for k in (s3_keys_raw or []) if k]
+                content_hashes = [h for h in (content_hashes_raw or []) if h]
+                scraper_ids = [s for s in (scraper_ids_raw or []) if s]
                 bucket = _bucket(county_name)
                 bucket["all_same_case_title_cluster"]["count"] += 1
                 if (
@@ -489,12 +569,13 @@ def run_audit(
                     < limit_examples
                 ):
                     bucket["all_same_case_title_cluster"]["examples"].append(
-                        {
-                            "s3_key": s3_key,
-                            "case_title": case_title,
-                            "ruling_count": ruling_count,
-                            "scraper_id": scraper_id,
-                        }
+                        _build_cluster_example(
+                            case_title=case_title,
+                            ruling_count=ruling_count,
+                            s3_keys=s3_keys,
+                            content_hashes=content_hashes,
+                            scraper_ids=scraper_ids,
+                        )
                     )
 
     # Compose final summary
@@ -600,7 +681,58 @@ def render_text_report(summary: dict[str, Any]) -> str:
             "Re-run with --json to inspect example ruling_id / s3_key / "
             "scraper_id values for each non-zero check."
         )
+
+    # Per-cluster keys-vs-blobs detail (#4344). Surfacing the inflation
+    # factor at audit time (``count: 30 (15 keys → 1 blob)``) lets
+    # investigators tell "real 30-ruling cluster" from "1-blob cluster
+    # amplified by S3 mislabeling" without out-of-band ``aws s3api
+    # head-object`` calls per cluster.
+    cluster_lines = _render_cluster_detail(summary)
+    if cluster_lines:
+        lines.append("")
+        lines.extend(cluster_lines)
     return "\n".join(lines)
+
+
+def _render_cluster_detail(summary: dict[str, Any]) -> list[str]:
+    """Return per-cluster ``count: N (K keys → B blobs)`` detail lines.
+
+    Empty list when no county has cluster examples to render.
+    """
+    out: list[str] = []
+    counties = summary.get("counties", {}) or {}
+    has_any = False
+    for county_name in sorted(counties):
+        county_bucket = counties[county_name]
+        cluster = county_bucket.get("all_same_case_title_cluster", {})
+        examples = cluster.get("examples") or []
+        if not examples:
+            continue
+        if not has_any:
+            out.append("Cluster details (all_same_case_title_cluster):")
+            has_any = True
+        out.append(f"  {county_name}:")
+        for ex in examples:
+            out.append(f"    - {_format_cluster_example(ex)}")
+    return out
+
+
+def _format_cluster_example(example: dict[str, Any]) -> str:
+    """Render one cluster example as ``count: N (K keys → B blobs) — title``.
+
+    The ``K keys → B blobs`` shape is what makes the
+    ``mislabeled-s3-writes-2026-04`` inflation visible at audit time
+    (#4344). When ``keys == blobs`` the cluster has no S3-mislabeling
+    inflation; when ``keys > blobs`` the inflation factor is exactly
+    ``keys / blobs``.
+    """
+    count = int(example.get("ruling_count", 0))
+    keys = int(example.get("distinct_keys", 0))
+    blobs = int(example.get("distinct_blobs", 0))
+    title = example.get("case_title") or "<untitled>"
+    keys_word = "key" if keys == 1 else "keys"
+    blobs_word = "blob" if blobs == 1 else "blobs"
+    return f"count: {count} ({keys} {keys_word} → {blobs} {blobs_word}) — {title}"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/drain_splitter_carry_forward_clusters.py
+++ b/scripts/drain_splitter_carry_forward_clusters.py
@@ -22,9 +22,13 @@ restore parent doc rows so the new splitter can re-run.
 
 This script does that work generically:
 
-  1. Identifies clusters using the same query shape as the audit's
-     ``_CLUSTER_QUERY``: ``(d.s3_key, c.case_title)`` tuples with
-     ruling_count >= 2 and exactly one distinct case_title.
+  1. Identifies clusters using a ``(d.s3_key, c.case_title)`` GROUP BY:
+     tuples with ruling_count >= 2 and exactly one distinct case_title.
+     Drain operates per S3 blob, so its grouping is per-s3_key — different
+     from the audit's per-``case_title`` aggregate that exposes
+     ``distinct_blobs`` (#4344). The drain's HAVING clause still matches
+     the audit's check 4: ``COUNT(*) >= 2`` and ``COUNT(DISTINCT r.id) =
+     COUNT(*)``.
   2. For each cluster, in a single transaction with ``SELECT ... FOR
      UPDATE`` row locks:
        a. Fetches the parent PDF from S3 using the cluster's ``s3_key`` /
@@ -175,9 +179,12 @@ logger = logging.getLogger(__name__)
 # Cluster discovery
 # ---------------------------------------------------------------------------
 
-# Same shape as ``audit_llm_carry_forward.py`` ``_CLUSTER_QUERY`` but adds
-# ``s3_bucket`` (needed to fetch the PDF) and ``ORDER BY`` for deterministic
-# iteration. The HAVING clauses match the audit's check 4 exactly.
+# Per-(s3_key, case_title) cluster query — drain operates on one S3 blob
+# at a time so it groups by ``s3_key`` (not the audit's content-hash-aware
+# ``case_title`` grain — see #4344). The HAVING clauses still match the
+# audit's check 4: ``COUNT(*) >= 2`` rulings, all distinct ruling IDs.
+# Adds ``s3_bucket`` (needed to fetch the PDF) and ``ORDER BY`` for
+# deterministic iteration.
 _CLUSTER_QUERY = """
     SELECT
         ct.county          AS county,

--- a/scripts/tests/test_audit_llm_carry_forward.py
+++ b/scripts/tests/test_audit_llm_carry_forward.py
@@ -449,14 +449,17 @@ class TestRunAuditIntegration:
         assert sf["case_title_text_mismatch"]["count"] == 1
 
     def test_cluster_signal(self) -> None:
-        # Cluster query result shape: (county, s3_key, scraper_id, case_title, count)
+        # Cluster query result shape (post-#4344):
+        # (county, case_title, ruling_count, s3_keys[], content_hashes[],
+        #  scraper_ids[])
         cluster_rows = [
             (
                 "Ventura",
-                "ca/ventura/raw/cluster.pdf",
-                "ca-ventura-tentatives",
                 "Smith v. Jones",
                 7,
+                ["ca/ventura/raw/cluster.pdf"],
+                ["abc123def456"],
+                ["ca-ventura-tentatives"],
             )
         ]
         conn = _mock_cursor_with_rows([], cluster_rows)
@@ -467,6 +470,161 @@ class TestRunAuditIntegration:
         ex = ven["all_same_case_title_cluster"]["examples"][0]
         assert ex["ruling_count"] == 7
         assert ex["s3_key"] == "ca/ventura/raw/cluster.pdf"
+        assert ex["case_title"] == "Smith v. Jones"
+        assert ex["distinct_blobs"] == 1
+        assert ex["distinct_keys"] == 1
+        assert ex["content_hash"] == "abc123def456"
+
+    def test_cluster_distinct_blobs_field_present(self) -> None:
+        """AC #1: every cluster example has a ``distinct_blobs`` field
+        (#4344). Single-key/single-blob example baseline."""
+        cluster_rows = [
+            (
+                "Riverside",
+                "Acme v. Widgets",
+                3,
+                ["ca/riverside/raw/single.pdf"],
+                ["singleblobhash"],
+                ["ca-riverside-tentatives-civil"],
+            )
+        ]
+        conn = _mock_cursor_with_rows([], cluster_rows)
+        with self._patch_psycopg(conn):
+            summary = run_audit("postgres://stub")
+        riv = summary["counties"]["Riverside"]
+        ex = riv["all_same_case_title_cluster"]["examples"][0]
+        # Every cluster example has the new distinct_blobs key.
+        assert "distinct_blobs" in ex
+        assert isinstance(ex["distinct_blobs"], int)
+
+    def test_cluster_keys_outnumber_blobs_inflation(self) -> None:
+        """AC #1+#2: 15 keys → 1 blob (mislabeled-s3-writes-2026-04 shape).
+
+        The audit reports the cluster once with ``distinct_blobs=1`` and
+        ``distinct_keys=15``, exposing the inflation factor at audit time
+        instead of producing 15 separate cluster rows the way the pre-#4344
+        ``GROUP BY s3_key`` query did.
+        """
+        s3_keys = [f"ca/santa-clara/raw/dept-6-tues_{i}.pdf" for i in range(15)]
+        cluster_rows = [
+            (
+                "Santa Clara",
+                "Doe v. Roe",
+                30,
+                s3_keys,
+                ["483f1da9e800deadbeef"],  # Single underlying blob
+                ["ca-santa-clara-tentatives"],
+            )
+        ]
+        conn = _mock_cursor_with_rows([], cluster_rows)
+        with self._patch_psycopg(conn):
+            summary = run_audit("postgres://stub")
+        sc = summary["counties"]["Santa Clara"]
+        # One cluster row, not 15.
+        assert sc["all_same_case_title_cluster"]["count"] == 1
+        ex = sc["all_same_case_title_cluster"]["examples"][0]
+        assert ex["ruling_count"] == 30
+        assert ex["distinct_keys"] == 15
+        assert ex["distinct_blobs"] == 1
+        # AC #2: examples deduped to one entry per content_hash —
+        # the s3_keys array still carries all 15, but only 1
+        # content_hash entry, and we expose just one example record for
+        # this cluster.
+        assert len(ex["content_hashes"]) == 1
+        assert ex["content_hashes"][0] == "483f1da9e800deadbeef"
+        assert len(ex["s3_keys"]) == 15
+
+    def test_cluster_examples_unique_content_hash_per_record(self) -> None:
+        """AC #2: when multiple distinct case_titles each have their own
+        ``content_hash``, every example object has a unique
+        ``content_hash``. (Two clusters → two examples → two distinct
+        content_hashes.)
+        """
+        cluster_rows = [
+            (
+                "San Francisco",
+                "Smith v. Jones",
+                4,
+                ["ca/sf/raw/key-a.pdf", "ca/sf/raw/key-a-mislabel.pdf"],
+                ["hash-a-aaaa"],
+                ["ca-sf-tentatives-civil"],
+            ),
+            (
+                "San Francisco",
+                "Doe v. Roe",
+                3,
+                ["ca/sf/raw/key-b.pdf"],
+                ["hash-b-bbbb"],
+                ["ca-sf-tentatives-civil"],
+            ),
+        ]
+        conn = _mock_cursor_with_rows([], cluster_rows)
+        with self._patch_psycopg(conn):
+            summary = run_audit("postgres://stub")
+        sf = summary["counties"]["San Francisco"]
+        examples = sf["all_same_case_title_cluster"]["examples"]
+        assert len(examples) == 2
+        seen_hashes = [ex["content_hash"] for ex in examples]
+        assert len(set(seen_hashes)) == len(seen_hashes), (
+            "every example must have a unique content_hash"
+        )
+
+    def test_cluster_genuinely_multi_blob(self) -> None:
+        """``distinct_blobs > 1`` reveals genuinely-different PDFs
+        sharing the same case_title — not S3 mislabeling. The audit
+        leaves both blobs visible in the example record so investigators
+        can tell apart `15 keys → 1 blob` (mislabel) from
+        `2 keys → 2 blobs` (real).
+        """
+        cluster_rows = [
+            (
+                "Orange",
+                "John Doe v. Jane Doe",
+                5,
+                ["ca/orange/raw/key-1.pdf", "ca/orange/raw/key-2.pdf"],
+                ["hash-1", "hash-2"],
+                ["ca-orange-tentatives"],
+            )
+        ]
+        conn = _mock_cursor_with_rows([], cluster_rows)
+        with self._patch_psycopg(conn):
+            summary = run_audit("postgres://stub")
+        oc = summary["counties"]["Orange"]
+        ex = oc["all_same_case_title_cluster"]["examples"][0]
+        assert ex["distinct_blobs"] == 2
+        assert ex["distinct_keys"] == 2
+        assert sorted(ex["content_hashes"]) == ["hash-1", "hash-2"]
+
+    def test_cluster_null_arrays_handled(self) -> None:
+        """Defensive: when psycopg returns ``None`` (or arrays with NULL
+        entries) for the aggregated array columns, the audit doesn't
+        crash and the per-cluster counts default to 0 / empty list.
+
+        ``ARRAY_AGG`` over a column where every row is NULL returns
+        ``[NULL]`` (a 1-element array containing NULL), not ``[]`` —
+        callers must handle both shapes. This test pins that contract.
+        """
+        cluster_rows = [
+            (
+                "Ventura",
+                "Some v. Title",
+                2,
+                None,  # s3_keys NULL
+                [None],  # content_hashes contains a NULL entry
+                ["ca-ventura-tentatives"],
+            )
+        ]
+        conn = _mock_cursor_with_rows([], cluster_rows)
+        with self._patch_psycopg(conn):
+            summary = run_audit("postgres://stub")
+        ven = summary["counties"]["Ventura"]
+        ex = ven["all_same_case_title_cluster"]["examples"][0]
+        assert ex["distinct_keys"] == 0
+        assert ex["distinct_blobs"] == 0
+        assert ex["s3_keys"] == []
+        assert ex["content_hashes"] == []
+        assert ex["content_hash"] is None
+        assert ex["s3_key"] is None
 
     def test_examples_capped(self) -> None:
         # 10 rulings all triggering outcome_continue, default limit_examples=5.
@@ -558,3 +716,124 @@ class TestRenderTextReport:
         assert "Carry-forward signals detected" in out
         assert "Ventura" in out
         assert "Since: 2026-01-01" in out
+
+    def test_cluster_detail_inflation_render(self) -> None:
+        """AC #3: human-readable output shows ``count: N (K keys → B blobs)``
+        when keys outnumber blobs (#4344). 30 rulings × 15 keys × 1 blob
+        is the canonical mislabeled-s3-writes-2026-04 shape.
+        """
+        summary = {
+            "filter": {"county": None, "since": None},
+            "counties": {
+                "Santa Clara": {
+                    "total_rulings": 100,
+                    "outcome_continue": {"count": 0, "examples": []},
+                    "motion_type_contradiction": {"count": 0, "examples": []},
+                    "case_title_text_mismatch": {"count": 0, "examples": []},
+                    "all_same_case_title_cluster": {
+                        "count": 1,
+                        "examples": [
+                            {
+                                "case_title": "Doe v. Roe",
+                                "ruling_count": 30,
+                                "distinct_keys": 15,
+                                "distinct_blobs": 1,
+                                "content_hash": "483f1da9",
+                                "s3_key": "ca/santa-clara/raw/dept-6-tues_0.pdf",
+                                "content_hashes": ["483f1da9"],
+                                "s3_keys": [
+                                    f"ca/santa-clara/raw/dept-6-tues_{i}.pdf"
+                                    for i in range(15)
+                                ],
+                                "scraper_id": "ca-santa-clara-tentatives",
+                                "scraper_ids": ["ca-santa-clara-tentatives"],
+                            }
+                        ],
+                    },
+                }
+            },
+            "totals": {
+                "rulings_audited": 100,
+                "outcome_continue": 0,
+                "motion_type_contradiction": 0,
+                "case_title_text_mismatch": 0,
+                "all_same_case_title_cluster": 1,
+            },
+            "all_clean": False,
+        }
+        out = render_text_report(summary)
+        # The exact phrasing "30 (15 keys → 1 blob)" is the AC #3 contract.
+        assert "30 (15 keys → 1 blob)" in out
+        assert "Doe v. Roe" in out
+        assert "Cluster details" in out
+
+    def test_cluster_detail_one_to_one_render(self) -> None:
+        """When ``keys == blobs`` (no S3 mislabeling) the same shape
+        renders both numbers — so investigators always have the
+        keys-vs-blobs comparator visible without re-running with --json.
+        """
+        summary = {
+            "filter": {"county": None, "since": None},
+            "counties": {
+                "Riverside": {
+                    "total_rulings": 50,
+                    "outcome_continue": {"count": 0, "examples": []},
+                    "motion_type_contradiction": {"count": 0, "examples": []},
+                    "case_title_text_mismatch": {"count": 0, "examples": []},
+                    "all_same_case_title_cluster": {
+                        "count": 1,
+                        "examples": [
+                            {
+                                "case_title": "Acme v. Widgets",
+                                "ruling_count": 4,
+                                "distinct_keys": 1,
+                                "distinct_blobs": 1,
+                                "content_hash": "h1",
+                                "s3_key": "ca/riverside/raw/single.pdf",
+                                "content_hashes": ["h1"],
+                                "s3_keys": ["ca/riverside/raw/single.pdf"],
+                                "scraper_id": "ca-riv",
+                                "scraper_ids": ["ca-riv"],
+                            }
+                        ],
+                    },
+                }
+            },
+            "totals": {
+                "rulings_audited": 50,
+                "outcome_continue": 0,
+                "motion_type_contradiction": 0,
+                "case_title_text_mismatch": 0,
+                "all_same_case_title_cluster": 1,
+            },
+            "all_clean": False,
+        }
+        out = render_text_report(summary)
+        # Pluralization: 1 key, 1 blob (not "1 keys", not "1 blobs").
+        assert "4 (1 key → 1 blob)" in out
+
+    def test_cluster_detail_skipped_when_no_examples(self) -> None:
+        """When no county has cluster examples, the detail section is
+        omitted (no empty header)."""
+        summary = {
+            "filter": {"county": None, "since": None},
+            "counties": {
+                "Riverside": {
+                    "total_rulings": 100,
+                    "outcome_continue": {"count": 0, "examples": []},
+                    "motion_type_contradiction": {"count": 0, "examples": []},
+                    "case_title_text_mismatch": {"count": 0, "examples": []},
+                    "all_same_case_title_cluster": {"count": 0, "examples": []},
+                }
+            },
+            "totals": {
+                "rulings_audited": 100,
+                "outcome_continue": 0,
+                "motion_type_contradiction": 0,
+                "case_title_text_mismatch": 0,
+                "all_same_case_title_cluster": 0,
+            },
+            "all_clean": True,
+        }
+        out = render_text_report(summary)
+        assert "Cluster details" not in out


### PR DESCRIPTION
## Summary

Adds content-hash awareness to `scripts/audit_llm_carry_forward.py` cluster output (`all_same_case_title_cluster`). The cluster query now groups by `(county, case_title)` and aggregates `s3_key` / `content_hash` / `scraper_id` as arrays via `ARRAY_AGG(DISTINCT ...)`. Each cluster row exposes `distinct_blobs` (count of unique `derived.documents.content_hash` values) alongside `distinct_keys` (count of unique `s3_key` values). The human-readable report renders `count: 30 (15 keys → 1 blob)` when keys outnumber blobs, making the `mislabeled-s3-writes-2026-04` inflation factor visible at audit time without out-of-band `aws s3api head-object` calls per cluster.

The drain script's per-s3_key grain (`scripts/drain_splitter_carry_forward_clusters.py`) is left as-is — correct for its purpose (one PDF blob to fetch at a time) — but the stale "same shape as audit" docstring is updated to call out the divergence.

Closes #4344

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Audit script run end-to-end on dev via `scripts/ecs-run-task.sh scripts/audit_llm_carry_forward.py -- --county "Santa Clara" --json` confirms `distinct_blobs` field on every cluster example.
- [x] Verification evidence posted on issue (#4344 comment trail).
