### PR TITLE
refactor(scraping): extract shared S3-key helpers to framework.s3_keys (#4447)

### DIFF
--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -57,6 +57,12 @@ from .retry import retry_async, retry_sync
 from .runner import get_scraper_ids, run_scrapers
 from .s3_cache import CachedS3Client, make_s3_client
 from .s3_integrity import S3MislabelError, assert_key_matches_bytes, verify_key_matches_bytes
+from .s3_keys import (
+    build_twin_key,
+    head_object_metadata_hash,
+    is_mislabel,
+    parse_flat_hash_key,
+)
 from .search import IndexingConsumer, create_index
 from .storage import S3Archiver, build_s3_key
 from .turnstile_solver import solve_turnstile
@@ -89,6 +95,10 @@ __all__ = [
     "S3Archiver",
     "S3MislabelError",
     "assert_key_matches_bytes",
+    "build_twin_key",
+    "head_object_metadata_hash",
+    "is_mislabel",
+    "parse_flat_hash_key",
     "verify_key_matches_bytes",
     "ScraperConfig",
     "ScraperHealthEvent",

--- a/packages/scraper-framework/src/framework/s3_keys.py
+++ b/packages/scraper-framework/src/framework/s3_keys.py
@@ -1,0 +1,148 @@
+"""Shared helpers for parsing flat-hash S3 keys and detecting mislabels.
+
+A "flat-hash" key has shape ``{state}/{county}/{court}/raw/{hex64}.{ext}``
+— the content-addressed scheme where the filename is the SHA-256 of the
+bytes. The 2026-03-28 migration in commit ``fbf8e38`` (archived as
+``scripts/archive/migrate_s3_keys.py``) rewrote objects under this shape;
+its ``CopyObject`` step preserved the original metadata ``content-hash``,
+so a mislabel is detectable by comparing filename hex64 to metadata
+``content-hash``.
+
+These helpers were duplicated verbatim across
+``scripts/cleanup_mislabeled_s3_2661.py`` and
+``scripts/repoint_mislabeled_documents_4439.py`` — both are ECS oneshot
+scripts run via ``scripts/ecs-run-task.sh`` which uploads only the single
+requested script to S3 at run time, so peer-script imports are not
+available. Importing from ``framework.*`` IS available because the
+helpers are bundled into the ingestion-worker / scraper-framework Docker
+image and reachable inside the oneshot container without extra ``COPY``
+steps (the existing ``from framework.logging import configure_structlog``
+imports in those scripts are precedent).
+
+The helpers in this module are pure functions over inputs the caller has
+already obtained (the S3 key string and the metadata ``content-hash``
+read via ``HeadObject``). Use ``framework.s3_integrity`` for the heavier
+three-way bytes-level integrity check that GETs the object.
+
+Note: the existing ``framework.s3_integrity.KEY_PATTERN`` regex matches
+content-addressed keys generally (``.*/raw/<hex64>.<ext>``) without
+capturing state/county/court. The flat-hash regex here is **stricter** —
+it requires the full ``{state}/{county}/{court}/raw/`` shape and captures
+each segment. Both regexes coexist intentionally: ``s3_integrity`` is
+used to verify any content-addressed key (e.g. court_directory snapshots
+under different prefixes), while ``s3_keys`` is used to enumerate and
+group the flat-hash subset by county.
+"""
+
+from __future__ import annotations
+
+import re
+
+from botocore.exceptions import ClientError
+
+# Matches content-addressed flat-hash keys:
+# ``{state}/{county}/{court}/raw/{hex64}.{ext}``.
+#
+# Captures state, county, court, the filename hash, and the extension so
+# callers can group by county and rebuild twin keys without re-parsing.
+# Lowercase hex is required by the upstream migration (the writers always
+# emit lowercase); uppercase hex is intentionally not accepted here so
+# that an audit caller does not silently treat capitalised legacy keys
+# as flat-hash matches.
+KEY_PATTERN = re.compile(
+    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/"
+    r"(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
+)
+
+
+def parse_flat_hash_key(key: str) -> dict[str, str] | None:
+    """Parse a flat-hash content-addressed key.
+
+    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``,
+    ``ext`` on match, or ``None`` if the key does not match the expected
+    shape.
+
+    Anything that does not match (e.g. date-partitioned legacy keys,
+    court_directory snapshots, non-raw paths) is silently skipped — the
+    return value of ``None`` is the canonical "not in scope" signal that
+    callers use to skip the row.
+
+    Examples::
+
+        parse_flat_hash_key("ca/orange/superior_court/raw/aabb...64.pdf")
+        # -> {"state": "ca", "county": "orange", "court": "superior_court",
+        #     "hash": "aabb...64", "ext": "pdf"}
+
+        parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/x.pdf")
+        # -> None
+    """
+    m = KEY_PATTERN.match(key)
+    if m is None:
+        return None
+    return dict(m.groupdict())
+
+
+def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
+    """Return ``True`` if *filename_hash* differs from *metadata_hash*.
+
+    The mislabel signature from the 2026-03-28 migration is:
+    filename hex64 ≠ metadata ``content-hash``. Both must be hex64
+    strings (this function does not normalise — the caller is expected
+    to have read the metadata via ``HeadObject`` which preserves the
+    original casing).
+
+    A missing metadata hash (``None`` or empty string) does **not**
+    count as a mislabel — that is a separate problem class handled by
+    the audit script (``scripts/audit_s3_raw_mislabels.py``). This
+    function is narrowly scoped to "filename ≠ metadata" (issue #2661).
+    """
+    if not metadata_hash:
+        return False
+    return filename_hash != metadata_hash
+
+
+def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
+    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
+
+    Returns ``None`` for **both** a missing metadata field AND a 404 —
+    callers must treat both cases as "not a mislabel" / "no twin
+    available." Both cleanup and repoint scripts rely on this collapsed
+    semantics; surfacing missing-metadata vs 404 separately is the
+    responsibility of the audit script.
+
+    Other ``ClientError`` codes (e.g. ``AccessDenied``) propagate to the
+    caller — silently swallowing them would mask a real problem.
+    """
+    try:
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+    metadata: dict[str, str] = head.get("Metadata", {}) or {}
+    return metadata.get("content-hash") or None
+
+
+def build_twin_key(mislabel_key: str, metadata_hash: str) -> str | None:
+    """Build the correctly-named twin key for *mislabel_key*.
+
+    The twin key reuses the same ``{state}/{county}/{court}/raw/``
+    prefix and file extension but replaces the filename hash with
+    *metadata_hash* — i.e. the location at which a correctly-named
+    copy of the same bytes would live if one exists.
+
+    Returns ``None`` if *mislabel_key* does not parse as a flat-hash
+    key.
+
+    Used by the repoint flow (``scripts/repoint_mislabeled_documents_4439.py``)
+    to compute the candidate twin from a mislabel's metadata, then HEAD
+    the twin to confirm it exists and is itself correctly-labelled.
+    """
+    parsed = parse_flat_hash_key(mislabel_key)
+    if parsed is None:
+        return None
+    return (
+        f"{parsed['state']}/{parsed['county']}/{parsed['court']}/raw/"
+        f"{metadata_hash}.{parsed['ext']}"
+    )

--- a/packages/scraper-framework/tests/test_s3_keys.py
+++ b/packages/scraper-framework/tests/test_s3_keys.py
@@ -1,0 +1,221 @@
+"""Tests for ``framework.s3_keys`` shared S3-key helpers (#4447).
+
+Covers each pure helper in isolation:
+- ``parse_flat_hash_key`` for valid, malformed, and edge-case keys
+- ``is_mislabel`` for matching/mismatching/missing-metadata cases
+- ``head_object_metadata_hash`` with mocked S3 client (200, 404, missing field)
+- ``build_twin_key`` for valid and non-parseable inputs
+
+The script-side tests
+(``scripts/tests/test_cleanup_mislabeled_s3_2661.py``,
+``scripts/tests/test_repoint_mislabeled_documents_4439.py``) re-verify the
+helpers end-to-end through the script's enumerate / repoint flow; the
+unit tests below verify the helper contracts at the module boundary so a
+future change to the helpers can be detected without booting the script
+mocks.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from framework.s3_keys import (
+    KEY_PATTERN,
+    build_twin_key,
+    head_object_metadata_hash,
+    is_mislabel,
+    parse_flat_hash_key,
+)
+
+HEX64_A = "a" * 64
+HEX64_B = "b" * 64
+HEX64_C = "c" * 64
+
+
+# ---------------------------------------------------------------------------
+# parse_flat_hash_key
+# ---------------------------------------------------------------------------
+
+
+class TestParseFlatHashKey:
+    def test_valid_pdf(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert result == {
+            "state": "ca",
+            "county": "orange",
+            "court": "superior_court",
+            "hash": HEX64_A,
+            "ext": "pdf",
+        }
+
+    def test_valid_html(self) -> None:
+        result = parse_flat_hash_key(f"ca/santa_clara/superior_court/raw/{HEX64_B}.html")
+        assert result is not None
+        assert result["county"] == "santa_clara"
+        assert result["ext"] == "html"
+
+    def test_valid_docx(self) -> None:
+        result = parse_flat_hash_key(f"ca/los_angeles/superior_court/raw/{HEX64_A}.docx")
+        assert result is not None
+        assert result["ext"] == "docx"
+
+    def test_valid_txt(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{HEX64_C}.txt")
+        assert result is not None
+        assert result["ext"] == "txt"
+
+    def test_date_partitioned_key_returns_none(self) -> None:
+        # Legacy date-partitioned keys are NOT in scope for the flat-hash
+        # cleanup/repoint flows — those go through different scripts.
+        result = parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/uuid.pdf")
+        assert result is None
+
+    def test_short_hash_returns_none(self) -> None:
+        # 63 chars instead of 64.
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'a' * 63}.pdf")
+        assert result is None
+
+    def test_uppercase_hash_returns_none(self) -> None:
+        # KEY_PATTERN requires lowercase hex — uppercase hex is intentionally
+        # rejected so audit callers do not silently treat capitalised legacy
+        # keys as flat-hash matches.
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'A' * 64}.pdf")
+        assert result is None
+
+    def test_non_raw_path_returns_none(self) -> None:
+        # ``transcripts/`` and other path segments are not in scope.
+        result = parse_flat_hash_key(f"ca/orange/superior_court/transcripts/{HEX64_A}.txt")
+        assert result is None
+
+    def test_court_directory_returns_none(self) -> None:
+        # ``court_directory`` snapshots and other non-document paths must not match.
+        result = parse_flat_hash_key("court_directory/ca/orange/snapshot.json")
+        assert result is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_flat_hash_key("") is None
+
+    def test_two_letter_state(self) -> None:
+        # Only two-letter state codes (per KEY_PATTERN). Three-letter must fail.
+        result = parse_flat_hash_key(f"cal/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# is_mislabel
+# ---------------------------------------------------------------------------
+
+
+class TestIsMislabel:
+    def test_matching_hashes_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_A) is False
+
+    def test_differing_hashes_is_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_B) is True
+
+    def test_missing_metadata_not_mislabel(self) -> None:
+        # Missing metadata is a separate problem class — handled by the
+        # audit script, not by the cleanup/repoint flows.
+        assert is_mislabel(HEX64_A, None) is False
+
+    def test_empty_metadata_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, "") is False
+
+
+# ---------------------------------------------------------------------------
+# head_object_metadata_hash
+# ---------------------------------------------------------------------------
+
+
+class TestHeadObjectMetadataHash:
+    def test_returns_hash_when_present(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        assert head_object_metadata_hash(s3, "bucket", "key") == HEX64_A
+
+    def test_returns_none_when_metadata_missing(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {}}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_metadata_field_absent(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError({"Error": {"Code": "404"}}, "HeadObject")
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404_via_no_such_key(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError({"Error": {"Code": "NoSuchKey"}}, "HeadObject")
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404_via_not_found(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError({"Error": {"Code": "NotFound"}}, "HeadObject")
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_propagates_other_errors(self) -> None:
+        # AccessDenied is not "not found" — it surfaces a real problem
+        # (IAM, bucket policy) and must propagate.
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject")
+        with pytest.raises(ClientError):
+            head_object_metadata_hash(s3, "bucket", "key")
+
+
+# ---------------------------------------------------------------------------
+# build_twin_key
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTwinKey:
+    def test_valid_mislabel_returns_twin(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        result = build_twin_key(mislabel, HEX64_B)
+        assert result == f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+
+    def test_preserves_extension(self) -> None:
+        mislabel = f"ca/santa_clara/superior_court/raw/{HEX64_A}.html"
+        result = build_twin_key(mislabel, HEX64_B)
+        assert result == f"ca/santa_clara/superior_court/raw/{HEX64_B}.html"
+
+    def test_preserves_state_county_court(self) -> None:
+        mislabel = f"ca/los_angeles/family_court/raw/{HEX64_A}.docx"
+        result = build_twin_key(mislabel, HEX64_C)
+        assert result == f"ca/los_angeles/family_court/raw/{HEX64_C}.docx"
+
+    def test_unparseable_key_returns_none(self) -> None:
+        # Date-partitioned legacy keys do not parse — cannot build twin.
+        result = build_twin_key("ca/orange/superior_court/raw/2026/04/01/x.pdf", HEX64_A)
+        assert result is None
+
+    def test_empty_key_returns_none(self) -> None:
+        assert build_twin_key("", HEX64_A) is None
+
+
+# ---------------------------------------------------------------------------
+# KEY_PATTERN (regex contract)
+# ---------------------------------------------------------------------------
+
+
+class TestKeyPattern:
+    def test_named_groups_match(self) -> None:
+        m = KEY_PATTERN.match(f"ca/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert m is not None
+        assert m.group("state") == "ca"
+        assert m.group("county") == "orange"
+        assert m.group("court") == "superior_court"
+        assert m.group("hash") == HEX64_A
+        assert m.group("ext") == "pdf"
+
+    def test_county_can_contain_underscore(self) -> None:
+        m = KEY_PATTERN.match(f"ca/santa_clara/superior_court/raw/{HEX64_A}.pdf")
+        assert m is not None
+        assert m.group("county") == "santa_clara"

--- a/scripts/cleanup_mislabeled_s3_2661.py
+++ b/scripts/cleanup_mislabeled_s3_2661.py
@@ -54,16 +54,19 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import sys
 from collections import defaultdict
 from collections.abc import Iterable
 
 import boto3
 import psycopg
-from botocore.exceptions import ClientError
 
 from framework.logging import configure_structlog
+from framework.s3_keys import (
+    head_object_metadata_hash,
+    is_mislabel,
+    parse_flat_hash_key,
+)
 
 # Canonical stdout/CloudWatch logger pattern (#4368/#4373).  Routes
 # stdlib ``logging.getLogger(__name__)`` calls through structlog's
@@ -79,12 +82,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
 
-# Matches content-addressed flat-hash keys: ca/{county}/{court}/raw/{hex64}.{ext}
-# Captures county and the filename hash for downstream grouping/comparison.
-KEY_PATTERN = re.compile(
-    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
-)
-
 # Sample size to log per county before truncating.
 SAMPLE_SIZE = 20
 
@@ -93,74 +90,15 @@ DELETE_BATCH_SIZE = 1000
 
 
 # ---------------------------------------------------------------------------
-# Pure helpers (unit-tested)
-# ---------------------------------------------------------------------------
-
-
-def parse_flat_hash_key(key: str) -> dict[str, str] | None:
-    """Parse a flat-hash content-addressed key.
-
-    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``, ``ext``
-    on match, or ``None`` if the key does not match the expected shape.
-
-    The function is the source of truth for what counts as a "flat-hash" key
-    in this script — anything that does not match (e.g. date-partitioned legacy
-    keys, court_directory snapshots, non-raw paths) is silently skipped.
-
-    Examples::
-
-        parse_flat_hash_key("ca/orange/superior_court/raw/aabb...64.pdf")
-        # -> {"state": "ca", "county": "orange", "court": "superior_court",
-        #     "hash": "aabb...64", "ext": "pdf"}
-
-        parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/x.pdf")
-        # -> None
-    """
-    m = KEY_PATTERN.match(key)
-    if m is None:
-        return None
-    return dict(m.groupdict())
-
-
-def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
-    """Return True if *filename_hash* differs from *metadata_hash*.
-
-    The mislabel signature from the 2026-03-28 migration is:
-    filename hex64 ≠ metadata ``content-hash``. Both must be hex64 strings (we
-    do not normalise here — the caller is expected to have read the metadata
-    via ``HeadObject`` which preserves the original casing).
-
-    A missing metadata hash (``None`` or empty) does **not** count as a
-    mislabel — the audit script (``audit_s3_raw_mislabels.py``) treats missing
-    metadata as a separate problem class and is the right place to surface it.
-    This script is narrowly scoped to "filename ≠ metadata" (issue #2661).
-    """
-    if not metadata_hash:
-        return False
-    return filename_hash != metadata_hash
-
-
-# ---------------------------------------------------------------------------
 # S3 enumeration
 # ---------------------------------------------------------------------------
-
-
-def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
-    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
-
-    Returns ``None`` for both a missing metadata field AND a 404 — callers are
-    expected to handle both cases as "not a mislabel" (the audit script is
-    the right place to surface those edge cases).
-    """
-    try:
-        head = s3_client.head_object(Bucket=bucket, Key=key)
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in ("404", "NoSuchKey", "NotFound"):
-            return None
-        raise
-    metadata: dict[str, str] = head.get("Metadata", {}) or {}
-    return metadata.get("content-hash") or None
+#
+# ``parse_flat_hash_key``, ``is_mislabel``, and ``head_object_metadata_hash``
+# (and the underlying ``KEY_PATTERN`` regex) are imported from
+# ``framework.s3_keys`` (see #4447). The ``framework.*`` imports are
+# reachable inside the ECS oneshot container because the helpers are
+# bundled into the scraper-framework Docker image — same precedent as the
+# ``framework.logging`` import above.
 
 
 def enumerate_mislabels(
@@ -170,7 +108,7 @@ def enumerate_mislabels(
 ) -> dict[str, list[dict[str, str]]]:
     """Enumerate mislabeled flat-hash keys under *prefix*, grouped by county.
 
-    For each key under *prefix* that matches ``KEY_PATTERN``:
+    For each key parsed by :func:`framework.s3_keys.parse_flat_hash_key`:
       1. HEAD the object to read its metadata ``content-hash``.
       2. If the metadata hash differs from the filename hash, record it.
 

--- a/scripts/repoint_mislabeled_documents_4439.py
+++ b/scripts/repoint_mislabeled_documents_4439.py
@@ -67,16 +67,20 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import sys
 from collections import defaultdict
 from collections.abc import Iterable
 
 import boto3
 import psycopg
-from botocore.exceptions import ClientError
 
 from framework.logging import configure_structlog
+from framework.s3_keys import (
+    build_twin_key,
+    head_object_metadata_hash,
+    is_mislabel,
+    parse_flat_hash_key,
+)
 
 # Canonical stdout/CloudWatch logger pattern (#4368/#4373).  Routes
 # stdlib ``logging.getLogger(__name__)`` calls through structlog's
@@ -91,93 +95,20 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
 
-# Matches content-addressed flat-hash keys: ca/{county}/{court}/raw/{hex64}.{ext}.
-# Captures county and the filename hash so the enumerate pass can group results
-# and build the twin key without re-parsing.
-KEY_PATTERN = re.compile(
-    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
-)
-
 # Sample size to log per county before truncating.
 SAMPLE_SIZE = 20
 
 
 # ---------------------------------------------------------------------------
-# Pure helpers (unit-tested)
-# ---------------------------------------------------------------------------
-
-
-def parse_flat_hash_key(key: str) -> dict[str, str] | None:
-    """Parse a flat-hash content-addressed key.
-
-    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``, ``ext``
-    on match, or ``None`` if the key does not match the expected shape.
-
-    Anything that does not match (e.g. date-partitioned legacy keys,
-    court_directory snapshots, non-raw paths) is silently skipped.
-
-    NOTE: this duplicates the helper in ``cleanup_mislabeled_s3_2661.py``
-    deliberately. ECS oneshot scripts cannot import from other ``scripts/*.py``
-    files (per CLAUDE.md / docs/agent/code-standards.md), so the small parser
-    is copied rather than shared.
-    """
-    m = KEY_PATTERN.match(key)
-    if m is None:
-        return None
-    return dict(m.groupdict())
-
-
-def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
-    """Return True if *filename_hash* differs from *metadata_hash*.
-
-    A missing metadata hash (``None`` or empty) does **not** count as a
-    mislabel — that is a separate problem class handled by
-    ``audit_s3_raw_mislabels.py``.
-    """
-    if not metadata_hash:
-        return False
-    return filename_hash != metadata_hash
-
-
-def build_twin_key(mislabel_key: str, metadata_hash: str) -> str | None:
-    """Build the correctly-named twin key for *mislabel_key*.
-
-    The twin key reuses the same ``state/county/court/raw/`` prefix and file
-    extension but replaces the filename hash with *metadata_hash* — i.e. the
-    location at which a correctly-named copy of the same bytes would live if
-    one exists.
-
-    Returns ``None`` if *mislabel_key* doesn't parse.
-    """
-    parsed = parse_flat_hash_key(mislabel_key)
-    if parsed is None:
-        return None
-    return (
-        f"{parsed['state']}/{parsed['county']}/{parsed['court']}/raw/"
-        f"{metadata_hash}.{parsed['ext']}"
-    )
-
-
-# ---------------------------------------------------------------------------
 # S3 enumeration
 # ---------------------------------------------------------------------------
-
-
-def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
-    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
-
-    Returns ``None`` for both a missing metadata field AND a 404 — callers
-    must treat both as "not a mislabel" / "no twin available."
-    """
-    try:
-        head = s3_client.head_object(Bucket=bucket, Key=key)
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in ("404", "NoSuchKey", "NotFound"):
-            return None
-        raise
-    metadata: dict[str, str] = head.get("Metadata", {}) or {}
-    return metadata.get("content-hash") or None
+#
+# ``parse_flat_hash_key``, ``is_mislabel``, ``head_object_metadata_hash``,
+# and ``build_twin_key`` (and the underlying ``KEY_PATTERN`` regex) are
+# imported from ``framework.s3_keys`` (see #4447). The ``framework.*``
+# imports are reachable inside the ECS oneshot container because the
+# helpers are bundled into the scraper-framework Docker image — same
+# precedent as the ``framework.logging`` import above.
 
 
 def verify_twin(s3_client: object, bucket: str, twin_key: str) -> bool:
@@ -207,7 +138,7 @@ def enumerate_repoint_pairs(
 ) -> dict[str, list[dict[str, str]]]:
     """Enumerate (mislabel, twin) repoint candidates under *prefix*, grouped by county.
 
-    For each key under *prefix* that matches ``KEY_PATTERN``:
+    For each key parsed by :func:`framework.s3_keys.parse_flat_hash_key`:
       1. HEAD the object to read its metadata ``content-hash``.
       2. If filename hash != metadata hash, build the twin key
          (same prefix, filename = metadata hash).

--- a/scripts/tests/test_cleanup_mislabeled_s3_2661.py
+++ b/scripts/tests/test_cleanup_mislabeled_s3_2661.py
@@ -2,8 +2,11 @@
 
 Tests cover:
 - parse_flat_hash_key for valid, malformed, and edge-case keys
+  (re-exported from ``framework.s3_keys`` after #4447)
 - is_mislabel for matching/mismatching/missing-metadata cases
+  (re-exported from ``framework.s3_keys`` after #4447)
 - head_object_metadata_hash with mocked S3 client (200, 404, missing field)
+  (re-exported from ``framework.s3_keys`` after #4447)
 - enumerate_mislabels end-to-end with mocked paginator + HEAD
 - find_referenced_keys with mocked psycopg connection
 - delete_in_batches in dry-run and apply modes, batch boundary
@@ -17,10 +20,18 @@ sys.modules before importing the script under test via the
 ``mock_sys_modules`` context manager from ``_mock_helpers`` (#4430) —
 the helper restores ``sys.modules`` automatically on exit so the mocks
 do not leak into later test files in the same pytest process (#4426).
+
+After #4447, the small pure helpers (``parse_flat_hash_key``,
+``is_mislabel``, ``head_object_metadata_hash``, ``KEY_PATTERN``) live in
+``framework.s3_keys``. We load that real module via ``importlib`` from
+its source path inside the mock_sys_modules block so the script under
+test imports the genuine implementation rather than a MagicMock — the
+helpers are pure-Python over ``re`` and the mocked ``botocore`` ``ClientError``.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -59,6 +70,33 @@ class _FakeClientError(Exception):
 _mock_botocore_exceptions.ClientError = _FakeClientError
 _mock_botocore.exceptions = _mock_botocore_exceptions
 
+
+def _load_real_s3_keys() -> object:
+    """Load ``framework.s3_keys`` from source so the script-under-test
+    imports the real helpers, not a MagicMock attribute. The module is
+    pure Python over ``re`` and ``botocore.exceptions.ClientError``;
+    this function is invoked INSIDE the ``mock_sys_modules`` block so
+    s3_keys' ``from botocore.exceptions import ClientError`` resolves to
+    the mocked ``_FakeClientError`` — making the ``except ClientError``
+    branch in ``head_object_metadata_hash`` reachable from tests that
+    raise ``_FakeClientError``."""
+    s3_keys_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "packages",
+        "scraper-framework",
+        "src",
+        "framework",
+        "s3_keys.py",
+    )
+    spec = importlib.util.spec_from_file_location("framework.s3_keys", s3_keys_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 with mock_sys_modules(
     {
         "psycopg": _mock_psycopg,
@@ -68,8 +106,19 @@ with mock_sys_modules(
         "structlog": _mock_structlog,
         "framework": _mock_framework,
         "framework.logging": _mock_framework_logging,
+        # Placeholder — replaced below with the real loaded module so the
+        # ``mock_sys_modules`` restore path cleans it up on exit.
+        "framework.s3_keys": MagicMock(),
     }
 ):
+    # Replace the placeholder with the genuine ``framework.s3_keys`` module
+    # loaded via importlib. The load happens INSIDE the mock context so the
+    # ``from botocore.exceptions import ClientError`` inside s3_keys.py
+    # resolves to ``_FakeClientError`` — keeping the ``except ClientError``
+    # branch reachable from tests that raise ``_FakeClientError``.
+    import sys as _sys
+
+    _sys.modules["framework.s3_keys"] = _load_real_s3_keys()
     import cleanup_mislabeled_s3_2661  # noqa: E402
 
 # The script's module-level boto3/psycopg bindings remain as mocks
@@ -89,7 +138,12 @@ report_enumeration = cleanup_mislabeled_s3_2661.report_enumeration
 run_cleanup = cleanup_mislabeled_s3_2661.run_cleanup
 build_parser = cleanup_mislabeled_s3_2661.build_parser
 main = cleanup_mislabeled_s3_2661.main
-ClientError = cleanup_mislabeled_s3_2661.ClientError
+# After #4447 the ``except ClientError`` branch lives in
+# ``framework.s3_keys.head_object_metadata_hash``, which uses the
+# ``_FakeClientError`` class that we installed on the mocked
+# ``botocore.exceptions``. Tests raise this same class so the ``isinstance``
+# check inside the helper succeeds.
+ClientError = _FakeClientError
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/tests/test_repoint_mislabeled_documents_4439.py
+++ b/scripts/tests/test_repoint_mislabeled_documents_4439.py
@@ -2,9 +2,13 @@
 
 Tests cover:
 - parse_flat_hash_key for valid, malformed, edge-case keys
+  (re-exported from ``framework.s3_keys`` after #4447)
 - is_mislabel for matching/mismatching/missing-metadata cases
+  (re-exported from ``framework.s3_keys`` after #4447)
 - build_twin_key for valid + non-parseable inputs
+  (re-exported from ``framework.s3_keys`` after #4447)
 - head_object_metadata_hash with mocked S3 client (200, 404, missing field)
+  (re-exported from ``framework.s3_keys`` after #4447)
 - verify_twin: valid, missing, invalid twin
 - enumerate_repoint_pairs end-to-end with mocked paginator + HEAD
   (records valid/missing/invalid twin states)
@@ -21,10 +25,17 @@ which may not be installed in the CI ``scripts-tests`` environment. We use
 to inject MagicMocks into sys.modules around the import — the helper restores
 sys.modules on exit so other tests in the same pytest run don't see the leaked
 mocks (#4426).
+
+After #4447, the small pure helpers (``parse_flat_hash_key``, ``is_mislabel``,
+``head_object_metadata_hash``, ``build_twin_key``, ``KEY_PATTERN``) live in
+``framework.s3_keys``. We load that real module via ``importlib`` from its
+source path inside the mock_sys_modules block so the script imports the
+genuine implementation rather than a MagicMock attribute.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -58,6 +69,30 @@ _mock_structlog = MagicMock()
 _mock_structlog.get_logger.return_value = MagicMock()
 
 
+def _load_real_s3_keys() -> object:
+    """Load ``framework.s3_keys`` from source so the script-under-test
+    imports the real helpers, not a MagicMock attribute. Pure Python over
+    ``re`` and ``botocore.exceptions.ClientError``; invoked INSIDE the
+    ``mock_sys_modules`` block so s3_keys' import of ``ClientError``
+    resolves to ``_FakeClientError`` — keeping the ``except ClientError``
+    branch reachable from tests that raise ``_FakeClientError``."""
+    s3_keys_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "packages",
+        "scraper-framework",
+        "src",
+        "framework",
+        "s3_keys.py",
+    )
+    spec = importlib.util.spec_from_file_location("framework.s3_keys", s3_keys_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 with mock_sys_modules(
     {
         "psycopg": MagicMock(),
@@ -67,8 +102,19 @@ with mock_sys_modules(
         "structlog": _mock_structlog,
         "framework": MagicMock(),
         "framework.logging": MagicMock(),
+        # Placeholder — replaced below with the real loaded module so the
+        # ``mock_sys_modules`` restore path cleans it up on exit.
+        "framework.s3_keys": MagicMock(),
     }
 ):
+    # Replace the placeholder with the genuine ``framework.s3_keys`` module
+    # loaded via importlib. The load happens INSIDE the mock context so the
+    # ``from botocore.exceptions import ClientError`` inside s3_keys.py
+    # resolves to ``_FakeClientError`` — keeping the ``except ClientError``
+    # branch reachable from tests that raise ``_FakeClientError``.
+    import sys as _sys
+
+    _sys.modules["framework.s3_keys"] = _load_real_s3_keys()
     import repoint_mislabeled_documents_4439  # noqa: E402
 
 parse_flat_hash_key = repoint_mislabeled_documents_4439.parse_flat_hash_key
@@ -85,7 +131,12 @@ report_enumeration = repoint_mislabeled_documents_4439.report_enumeration
 run_repoint = repoint_mislabeled_documents_4439.run_repoint
 build_parser = repoint_mislabeled_documents_4439.build_parser
 main = repoint_mislabeled_documents_4439.main
-ClientError = repoint_mislabeled_documents_4439.ClientError
+# After #4447 the ``except ClientError`` branch lives in
+# ``framework.s3_keys.head_object_metadata_hash``, which uses the
+# ``_FakeClientError`` class that we installed on the mocked
+# ``botocore.exceptions``. Tests raise this same class so the ``isinstance``
+# check inside the helper succeeds.
+ClientError = _FakeClientError
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extract the four small S3-key helpers (`parse_flat_hash_key`, `is_mislabel`, `head_object_metadata_hash`, `build_twin_key`) and the underlying `KEY_PATTERN` regex from `scripts/cleanup_mislabeled_s3_2661.py` and `scripts/repoint_mislabeled_documents_4439.py` into a new `framework.s3_keys` module. Removes ~80 lines of verbatim drift surface across the two ECS oneshot scripts and gives any future S3-shape script (e.g. the `CopyObject`-twins follow-up #4446) a single import target.

Closes #4447

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (refactor of existing pure helpers; behaviour unchanged, ECS oneshot scripts pick up the new module bundle on their next image build)
- [x] Verification evidence posted on issue (see A.8) — https://github.com/judgemind/judgemind/issues/4447#issuecomment-4411664076
