### PR TITLE
refactor(dx): centralise persist-test docker-postgres bootstrap (#4424)

### DIFF
--- a/scripts/tests/_dispatcher_test_bootstrap.py
+++ b/scripts/tests/_dispatcher_test_bootstrap.py
@@ -1,0 +1,294 @@
+# venv: none
+"""Shared dispatcher-test bootstrap (#4424).
+
+Currently the only consumer is the family of behavioural tests that
+round-trip ``persist_*`` bash functions from
+``scripts/dispatcher/agent-runner-entrypoint.sh`` against a local
+docker-compose postgres:
+
+  - ``test_persist_phase_output_jsonb_safety.py``
+  - ``test_persist_phase_output_writes_phase_transition.py``
+  - ``test_persist_ralph_patch_safety.py``
+
+Before #4424 each of those files inlined its own copy of the
+``dispatcher`` schema bootstrap. Three of the bootstraps overlapped on
+``phase_outputs`` + ``phase_transitions`` + ``ralph_patches`` + the
+``agents`` stub, but they drifted: when production added a second
+``INSERT INTO dispatcher.phase_transitions`` to ``persist_phase_output``
+(#3697), only one of the three bootstraps was updated; the other two
+silently broke for ~12 days until #4418 noticed it. The CI shard that
+runs these tests skips the behavioural ones (no docker postgres in CI),
+so the rot was invisible until a developer ran the suite locally.
+
+This module collapses the N copies into 1. Each test still picks its own
+unique test-DB name (so cross-test leakage stays impossible), but the
+schema DDL is one source of truth — the union of every column /
+table the persist-* functions reference. Future production additions
+break all three behavioural tests at once and are impossible to miss.
+
+The companion structural test
+``test_persist_bootstrap_mirrors_production_inserts.py`` enforces the
+union-property mechanically: it greps the entrypoint for every
+``INSERT INTO dispatcher.<table>`` and asserts the bootstrap creates the
+table with the columns the INSERT references. That test runs in CI
+without postgres and is the regression gate against the same drift
+class.
+
+The module name (``_dispatcher_test_bootstrap``) starts with an
+underscore so pytest does not auto-collect it as a test file; the
+prefix also signals to readers that it is a shared helper rather than a
+``test_*`` test. We deliberately did NOT use ``conftest.py`` — pytest
+auto-loads conftest.py for fixture / plugin discovery, but importing
+fully-qualified helper symbols from it requires path acrobatics that
+break when pytest's rootdir resolution changes. A plain sibling module
+imported via the test directory's ``sys.path`` entry (added by pytest
+during collection) is the simpler path.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from typing import Final
+
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Default DSN for the local docker-compose postgres. Mirrors the
+#: per-file constants in the prior in-test bootstraps so the behaviour
+#: matches exactly across the move. Override via ``TEST_DSN`` env var.
+DEFAULT_DOCKER_DSN: Final[str] = (
+    "postgres://judgemind:localdev@localhost:5432/judgemind"
+)
+
+#: Skip-reason used by every persist-* test that consumes the helpers
+#: below. Centralised so all tests print the same message in CI logs.
+DOCKER_POSTGRES_SKIP_REASON: Final[str] = (
+    "local docker postgres not reachable; behavioural test skipped "
+    "(schema-parity test in test_phase_outputs_insert_shape.py still runs)"
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared schema DDL — single source of truth (#4424)
+# ---------------------------------------------------------------------------
+#
+# Union of every ``dispatcher.*`` table the persist-* test family
+# touches via INSERT or UPDATE. Whenever production adds a new INSERT
+# target to ``scripts/dispatcher/agent-runner-entrypoint.sh`` (or
+# extends an existing INSERT's column set), this DDL is the one place
+# that needs an update — every consumer test then breaks until the DDL
+# catches up, instead of one consumer breaking silently while the
+# others' isolated bootstraps still work.
+#
+# The shape is deliberately a *minimal* mirror of production migrations
+# 21 (dispatcher schema base), 27 (``log_text`` column), and 38
+# (``ralph_patches``):
+#
+#   - No FK constraints — the persist functions hard-code agent_ids
+#     that won't match real seed rows.
+#   - No NOT NULL on optional metering columns — the bash side omits
+#     them, so production-default-NULL is the test invariant.
+#   - One unique index on ``phase_outputs (agent_id, phase, attempt)``
+#     so the ON CONFLICT clause inside ``persist_phase_output`` has a
+#     real target to upsert against. The dedicated test DB means there
+#     is no collision risk with whatever indexes the real ``dispatcher``
+#     schema may also define.
+#   - ``ralph_patches`` PRIMARY KEY uses ``gen_random_uuid()`` —
+#     production migration 38 enables ``pgcrypto`` for the same reason;
+#     docker-compose postgres ships pgcrypto by default so no extra
+#     ``CREATE EXTENSION`` is needed here.
+#   - ``agents`` is a STUB with only the columns the persist-*
+#     UPDATEs reference (``agent_id``, ``ralph_iterations_observed``).
+#     We deliberately do not mirror the full agents table — adding
+#     columns there as production grows is the daemon-test family's
+#     concern, not the persist-* family's.
+SHARED_DISPATCHER_SCHEMA_DDL: Final[str] = textwrap.dedent(
+    """
+    CREATE SCHEMA IF NOT EXISTS dispatcher;
+
+    -- phase_outputs: every persist_phase_output INSERT site writes here.
+    -- Columns mirror the union of:
+    --   * the no-log-text branch (agent_id, phase, output_json)
+    --   * the with-log-text branch (#3694; adds log_text)
+    --   * the agent_runner_reaped_failure inline INSERT (same shape)
+    -- The ON CONFLICT (agent_id, phase, attempt) target requires the
+    -- unique index below.
+    CREATE TABLE IF NOT EXISTS dispatcher.phase_outputs (
+        agent_id    uuid        NOT NULL,
+        phase       text        NOT NULL,
+        attempt     int         NOT NULL DEFAULT 1,
+        output_json jsonb       NOT NULL,
+        log_text    text,
+        ts          timestamptz NOT NULL DEFAULT now()
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS
+        idx_phase_outputs_shared_agent_phase_attempt
+        ON dispatcher.phase_outputs (agent_id, phase, attempt);
+
+    -- phase_transitions: persist_phase_output's second INSERT (#3697 /
+    -- #3695). BIGSERIAL PK with no unique on (agent_id, phase) so
+    -- repeat calls within a phase append rows (the daemon's
+    -- _check_stuck_agents reads MAX(ts) for per-phase progress).
+    CREATE TABLE IF NOT EXISTS dispatcher.phase_transitions (
+        transition_id   bigserial   PRIMARY KEY,
+        agent_id        uuid        NOT NULL,
+        phase           text        NOT NULL,
+        ts              timestamptz NOT NULL DEFAULT now()
+    );
+
+    -- ralph_patches: persist_ralph_patch + ralph_head_watcher_persist
+    -- both INSERT here. iteration_n + verdict are NULL on the
+    -- persist_ralph_patch path (added by ralph_head_watcher_persist).
+    CREATE TABLE IF NOT EXISTS dispatcher.ralph_patches (
+        patch_id       uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+        agent_id       uuid        NOT NULL,
+        issue_number   int         NOT NULL,
+        patch_content  text        NOT NULL,
+        commit_sha     text,
+        iteration_n    int,
+        verdict        text,
+        created_at     timestamptz NOT NULL DEFAULT now()
+    );
+
+    -- agents stub: ralph_head_watcher_persist UPDATEs
+    -- ralph_iterations_observed; persist_ralph_patch leaves it alone.
+    -- This is intentionally a stub — the full table is owned by the
+    -- daemon-test family.
+    CREATE TABLE IF NOT EXISTS dispatcher.agents (
+        agent_id                    uuid PRIMARY KEY,
+        ralph_iterations_observed   int  NOT NULL DEFAULT 0
+    );
+    """
+).strip()
+
+
+# ---------------------------------------------------------------------------
+# Probe + bootstrap helpers
+# ---------------------------------------------------------------------------
+
+
+def docker_postgres_admin_dsn() -> str | None:
+    """Return a DSN if the docker-compose postgres is reachable, else None.
+
+    Mirrors the per-test ``_docker_postgres_dsn`` helpers the persist-*
+    tests previously inlined. The return value names the *admin*
+    database (i.e. the docker-compose default ``judgemind`` DB) — call
+    sites pass it to :func:`bootstrap_dispatcher_test_db` to derive a
+    dedicated test-DB DSN.
+
+    The probe runs ``psql -X``-with-``SELECT 1``; ``-X`` skips
+    ``~/.psqlrc`` so prelude lines from a developer's local config (e.g.
+    ``\\set ECHO_HIDDEN``) don't pollute the comparison against ``"1"``.
+
+    Returns:
+        DSN string when reachable, ``None`` when ``psql`` is not in
+        ``PATH``, the probe times out, the connection is refused, or the
+        SELECT returns anything other than ``"1"``.
+    """
+    if shutil.which("psql") is None:
+        return None
+    dsn = os.environ.get("TEST_DSN", DEFAULT_DOCKER_DSN)
+    try:
+        r = subprocess.run(
+            ["psql", "-X", dsn, "-At", "-c", "SELECT 1"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if r.returncode != 0 or r.stdout.strip() != "1":
+        return None
+    return dsn
+
+
+def bootstrap_dispatcher_test_db(admin_dsn: str, test_db_name: str) -> str:
+    """Create a dedicated test database, apply the shared schema, return its DSN.
+
+    Idempotent — re-running against an existing test DB is a no-op (the
+    schema DDL itself uses ``IF NOT EXISTS`` everywhere). Each persist-*
+    test passes its own ``test_db_name`` so concurrent tests run against
+    isolated DBs and share nothing.
+
+    Args:
+        admin_dsn: A working DSN against the docker-compose admin DB
+            (typically the return value of
+            :func:`docker_postgres_admin_dsn`).
+        test_db_name: Name of the dedicated test database (e.g.
+            ``"judgemind_test_persist_phase_output"``). The function
+            creates it if absent.
+
+    Returns:
+        DSN pointed at ``test_db_name`` with the shared dispatcher
+        schema applied.
+
+    Raises:
+        AssertionError: when the existence probe fails, the
+            ``CREATE DATABASE`` returns an error other than the benign
+            ``already exists`` race, or the schema DDL does not apply
+            cleanly.
+    """
+    # Step 1: probe whether the test DB already exists. ``CREATE
+    # DATABASE`` can't run inside a transaction, so we use ``-c`` which
+    # auto-commits — and we only attempt the create when the probe says
+    # the DB is absent (a benign race with a concurrent test creating
+    # the same DB is tolerated below).
+    probe = subprocess.run(
+        [
+            "psql",
+            "-X",
+            admin_dsn,
+            "-At",
+            "-c",
+            f"SELECT 1 FROM pg_database WHERE datname='{test_db_name}';",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if probe.returncode != 0:
+        raise AssertionError(f"db existence probe failed: {probe.stderr}")
+    if probe.stdout.strip() != "1":
+        cr = subprocess.run(
+            [
+                "psql",
+                "-X",
+                admin_dsn,
+                "-c",
+                f'CREATE DATABASE "{test_db_name}";',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if cr.returncode != 0 and "already exists" not in cr.stderr:
+            raise AssertionError(f"create db failed: {cr.stderr}")
+
+    # Step 2: derive the test DSN by swapping the database name on the
+    # admin DSN. Both DSNs share host / port / credentials.
+    test_dsn = admin_dsn.rsplit("/", 1)[0] + f"/{test_db_name}"
+
+    # Step 3: apply the shared DDL. ``ON_ERROR_STOP=1`` prevents psql
+    # from continuing past a CREATE failure; every CREATE uses
+    # ``IF NOT EXISTS`` so re-runs are no-ops.
+    r = subprocess.run(
+        [
+            "psql",
+            "-X",
+            test_dsn,
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-c",
+            SHARED_DISPATCHER_SCHEMA_DDL,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert r.returncode == 0, f"schema setup failed: {r.stderr}"
+    return test_dsn

--- a/scripts/tests/test_persist_bootstrap_mirrors_production_inserts.py
+++ b/scripts/tests/test_persist_bootstrap_mirrors_production_inserts.py
@@ -1,0 +1,300 @@
+# venv: none
+"""Regression: shared persist-test bootstrap must mirror production INSERTs (#4424).
+
+This test is the structural backstop that prevents the failure mode #4418
+caught manually: production added a second ``INSERT INTO
+dispatcher.phase_transitions`` to ``persist_phase_output`` (#3697) and only
+one of the three persist-* tests had its bootstrap updated; the other two
+silently broke for ~12 days because the CI shard skips the behavioural
+tests (no docker postgres in CI).
+
+The structural property we enforce: every ``INSERT INTO dispatcher.<table>``
+target referenced by the persist-* / ralph_head_watcher functions in
+``scripts/dispatcher/agent-runner-entrypoint.sh`` exists as a
+``CREATE TABLE`` in the shared bootstrap. Every column listed inside an
+INSERT also exists on the corresponding bootstrap table. New INSERT
+targets break this test at parse time — there is no way for a future
+production change to add a third INSERT target without forcing a one-line
+update to ``_dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL``.
+
+Runs in CI without postgres — the assertions are pure string parsing
+against the entrypoint script and the bootstrap module.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_ENTRYPOINT_SH = _REPO_ROOT / "scripts" / "dispatcher" / "agent-runner-entrypoint.sh"
+
+# Functions whose INSERTs the shared bootstrap must mirror. Other
+# functions in the entrypoint also INSERT into ``dispatcher.*``
+# (handlers, the agent_runner_reaped_failure inline INSERT) — we cover
+# the agent_runner_reaped_failure INSERT explicitly because it shares
+# the ``phase_outputs`` shape with persist_phase_output. We do not try
+# to cover every UPDATE site (the agents table is used as a stub that
+# only needs ``ralph_iterations_observed`` for the watcher's UPDATE).
+_TARGET_FUNCTIONS = (
+    "persist_phase_output",
+    "persist_ralph_patch",
+    "ralph_head_watcher_persist",
+    "agent_runner_reaped_failure",
+)
+
+
+def _read_function_body(text: str, fn_name: str) -> str | None:
+    """Return the body of a top-level bash function, or None if absent.
+
+    Mirrors the extraction logic each persist-* test inlines: scan for a
+    line starting with ``<fn_name>()`` and slice through to the first
+    line beginning with ``}``. Returns the body inclusive of the opening
+    declaration and closing brace.
+    """
+    lines = text.splitlines()
+    fn_start = None
+    for i, line in enumerate(lines):
+        if line.startswith(f"{fn_name}()"):
+            fn_start = i
+            break
+    if fn_start is None:
+        return None
+    fn_lines = [lines[fn_start]]
+    for line in lines[fn_start + 1 :]:
+        fn_lines.append(line)
+        if line.startswith("}"):
+            break
+    return "\n".join(fn_lines)
+
+
+# Regex that matches ``INSERT INTO dispatcher.<table> (col1, col2, ...)``
+# allowing arbitrary whitespace + newlines between the table name and
+# the column list. The bash sources lay these out across multiple lines
+# inside heredocs, so DOTALL is required.
+_INSERT_RE = re.compile(
+    r"INSERT\s+INTO\s+dispatcher\.([a-z_]+)\s*\(([^)]+)\)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _extract_dispatcher_inserts(text: str) -> list[tuple[str, frozenset[str]]]:
+    """Return ``(table, columns)`` tuples for every ``INSERT INTO dispatcher.*``.
+
+    Columns are normalised — whitespace and newlines stripped, lowercase.
+    Duplicates are kept (the same INSERT may appear in both branches of
+    an ``\\if`` block) — caller deduplicates if needed.
+    """
+    out: list[tuple[str, frozenset[str]]] = []
+    for m in _INSERT_RE.finditer(text):
+        table = m.group(1).strip().lower()
+        col_blob = m.group(2)
+        cols = frozenset(
+            c.strip().lower()
+            for c in col_blob.replace("\n", ",").split(",")
+            if c.strip()
+        )
+        out.append((table, cols))
+    return out
+
+
+# Tables the bootstrap MUST create — the union across every INSERT
+# site under _TARGET_FUNCTIONS. Computed once at import time so a
+# missing table fails at collection rather than during the test body.
+_ENTRYPOINT_TEXT = _ENTRYPOINT_SH.read_text(encoding="utf-8")
+
+
+def _expected_inserts() -> list[tuple[str, frozenset[str]]]:
+    """Walk every target function and collect (table, columns) tuples."""
+    found: list[tuple[str, frozenset[str]]] = []
+    for fn in _TARGET_FUNCTIONS:
+        body = _read_function_body(_ENTRYPOINT_TEXT, fn)
+        assert body is not None, (
+            f"function {fn!r} not found in {_ENTRYPOINT_SH} — "
+            "either renamed or removed; update _TARGET_FUNCTIONS."
+        )
+        for table, cols in _extract_dispatcher_inserts(body):
+            found.append((table, cols))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap-side parser: read the shared DDL from _dispatcher_test_bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _bootstrap_tables() -> dict[str, frozenset[str]]:
+    """Parse ``_dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL`` into ``{table: columns}``.
+
+    Returns columns lowercased and stripped of type / NOT NULL /
+    DEFAULT clauses. Imports the helper module rather than re-reading
+    the file so a future shape change (e.g. moving the DDL into a
+    Python list literal) still works as long as the constant name is
+    preserved.
+    """
+    # _dispatcher_test_bootstrap.py lives in the same directory as this
+    # test. ``scripts/tests/__init__.py`` exists, so pytest treats
+    # ``tests`` as a package — combined with ``PYTHONPATH=scripts`` (set
+    # by the CI shard, defined in .github/workflows/ci.yml's
+    # scripts-tests job) we import via the fully-qualified package path.
+    from tests import _dispatcher_test_bootstrap
+
+    ddl: str = _dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL
+    out: dict[str, frozenset[str]] = {}
+
+    # Match `CREATE TABLE [IF NOT EXISTS] dispatcher.<table> ( <body> );`
+    table_re = re.compile(
+        r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?dispatcher\.([a-z_]+)\s*\((.*?)\);",
+        re.IGNORECASE | re.DOTALL,
+    )
+    for m in table_re.finditer(ddl):
+        table = m.group(1).strip().lower()
+        body = m.group(2)
+        cols: set[str] = set()
+        # Each column declaration occupies one comma-separated chunk.
+        # Take the first whitespace-separated token of each chunk as the
+        # column name. Skip table-level constraints and unique indexes
+        # that don't begin with a bare identifier (e.g. ``CREATE
+        # UNIQUE INDEX ...`` lives outside the parenthesised body so it
+        # never appears here, but we defensively skip ``PRIMARY KEY
+        # (...)`` / ``UNIQUE (...)`` / ``FOREIGN KEY ...`` / ``CHECK
+        # ...`` shapes anyway).
+        for chunk in body.split(","):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            head = chunk.split()[0].strip().lower()
+            if head in {"primary", "unique", "foreign", "check", "constraint"}:
+                continue
+            # ``--`` line comments inside the DDL surface as a head
+            # token of ``--``; skip them too.
+            if head.startswith("--"):
+                continue
+            cols.add(head)
+        out[table] = frozenset(cols)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_every_insert_target_has_a_bootstrap_table() -> None:
+    """Each ``INSERT INTO dispatcher.<table>`` target has a CREATE TABLE.
+
+    A future production change that adds a third INSERT target (e.g.
+    ``INSERT INTO dispatcher.cost_breakdown``) without updating the
+    shared bootstrap fails this test at collection time.
+    """
+    inserts = _expected_inserts()
+    bootstrap = _bootstrap_tables()
+    targets = {table for table, _ in inserts}
+    missing = targets - set(bootstrap)
+    assert not missing, (
+        f"INSERT targets present in {_ENTRYPOINT_SH.name} but missing from "
+        f"_dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL: {sorted(missing)}.\n"
+        f"Add a CREATE TABLE for each missing target in conftest.py."
+    )
+
+
+def test_every_insert_column_exists_in_bootstrap() -> None:
+    """Each column listed in an INSERT exists in the bootstrap CREATE TABLE.
+
+    Catches the narrower drift where a new column is added to an
+    existing INSERT without being added to the bootstrap. Without this,
+    a future production change that adds (e.g.) ``output_json,
+    log_text, cost_usd`` to ``persist_phase_output`` would only fail
+    the behavioural tests on first round-trip — and the behavioural
+    tests skip in CI.
+    """
+    inserts = _expected_inserts()
+    bootstrap = _bootstrap_tables()
+    failures: list[str] = []
+    for table, cols in inserts:
+        if table not in bootstrap:
+            # Already covered by the test above; skip here so the
+            # failure message stays readable.
+            continue
+        missing = cols - bootstrap[table]
+        if missing:
+            failures.append(
+                f"  dispatcher.{table}: INSERT columns {sorted(missing)} "
+                f"are not present on the bootstrap table "
+                f"(bootstrap has {sorted(bootstrap[table])})"
+            )
+    assert not failures, (
+        "INSERT columns present in the entrypoint but missing from the "
+        "shared bootstrap — add them to "
+        "_dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL:\n"
+        + "\n".join(failures)
+    )
+
+
+@pytest.mark.parametrize(
+    "table",
+    ("phase_outputs", "phase_transitions", "ralph_patches", "agents"),
+)
+def test_known_target_tables_are_present(table: str) -> None:
+    """Pin the four known target tables exist in the bootstrap.
+
+    Belt-and-suspenders against the broader regex above silently
+    matching zero INSERTs (e.g. if the entrypoint script is renamed and
+    the open + close logic above stops finding any function bodies).
+    """
+    bootstrap = _bootstrap_tables()
+    assert table in bootstrap, (
+        f"shared bootstrap is missing dispatcher.{table} — every "
+        "persist-* test relies on this table existing. Update "
+        "_dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL."
+    )
+
+
+def test_phase_outputs_required_floor_present() -> None:
+    """phase_outputs has the three columns every INSERT site requires.
+
+    Mirrors the floor enforced by
+    ``test_phase_outputs_insert_shape.py::_REQUIRED_FLOOR`` for the
+    bootstrap side: even if a future change drops the optional
+    metering columns, ``agent_id`` + ``phase`` + ``output_json`` are
+    structurally required.
+    """
+    bootstrap = _bootstrap_tables()
+    required = frozenset({"agent_id", "phase", "output_json"})
+    actual = bootstrap.get("phase_outputs", frozenset())
+    missing = required - actual
+    assert not missing, (
+        f"shared bootstrap dispatcher.phase_outputs is missing "
+        f"required columns: {sorted(missing)}. The required floor matches "
+        f"the schema-parity test in test_phase_outputs_insert_shape.py."
+    )
+
+
+def test_no_inline_create_table_in_persist_test_files() -> None:
+    """No persist-* test file inlines its own ``CREATE TABLE`` DDL.
+
+    Direct enforcement of the AC: ``grep -n 'CREATE TABLE.*dispatcher'
+    scripts/tests/test_persist_*`` must show zero matches. The shared
+    bootstrap in conftest.py is the single source of truth.
+    """
+    persist_tests = sorted((_REPO_ROOT / "scripts" / "tests").glob("test_persist_*.py"))
+    assert persist_tests, (
+        "no persist-* test files found — glob pattern is wrong or the "
+        "files were renamed."
+    )
+    inline = re.compile(r"CREATE\s+TABLE.*dispatcher\.", re.IGNORECASE)
+    failures: list[str] = []
+    for p in persist_tests:
+        # Skip the structural test itself — its bootstrap-parser regex
+        # contains the pattern as a string literal we want to find.
+        if p.name == Path(__file__).name:
+            continue
+        if inline.search(p.read_text(encoding="utf-8")):
+            failures.append(str(p.relative_to(_REPO_ROOT)))
+    assert not failures, (
+        "persist-* test files still inline ``CREATE TABLE dispatcher.*`` "
+        "DDL — move it to _dispatcher_test_bootstrap.SHARED_DISPATCHER_SCHEMA_DDL. "
+        f"Offenders: {failures}"
+    )

--- a/scripts/tests/test_persist_phase_output_jsonb_safety.py
+++ b/scripts/tests/test_persist_phase_output_jsonb_safety.py
@@ -28,8 +28,6 @@ behavioural guarantee for the docker-compose dev environment.
 from __future__ import annotations
 
 import json
-import os
-import shutil
 import subprocess
 import textwrap
 import uuid
@@ -37,138 +35,34 @@ from pathlib import Path
 
 import pytest
 
+from tests._dispatcher_test_bootstrap import (
+    DOCKER_POSTGRES_SKIP_REASON,
+    bootstrap_dispatcher_test_db,
+    docker_postgres_admin_dsn,
+)
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _ENTRYPOINT_SH = _REPO_ROOT / "scripts" / "dispatcher" / "agent-runner-entrypoint.sh"
 
-
-def _docker_postgres_dsn() -> str | None:
-    """Return a DSN if the docker-compose postgres is reachable, else None."""
-    if shutil.which("psql") is None:
-        return None
-    # Match the local docker-compose postgres (judgemind-bootstrap-postgres-1).
-    # Credentials are the docker-compose defaults from docker-compose.yml.
-    # Allow override via TEST_DSN env var so this test also runs against
-    # an alternative local postgres (e.g. a maintainer's custom setup).
-    dsn = os.environ.get(
-        "TEST_DSN",
-        "postgres://judgemind:localdev@localhost:5432/judgemind",
-    )
-    try:
-        r = subprocess.run(
-            # ``-X`` skips ~/.psqlrc so extra prelude lines (Expanded
-            # display / Pager usage) don't pollute stdout.
-            ["psql", "-X", dsn, "-At", "-c", "SELECT 1"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    if r.returncode != 0 or r.stdout.strip() != "1":
-        return None
-    return dsn
-
-
-_DSN = _docker_postgres_dsn()
+# #4424 — schema bootstrap is now centralised in
+# ``scripts/tests/_dispatcher_test_bootstrap.py`` (one source of truth for
+# the union of ``dispatcher.*`` tables every persist-* test family member
+# touches). Each test file still picks its own dedicated test-DB name to
+# keep cross-test leakage impossible; only the DDL is shared.
+_DSN = docker_postgres_admin_dsn()
 pytestmark = pytest.mark.skipif(
     _DSN is None,
-    reason="local docker postgres not reachable; behavioural test skipped "
-    "(schema-parity test in test_phase_outputs_insert_shape.py still runs)",
+    reason=DOCKER_POSTGRES_SKIP_REASON,
 )
 
-
-# Test schema name. We deliberately don't use ``dispatcher`` so the test
-# never collides with the operational schema that may be loaded into the
-# same local docker postgres (it has FKs and unique constraints we can't
-# easily seed). The bash function under test executes
-# ``INSERT INTO dispatcher.phase_outputs ...`` with that schema name
-# hard-coded — so we run the bash function pointed at a separate database
-# DSN where we own the ``dispatcher`` schema entirely.
+# Test database name. We deliberately don't reuse ``dispatcher`` inside
+# the docker-compose admin DB so the test never collides with the
+# operational schema that may also be loaded there (it has FKs and
+# unique constraints we can't easily seed). The bash function under
+# test executes ``INSERT INTO dispatcher.phase_outputs ...`` with that
+# schema name hard-coded — so we run the bash function pointed at a
+# separate database DSN where we own the ``dispatcher`` schema entirely.
 _TEST_DB_NAME = "judgemind_test_persist_phase_output"
-
-
-def _bootstrap_test_database(admin_dsn: str) -> str:
-    """Create a dedicated test database and return its DSN.
-
-    Idempotent — re-runs of the test reuse the same database. The
-    ``dispatcher`` schema inside this database is pristine (no FKs, no
-    unique constraints beyond the (agent_id, phase, attempt) target the
-    function's ON CONFLICT clause references).
-    """
-    # Create the database via the admin DSN's connection (postgres
-    # doesn't allow CREATE DATABASE inside a transaction; we use
-    # ``-c`` which auto-commits.)
-    create = subprocess.run(
-        [
-            "psql",
-            "-X",
-            admin_dsn,
-            "-At",
-            "-c",
-            f"SELECT 1 FROM pg_database WHERE datname='{_TEST_DB_NAME}';",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if create.returncode != 0:
-        raise AssertionError(f"db existence probe failed: {create.stderr}")
-    if create.stdout.strip() != "1":
-        # Create the database; expect success or a concurrent-create race
-        # which is benign.
-        cr = subprocess.run(
-            [
-                "psql",
-                "-X",
-                admin_dsn,
-                "-c",
-                f'CREATE DATABASE "{_TEST_DB_NAME}";',
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if cr.returncode != 0 and "already exists" not in cr.stderr:
-            raise AssertionError(f"create db failed: {cr.stderr}")
-
-    # Build the test DSN.
-    test_dsn = admin_dsn.rsplit("/", 1)[0] + f"/{_TEST_DB_NAME}"
-
-    # #4418 — persist_phase_output gained a second INSERT into
-    # ``dispatcher.phase_transitions`` in #3697 (commit a5c8b6c5). The
-    # safety-test bootstrap was authored before that change and never updated,
-    # so every round-trip call here failed with rc=3 / ``relation
-    # dispatcher.phase_transitions does not exist``. The companion test
-    # ``test_persist_phase_output_writes_phase_transition.py`` already
-    # creates this table; mirroring its shape keeps both bootstraps in sync.
-    schema_sql = textwrap.dedent("""
-        CREATE SCHEMA IF NOT EXISTS dispatcher;
-        CREATE TABLE IF NOT EXISTS dispatcher.phase_outputs (
-            agent_id    uuid    NOT NULL,
-            phase       text    NOT NULL,
-            attempt     int     NOT NULL DEFAULT 1,
-            output_json jsonb   NOT NULL,
-            ts          timestamptz NOT NULL DEFAULT now()
-        );
-        CREATE UNIQUE INDEX IF NOT EXISTS
-            idx_phase_outputs_test_agent_phase_attempt
-            ON dispatcher.phase_outputs (agent_id, phase, attempt);
-        CREATE TABLE IF NOT EXISTS dispatcher.phase_transitions (
-            transition_id   bigserial   PRIMARY KEY,
-            agent_id        uuid        NOT NULL,
-            phase           text        NOT NULL,
-            ts              timestamptz NOT NULL DEFAULT now()
-        );
-    """)
-    r = subprocess.run(
-        ["psql", "-X", test_dsn, "-v", "ON_ERROR_STOP=1", "-c", schema_sql],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert r.returncode == 0, f"schema setup failed: {r.stderr}"
-    return test_dsn
-
 
 _TEST_DSN: str | None = None
 
@@ -180,7 +74,7 @@ def _get_test_dsn() -> str | None:
         return _TEST_DSN
     if _DSN is None:
         return None
-    _TEST_DSN = _bootstrap_test_database(_DSN)
+    _TEST_DSN = bootstrap_dispatcher_test_db(_DSN, _TEST_DB_NAME)
     return _TEST_DSN
 
 

--- a/scripts/tests/test_persist_phase_output_writes_phase_transition.py
+++ b/scripts/tests/test_persist_phase_output_writes_phase_transition.py
@@ -20,8 +20,6 @@ the docker-compose dev environment specifically).
 
 from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 import textwrap
 import uuid
@@ -29,111 +27,26 @@ from pathlib import Path
 
 import pytest
 
+from tests._dispatcher_test_bootstrap import (
+    DOCKER_POSTGRES_SKIP_REASON,
+    bootstrap_dispatcher_test_db,
+    docker_postgres_admin_dsn,
+)
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _ENTRYPOINT_SH = _REPO_ROOT / "scripts" / "dispatcher" / "agent-runner-entrypoint.sh"
 
-
-def _docker_postgres_dsn() -> str | None:
-    """Return a DSN if the docker-compose postgres is reachable, else None."""
-    if shutil.which("psql") is None:
-        return None
-    dsn = os.environ.get(
-        "TEST_DSN",
-        "postgres://judgemind:localdev@localhost:5432/judgemind",
-    )
-    try:
-        r = subprocess.run(
-            ["psql", "-X", dsn, "-At", "-c", "SELECT 1"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    if r.returncode != 0 or r.stdout.strip() != "1":
-        return None
-    return dsn
-
-
-_DSN = _docker_postgres_dsn()
+# #4424 — schema bootstrap is now centralised in
+# ``scripts/tests/_dispatcher_test_bootstrap.py`` (one source of truth for
+# the union of ``dispatcher.*`` tables every persist-* test family member
+# touches).
+_DSN = docker_postgres_admin_dsn()
 pytestmark = pytest.mark.skipif(
     _DSN is None,
-    reason="local docker postgres not reachable; behavioural test skipped "
-    "(schema-parity test in test_phase_outputs_insert_shape.py still runs)",
+    reason=DOCKER_POSTGRES_SKIP_REASON,
 )
 
 _TEST_DB_NAME = "judgemind_test_persist_phase_transition"
-
-
-def _bootstrap_test_database(admin_dsn: str) -> str:
-    """Create a dedicated test database and return its DSN.
-
-    Idempotent — re-runs of the test reuse the same database.  Both
-    ``dispatcher.phase_outputs`` and ``dispatcher.phase_transitions`` are
-    created in their minimal forms (no FK constraints, no extra indexes beyond
-    what the bash function needs).
-    """
-    create = subprocess.run(
-        [
-            "psql",
-            "-X",
-            admin_dsn,
-            "-At",
-            "-c",
-            f"SELECT 1 FROM pg_database WHERE datname='{_TEST_DB_NAME}';",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if create.returncode != 0:
-        raise AssertionError(f"db existence probe failed: {create.stderr}")
-    if create.stdout.strip() != "1":
-        cr = subprocess.run(
-            [
-                "psql",
-                "-X",
-                admin_dsn,
-                "-c",
-                f'CREATE DATABASE "{_TEST_DB_NAME}";',
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if cr.returncode != 0 and "already exists" not in cr.stderr:
-            raise AssertionError(f"create db failed: {cr.stderr}")
-
-    test_dsn = admin_dsn.rsplit("/", 1)[0] + f"/{_TEST_DB_NAME}"
-
-    schema_sql = textwrap.dedent("""
-        CREATE SCHEMA IF NOT EXISTS dispatcher;
-        CREATE TABLE IF NOT EXISTS dispatcher.phase_outputs (
-            agent_id    uuid    NOT NULL,
-            phase       text    NOT NULL,
-            attempt     int     NOT NULL DEFAULT 1,
-            output_json jsonb   NOT NULL,
-            ts          timestamptz NOT NULL DEFAULT now()
-        );
-        CREATE UNIQUE INDEX IF NOT EXISTS
-            idx_phase_outputs_pt_agent_phase_attempt
-            ON dispatcher.phase_outputs (agent_id, phase, attempt);
-        CREATE TABLE IF NOT EXISTS dispatcher.phase_transitions (
-            transition_id   bigserial   PRIMARY KEY,
-            agent_id        uuid        NOT NULL,
-            phase           text        NOT NULL,
-            ts              timestamptz NOT NULL DEFAULT now()
-        );
-    """)
-    r = subprocess.run(
-        ["psql", "-X", test_dsn, "-v", "ON_ERROR_STOP=1", "-c", schema_sql],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert r.returncode == 0, f"schema setup failed: {r.stderr}"
-    return test_dsn
-
 
 _TEST_DSN: str | None = None
 
@@ -145,7 +58,7 @@ def _get_test_dsn() -> str | None:
         return _TEST_DSN
     if _DSN is None:
         return None
-    _TEST_DSN = _bootstrap_test_database(_DSN)
+    _TEST_DSN = bootstrap_dispatcher_test_db(_DSN, _TEST_DB_NAME)
     return _TEST_DSN
 
 
@@ -275,7 +188,9 @@ def test_second_call_different_phase_adds_second_row() -> None:
     rc1, _, stderr1 = _invoke_persist(test_dsn, agent_id, "plan", '{"go": true}')
     assert rc1 == 0, f"first call failed rc={rc1}\n{stderr1}"
 
-    rc2, _, stderr2 = _invoke_persist(test_dsn, agent_id, "ralph", '{"verdict": "SHIP"}')
+    rc2, _, stderr2 = _invoke_persist(
+        test_dsn, agent_id, "ralph", '{"verdict": "SHIP"}'
+    )
     assert rc2 == 0, f"second call failed rc={rc2}\n{stderr2}"
 
     count = _count_phase_transitions(test_dsn, agent_id)

--- a/scripts/tests/test_persist_ralph_patch_safety.py
+++ b/scripts/tests/test_persist_ralph_patch_safety.py
@@ -25,8 +25,6 @@ and is gated on the docker-compose stack being up).
 
 from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 import textwrap
 import uuid
@@ -34,116 +32,33 @@ from pathlib import Path
 
 import pytest
 
+from tests._dispatcher_test_bootstrap import (
+    DOCKER_POSTGRES_SKIP_REASON,
+    bootstrap_dispatcher_test_db,
+    docker_postgres_admin_dsn,
+)
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _ENTRYPOINT_SH = _REPO_ROOT / "scripts" / "dispatcher" / "agent-runner-entrypoint.sh"
 
-
-def _docker_postgres_dsn() -> str | None:
-    """Return a DSN if the docker-compose postgres is reachable, else None."""
-    if shutil.which("psql") is None:
-        return None
-    dsn = os.environ.get(
-        "TEST_DSN",
-        "postgres://judgemind:localdev@localhost:5432/judgemind",
-    )
-    try:
-        r = subprocess.run(
-            ["psql", "-X", dsn, "-At", "-c", "SELECT 1"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    if r.returncode != 0 or r.stdout.strip() != "1":
-        return None
-    return dsn
-
-
-_DSN = _docker_postgres_dsn()
+# #4424 — schema bootstrap is now centralised in
+# ``scripts/tests/_dispatcher_test_bootstrap.py`` (one source of truth for
+# the union of ``dispatcher.*`` tables every persist-* test family member
+# touches).
+_DSN = docker_postgres_admin_dsn()
 pytestmark = pytest.mark.skipif(
     _DSN is None,
-    reason="local docker postgres not reachable; behavioural test skipped "
-    "(schema-parity test in test_phase_outputs_insert_shape.py still runs)",
+    reason=DOCKER_POSTGRES_SKIP_REASON,
 )
 
-# Test schema name — deliberately separate from ``dispatcher`` so the test
-# never collides with the operational schema that may be loaded in the same
-# docker postgres (it has FKs and constraints we can't easily seed). The bash
-# function under test executes ``INSERT INTO dispatcher.ralph_patches ...`` with
-# that schema name hard-coded, so we point it at a dedicated test database
-# where we own the ``dispatcher`` schema entirely.
+# Test database name — deliberately separate from ``dispatcher`` inside
+# the docker-compose admin DB so the test never collides with the
+# operational schema that may also be loaded there (it has FKs and
+# constraints we can't easily seed). The bash function under test
+# executes ``INSERT INTO dispatcher.ralph_patches ...`` with that schema
+# name hard-coded, so we point it at a dedicated test database where we
+# own the ``dispatcher`` schema entirely.
 _TEST_DB_NAME = "judgemind_test_persist_ralph_patch"
-
-
-def _bootstrap_test_database(admin_dsn: str) -> str:
-    """Create a dedicated test database and return its DSN.
-
-    Idempotent — re-runs of the test reuse the same database.
-    """
-    probe = subprocess.run(
-        [
-            "psql",
-            "-X",
-            admin_dsn,
-            "-At",
-            "-c",
-            f"SELECT 1 FROM pg_database WHERE datname='{_TEST_DB_NAME}';",
-        ],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    if probe.returncode != 0:
-        raise AssertionError(f"db existence probe failed: {probe.stderr}")
-    if probe.stdout.strip() != "1":
-        cr = subprocess.run(
-            [
-                "psql",
-                "-X",
-                admin_dsn,
-                "-c",
-                f'CREATE DATABASE "{_TEST_DB_NAME}";',
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if cr.returncode != 0 and "already exists" not in cr.stderr:
-            raise AssertionError(f"create db failed: {cr.stderr}")
-
-    test_dsn = admin_dsn.rsplit("/", 1)[0] + f"/{_TEST_DB_NAME}"
-
-    # Minimal schema mirroring production columns. No FKs — agents table is
-    # referenced by the UPDATE in ralph_head_watcher_persist; we create a stub
-    # with the same column shape so the UPDATE is a no-op (WHERE clause never
-    # matches a real agent_id, which is fine — we only need the INSERT to work).
-    schema_sql = textwrap.dedent("""
-        CREATE SCHEMA IF NOT EXISTS dispatcher;
-        CREATE TABLE IF NOT EXISTS dispatcher.ralph_patches (
-            patch_id       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-            agent_id       UUID        NOT NULL,
-            issue_number   INT         NOT NULL,
-            patch_content  TEXT        NOT NULL,
-            commit_sha     TEXT,
-            iteration_n    INT,
-            verdict        TEXT,
-            created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
-        );
-        CREATE TABLE IF NOT EXISTS dispatcher.agents (
-            agent_id                    UUID PRIMARY KEY,
-            ralph_iterations_observed   INT NOT NULL DEFAULT 0
-        );
-    """)
-    r = subprocess.run(
-        ["psql", "-X", test_dsn, "-v", "ON_ERROR_STOP=1", "-c", schema_sql],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    assert r.returncode == 0, f"schema setup failed: {r.stderr}"
-    return test_dsn
-
 
 _TEST_DSN: str | None = None
 
@@ -155,7 +70,7 @@ def _get_test_dsn() -> str | None:
         return _TEST_DSN
     if _DSN is None:
         return None
-    _TEST_DSN = _bootstrap_test_database(_DSN)
+    _TEST_DSN = bootstrap_dispatcher_test_db(_DSN, _TEST_DB_NAME)
     return _TEST_DSN
 
 


### PR DESCRIPTION
## Summary

Centralises the docker-postgres `dispatcher` schema bootstrap that the three `test_persist_*_safety.py` files inlined into a single source-of-truth helper at `scripts/tests/_dispatcher_test_bootstrap.py`. Adds `test_persist_bootstrap_mirrors_production_inserts.py` as a structural backstop that parses every `INSERT INTO dispatcher.<table>` in the entrypoint and asserts the shared bootstrap covers it — runs in CI without postgres, so a future production INSERT addition can no longer rot silently the way #3697 did until #4418 caught it.

Closes #4424

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (test-fixture refactor only; no production code touched)
