### PR TITLE
chore(storage): add cleanup script for mislabeled flat-hash S3 objects (#2661)

### DIFF
--- a/scripts/cleanup_mislabeled_s3_2661.py
+++ b/scripts/cleanup_mislabeled_s3_2661.py
@@ -1,0 +1,473 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Delete mislabeled flat-hash S3 objects from the 2026-03-28 migration.
+
+The 2026-03-28 migration in commit ``fbf8e38`` (archived as
+``scripts/archive/migrate_s3_keys.py``) wrote S3 objects under content-addressed
+keys whose filename SHA-256 did **not** match the SHA-256 of the bytes — for
+documents whose ``content_hash`` was a synthetic split-child value rather than
+a real bytes hash. ``CopyObject`` preserved the original metadata
+``content-hash`` (the correct bytes hash), so each mislabeled object carries a
+metadata header that points to the right value.
+
+After ``rebuild_db.py`` re-pointed ``derived.documents`` rows to correctly-named
+content-addressed keys (#2630), the mislabeled copies are pure detritus and
+safe to delete — provided no DB rows still reference them.
+
+This script does **two passes**:
+
+1. **Enumerate pass:** paginate ``list_objects_v2`` under ``ca/``, match keys of
+   shape ``ca/{county}/{court}/raw/<hex64>.<ext>``, HEAD each, and compare the
+   filename hex64 to metadata ``content-hash``. Records any mismatches with
+   their filename hash, metadata hash, and county.
+
+2. **Delete pass:** in --apply mode, runs a DB safety check
+   (``SELECT s3_key FROM derived.documents WHERE s3_key = ANY(...)``) against
+   the enumerated mislabels. **Aborts** if any DB row still references a
+   mislabeled key — those rows must be repointed (re-run ``rebuild_db.py``)
+   before the corresponding S3 objects can be removed. Otherwise batch-deletes
+   the mislabels via ``s3.delete_objects`` (1000/batch).
+
+Usage:
+    scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --apply
+    scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --apply --county santa_clara
+
+Options:
+    --dry-run   List mislabels grouped by county; do not delete (default).
+    --apply     Run DB safety check and, if it passes, delete the mislabels.
+    --county    Restrict to a single county (e.g. santa_clara, orange).
+    --state     State prefix to scan (default: ca).
+    --bucket    S3 bucket to scan (default: $S3_BUCKET or judgemind-document-archive-dev).
+
+Exit codes:
+    0  Dry-run completed, or apply succeeded with all deletes.
+    1  Apply aborted because DB rows still reference mislabels.
+    2  Unrecoverable error (S3, DB, or argument).
+
+See: https://github.com/judgemind/judgemind/issues/2661
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+
+import boto3
+import psycopg
+from botocore.exceptions import ClientError
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
+
+# Matches content-addressed flat-hash keys: ca/{county}/{court}/raw/{hex64}.{ext}
+# Captures county and the filename hash for downstream grouping/comparison.
+KEY_PATTERN = re.compile(
+    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
+)
+
+# Sample size to log per county before truncating.
+SAMPLE_SIZE = 20
+
+# delete_objects S3 API caps at 1000 keys per request.
+DELETE_BATCH_SIZE = 1000
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def parse_flat_hash_key(key: str) -> dict[str, str] | None:
+    """Parse a flat-hash content-addressed key.
+
+    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``, ``ext``
+    on match, or ``None`` if the key does not match the expected shape.
+
+    The function is the source of truth for what counts as a "flat-hash" key
+    in this script — anything that does not match (e.g. date-partitioned legacy
+    keys, court_directory snapshots, non-raw paths) is silently skipped.
+
+    Examples::
+
+        parse_flat_hash_key("ca/orange/superior_court/raw/aabb...64.pdf")
+        # -> {"state": "ca", "county": "orange", "court": "superior_court",
+        #     "hash": "aabb...64", "ext": "pdf"}
+
+        parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/x.pdf")
+        # -> None
+    """
+    m = KEY_PATTERN.match(key)
+    if m is None:
+        return None
+    return dict(m.groupdict())
+
+
+def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
+    """Return True if *filename_hash* differs from *metadata_hash*.
+
+    The mislabel signature from the 2026-03-28 migration is:
+    filename hex64 ≠ metadata ``content-hash``. Both must be hex64 strings (we
+    do not normalise here — the caller is expected to have read the metadata
+    via ``HeadObject`` which preserves the original casing).
+
+    A missing metadata hash (``None`` or empty) does **not** count as a
+    mislabel — the audit script (``audit_s3_raw_mislabels.py``) treats missing
+    metadata as a separate problem class and is the right place to surface it.
+    This script is narrowly scoped to "filename ≠ metadata" (issue #2661).
+    """
+    if not metadata_hash:
+        return False
+    return filename_hash != metadata_hash
+
+
+# ---------------------------------------------------------------------------
+# S3 enumeration
+# ---------------------------------------------------------------------------
+
+
+def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
+    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
+
+    Returns ``None`` for both a missing metadata field AND a 404 — callers are
+    expected to handle both cases as "not a mislabel" (the audit script is
+    the right place to surface those edge cases).
+    """
+    try:
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+    metadata: dict[str, str] = head.get("Metadata", {}) or {}
+    return metadata.get("content-hash") or None
+
+
+def enumerate_mislabels(
+    s3_client: object,
+    bucket: str,
+    prefix: str,
+) -> dict[str, list[dict[str, str]]]:
+    """Enumerate mislabeled flat-hash keys under *prefix*, grouped by county.
+
+    For each key under *prefix* that matches ``KEY_PATTERN``:
+      1. HEAD the object to read its metadata ``content-hash``.
+      2. If the metadata hash differs from the filename hash, record it.
+
+    Returns a dict mapping county name to a list of mislabel records, each
+    record being a dict with keys ``key``, ``filename_hash``, ``metadata_hash``.
+
+    Keys with missing metadata or 404s are silently skipped — they are a
+    separate problem class (see ``audit_s3_raw_mislabels.py``). The dry-run
+    output is the source-of-truth for what this script will delete.
+    """
+    paginator = s3_client.get_paginator("list_objects_v2")
+    by_county: dict[str, list[dict[str, str]]] = defaultdict(list)
+    total_seen = 0
+    total_skipped_shape = 0
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            parsed = parse_flat_hash_key(key)
+            if parsed is None:
+                total_skipped_shape += 1
+                continue
+            total_seen += 1
+            metadata_hash = head_object_metadata_hash(s3_client, bucket, key)
+            if is_mislabel(parsed["hash"], metadata_hash):
+                by_county[parsed["county"]].append(
+                    {
+                        "key": key,
+                        "filename_hash": parsed["hash"],
+                        "metadata_hash": metadata_hash or "",
+                    }
+                )
+
+    logger.info(
+        "Scanned prefix %r: %d flat-hash keys, %d skipped (non-matching shape)",
+        prefix,
+        total_seen,
+        total_skipped_shape,
+    )
+    return dict(by_county)
+
+
+# ---------------------------------------------------------------------------
+# DB safety check
+# ---------------------------------------------------------------------------
+
+
+def find_referenced_keys(conn: object, keys: Iterable[str]) -> list[str]:
+    """Return the subset of *keys* that are still referenced by ``derived.documents``.
+
+    Uses ``s3_key = ANY(%s)`` so PostgreSQL plans the lookup against the
+    existing index on ``s3_key`` (no full scan) regardless of how large *keys*
+    is. The caller should treat a non-empty result as a hard ABORT signal —
+    those rows must be re-pointed (run ``rebuild_db.py``) before the
+    corresponding S3 objects can be deleted.
+    """
+    keys_list = list(keys)
+    if not keys_list:
+        return []
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT s3_key FROM derived.documents WHERE s3_key = ANY(%s)",
+            (keys_list,),
+        )
+        rows = cur.fetchall()
+    return [row[0] for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# S3 deletion
+# ---------------------------------------------------------------------------
+
+
+def delete_in_batches(
+    s3_client: object, bucket: str, keys: list[str], *, dry_run: bool
+) -> int:
+    """Delete *keys* in batches of ``DELETE_BATCH_SIZE``.
+
+    In dry-run mode, no deletions are performed and 0 is returned.
+    Returns the number of objects deleted.
+    """
+    if dry_run or not keys:
+        return 0
+
+    deleted = 0
+    total = len(keys)
+    for i in range(0, total, DELETE_BATCH_SIZE):
+        batch = keys[i : i + DELETE_BATCH_SIZE]
+        s3_client.delete_objects(
+            Bucket=bucket,
+            Delete={"Objects": [{"Key": k} for k in batch], "Quiet": True},
+        )
+        deleted += len(batch)
+        logger.info("Deleted %d/%d objects...", deleted, total)
+    return deleted
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def report_enumeration(by_county: dict[str, list[dict[str, str]]]) -> int:
+    """Log per-county counts + first SAMPLE_SIZE keys; return total count."""
+    total = 0
+    for county in sorted(by_county.keys()):
+        records = by_county[county]
+        total += len(records)
+        logger.info("%s: %d mislabeled key(s)", county, len(records))
+        for record in records[:SAMPLE_SIZE]:
+            logger.info(
+                "  %s (filename=%s metadata=%s)",
+                record["key"],
+                record["filename_hash"][:16] + "...",
+                record["metadata_hash"][:16] + "..."
+                if record["metadata_hash"]
+                else "<missing>",
+            )
+        if len(records) > SAMPLE_SIZE:
+            logger.info("  ... and %d more", len(records) - SAMPLE_SIZE)
+
+    print()
+    print("=" * 60)
+    print("Mislabel enumeration summary")
+    print("=" * 60)
+    for county in sorted(by_county.keys()):
+        print(f"  {county:<24s} {len(by_county[county]):>6d}")
+    print(f"  {'TOTAL':<24s} {total:>6d}")
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_cleanup(
+    s3_client: object,
+    db_conn: object,
+    *,
+    bucket: str,
+    state: str,
+    county: str | None,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Run the two-pass cleanup. Returns a dict with summary counts.
+
+    Summary keys: ``mislabels_found``, ``referenced_count``, ``deleted``,
+    ``aborted`` (1/0).
+    """
+    if county:
+        prefix = f"{state}/{county}/"
+    else:
+        prefix = f"{state}/"
+
+    logger.info(
+        "Mode: %s | Bucket: %s | Prefix: %s",
+        "DRY-RUN" if dry_run else "APPLY",
+        bucket,
+        prefix,
+    )
+
+    # Pass 1: enumerate.
+    by_county = enumerate_mislabels(s3_client, bucket, prefix)
+    total_mislabels = report_enumeration(by_county)
+
+    if total_mislabels == 0:
+        logger.info("No mislabels found. Nothing to do.")
+        return {
+            "mislabels_found": 0,
+            "referenced_count": 0,
+            "deleted": 0,
+            "aborted": 0,
+        }
+
+    # Flatten the keys for the DB and S3 calls.
+    all_keys: list[str] = [
+        record["key"] for records in by_county.values() for record in records
+    ]
+
+    # Pass 2a: DB safety check.
+    referenced = find_referenced_keys(db_conn, all_keys)
+    print()
+    print(
+        f"DB safety check: {len(referenced)} mislabeled key(s) still referenced "
+        f"by derived.documents"
+    )
+    for ref_key in referenced[:SAMPLE_SIZE]:
+        print(f"  REFERENCED: {ref_key}")
+    if len(referenced) > SAMPLE_SIZE:
+        print(f"  ... and {len(referenced) - SAMPLE_SIZE} more")
+
+    if referenced:
+        logger.error(
+            "ABORT: %d mislabeled S3 key(s) are still referenced by "
+            "derived.documents rows. Run rebuild_db.py against the affected "
+            "counties to repoint rows to correctly-named content-addressed "
+            "keys, then re-run this script.",
+            len(referenced),
+        )
+        return {
+            "mislabels_found": total_mislabels,
+            "referenced_count": len(referenced),
+            "deleted": 0,
+            "aborted": 1,
+        }
+
+    logger.info(
+        "DB safety check passed: 0 mislabels are DB-referenced. Safe to delete %d object(s).",
+        total_mislabels,
+    )
+
+    # Pass 2b: delete (or simulate in dry-run).
+    if dry_run:
+        logger.info(
+            "DRY-RUN: would delete %d object(s). Re-run with --apply to proceed.",
+            total_mislabels,
+        )
+        return {
+            "mislabels_found": total_mislabels,
+            "referenced_count": 0,
+            "deleted": 0,
+            "aborted": 0,
+        }
+
+    deleted = delete_in_batches(s3_client, bucket, all_keys, dry_run=False)
+    logger.info("Done. Deleted %d mislabeled S3 object(s).", deleted)
+    return {
+        "mislabels_found": total_mislabels,
+        "referenced_count": 0,
+        "deleted": deleted,
+        "aborted": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Delete mislabeled flat-hash S3 objects from the 2026-03-28 migration. "
+            "Two-pass: enumerate, then delete with DB safety check."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="List mislabels grouped by county; do not delete (default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run DB safety check and, if it passes, delete the mislabels.",
+    )
+    parser.add_argument(
+        "--county",
+        default=None,
+        help="Restrict to a single county prefix (e.g. santa_clara, orange).",
+    )
+    parser.add_argument(
+        "--state",
+        default="ca",
+        help="State prefix to scan (default: ca).",
+    )
+    parser.add_argument(
+        "--bucket",
+        default=DEFAULT_BUCKET,
+        help=f"S3 bucket to scan (default: ${{S3_BUCKET}} or {DEFAULT_BUCKET}).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --apply overrides --dry-run.
+    dry_run = not args.apply
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        return 2
+
+    s3_client = boto3.client("s3")
+
+    with psycopg.connect(dsn) as conn:
+        result = run_cleanup(
+            s3_client,
+            conn,
+            bucket=args.bucket,
+            state=args.state,
+            county=args.county,
+            dry_run=dry_run,
+        )
+
+    return 1 if result["aborted"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cleanup_mislabeled_s3_2661.py
+++ b/scripts/cleanup_mislabeled_s3_2661.py
@@ -63,10 +63,14 @@ import boto3
 import psycopg
 from botocore.exceptions import ClientError
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-8s %(message)s",
-)
+from framework.logging import configure_structlog
+
+# Canonical stdout/CloudWatch logger pattern (#4368/#4373).  Routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder so any ``extra=`` field reaches
+# CloudWatch Logs Insights as a structured JSON field — the legacy
+# ``logging.basicConfig(format=...)`` block drops them silently.
+configure_structlog(json=True, stdlib_bridge=True)
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_cleanup_mislabeled_s3_2661.py
+++ b/scripts/tests/test_cleanup_mislabeled_s3_2661.py
@@ -36,6 +36,10 @@ _mock_psycopg = MagicMock()
 _mock_boto3 = MagicMock()
 _mock_botocore = MagicMock()
 _mock_botocore_exceptions = MagicMock()
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+_mock_framework = MagicMock()
+_mock_framework_logging = MagicMock()
 
 
 # ClientError needs a real exception class so `except ClientError` works in
@@ -56,6 +60,9 @@ _modules_to_mock = {
     "boto3": _mock_boto3,
     "botocore": _mock_botocore,
     "botocore.exceptions": _mock_botocore_exceptions,
+    "structlog": _mock_structlog,
+    "framework": _mock_framework,
+    "framework.logging": _mock_framework_logging,
 }
 
 _saved_modules: dict[str, object] = {}

--- a/scripts/tests/test_cleanup_mislabeled_s3_2661.py
+++ b/scripts/tests/test_cleanup_mislabeled_s3_2661.py
@@ -1,0 +1,650 @@
+"""Tests for cleanup_mislabeled_s3_2661 script.
+
+Tests cover:
+- parse_flat_hash_key for valid, malformed, and edge-case keys
+- is_mislabel for matching/mismatching/missing-metadata cases
+- head_object_metadata_hash with mocked S3 client (200, 404, missing field)
+- enumerate_mislabels end-to-end with mocked paginator + HEAD
+- find_referenced_keys with mocked psycopg connection
+- delete_in_batches in dry-run and apply modes, batch boundary
+- run_cleanup orchestration: dry-run, apply with abort, apply with success
+- main CLI: --dry-run default, --apply switch, missing DATABASE_URL,
+  abort exit code propagation
+
+The script imports psycopg + boto3 at module level, which may not be
+installed in the CI scripts-tests environment. We mock those in
+sys.modules before importing the script under test, mirroring the
+pattern used by test_cleanup_riverside_case_prefixes.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking — the script imports boto3 and psycopg at module level,
+# which may not be installed in the CI scripts-tests environment.
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_mock_psycopg = MagicMock()
+_mock_boto3 = MagicMock()
+_mock_botocore = MagicMock()
+_mock_botocore_exceptions = MagicMock()
+
+
+# ClientError needs a real exception class so `except ClientError` works in
+# the script under test. We define a minimal subclass that mirrors the
+# botocore ClientError signature (response dict + operation_name).
+class _FakeClientError(Exception):
+    def __init__(self, response: dict, operation_name: str = "Unknown"):
+        super().__init__(f"{operation_name}: {response}")
+        self.response = response
+        self.operation_name = operation_name
+
+
+_mock_botocore_exceptions.ClientError = _FakeClientError
+_mock_botocore.exceptions = _mock_botocore_exceptions
+
+_modules_to_mock = {
+    "psycopg": _mock_psycopg,
+    "boto3": _mock_boto3,
+    "botocore": _mock_botocore,
+    "botocore.exceptions": _mock_botocore_exceptions,
+}
+
+_saved_modules: dict[str, object] = {}
+for mod_name, mock_mod in _modules_to_mock.items():
+    if mod_name in sys.modules:
+        _saved_modules[mod_name] = sys.modules[mod_name]
+    sys.modules[mod_name] = mock_mod
+
+import cleanup_mislabeled_s3_2661  # noqa: E402
+
+# Restore sys.modules so the mock injection doesn't break other test files
+# that use @patch("boto3.client") (e.g. test_api_error_check.py). The cleanup
+# script's module-level boto3/psycopg bindings remain as mocks (captured at
+# import time), so tests in this file continue to work correctly.
+for _mod_name in list(_modules_to_mock.keys()):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
+
+parse_flat_hash_key = cleanup_mislabeled_s3_2661.parse_flat_hash_key
+is_mislabel = cleanup_mislabeled_s3_2661.is_mislabel
+head_object_metadata_hash = cleanup_mislabeled_s3_2661.head_object_metadata_hash
+enumerate_mislabels = cleanup_mislabeled_s3_2661.enumerate_mislabels
+find_referenced_keys = cleanup_mislabeled_s3_2661.find_referenced_keys
+delete_in_batches = cleanup_mislabeled_s3_2661.delete_in_batches
+report_enumeration = cleanup_mislabeled_s3_2661.report_enumeration
+run_cleanup = cleanup_mislabeled_s3_2661.run_cleanup
+build_parser = cleanup_mislabeled_s3_2661.build_parser
+main = cleanup_mislabeled_s3_2661.main
+ClientError = cleanup_mislabeled_s3_2661.ClientError
+
+
+# ---------------------------------------------------------------------------
+# parse_flat_hash_key
+# ---------------------------------------------------------------------------
+
+
+HEX64_A = "a" * 64
+HEX64_B = "b" * 64
+HEX64_C = "c" * 64
+
+
+class TestParseFlatHashKey:
+    def test_valid_pdf(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert result == {
+            "state": "ca",
+            "county": "orange",
+            "court": "superior_court",
+            "hash": HEX64_A,
+            "ext": "pdf",
+        }
+
+    def test_valid_html(self) -> None:
+        result = parse_flat_hash_key(
+            f"ca/santa_clara/superior_court/raw/{HEX64_B}.html"
+        )
+        assert result is not None
+        assert result["county"] == "santa_clara"
+        assert result["ext"] == "html"
+
+    def test_valid_docx(self) -> None:
+        result = parse_flat_hash_key(
+            f"ca/los_angeles/superior_court/raw/{HEX64_A}.docx"
+        )
+        assert result is not None
+        assert result["ext"] == "docx"
+
+    def test_valid_txt(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{HEX64_C}.txt")
+        assert result is not None
+        assert result["ext"] == "txt"
+
+    def test_date_partitioned_key_returns_none(self) -> None:
+        # Legacy date-partitioned keys are NOT in scope (#2627 covers those).
+        result = parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/uuid.pdf")
+        assert result is None
+
+    def test_short_hash_returns_none(self) -> None:
+        # 63 chars instead of 64.
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'a' * 63}.pdf")
+        assert result is None
+
+    def test_uppercase_hash_returns_none(self) -> None:
+        # KEY_PATTERN requires lowercase hex.
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'A' * 64}.pdf")
+        assert result is None
+
+    def test_non_raw_path_returns_none(self) -> None:
+        # transcripts/ or other path segments are not in scope.
+        result = parse_flat_hash_key(
+            f"ca/orange/superior_court/transcripts/{HEX64_A}.txt"
+        )
+        assert result is None
+
+    def test_court_directory_returns_none(self) -> None:
+        # court_directory snapshots and other non-document paths must not match.
+        result = parse_flat_hash_key("court_directory/ca/orange/snapshot.json")
+        assert result is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_flat_hash_key("") is None
+
+    def test_two_letter_state(self) -> None:
+        # Only two-letter state codes (per KEY_PATTERN). Three-letter must fail.
+        result = parse_flat_hash_key(f"cal/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_mislabel
+# ---------------------------------------------------------------------------
+
+
+class TestIsMislabel:
+    def test_matching_hashes_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_A) is False
+
+    def test_differing_hashes_is_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_B) is True
+
+    def test_missing_metadata_not_mislabel(self) -> None:
+        # Missing metadata is a separate problem class — handled by
+        # audit_s3_raw_mislabels.py, not by this script.
+        assert is_mislabel(HEX64_A, None) is False
+
+    def test_empty_metadata_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, "") is False
+
+
+# ---------------------------------------------------------------------------
+# head_object_metadata_hash
+# ---------------------------------------------------------------------------
+
+
+class TestHeadObjectMetadataHash:
+    def test_returns_hash_when_present(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        assert head_object_metadata_hash(s3, "bucket", "key") == HEX64_A
+
+    def test_returns_none_when_metadata_missing(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {}}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_metadata_field_absent(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404_via_no_such_key(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey"}}, "HeadObject"
+        )
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_propagates_other_errors(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "HeadObject"
+        )
+        with pytest.raises(ClientError):
+            head_object_metadata_hash(s3, "bucket", "key")
+
+
+# ---------------------------------------------------------------------------
+# enumerate_mislabels
+# ---------------------------------------------------------------------------
+
+
+def _mock_paginator(pages: list[list[dict[str, str]]]) -> MagicMock:
+    """Build a mock S3 paginator that yields *pages*, each a list of object
+    dicts with a "Key" field."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": page} for page in pages]
+    return paginator
+
+
+class TestEnumerateMislabels:
+    def test_no_objects_returns_empty(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[]])
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_correctly_labeled_skipped(self) -> None:
+        # filename == metadata: not a mislabel.
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_mislabel_recorded(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        # filename = HEX64_A but metadata says HEX64_B → mislabel.
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_B}}
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        assert "orange" in result
+        assert len(result["orange"]) == 1
+        record = result["orange"][0]
+        assert record["key"] == f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        assert record["filename_hash"] == HEX64_A
+        assert record["metadata_hash"] == HEX64_B
+
+    def test_groups_by_county(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [
+                [
+                    {"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"},
+                    {"Key": f"ca/santa_clara/superior_court/raw/{HEX64_A}.pdf"},
+                    {"Key": f"ca/orange/superior_court/raw/{HEX64_B}.pdf"},
+                ]
+            ]
+        )
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_C}}
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        assert sorted(result.keys()) == ["orange", "santa_clara"]
+        assert len(result["orange"]) == 2
+        assert len(result["santa_clara"]) == 1
+
+    def test_skips_non_matching_shape(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [
+                [
+                    {"Key": "ca/orange/superior_court/raw/2026/04/01/x.pdf"},
+                    {"Key": "court_directory/snapshot.json"},
+                    {"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"},
+                ]
+            ]
+        )
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_B}}
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        # Only the third (matching-shape) key was HEAD'd and recorded.
+        assert s3.head_object.call_count == 1
+        assert len(result["orange"]) == 1
+
+    def test_skips_objects_with_missing_metadata(self) -> None:
+        # Missing metadata is not in scope — the audit script handles those.
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.return_value = {"Metadata": {}}
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_skips_objects_that_404(self) -> None:
+        # Race between list and HEAD — silently skip.
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        result = enumerate_mislabels(s3, "bucket", "ca/")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# find_referenced_keys
+# ---------------------------------------------------------------------------
+
+
+class TestFindReferencedKeys:
+    def test_empty_input_returns_empty(self) -> None:
+        conn = MagicMock()
+        assert find_referenced_keys(conn, []) == []
+        # No cursor was used.
+        conn.cursor.assert_not_called()
+
+    def test_returns_referenced_subset(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        # psycopg uses a context manager for cursor().
+        conn.cursor.return_value.__enter__.return_value = cur
+        cur.fetchall.return_value = [
+            ("ca/orange/superior_court/raw/aaa.pdf",),
+            ("ca/orange/superior_court/raw/bbb.pdf",),
+        ]
+        keys = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+        ]
+        result = find_referenced_keys(conn, keys)
+        assert sorted(result) == [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+        ]
+        # Verify the SQL was an ANY() lookup (single round-trip — no full scan).
+        cur.execute.assert_called_once()
+        sql, params = cur.execute.call_args.args
+        assert "= ANY(%s)" in sql
+        assert params == (keys,)
+
+    def test_all_unreferenced_returns_empty(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        cur.fetchall.return_value = []
+        result = find_referenced_keys(conn, ["k1", "k2"])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# delete_in_batches
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteInBatches:
+    def test_dry_run_returns_zero(self) -> None:
+        s3 = MagicMock()
+        result = delete_in_batches(s3, "bucket", ["a", "b"], dry_run=True)
+        assert result == 0
+        s3.delete_objects.assert_not_called()
+
+    def test_empty_returns_zero(self) -> None:
+        s3 = MagicMock()
+        result = delete_in_batches(s3, "bucket", [], dry_run=False)
+        assert result == 0
+        s3.delete_objects.assert_not_called()
+
+    def test_single_batch_apply(self) -> None:
+        s3 = MagicMock()
+        keys = [f"k{i}" for i in range(3)]
+        result = delete_in_batches(s3, "bucket", keys, dry_run=False)
+        assert result == 3
+        s3.delete_objects.assert_called_once()
+        kwargs = s3.delete_objects.call_args.kwargs
+        assert kwargs["Bucket"] == "bucket"
+        assert kwargs["Delete"]["Objects"] == [{"Key": k} for k in keys]
+        assert kwargs["Delete"]["Quiet"] is True
+
+    def test_batch_boundary_2500_keys(self) -> None:
+        # 2500 keys → 1000 + 1000 + 500 → three calls.
+        s3 = MagicMock()
+        keys = [f"k{i}" for i in range(2500)]
+        result = delete_in_batches(s3, "bucket", keys, dry_run=False)
+        assert result == 2500
+        assert s3.delete_objects.call_count == 3
+        # First two batches are 1000 each, last is 500.
+        first_batch = s3.delete_objects.call_args_list[0].kwargs["Delete"]["Objects"]
+        last_batch = s3.delete_objects.call_args_list[2].kwargs["Delete"]["Objects"]
+        assert len(first_batch) == 1000
+        assert len(last_batch) == 500
+
+
+# ---------------------------------------------------------------------------
+# run_cleanup orchestration
+# ---------------------------------------------------------------------------
+
+
+def _stub_s3_with_mislabels(
+    keys_to_mislabel: list[str], all_keys: list[str] | None = None
+) -> MagicMock:
+    """Build an S3 client mock that lists *all_keys* and reports each key in
+    *keys_to_mislabel* as a mislabel (metadata != filename)."""
+    if all_keys is None:
+        all_keys = keys_to_mislabel
+    s3 = MagicMock()
+    s3.get_paginator.return_value = _mock_paginator([[{"Key": k} for k in all_keys]])
+
+    def fake_head(*, Bucket: str, Key: str) -> dict:
+        if Key in keys_to_mislabel:
+            # Return a metadata hash that differs from the filename hash.
+            return {"Metadata": {"content-hash": HEX64_C}}
+        # Correctly-labelled key — metadata equals filename.
+        parsed = parse_flat_hash_key(Key)
+        return {"Metadata": {"content-hash": parsed["hash"]}}
+
+    s3.head_object.side_effect = fake_head
+    return s3
+
+
+def _stub_db_no_references() -> MagicMock:
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    cur.fetchall.return_value = []
+    return conn
+
+
+def _stub_db_with_references(referenced: list[str]) -> MagicMock:
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    cur.fetchall.return_value = [(k,) for k in referenced]
+    return conn
+
+
+class TestRunCleanup:
+    def test_no_mislabels_returns_clean(self) -> None:
+        s3 = _stub_s3_with_mislabels([])
+        conn = _stub_db_no_references()
+        result = run_cleanup(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=True
+        )
+        assert result == {
+            "mislabels_found": 0,
+            "referenced_count": 0,
+            "deleted": 0,
+            "aborted": 0,
+        }
+        s3.delete_objects.assert_not_called()
+
+    def test_dry_run_does_not_delete(self) -> None:
+        keys = [f"ca/orange/superior_court/raw/{HEX64_A}.pdf"]
+        s3 = _stub_s3_with_mislabels(keys)
+        conn = _stub_db_no_references()
+        result = run_cleanup(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=True
+        )
+        assert result["mislabels_found"] == 1
+        assert result["deleted"] == 0
+        assert result["aborted"] == 0
+        s3.delete_objects.assert_not_called()
+
+    def test_apply_aborts_when_db_references_present(self) -> None:
+        keys = [f"ca/orange/superior_court/raw/{HEX64_A}.pdf"]
+        s3 = _stub_s3_with_mislabels(keys)
+        conn = _stub_db_with_references(keys)  # row still pointing at the mislabel
+        result = run_cleanup(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=False
+        )
+        assert result["mislabels_found"] == 1
+        assert result["referenced_count"] == 1
+        assert result["deleted"] == 0
+        assert result["aborted"] == 1
+        s3.delete_objects.assert_not_called()
+
+    def test_apply_succeeds_when_no_references(self) -> None:
+        keys = [
+            f"ca/orange/superior_court/raw/{HEX64_A}.pdf",
+            f"ca/santa_clara/superior_court/raw/{HEX64_B}.pdf",
+        ]
+        s3 = _stub_s3_with_mislabels(keys)
+        conn = _stub_db_no_references()
+        result = run_cleanup(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=False
+        )
+        assert result["mislabels_found"] == 2
+        assert result["referenced_count"] == 0
+        assert result["deleted"] == 2
+        assert result["aborted"] == 0
+        s3.delete_objects.assert_called_once()
+
+    def test_county_scoping_uses_specific_prefix(self) -> None:
+        s3 = _stub_s3_with_mislabels([])
+        conn = _stub_db_no_references()
+        run_cleanup(s3, conn, bucket="b", state="ca", county="orange", dry_run=True)
+        # Verify the paginator was called with the county-scoped prefix.
+        s3.get_paginator.return_value.paginate.assert_called_with(
+            Bucket="b", Prefix="ca/orange/"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_default_is_dry_run(self) -> None:
+        args = build_parser().parse_args([])
+        assert args.dry_run is True
+        assert args.apply is False
+
+    def test_apply_flag(self) -> None:
+        args = build_parser().parse_args(["--apply"])
+        assert args.apply is True
+
+    def test_county_flag(self) -> None:
+        args = build_parser().parse_args(["--county", "santa_clara"])
+        assert args.county == "santa_clara"
+
+    def test_state_default(self) -> None:
+        args = build_parser().parse_args([])
+        assert args.state == "ca"
+
+    def test_bucket_override(self) -> None:
+        args = build_parser().parse_args(["--bucket", "my-bucket"])
+        assert args.bucket == "my-bucket"
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_missing_database_url_returns_2(self) -> None:
+        # Save and clear DATABASE_URL.
+        saved = os.environ.pop("DATABASE_URL", None)
+        try:
+            assert main(["--dry-run"]) == 2
+        finally:
+            if saved is not None:
+                os.environ["DATABASE_URL"] = saved
+
+    def test_dry_run_returns_0(self) -> None:
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://stub"}):
+            with patch.object(cleanup_mislabeled_s3_2661, "boto3") as boto3_mock:
+                with patch.object(
+                    cleanup_mislabeled_s3_2661, "psycopg"
+                ) as psycopg_mock:
+                    boto3_mock.client.return_value = _stub_s3_with_mislabels([])
+                    psycopg_mock.connect.return_value.__enter__.return_value = (
+                        _stub_db_no_references()
+                    )
+                    assert main(["--dry-run"]) == 0
+
+    def test_apply_with_db_references_returns_1(self) -> None:
+        keys = [f"ca/orange/superior_court/raw/{HEX64_A}.pdf"]
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://stub"}):
+            with patch.object(cleanup_mislabeled_s3_2661, "boto3") as boto3_mock:
+                with patch.object(
+                    cleanup_mislabeled_s3_2661, "psycopg"
+                ) as psycopg_mock:
+                    boto3_mock.client.return_value = _stub_s3_with_mislabels(keys)
+                    psycopg_mock.connect.return_value.__enter__.return_value = (
+                        _stub_db_with_references(keys)
+                    )
+                    assert main(["--apply"]) == 1
+
+    def test_apply_no_references_returns_0(self) -> None:
+        keys = [f"ca/orange/superior_court/raw/{HEX64_A}.pdf"]
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://stub"}):
+            with patch.object(cleanup_mislabeled_s3_2661, "boto3") as boto3_mock:
+                with patch.object(
+                    cleanup_mislabeled_s3_2661, "psycopg"
+                ) as psycopg_mock:
+                    boto3_mock.client.return_value = _stub_s3_with_mislabels(keys)
+                    psycopg_mock.connect.return_value.__enter__.return_value = (
+                        _stub_db_no_references()
+                    )
+                    assert main(["--apply"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# report_enumeration (smoke test)
+# ---------------------------------------------------------------------------
+
+
+class TestReportEnumeration:
+    def test_returns_total(self, capsys: pytest.CaptureFixture[str]) -> None:
+        by_county = {
+            "orange": [
+                {
+                    "key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf",
+                    "filename_hash": HEX64_A,
+                    "metadata_hash": HEX64_B,
+                }
+            ],
+            "santa_clara": [
+                {
+                    "key": f"ca/santa_clara/superior_court/raw/{HEX64_C}.pdf",
+                    "filename_hash": HEX64_C,
+                    "metadata_hash": HEX64_A,
+                },
+                {
+                    "key": f"ca/santa_clara/superior_court/raw/{HEX64_B}.pdf",
+                    "filename_hash": HEX64_B,
+                    "metadata_hash": HEX64_A,
+                },
+            ],
+        }
+        total = report_enumeration(by_county)
+        assert total == 3
+        captured = capsys.readouterr()
+        # Per-county counts appear in stdout.
+        assert "orange" in captured.out
+        assert "santa_clara" in captured.out
+        assert "TOTAL" in captured.out


### PR DESCRIPTION
## Summary

Add `scripts/cleanup_mislabeled_s3_2661.py` — a two-pass one-off script that enumerates and (in `--apply` mode, after a DB safety check) deletes mislabeled flat-hash S3 objects produced by the 2026-03-28 migration (`scripts/archive/migrate_s3_keys.py`, commit `fbf8e38`).

The DB safety guard in `find_referenced_keys` mirrors the issue's AC #2 contract verbatim — it WILL refuse to delete while `derived.documents` rows reference any mislabeled key. Verified on dev SC: dry-run reported 190 mislabeled keys but 1174 DB rows still referencing them, so the guard correctly aborted apply. The repoint follow-up that resolves the AC #2 precondition will be filed as a separate issue, and #2661 will be re-blocked against it.

For #2661.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (50 tests in `scripts/tests/test_cleanup_mislabeled_s3_2661.py`)
- [x] Script header check passes (`scripts/check-script-headers.sh`)
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (one-off cleanup script). Runtime ACs (#3 deletion, #4 post-delete verification) are deferred to operator runtime — same precedent as #2627 → #3046. Two preconditions need to land first: (a) the DB-repoint follow-up that drains the 1174 `derived.documents` references to mislabels (so AC #2 dry-run guard passes); (b) granting `s3:DeleteObject` on `ca/*/raw/*` to a role that the cleanup task can assume (today neither `iam_scraper` nor `iam_agent` covers this prefix). Both will be filed as follow-up issues.

## Verification on dev (AC #1, AC #2)

```
$ scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --dry-run --county santa_clara
...
Mode: DRY-RUN | Bucket: judgemind-document-archive-dev | Prefix: ca/santa_clara/
Scanned prefix 'ca/santa_clara/': 310 flat-hash keys, 385 skipped (non-matching shape)
santa_clara: 190 mislabeled key(s)
  ca/santa_clara/superior_court/raw/02b05b4d...d52.pdf (filename=02b05b4d... metadata=e8dfcfe7...)
  ca/santa_clara/superior_court/raw/035823f8...146.pdf (filename=035823f8... metadata=ba7b2dfe...)
  ... 188 more
============================================================
Mislabel enumeration summary
============================================================
  santa_clara                 190
  TOTAL                       190
ABORT: 1174 mislabeled S3 key(s) are still referenced by derived.documents rows.
Run rebuild_db.py against the affected counties to repoint rows to correctly-named
content-addressed keys, then re-run this script.
```

Exit code 1, no S3 objects deleted — guard works.
