### PR TITLE
fix(ingestion): add repoint script for mislabeled S3 keys (#4439)

### DIFF
--- a/scripts/repoint_mislabeled_documents_4439.py
+++ b/scripts/repoint_mislabeled_documents_4439.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Repoint ``derived.documents`` rows from mislabeled flat-hash S3 keys to
+their correctly-named twins.
+
+The 2026-03-28 migration in commit ``fbf8e38`` (archived as
+``scripts/archive/migrate_s3_keys.py``) wrote S3 objects under content-addressed
+keys whose filename SHA-256 did **not** match the SHA-256 of the bytes — for
+documents whose ``content_hash`` was a synthetic split-child value rather than
+a real bytes hash. ``CopyObject`` preserved the original metadata
+``content-hash`` (the correct bytes hash), so each mislabeled object carries a
+metadata header that points to the right value.
+
+Many of the mislabels were paired — at the same `ca/{county}/{court}/raw/`
+prefix the bytes also live under a *correctly-named* twin where filename hash
+== metadata hash == bytes hash. ``rebuild_db.py`` (without ``--reset``) only
+**adds** rows for newly-discovered S3 keys; it does not **update** existing
+rows whose ``s3_key`` points at a now-superseded mislabel. As a result
+``derived.documents`` still references the mislabel even after a rebuild has
+discovered the correctly-named twin.
+
+This script repoints those rows. It does **two passes**:
+
+1. **Enumerate pass:** paginate ``list_objects_v2`` under ``ca/`` (or a single
+   county prefix), match keys of shape ``ca/{county}/{court}/raw/<hex64>.<ext>``,
+   HEAD each, compare filename hex64 to metadata ``content-hash``. For each
+   mislabel, build the ``twin`` key (same prefix, filename = metadata hash) and
+   HEAD it. The twin is **valid** only when (a) it exists in S3 AND (b) its
+   filename hex64 == its own metadata ``content-hash`` (i.e., the twin is
+   correctly-labelled).
+
+2. **Repoint pass:** in --apply mode, for each (mislabel, twin) pair, run
+   ``UPDATE derived.documents SET s3_key = <twin> WHERE s3_key = <mislabel>``
+   inside a per-county transaction. Before and after the UPDATE, count the
+   per-county rows in ``derived.documents JOIN derived.courts`` and ABORT the
+   transaction if the counts diverge — repointing must not drop or duplicate
+   rows.
+
+After this script runs and commits, ``cleanup_mislabeled_s3_2661.py``'s DB
+safety check will pass and the mislabeled S3 objects can be deleted (issue
+#2661).
+
+Usage:
+    scripts/ecs-run-task.sh scripts/repoint_mislabeled_documents_4439.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/repoint_mislabeled_documents_4439.py -- --apply
+    scripts/ecs-run-task.sh scripts/repoint_mislabeled_documents_4439.py -- --apply --county santa_clara
+
+Options:
+    --dry-run   Enumerate mislabel/twin pairs and show planned repoints; do not write (default).
+    --apply     Run the per-county UPDATEs after the row-count invariant check.
+    --county    Restrict to a single county (e.g. santa_clara, orange).
+    --state     State prefix to scan (default: ca).
+    --bucket    S3 bucket to scan (default: $S3_BUCKET or judgemind-document-archive-dev).
+
+Exit codes:
+    0  Dry-run completed, or apply succeeded with all repoints committed.
+    1  Apply aborted because the row-count invariant failed for at least one county.
+    2  Unrecoverable error (S3, DB, or argument).
+
+See: https://github.com/judgemind/judgemind/issues/4439
+Blocks: https://github.com/judgemind/judgemind/issues/2661
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+
+import boto3
+import psycopg
+from botocore.exceptions import ClientError
+
+from framework.logging import configure_structlog
+
+# Canonical stdout/CloudWatch logger pattern (#4368/#4373).  Routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder so any ``extra=`` field reaches
+# CloudWatch Logs Insights as a structured JSON field.
+configure_structlog(json=True, stdlib_bridge=True)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
+
+# Matches content-addressed flat-hash keys: ca/{county}/{court}/raw/{hex64}.{ext}.
+# Captures county and the filename hash so the enumerate pass can group results
+# and build the twin key without re-parsing.
+KEY_PATTERN = re.compile(
+    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
+)
+
+# Sample size to log per county before truncating.
+SAMPLE_SIZE = 20
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def parse_flat_hash_key(key: str) -> dict[str, str] | None:
+    """Parse a flat-hash content-addressed key.
+
+    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``, ``ext``
+    on match, or ``None`` if the key does not match the expected shape.
+
+    Anything that does not match (e.g. date-partitioned legacy keys,
+    court_directory snapshots, non-raw paths) is silently skipped.
+
+    NOTE: this duplicates the helper in ``cleanup_mislabeled_s3_2661.py``
+    deliberately. ECS oneshot scripts cannot import from other ``scripts/*.py``
+    files (per CLAUDE.md / docs/agent/code-standards.md), so the small parser
+    is copied rather than shared.
+    """
+    m = KEY_PATTERN.match(key)
+    if m is None:
+        return None
+    return dict(m.groupdict())
+
+
+def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
+    """Return True if *filename_hash* differs from *metadata_hash*.
+
+    A missing metadata hash (``None`` or empty) does **not** count as a
+    mislabel — that is a separate problem class handled by
+    ``audit_s3_raw_mislabels.py``.
+    """
+    if not metadata_hash:
+        return False
+    return filename_hash != metadata_hash
+
+
+def build_twin_key(mislabel_key: str, metadata_hash: str) -> str | None:
+    """Build the correctly-named twin key for *mislabel_key*.
+
+    The twin key reuses the same ``state/county/court/raw/`` prefix and file
+    extension but replaces the filename hash with *metadata_hash* — i.e. the
+    location at which a correctly-named copy of the same bytes would live if
+    one exists.
+
+    Returns ``None`` if *mislabel_key* doesn't parse.
+    """
+    parsed = parse_flat_hash_key(mislabel_key)
+    if parsed is None:
+        return None
+    return (
+        f"{parsed['state']}/{parsed['county']}/{parsed['court']}/raw/"
+        f"{metadata_hash}.{parsed['ext']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# S3 enumeration
+# ---------------------------------------------------------------------------
+
+
+def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
+    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
+
+    Returns ``None`` for both a missing metadata field AND a 404 — callers
+    must treat both as "not a mislabel" / "no twin available."
+    """
+    try:
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+    metadata: dict[str, str] = head.get("Metadata", {}) or {}
+    return metadata.get("content-hash") or None
+
+
+def verify_twin(s3_client: object, bucket: str, twin_key: str) -> bool:
+    """Return True if *twin_key* exists AND is correctly-labelled.
+
+    A twin is "valid" only when its filename hex64 == its own metadata
+    ``content-hash``. This is the safety guard that prevents repointing a
+    DB row at *another* mislabeled key (which would just kick the can down
+    the road).
+
+    Returns False if the twin is missing (404), has no metadata, or is itself
+    mislabeled.
+    """
+    parsed = parse_flat_hash_key(twin_key)
+    if parsed is None:
+        return False
+    twin_metadata_hash = head_object_metadata_hash(s3_client, bucket, twin_key)
+    if not twin_metadata_hash:
+        return False
+    return parsed["hash"] == twin_metadata_hash
+
+
+def enumerate_repoint_pairs(
+    s3_client: object,
+    bucket: str,
+    prefix: str,
+) -> dict[str, list[dict[str, str]]]:
+    """Enumerate (mislabel, twin) repoint candidates under *prefix*, grouped by county.
+
+    For each key under *prefix* that matches ``KEY_PATTERN``:
+      1. HEAD the object to read its metadata ``content-hash``.
+      2. If filename hash != metadata hash, build the twin key
+         (same prefix, filename = metadata hash).
+      3. HEAD the twin and confirm filename == metadata on the twin.
+      4. Record the (mislabel, twin) pair.
+
+    Returns a dict mapping county name to a list of pair records, each a dict
+    with keys ``mislabel_key``, ``twin_key``, ``filename_hash``,
+    ``metadata_hash``, ``twin_status``.
+
+    ``twin_status`` is one of:
+      * ``"valid"``   — twin exists and is correctly-labelled (will repoint).
+      * ``"missing"`` — twin does not exist in S3 (cannot repoint).
+      * ``"invalid"`` — twin exists but is itself mislabeled (cannot repoint).
+
+    The dry-run output is the source-of-truth for what this script will UPDATE
+    when run with --apply.
+    """
+    paginator = s3_client.get_paginator("list_objects_v2")
+    by_county: dict[str, list[dict[str, str]]] = defaultdict(list)
+    total_seen = 0
+    total_skipped_shape = 0
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            parsed = parse_flat_hash_key(key)
+            if parsed is None:
+                total_skipped_shape += 1
+                continue
+            total_seen += 1
+            metadata_hash = head_object_metadata_hash(s3_client, bucket, key)
+            if not is_mislabel(parsed["hash"], metadata_hash):
+                continue
+            assert metadata_hash is not None  # is_mislabel rejects None
+            twin_key = build_twin_key(key, metadata_hash)
+            assert twin_key is not None  # parsed already non-None
+            twin_metadata_hash = head_object_metadata_hash(s3_client, bucket, twin_key)
+            if twin_metadata_hash is None:
+                twin_status = "missing"
+            elif twin_metadata_hash != metadata_hash:
+                # The twin exists but its metadata disagrees with the filename
+                # we built it under — i.e. the twin is itself mislabeled.
+                twin_status = "invalid"
+            else:
+                twin_status = "valid"
+            by_county[parsed["county"]].append(
+                {
+                    "mislabel_key": key,
+                    "twin_key": twin_key,
+                    "filename_hash": parsed["hash"],
+                    "metadata_hash": metadata_hash,
+                    "twin_status": twin_status,
+                }
+            )
+
+    logger.info(
+        "Scanned prefix %r: %d flat-hash keys, %d skipped (non-matching shape)",
+        prefix,
+        total_seen,
+        total_skipped_shape,
+    )
+    return dict(by_county)
+
+
+# ---------------------------------------------------------------------------
+# DB row-count invariant
+# ---------------------------------------------------------------------------
+
+
+def count_documents_for_county(conn: object, county: str) -> int:
+    """Return the number of ``derived.documents`` rows in *county*.
+
+    Used as the row-count invariant: pre-UPDATE count must equal post-UPDATE
+    count. Otherwise the repoint dropped or duplicated rows.
+
+    The SELECT joins ``derived.courts`` because ``derived.documents`` does not
+    carry county directly — county lives on the joined courts row.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT COUNT(*)
+            FROM derived.documents d
+            JOIN derived.courts c ON d.court_id = c.id
+            WHERE LOWER(c.county) = LOWER(%s)
+            """,
+            (county,),
+        )
+        row = cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+# ---------------------------------------------------------------------------
+# DB repoint
+# ---------------------------------------------------------------------------
+
+
+def repoint_pairs_for_county(
+    conn: object,
+    pairs: Iterable[dict[str, str]],
+    *,
+    county: str,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Apply (mislabel → twin) repoints for *county* in a single transaction.
+
+    Filters *pairs* to those with ``twin_status == "valid"`` (the only ones
+    safe to repoint) and runs one ``UPDATE`` per pair inside a single
+    transaction so the per-county work is atomic. The pre/post row-count
+    invariant runs inside the same transaction; a mismatch ABORTs the
+    transaction (psycopg's ``with conn:`` block handles ROLLBACK on raise).
+
+    In dry-run mode no DB writes are issued; the function returns the planned
+    repoint count.
+
+    Returns a dict with keys: ``planned``, ``updated``, ``skipped_invalid``,
+    ``skipped_missing``, ``aborted`` (1/0).
+    """
+    pairs_list = list(pairs)
+    valid = [p for p in pairs_list if p.get("twin_status") == "valid"]
+    skipped_missing = sum(1 for p in pairs_list if p.get("twin_status") == "missing")
+    skipped_invalid = sum(1 for p in pairs_list if p.get("twin_status") == "invalid")
+
+    if not valid:
+        logger.info(
+            "[%s] No valid twins to repoint (planned=0, missing=%d, invalid=%d)",
+            county,
+            skipped_missing,
+            skipped_invalid,
+        )
+        return {
+            "planned": 0,
+            "updated": 0,
+            "skipped_invalid": skipped_invalid,
+            "skipped_missing": skipped_missing,
+            "aborted": 0,
+        }
+
+    if dry_run:
+        logger.info(
+            "[%s] DRY-RUN: would repoint %d row(s) (missing=%d, invalid=%d)",
+            county,
+            len(valid),
+            skipped_missing,
+            skipped_invalid,
+        )
+        for p in valid[:SAMPLE_SIZE]:
+            logger.info(
+                "  %s -> %s",
+                p["mislabel_key"],
+                p["twin_key"],
+            )
+        if len(valid) > SAMPLE_SIZE:
+            logger.info("  ... and %d more", len(valid) - SAMPLE_SIZE)
+        return {
+            "planned": len(valid),
+            "updated": 0,
+            "skipped_invalid": skipped_invalid,
+            "skipped_missing": skipped_missing,
+            "aborted": 0,
+        }
+
+    pre_count = count_documents_for_county(conn, county)
+    updated = 0
+    try:
+        with conn.transaction():
+            with conn.cursor() as cur:
+                for p in valid:
+                    cur.execute(
+                        """
+                        UPDATE derived.documents
+                        SET s3_key = %s
+                        WHERE s3_key = %s
+                        """,
+                        (p["twin_key"], p["mislabel_key"]),
+                    )
+                    updated += cur.rowcount or 0
+            post_count = count_documents_for_county(conn, county)
+            if post_count != pre_count:
+                logger.error(
+                    "[%s] ROW-COUNT INVARIANT VIOLATED: pre=%d post=%d "
+                    "— transaction will be ABORTED",
+                    county,
+                    pre_count,
+                    post_count,
+                )
+                raise RuntimeError(
+                    f"Row-count invariant violated for {county}: "
+                    f"pre={pre_count} post={post_count}"
+                )
+            logger.info(
+                "[%s] Repointed %d row(s); pre/post row count invariant held at %d",
+                county,
+                updated,
+                pre_count,
+            )
+    except RuntimeError:
+        return {
+            "planned": len(valid),
+            "updated": 0,
+            "skipped_invalid": skipped_invalid,
+            "skipped_missing": skipped_missing,
+            "aborted": 1,
+        }
+
+    return {
+        "planned": len(valid),
+        "updated": updated,
+        "skipped_invalid": skipped_invalid,
+        "skipped_missing": skipped_missing,
+        "aborted": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def report_enumeration(by_county: dict[str, list[dict[str, str]]]) -> dict[str, int]:
+    """Log per-county counts; return summary totals (valid/missing/invalid)."""
+    totals: dict[str, int] = defaultdict(int)
+    for county in sorted(by_county.keys()):
+        records = by_county[county]
+        valid = sum(1 for r in records if r.get("twin_status") == "valid")
+        missing = sum(1 for r in records if r.get("twin_status") == "missing")
+        invalid = sum(1 for r in records if r.get("twin_status") == "invalid")
+        totals["valid"] += valid
+        totals["missing"] += missing
+        totals["invalid"] += invalid
+        totals["total"] += len(records)
+        logger.info(
+            "%s: %d mislabel(s) — %d valid twin(s), %d missing, %d invalid",
+            county,
+            len(records),
+            valid,
+            missing,
+            invalid,
+        )
+
+    print()
+    print("=" * 72)
+    print("Mislabel/twin enumeration summary")
+    print("=" * 72)
+    print(
+        f"  {'county':<24s} {'total':>8s} {'valid':>8s} {'missing':>8s} {'invalid':>8s}"
+    )
+    for county in sorted(by_county.keys()):
+        records = by_county[county]
+        valid = sum(1 for r in records if r.get("twin_status") == "valid")
+        missing = sum(1 for r in records if r.get("twin_status") == "missing")
+        invalid = sum(1 for r in records if r.get("twin_status") == "invalid")
+        print(
+            f"  {county:<24s} {len(records):>8d} {valid:>8d} {missing:>8d} {invalid:>8d}"
+        )
+    print(
+        f"  {'TOTAL':<24s} {totals['total']:>8d} {totals['valid']:>8d} "
+        f"{totals['missing']:>8d} {totals['invalid']:>8d}"
+    )
+    return dict(totals)
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_repoint(
+    s3_client: object,
+    db_conn: object,
+    *,
+    bucket: str,
+    state: str,
+    county: str | None,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Run the two-pass repoint. Returns a dict with summary counts.
+
+    Summary keys: ``mislabels_found``, ``valid_twins``, ``missing_twins``,
+    ``invalid_twins``, ``planned``, ``updated``, ``aborted_counties``.
+    """
+    if county:
+        prefix = f"{state}/{county}/"
+    else:
+        prefix = f"{state}/"
+
+    logger.info(
+        "Mode: %s | Bucket: %s | Prefix: %s",
+        "DRY-RUN" if dry_run else "APPLY",
+        bucket,
+        prefix,
+    )
+
+    # Pass 1: enumerate.
+    by_county = enumerate_repoint_pairs(s3_client, bucket, prefix)
+    enum_totals = report_enumeration(by_county)
+
+    if enum_totals.get("total", 0) == 0:
+        logger.info("No mislabels found. Nothing to do.")
+        return {
+            "mislabels_found": 0,
+            "valid_twins": 0,
+            "missing_twins": 0,
+            "invalid_twins": 0,
+            "planned": 0,
+            "updated": 0,
+            "aborted_counties": 0,
+        }
+
+    # Pass 2: repoint per county.
+    total_planned = 0
+    total_updated = 0
+    aborted_counties = 0
+    for county_name in sorted(by_county.keys()):
+        result = repoint_pairs_for_county(
+            db_conn,
+            by_county[county_name],
+            county=county_name,
+            dry_run=dry_run,
+        )
+        total_planned += result["planned"]
+        total_updated += result["updated"]
+        aborted_counties += result["aborted"]
+
+    logger.info(
+        "Done. planned=%d, updated=%d, aborted_counties=%d",
+        total_planned,
+        total_updated,
+        aborted_counties,
+    )
+    return {
+        "mislabels_found": enum_totals.get("total", 0),
+        "valid_twins": enum_totals.get("valid", 0),
+        "missing_twins": enum_totals.get("missing", 0),
+        "invalid_twins": enum_totals.get("invalid", 0),
+        "planned": total_planned,
+        "updated": total_updated,
+        "aborted_counties": aborted_counties,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Repoint derived.documents rows from mislabeled flat-hash S3 "
+            "keys to their correctly-named twins. Two-pass: enumerate "
+            "(mislabel, twin) pairs, then UPDATE per-county within a "
+            "transaction guarded by a row-count invariant."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Enumerate pairs and show planned repoints; do not write (default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run the per-county UPDATEs after the row-count invariant check.",
+    )
+    parser.add_argument(
+        "--county",
+        default=None,
+        help="Restrict to a single county prefix (e.g. santa_clara, orange).",
+    )
+    parser.add_argument(
+        "--state",
+        default="ca",
+        help="State prefix to scan (default: ca).",
+    )
+    parser.add_argument(
+        "--bucket",
+        default=DEFAULT_BUCKET,
+        help=f"S3 bucket to scan (default: ${{S3_BUCKET}} or {DEFAULT_BUCKET}).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --apply overrides --dry-run.
+    dry_run = not args.apply
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        return 2
+
+    s3_client = boto3.client("s3")
+
+    with psycopg.connect(dsn) as conn:
+        result = run_repoint(
+            s3_client,
+            conn,
+            bucket=args.bucket,
+            state=args.state,
+            county=args.county,
+            dry_run=dry_run,
+        )
+
+    return 1 if result["aborted_counties"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_repoint_mislabeled_documents_4439.py
+++ b/scripts/tests/test_repoint_mislabeled_documents_4439.py
@@ -1,0 +1,800 @@
+"""Tests for repoint_mislabeled_documents_4439 script.
+
+Tests cover:
+- parse_flat_hash_key for valid, malformed, edge-case keys
+- is_mislabel for matching/mismatching/missing-metadata cases
+- build_twin_key for valid + non-parseable inputs
+- head_object_metadata_hash with mocked S3 client (200, 404, missing field)
+- verify_twin: valid, missing, invalid twin
+- enumerate_repoint_pairs end-to-end with mocked paginator + HEAD
+  (records valid/missing/invalid twin states)
+- count_documents_for_county with mocked psycopg connection
+- repoint_pairs_for_county: dry-run, valid-only filter, row-count invariant
+  abort, success path
+- run_repoint orchestration: empty, dry-run, apply with valid + missing twins
+- main CLI: --dry-run default, --apply switch, missing DATABASE_URL,
+  abort exit code propagation
+
+The script imports psycopg + boto3 + structlog + framework.* at module level,
+which may not be installed in the CI ``scripts-tests`` environment. We use
+``tests._mock_helpers.mock_sys_modules`` (the canonical pattern as of #4430)
+to inject MagicMocks into sys.modules around the import — the helper restores
+sys.modules on exit so other tests in the same pytest run don't see the leaked
+mocks (#4426).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts/ to sys.path so the script-under-test imports cleanly, and
+# scripts/tests/ to sys.path so the helper module is reachable as
+# ``tests._mock_helpers``.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tests._mock_helpers import mock_sys_modules  # noqa: E402
+
+
+# ClientError needs a real exception class so `except ClientError` works in
+# the script under test. We define a minimal subclass that mirrors the
+# botocore ClientError signature (response dict + operation_name).
+class _FakeClientError(Exception):
+    def __init__(self, response: dict, operation_name: str = "Unknown"):
+        super().__init__(f"{operation_name}: {response}")
+        self.response = response
+        self.operation_name = operation_name
+
+
+_mock_botocore = MagicMock()
+_mock_botocore_exceptions = MagicMock()
+_mock_botocore_exceptions.ClientError = _FakeClientError
+_mock_botocore.exceptions = _mock_botocore_exceptions
+
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+
+
+with mock_sys_modules(
+    {
+        "psycopg": MagicMock(),
+        "boto3": MagicMock(),
+        "botocore": _mock_botocore,
+        "botocore.exceptions": _mock_botocore_exceptions,
+        "structlog": _mock_structlog,
+        "framework": MagicMock(),
+        "framework.logging": MagicMock(),
+    }
+):
+    import repoint_mislabeled_documents_4439  # noqa: E402
+
+parse_flat_hash_key = repoint_mislabeled_documents_4439.parse_flat_hash_key
+is_mislabel = repoint_mislabeled_documents_4439.is_mislabel
+build_twin_key = repoint_mislabeled_documents_4439.build_twin_key
+head_object_metadata_hash = repoint_mislabeled_documents_4439.head_object_metadata_hash
+verify_twin = repoint_mislabeled_documents_4439.verify_twin
+enumerate_repoint_pairs = repoint_mislabeled_documents_4439.enumerate_repoint_pairs
+count_documents_for_county = (
+    repoint_mislabeled_documents_4439.count_documents_for_county
+)
+repoint_pairs_for_county = repoint_mislabeled_documents_4439.repoint_pairs_for_county
+report_enumeration = repoint_mislabeled_documents_4439.report_enumeration
+run_repoint = repoint_mislabeled_documents_4439.run_repoint
+build_parser = repoint_mislabeled_documents_4439.build_parser
+main = repoint_mislabeled_documents_4439.main
+ClientError = repoint_mislabeled_documents_4439.ClientError
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+HEX64_A = "a" * 64
+HEX64_B = "b" * 64
+HEX64_C = "c" * 64
+HEX64_D = "d" * 64
+
+
+# ---------------------------------------------------------------------------
+# parse_flat_hash_key
+# ---------------------------------------------------------------------------
+
+
+class TestParseFlatHashKey:
+    def test_valid_pdf(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert result == {
+            "state": "ca",
+            "county": "orange",
+            "court": "superior_court",
+            "hash": HEX64_A,
+            "ext": "pdf",
+        }
+
+    def test_short_hash_returns_none(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'a' * 63}.pdf")
+        assert result is None
+
+    def test_uppercase_hash_returns_none(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'A' * 64}.pdf")
+        assert result is None
+
+    def test_date_partitioned_key_returns_none(self) -> None:
+        result = parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/uuid.pdf")
+        assert result is None
+
+    def test_non_raw_path_returns_none(self) -> None:
+        result = parse_flat_hash_key(
+            f"ca/orange/superior_court/transcripts/{HEX64_A}.txt"
+        )
+        assert result is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_flat_hash_key("") is None
+
+
+# ---------------------------------------------------------------------------
+# is_mislabel
+# ---------------------------------------------------------------------------
+
+
+class TestIsMislabel:
+    def test_matching_hashes_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_A) is False
+
+    def test_differing_hashes_is_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_B) is True
+
+    def test_missing_metadata_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, None) is False
+
+    def test_empty_metadata_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, "") is False
+
+
+# ---------------------------------------------------------------------------
+# build_twin_key
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTwinKey:
+    def test_replaces_filename_hash_preserves_rest(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = build_twin_key(mislabel, HEX64_B)
+        assert twin == f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+
+    def test_preserves_extension_html(self) -> None:
+        mislabel = f"ca/santa_clara/superior_court/raw/{HEX64_A}.html"
+        twin = build_twin_key(mislabel, HEX64_C)
+        assert twin == f"ca/santa_clara/superior_court/raw/{HEX64_C}.html"
+
+    def test_preserves_court_segment(self) -> None:
+        mislabel = f"ca/los_angeles/some_court/raw/{HEX64_A}.docx"
+        twin = build_twin_key(mislabel, HEX64_D)
+        assert twin == f"ca/los_angeles/some_court/raw/{HEX64_D}.docx"
+
+    def test_returns_none_for_non_parseable(self) -> None:
+        # Date-partitioned legacy key — does not match KEY_PATTERN.
+        assert (
+            build_twin_key("ca/orange/superior_court/raw/2026/04/01/x.pdf", HEX64_A)
+            is None
+        )
+
+    def test_returns_none_for_empty(self) -> None:
+        assert build_twin_key("", HEX64_A) is None
+
+
+# ---------------------------------------------------------------------------
+# head_object_metadata_hash
+# ---------------------------------------------------------------------------
+
+
+class TestHeadObjectMetadataHash:
+    def test_returns_hash_when_present(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        assert head_object_metadata_hash(s3, "bucket", "key") == HEX64_A
+
+    def test_returns_none_when_metadata_missing(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {}}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_metadata_field_absent(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_no_such_key(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey"}}, "HeadObject"
+        )
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_propagates_other_errors(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "HeadObject"
+        )
+        with pytest.raises(ClientError):
+            head_object_metadata_hash(s3, "bucket", "key")
+
+
+# ---------------------------------------------------------------------------
+# verify_twin
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTwin:
+    def test_valid_twin_returns_true(self) -> None:
+        # Twin filename hash == twin metadata hash → valid.
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_B}}
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is True
+
+    def test_missing_twin_returns_false(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is False
+
+    def test_invalid_twin_returns_false(self) -> None:
+        # Twin exists but its filename hash != its own metadata hash → invalid.
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_C}}
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is False
+
+    def test_twin_with_no_metadata_returns_false(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {}}
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is False
+
+    def test_non_parseable_twin_returns_false(self) -> None:
+        s3 = MagicMock()
+        # No HEAD should occur for a key that doesn't even parse.
+        assert verify_twin(s3, "bucket", "garbage") is False
+        s3.head_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# enumerate_repoint_pairs
+# ---------------------------------------------------------------------------
+
+
+def _mock_paginator(pages: list[list[dict[str, str]]]) -> MagicMock:
+    """Build a mock S3 paginator that yields *pages*, each a list of object
+    dicts with a "Key" field."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": page} for page in pages]
+    return paginator
+
+
+class TestEnumerateRepointPairs:
+    def test_no_objects_returns_empty(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[]])
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_correctly_labeled_skipped(self) -> None:
+        # filename == metadata: not a mislabel, no pair recorded.
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_mislabel_with_valid_twin_recorded(self) -> None:
+        mislabel_key = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel_key}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel_key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin_key:
+                # Twin's filename HEX64_B == metadata HEX64_B — valid.
+                return {"Metadata": {"content-hash": HEX64_B}}
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert "orange" in result
+        assert len(result["orange"]) == 1
+        record = result["orange"][0]
+        assert record["mislabel_key"] == mislabel_key
+        assert record["twin_key"] == twin_key
+        assert record["filename_hash"] == HEX64_A
+        assert record["metadata_hash"] == HEX64_B
+        assert record["twin_status"] == "valid"
+
+    def test_mislabel_with_missing_twin_recorded(self) -> None:
+        mislabel_key = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel_key}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel_key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin_key:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert len(result["orange"]) == 1
+        assert result["orange"][0]["twin_status"] == "missing"
+
+    def test_mislabel_with_invalid_twin_recorded(self) -> None:
+        # Twin exists but its metadata disagrees with its filename → invalid.
+        mislabel_key = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel_key}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel_key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin_key:
+                # Twin claims content is HEX64_C, not HEX64_B — itself mislabeled.
+                return {"Metadata": {"content-hash": HEX64_C}}
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert result["orange"][0]["twin_status"] == "invalid"
+
+    def test_groups_by_county(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [
+                [
+                    {"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"},
+                    {"Key": f"ca/santa_clara/superior_court/raw/{HEX64_A}.pdf"},
+                ]
+            ]
+        )
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            # Every mislabel with metadata HEX64_B; every twin valid.
+            if HEX64_A in Key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if HEX64_B in Key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            return {"Metadata": {}}
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert sorted(result.keys()) == ["orange", "santa_clara"]
+
+    def test_skips_non_matching_shape(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [
+                [
+                    {"Key": "ca/orange/superior_court/raw/2026/04/01/x.pdf"},
+                    {"Key": "court_directory/snapshot.json"},
+                ]
+            ]
+        )
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert result == {}
+        s3.head_object.assert_not_called()
+
+    def test_skips_objects_with_missing_metadata(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.return_value = {"Metadata": {}}
+        result = enumerate_repoint_pairs(s3, "bucket", "ca/")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# count_documents_for_county
+# ---------------------------------------------------------------------------
+
+
+class TestCountDocumentsForCounty:
+    def test_returns_count(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        cur.fetchone.return_value = (1174,)
+        result = count_documents_for_county(conn, "Santa Clara")
+        assert result == 1174
+        cur.execute.assert_called_once()
+        sql, params = cur.execute.call_args.args
+        assert "JOIN derived.courts" in sql
+        assert "LOWER(c.county) = LOWER(%s)" in sql
+        assert params == ("Santa Clara",)
+
+    def test_returns_zero_when_none(self) -> None:
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        cur.fetchone.return_value = None
+        result = count_documents_for_county(conn, "Orange")
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# repoint_pairs_for_county
+# ---------------------------------------------------------------------------
+
+
+def _stub_db_with_count(value: int) -> MagicMock:
+    """Build a psycopg-shaped mock conn whose count_documents_for_county
+    returns *value*. Cursor.rowcount returns 1 for each UPDATE."""
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__.return_value = cur
+    cur.fetchone.return_value = (value,)
+    cur.rowcount = 1
+    # transaction() returns a context manager that does nothing.
+    conn.transaction.return_value.__enter__.return_value = None
+    conn.transaction.return_value.__exit__.return_value = None
+    return conn
+
+
+class TestRepointPairsForCounty:
+    def test_no_valid_pairs_returns_zero(self) -> None:
+        conn = MagicMock()
+        pairs = [
+            {
+                "mislabel_key": "k1",
+                "twin_key": "k1t",
+                "filename_hash": HEX64_A,
+                "metadata_hash": HEX64_B,
+                "twin_status": "missing",
+            }
+        ]
+        result = repoint_pairs_for_county(conn, pairs, county="orange", dry_run=False)
+        assert result == {
+            "planned": 0,
+            "updated": 0,
+            "skipped_invalid": 0,
+            "skipped_missing": 1,
+            "aborted": 0,
+        }
+        conn.cursor.assert_not_called()
+
+    def test_dry_run_does_not_write(self) -> None:
+        conn = MagicMock()
+        pairs = [
+            {
+                "mislabel_key": "k1",
+                "twin_key": "k1t",
+                "filename_hash": HEX64_A,
+                "metadata_hash": HEX64_B,
+                "twin_status": "valid",
+            },
+            {
+                "mislabel_key": "k2",
+                "twin_key": "k2t",
+                "filename_hash": HEX64_C,
+                "metadata_hash": HEX64_D,
+                "twin_status": "missing",
+            },
+        ]
+        result = repoint_pairs_for_county(conn, pairs, county="orange", dry_run=True)
+        assert result["planned"] == 1
+        assert result["updated"] == 0
+        assert result["skipped_missing"] == 1
+        assert result["aborted"] == 0
+        conn.cursor.assert_not_called()
+        conn.transaction.assert_not_called()
+
+    def test_apply_success_rowcount_invariant_holds(self) -> None:
+        # Pre-count and post-count both 100; transaction should commit.
+        conn = _stub_db_with_count(100)
+        pairs = [
+            {
+                "mislabel_key": "k1",
+                "twin_key": "k1t",
+                "filename_hash": HEX64_A,
+                "metadata_hash": HEX64_B,
+                "twin_status": "valid",
+            },
+            {
+                "mislabel_key": "k2",
+                "twin_key": "k2t",
+                "filename_hash": HEX64_B,
+                "metadata_hash": HEX64_C,
+                "twin_status": "valid",
+            },
+        ]
+        result = repoint_pairs_for_county(conn, pairs, county="orange", dry_run=False)
+        assert result["planned"] == 2
+        assert result["updated"] == 2  # rowcount=1 per UPDATE x 2 calls
+        assert result["aborted"] == 0
+        conn.transaction.assert_called_once()
+
+    def test_apply_aborts_on_invariant_violation(self) -> None:
+        # Pre-count 100, post-count 99 → invariant violated, abort.
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        # First fetchone (pre-count) = 100, second (post-count) = 99.
+        cur.fetchone.side_effect = [(100,), (99,)]
+        cur.rowcount = 0
+        # transaction() context manager re-raises on exit when body raises.
+        tx_cm = MagicMock()
+        tx_cm.__enter__.return_value = None
+        # __exit__ must return False (or None) so the RuntimeError propagates.
+        tx_cm.__exit__.return_value = False
+        conn.transaction.return_value = tx_cm
+
+        pairs = [
+            {
+                "mislabel_key": "k1",
+                "twin_key": "k1t",
+                "filename_hash": HEX64_A,
+                "metadata_hash": HEX64_B,
+                "twin_status": "valid",
+            }
+        ]
+        result = repoint_pairs_for_county(conn, pairs, county="orange", dry_run=False)
+        assert result["aborted"] == 1
+        assert result["updated"] == 0
+        assert result["planned"] == 1
+
+
+# ---------------------------------------------------------------------------
+# run_repoint orchestration
+# ---------------------------------------------------------------------------
+
+
+def _stub_s3_with_pairs(
+    mislabels_to_pairs: dict[str, str],
+    list_keys: list[str] | None = None,
+    invalid_twins: set[str] | None = None,
+    missing_twins: set[str] | None = None,
+) -> MagicMock:
+    """Build an S3 client mock that:
+    - lists *list_keys* (defaults to mislabels_to_pairs.keys())
+    - HEAD on a mislabel key returns metadata == its mapped twin's filename hash
+    - HEAD on a twin key returns metadata == its filename (valid) unless in
+      *invalid_twins* (returns mismatching) or *missing_twins* (raises 404)
+    """
+    if list_keys is None:
+        list_keys = list(mislabels_to_pairs.keys())
+    invalid_twins = invalid_twins or set()
+    missing_twins = missing_twins or set()
+    s3 = MagicMock()
+    s3.get_paginator.return_value = _mock_paginator([[{"Key": k} for k in list_keys]])
+
+    twin_to_mislabel = {v: k for k, v in mislabels_to_pairs.items()}
+
+    def fake_head(*, Bucket: str, Key: str) -> dict:
+        if Key in mislabels_to_pairs:
+            twin = mislabels_to_pairs[Key]
+            twin_parsed = parse_flat_hash_key(twin)
+            assert twin_parsed is not None
+            return {"Metadata": {"content-hash": twin_parsed["hash"]}}
+        if Key in missing_twins:
+            raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        if Key in twin_to_mislabel:
+            twin_parsed = parse_flat_hash_key(Key)
+            assert twin_parsed is not None
+            if Key in invalid_twins:
+                # Return a metadata hash that disagrees with the filename.
+                return {"Metadata": {"content-hash": HEX64_D}}
+            return {"Metadata": {"content-hash": twin_parsed["hash"]}}
+        # Correctly-labelled standalone key.
+        parsed = parse_flat_hash_key(Key)
+        if parsed:
+            return {"Metadata": {"content-hash": parsed["hash"]}}
+        return {"Metadata": {}}
+
+    s3.head_object.side_effect = fake_head
+    return s3
+
+
+class TestRunRepoint:
+    def test_no_mislabels_returns_clean(self) -> None:
+        s3 = _stub_s3_with_pairs({})
+        conn = MagicMock()
+        result = run_repoint(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=True
+        )
+        assert result["mislabels_found"] == 0
+        assert result["valid_twins"] == 0
+        assert result["planned"] == 0
+        assert result["aborted_counties"] == 0
+
+    def test_dry_run_with_valid_twin_plans_repoint(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = _stub_s3_with_pairs({mislabel: twin})
+        conn = MagicMock()
+        result = run_repoint(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=True
+        )
+        assert result["mislabels_found"] == 1
+        assert result["valid_twins"] == 1
+        assert result["planned"] == 1
+        assert result["updated"] == 0
+        assert result["aborted_counties"] == 0
+        conn.cursor.assert_not_called()
+
+    def test_dry_run_with_missing_twin_does_not_plan(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = _stub_s3_with_pairs({mislabel: twin}, missing_twins={twin})
+        conn = MagicMock()
+        result = run_repoint(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=True
+        )
+        assert result["mislabels_found"] == 1
+        assert result["valid_twins"] == 0
+        assert result["missing_twins"] == 1
+        assert result["planned"] == 0
+
+    def test_county_scoping_uses_specific_prefix(self) -> None:
+        s3 = _stub_s3_with_pairs({})
+        conn = MagicMock()
+        run_repoint(s3, conn, bucket="b", state="ca", county="orange", dry_run=True)
+        s3.get_paginator.return_value.paginate.assert_called_with(
+            Bucket="b", Prefix="ca/orange/"
+        )
+
+    def test_apply_success_updates_rows(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = _stub_s3_with_pairs({mislabel: twin})
+        conn = _stub_db_with_count(50)
+        result = run_repoint(
+            s3, conn, bucket="b", state="ca", county=None, dry_run=False
+        )
+        assert result["planned"] == 1
+        assert result["updated"] == 1
+        assert result["aborted_counties"] == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_default_is_dry_run(self) -> None:
+        args = build_parser().parse_args([])
+        assert args.dry_run is True
+        assert args.apply is False
+
+    def test_apply_flag(self) -> None:
+        args = build_parser().parse_args(["--apply"])
+        assert args.apply is True
+
+    def test_county_flag(self) -> None:
+        args = build_parser().parse_args(["--county", "santa_clara"])
+        assert args.county == "santa_clara"
+
+    def test_state_default(self) -> None:
+        args = build_parser().parse_args([])
+        assert args.state == "ca"
+
+    def test_bucket_override(self) -> None:
+        args = build_parser().parse_args(["--bucket", "my-bucket"])
+        assert args.bucket == "my-bucket"
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_missing_database_url_returns_2(self) -> None:
+        saved = os.environ.pop("DATABASE_URL", None)
+        try:
+            assert main(["--dry-run"]) == 2
+        finally:
+            if saved is not None:
+                os.environ["DATABASE_URL"] = saved
+
+    def test_dry_run_returns_0(self) -> None:
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://stub"}):
+            with patch.object(repoint_mislabeled_documents_4439, "boto3") as boto3_mock:
+                with patch.object(
+                    repoint_mislabeled_documents_4439, "psycopg"
+                ) as psycopg_mock:
+                    boto3_mock.client.return_value = _stub_s3_with_pairs({})
+                    psycopg_mock.connect.return_value.__enter__.return_value = (
+                        MagicMock()
+                    )
+                    assert main(["--dry-run"]) == 0
+
+    def test_apply_with_invariant_violation_returns_1(self) -> None:
+        # Build an S3 stub with one valid mislabel/twin pair.
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = _stub_s3_with_pairs({mislabel: twin})
+
+        # Build a psycopg-shaped mock whose pre/post counts mismatch.
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        cur.fetchone.side_effect = [(100,), (99,)]
+        cur.rowcount = 0
+        tx_cm = MagicMock()
+        tx_cm.__enter__.return_value = None
+        tx_cm.__exit__.return_value = False
+        conn.transaction.return_value = tx_cm
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://stub"}):
+            with patch.object(repoint_mislabeled_documents_4439, "boto3") as boto3_mock:
+                with patch.object(
+                    repoint_mislabeled_documents_4439, "psycopg"
+                ) as psycopg_mock:
+                    boto3_mock.client.return_value = s3
+                    psycopg_mock.connect.return_value.__enter__.return_value = conn
+                    assert main(["--apply"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# report_enumeration (smoke test)
+# ---------------------------------------------------------------------------
+
+
+class TestReportEnumeration:
+    def test_returns_totals(self, capsys: pytest.CaptureFixture[str]) -> None:
+        by_county = {
+            "orange": [
+                {
+                    "mislabel_key": "k1",
+                    "twin_key": "k1t",
+                    "filename_hash": HEX64_A,
+                    "metadata_hash": HEX64_B,
+                    "twin_status": "valid",
+                },
+                {
+                    "mislabel_key": "k2",
+                    "twin_key": "k2t",
+                    "filename_hash": HEX64_C,
+                    "metadata_hash": HEX64_D,
+                    "twin_status": "missing",
+                },
+            ],
+            "santa_clara": [
+                {
+                    "mislabel_key": "k3",
+                    "twin_key": "k3t",
+                    "filename_hash": HEX64_A,
+                    "metadata_hash": HEX64_B,
+                    "twin_status": "invalid",
+                }
+            ],
+        }
+        totals = report_enumeration(by_county)
+        assert totals["total"] == 3
+        assert totals["valid"] == 1
+        assert totals["missing"] == 1
+        assert totals["invalid"] == 1
+        captured = capsys.readouterr()
+        assert "orange" in captured.out
+        assert "santa_clara" in captured.out
+        assert "TOTAL" in captured.out


### PR DESCRIPTION
## Summary

Adds `scripts/repoint_mislabeled_documents_4439.py`, a one-off two-pass script that repoints `derived.documents` rows from mislabeled flat-hash S3 keys to their correctly-named twins. Pass 1 enumerates `(mislabel, twin)` candidates by HEAD-ing each flat-hash key under `ca/{county}/` and verifying the twin is correctly-labelled. Pass 2 (under `--apply`) issues per-mislabel `UPDATE`s inside a per-county transaction guarded by a pre/post row-count invariant — divergence aborts and rolls back. This unblocks `cleanup_mislabeled_s3_2661.py` (#2661), whose DB safety guard refuses to delete mislabeled S3 objects while DB rows still reference them.

Surgical UPDATE was chosen over the alternative `rebuild_db.py --reset` (option 1 in the issue) because `--reset` would re-run LLM extraction at ~hours per county and risks dropping accumulated split-children state. The repoint script touches only `s3_key` on existing rows; the row-count invariant is the belt-and-braces check that no rows are dropped or duplicated.

54 unit tests via the `mock_sys_modules` helper; 99% line coverage.

Closes #4439

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (54 new + 1486 total scripts/tests; no regressions)
- [x] CI green

### Post-deploy verification
- [ ] Run `scripts/ecs-run-task.sh scripts/repoint_mislabeled_documents_4439.py -- --dry-run --county santa_clara` on dev and confirm enumeration reports valid twins for the ~190 mislabels (vs 1174 DB rows referencing them)
- [ ] Run `--apply --county santa_clara` and confirm row-count invariant holds + planned == updated
- [ ] Re-run `scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --dry-run --county santa_clara` and confirm `DB safety check: 0 mislabeled key(s) still referenced`
- [ ] Repeat for `orange`, `riverside`, `fresno`
- [ ] Verification evidence posted on issue (see A.8)
