### PR TITLE
fix(ingestion): resolve SD legacy-snapshot C-NN/NN dept mismatch (#4437)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1110,6 +1110,18 @@ def resolve_judge_from_department(
     during both normal ingestion and rebuilds, regardless of ``_llm_extracted``
     status.
 
+    Lookup chain
+    ------------
+    1. Literal match against the snapshot mapping.
+    2. Case-insensitive match against every key.
+    3. **San Diego legacy-snapshot fallback (#4437):** if the input
+       department is ``C-NN`` (numeric tail) and only ``NN`` is in the
+       mapping — or vice versa — return the alternate-form mapping value.
+       The SD scraper aliases both keys for civil-Central departments
+       (#3862), so any cross-form match is provably the same judge.  The
+       fallback is intentionally narrow (numeric tail only) so it cannot
+       fire on unrelated ``C-`` prefixes in other counties.
+
     Parameters
     ----------
     conn : psycopg.Connection
@@ -1206,6 +1218,37 @@ def resolve_judge_from_department(
     for key, value in mapping.items():
         if key.lower().strip() == dept_lower:
             return value
+
+    # San Diego legacy-snapshot fallback (#4437): the SD scraper now writes
+    # both ``"NN"`` and ``"C-NN"`` keys for civil-Central departments
+    # (#3862, ``sd_dept_judges.build_department_judge_map``), but snapshots
+    # captured before that fix landed (2026-04-30) only carry the
+    # bare-numeric form.  When a ruling's department string is ``C-NN`` and
+    # the snapshot only has ``NN`` (or vice versa), the literal/lower-case
+    # match above fails and the resolver returns ``None`` — leaving 54
+    # SD rulings (in dev as of 2026-05-04) with ``judge_id = NULL``
+    # despite a perfectly good mapping entry under the alternate form.
+    #
+    # The aliasing is provably safe for SD: the dual-key writer aliases
+    # exactly these two forms ("NN" → judge X also writes "C-NN" → judge X),
+    # so any cross-form match against an SD snapshot recovers the same
+    # judge name a current snapshot would return for the literal form.
+    # The fallback is intentionally narrow — only the C-NN ↔ NN pair, where
+    # NN is purely numeric — so it cannot fire spuriously on alphanumeric
+    # codes like "C-NQ" or other counties' unrelated "C-" prefixes.
+    alt_forms: list[str] = []
+    c_match = re.match(r"^[Cc]-(\d+)$", department.strip())
+    if c_match is not None:
+        alt_forms.append(c_match.group(1))
+    elif department.strip().isdigit():
+        alt_forms.append(f"C-{department.strip()}")
+    for alt in alt_forms:
+        if alt in mapping:
+            return mapping[alt]
+        alt_lower = alt.lower().strip()
+        for key, value in mapping.items():
+            if key.lower().strip() == alt_lower:
+                return value
     return None
 
 

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -3273,6 +3273,95 @@ class TestResolveJudgeFromDepartment:
         # Only two execute calls: court_code + historical snapshot — no fallback
         assert len(cur.execute.call_args_list) == 2
 
+    def test_falls_back_from_c_prefix_to_bare_numeric_for_sd_legacy_snapshot(
+        self,
+    ) -> None:
+        """``C-NN`` department resolves against a snapshot that has only ``NN`` (#4437).
+
+        Regression: 54 SD rulings on civil-Central depts ``C-63``..``C-75`` had
+        hearing dates predating the earliest SD snapshot (2026-03-31), and the
+        earliest snapshot only had bare-numeric keys (``"63"``, ``"64"``, ...)
+        because the dual-key writer in
+        ``sd_dept_judges.build_department_judge_map`` (#3862) had not yet
+        landed when those snapshots were captured.  The pre-snapshot fallback
+        (#2618) found the earliest snapshot, but the literal+lower-case
+        lookup against ``"C-63"`` failed against keys ``"63"``, returning
+        ``None`` despite a perfectly good mapping entry under the alternate
+        form.  The SD-form fallback recovers the bare-numeric key.
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # Earliest snapshot has only the bare-numeric form — mirrors the
+        # pre-#3862 SD snapshot shape.
+        earliest_mapping = {"63": "Katherine A. Bacal", "64": "Loren G. Freestone"}
+        cur.fetchone.side_effect = [
+            ("ca-san-diego",),
+            None,  # historical snapshot: no row (hearing predates window)
+            (earliest_mapping,),  # earliest-snapshot fallback returns bare-numeric mapping
+        ]
+        hearing_dt = date(2026, 3, 27)
+
+        result = resolve_judge_from_department(
+            conn, "court-uuid-1", "C-63", hearing_date=hearing_dt
+        )
+        assert result == "Katherine A. Bacal"
+
+    def test_falls_back_from_bare_numeric_to_c_prefix(self) -> None:
+        """Inverse: ``63`` resolves against a snapshot that has only ``C-63`` (#4437).
+
+        Defensive guard against the symmetric mismatch — if a future
+        ingestion path writes ``r.department = "63"`` (bare numeric) but
+        the relevant snapshot only has ``"C-63"``, the fallback should
+        still resolve.
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"C-63": "Katherine A. Bacal"}
+        cur.fetchone.side_effect = [("ca-san-diego",), (mapping,)]
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "63")
+        assert result == "Katherine A. Bacal"
+
+    def test_sd_form_fallback_uses_case_insensitive_alt_form_match(self) -> None:
+        """SD-form fallback also handles case-insensitive alt-form matches (#4437).
+
+        If a snapshot was captured with a lowercased ``c-63`` key, the
+        alternate-form lookup against ``"63"`` (which is unaffected by case)
+        still succeeds via the case-insensitive iteration.  This branch
+        guards the case-insensitive alt-form matcher (line 1251 of db.py).
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # Mapping has only the lowercased C-prefix form.
+        mapping = {"c-63": "Katherine A. Bacal"}
+        cur.fetchone.side_effect = [("ca-san-diego",), (mapping,)]
+
+        # Lookup with bare-numeric form — neither literal nor lowercase
+        # match the only key, so the SD-form fallback fires and tries
+        # ``"C-63"`` against ``"c-63"`` via the case-insensitive matcher.
+        result = resolve_judge_from_department(conn, "court-uuid-1", "63")
+        assert result == "Katherine A. Bacal"
+
+    def test_sd_form_fallback_does_not_fire_on_alphanumeric_tail(self) -> None:
+        """``C-NQ`` does NOT trigger the bare-form fallback (#4437).
+
+        The fallback is intentionally narrow — numeric tail only — so a
+        hypothetical alphanumeric code like ``C-NQ`` does not get
+        rewritten to a bare ``NQ`` lookup.  This guards against
+        spurious cross-form matches in counties that use ``C-`` for
+        unrelated codes.
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"NQ": "Some Judge", "63": "Katherine A. Bacal"}
+        cur.fetchone.side_effect = [("ca-san-diego",), (mapping,)]
+
+        # ``C-NQ`` does not match ``^[Cc]-(\d+)$`` so the fallback does not
+        # fire — the literal/lower-case lookups already failed, so we get
+        # ``None`` instead of an unrelated ``"NQ"`` -> ``"Some Judge"`` hit.
+        result = resolve_judge_from_department(conn, "court-uuid-1", "C-NQ")
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # delete_stale_split_children


### PR DESCRIPTION
## Summary

Root-causes the 13.24% San Diego NULL-judge rate (54/408 in-mapping rulings) and adds a narrowly-scoped fallback to `resolve_judge_from_department` so legacy snapshots resolve correctly.

The 54 NULL rulings are on civil-Central depts (`C-63`..`C-75`) with hearing dates 2026-03-25..2026-04-02 — they predate the earliest SD `court_directory_snapshots` row (2026-03-31). The pre-snapshot fallback (#2618) finds the earliest snapshot, but that snapshot only contains bare-numeric keys (`"63"`, `"64"`, ...) because the dual-key writer in `sd_dept_judges.build_department_judge_map` (#3862, merged 2026-04-30) hadn't landed yet. The first SD snapshot containing both `NN` and `C-NN` keys was captured 2026-05-01. So the resolver tries `mapping["C-63"]` against an old snapshot whose only key is `"63"` and returns `None`.

This PR extends the resolver's lookup chain with a third step: when the literal + case-insensitive lookup misses, if the dept matches `^[Cc]-(\d+)$` retry with the bare-numeric tail (and conversely for purely-numeric dept inputs). The aliasing is provably safe — the dual-key writer aliases both forms to the same judge for current snapshots — and the regex gate (numeric tail only) prevents spurious matches on alphanumeric codes (`C-NQ`) or other counties' unrelated `C-` prefixes.

Closes #4437

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass — 7608 passed, 3 skipped (full scraper-framework suite); 4 new regression tests in `TestResolveJudgeFromDepartment`
- [x] Diff coverage 100% (13/13 added lines covered)
- [ ] CI green

### Post-deploy verification
- [ ] Run `scripts/ecs-run-task.sh scripts/reingest_from_s3.py --county "San Diego"` (or `rebuild_db.py --county "San Diego"`) on dev after the new ingestion-worker image deploys.
- [ ] Re-run the verification SQL from the issue body and confirm `null_pct` for San Diego (in-mapping) drops from 13.24% to <= 5%.
- [ ] Spotcheck a sample of fixed rulings against `derived.judges.canonical_name` (a few rows per dept) to confirm the alt-form fallback resolves to the same judge a current snapshot would store.
- [ ] Verification evidence posted on issue (see A.8)
