### PR TITLE
fix(storage): create twins in S3 for 970 missing-twin mislabels (#4446)

### DIFF
--- a/scripts/create_missing_twins_4446.py
+++ b/scripts/create_missing_twins_4446.py
@@ -1,0 +1,773 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Create correctly-labelled twin S3 objects for missing-twin mislabels.
+
+The 2026-03-28 migration in commit ``fbf8e38`` (archived as
+``scripts/archive/migrate_s3_keys.py``) wrote some S3 objects under
+content-addressed keys whose filename SHA-256 did **not** match the SHA-256
+of the bytes — for documents whose ``content_hash`` was a synthetic
+split-child value rather than a real bytes hash. ``CopyObject`` preserved
+the original metadata ``content-hash`` (the correct bytes hash), so each
+mislabeled object carries a metadata header that points to the right value.
+
+The companion script ``repoint_mislabeled_documents_4439.py`` repoints
+``derived.documents`` rows from mislabel keys to their correctly-named
+twins — but only when a valid twin already exists. Across orange,
+riverside, and santa_clara, ~970 mislabeled keys have **no** correctly-named
+twin in S3 today (per the 2026-05-09 dry-run of the repoint script). Those
+rows cannot be repointed by the surgical UPDATE path because there is
+nothing valid to point them at.
+
+This script (Path A from issue #4446) materialises the missing twins by
+``CopyObject``-ing each missing-twin mislabel to its correctly-named twin
+location. Because ``copy_object`` defaults to ``MetadataDirective: COPY``,
+the source metadata ``content-hash`` is preserved verbatim on the new
+object — so the resulting twin satisfies the invariant
+``filename hex64 == metadata content-hash`` by construction.
+
+After this script runs and ``repoint_mislabeled_documents_4439.py --apply``
+finishes the corresponding DB repoints, every ``derived.documents`` row
+points at a correctly-named content-addressed key, the cleanup script
+``cleanup_mislabeled_s3_2661.py`` can complete its DB-safety check, and
+the mislabeled S3 objects can be deleted (issue #2661).
+
+This script does **two passes**:
+
+1. **Enumerate pass:** paginate ``list_objects_v2`` under ``ca/`` (or a
+   single county prefix), match keys of shape
+   ``ca/{county}/{court}/raw/<hex64>.<ext>``, HEAD each, compare filename
+   hex64 to metadata ``content-hash``. For each mislabel, build the
+   ``twin`` key (same prefix, filename = metadata hash) and HEAD the
+   twin to determine ``twin_status`` ∈ {``valid``, ``missing``,
+   ``invalid``}.
+
+2. **Create pass:** in --apply mode, for each (mislabel, twin) pair with
+   ``twin_status == "missing"``:
+     - Pre-HEAD the twin one more time (handles the race where another
+       writer materialised the twin between enumerate and create).
+     - If the twin now exists and is correctly-labelled, count
+       ``already_exists`` and skip.
+     - If the twin now exists but is itself mislabeled (collision with a
+       sibling mislabel), count ``collision_skipped``, log an error, and
+       skip — operator must resolve.
+     - Otherwise call ``s3.copy_object(Bucket=bucket,
+       CopySource={"Bucket": bucket, "Key": mislabel}, Key=twin)``. The
+       default ``MetadataDirective: COPY`` preserves the source metadata
+       ``content-hash`` on the new object.
+     - Post-HEAD the new twin and confirm filename hex64 == metadata
+       ``content-hash``. If verification fails, count ``verify_failed``
+       and log an error (do NOT raise; we still want the per-county
+       summary to be reported).
+
+Idempotence: the pre-HEAD-then-decide flow makes the script safe to
+re-run. A second --apply pass over the same prefix counts every twin
+created by the first pass under ``already_exists`` and is otherwise a
+no-op. Errors and verification failures are recorded as counters and do
+not abort the per-county loop.
+
+This script does **not** touch the DB. The companion repoint script
+handles the DB side once the twins are created. ``DATABASE_URL`` is not
+required.
+
+Usage:
+    scripts/ecs-run-task.sh scripts/create_missing_twins_4446.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/create_missing_twins_4446.py -- --apply
+    scripts/ecs-run-task.sh scripts/create_missing_twins_4446.py -- --apply --county santa_clara
+
+Options:
+    --dry-run   Enumerate missing-twin mislabels and show planned
+                CopyObject calls; do not write to S3 (default).
+    --apply     Run CopyObject calls for every missing-twin mislabel.
+    --county    Restrict to a single county (e.g. santa_clara, orange).
+    --state     State prefix to scan (default: ca).
+    --bucket    S3 bucket to scan (default: $S3_BUCKET or
+                judgemind-document-archive-dev).
+
+Exit codes:
+    0  Dry-run completed, or apply succeeded with errors == 0 AND
+       verify_failed == 0.
+    1  Apply completed but at least one error or verification failure
+       was recorded (operator must investigate the affected keys).
+    2  Unrecoverable error (S3 client construction, argument).
+
+See: https://github.com/judgemind/judgemind/issues/4446
+Blocks: https://github.com/judgemind/judgemind/issues/2661
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from collections import defaultdict
+from collections.abc import Iterable
+
+import boto3
+from botocore.exceptions import ClientError
+
+from framework.logging import configure_structlog
+
+# Canonical stdout/CloudWatch logger pattern (#4368/#4373).  Routes
+# stdlib ``logging.getLogger(__name__)`` calls through structlog's
+# ProcessorFormatter + ExtraAdder so any ``extra=`` field reaches
+# CloudWatch Logs Insights as a structured JSON field.
+configure_structlog(json=True, stdlib_bridge=True)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
+
+# Matches content-addressed flat-hash keys: ca/{county}/{court}/raw/{hex64}.{ext}.
+# Captures county and the filename hash so the enumerate pass can group results
+# and build the twin key without re-parsing.
+KEY_PATTERN = re.compile(
+    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
+)
+
+# Sample size to log per county before truncating.
+SAMPLE_SIZE = 20
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def parse_flat_hash_key(key: str) -> dict[str, str] | None:
+    """Parse a flat-hash content-addressed key.
+
+    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``,
+    ``ext`` on match, or ``None`` if the key does not match the expected
+    shape.
+
+    Anything that does not match (e.g. date-partitioned legacy keys,
+    court_directory snapshots, non-raw paths) is silently skipped.
+
+    NOTE: this duplicates the helper in
+    ``repoint_mislabeled_documents_4439.py`` and
+    ``cleanup_mislabeled_s3_2661.py`` deliberately. ECS oneshot scripts
+    cannot import from other ``scripts/*.py`` files (per CLAUDE.md /
+    docs/agent/code-standards.md), so the small parser is copied rather
+    than shared.
+    """
+    m = KEY_PATTERN.match(key)
+    if m is None:
+        return None
+    return dict(m.groupdict())
+
+
+def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
+    """Return True if *filename_hash* differs from *metadata_hash*.
+
+    A missing metadata hash (``None`` or empty) does **not** count as a
+    mislabel — that is a separate problem class handled by
+    ``audit_s3_raw_mislabels.py``.
+    """
+    if not metadata_hash:
+        return False
+    return filename_hash != metadata_hash
+
+
+def build_twin_key(mislabel_key: str, metadata_hash: str) -> str | None:
+    """Build the correctly-named twin key for *mislabel_key*.
+
+    The twin key reuses the same ``state/county/court/raw/`` prefix and
+    file extension but replaces the filename hash with *metadata_hash* —
+    i.e. the location at which a correctly-named copy of the same bytes
+    would live.
+
+    Returns ``None`` if *mislabel_key* doesn't parse.
+    """
+    parsed = parse_flat_hash_key(mislabel_key)
+    if parsed is None:
+        return None
+    return (
+        f"{parsed['state']}/{parsed['county']}/{parsed['court']}/raw/"
+        f"{metadata_hash}.{parsed['ext']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# S3 enumeration
+# ---------------------------------------------------------------------------
+
+
+def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
+    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
+
+    Returns ``None`` for both a missing metadata field AND a 404 — callers
+    must treat both as "not a mislabel" / "no twin available."
+    """
+    try:
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+    except ClientError as exc:
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in ("404", "NoSuchKey", "NotFound"):
+            return None
+        raise
+    metadata: dict[str, str] = head.get("Metadata", {}) or {}
+    return metadata.get("content-hash") or None
+
+
+def verify_twin(s3_client: object, bucket: str, twin_key: str) -> bool:
+    """Return True if *twin_key* exists AND is correctly-labelled.
+
+    A twin is "valid" only when its filename hex64 == its own metadata
+    ``content-hash``. This is the safety guard that prevents repointing /
+    creating against another mislabeled key.
+
+    Returns False if the twin is missing (404), has no metadata, or is
+    itself mislabeled.
+    """
+    parsed = parse_flat_hash_key(twin_key)
+    if parsed is None:
+        return False
+    twin_metadata_hash = head_object_metadata_hash(s3_client, bucket, twin_key)
+    if not twin_metadata_hash:
+        return False
+    return parsed["hash"] == twin_metadata_hash
+
+
+def enumerate_mislabel_pairs(
+    s3_client: object,
+    bucket: str,
+    prefix: str,
+) -> dict[str, list[dict[str, str]]]:
+    """Enumerate (mislabel, twin) candidates under *prefix*, grouped by county.
+
+    For each key under *prefix* that matches ``KEY_PATTERN``:
+      1. HEAD the object to read its metadata ``content-hash``.
+      2. If filename hash != metadata hash, build the twin key
+         (same prefix, filename = metadata hash).
+      3. HEAD the twin and compare its filename to its metadata hash to
+         determine ``twin_status``.
+      4. Record the pair.
+
+    Returns a dict mapping county name to a list of pair records, each a
+    dict with keys ``mislabel_key``, ``twin_key``, ``filename_hash``,
+    ``metadata_hash``, ``twin_status``.
+
+    ``twin_status`` is one of:
+      * ``"valid"``   — twin exists and is correctly-labelled (separate
+        repoint script handles these; this script no-ops on them).
+      * ``"missing"`` — twin does not exist in S3 (this is the work
+        unit — Pass 2 ``CopyObject``s these to the twin location).
+      * ``"invalid"`` — twin exists but is itself mislabeled (operator
+        intervention required; this script logs and skips).
+
+    The dry-run output is the source-of-truth for what this script will
+    ``CopyObject`` when run with --apply.
+    """
+    paginator = s3_client.get_paginator("list_objects_v2")
+    by_county: dict[str, list[dict[str, str]]] = defaultdict(list)
+    total_seen = 0
+    total_skipped_shape = 0
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            parsed = parse_flat_hash_key(key)
+            if parsed is None:
+                total_skipped_shape += 1
+                continue
+            total_seen += 1
+            metadata_hash = head_object_metadata_hash(s3_client, bucket, key)
+            if not is_mislabel(parsed["hash"], metadata_hash):
+                continue
+            assert metadata_hash is not None  # is_mislabel rejects None
+            twin_key = build_twin_key(key, metadata_hash)
+            assert twin_key is not None  # parsed already non-None
+            twin_metadata_hash = head_object_metadata_hash(s3_client, bucket, twin_key)
+            if twin_metadata_hash is None:
+                twin_status = "missing"
+            elif twin_metadata_hash != metadata_hash:
+                # The twin exists but its metadata disagrees with the filename
+                # we built it under — i.e. the twin is itself mislabeled.
+                twin_status = "invalid"
+            else:
+                twin_status = "valid"
+            by_county[parsed["county"]].append(
+                {
+                    "mislabel_key": key,
+                    "twin_key": twin_key,
+                    "filename_hash": parsed["hash"],
+                    "metadata_hash": metadata_hash,
+                    "twin_status": twin_status,
+                }
+            )
+
+    logger.info(
+        "Scanned prefix %r: %d flat-hash keys, %d skipped (non-matching shape)",
+        prefix,
+        total_seen,
+        total_skipped_shape,
+    )
+    return dict(by_county)
+
+
+# ---------------------------------------------------------------------------
+# S3 twin creation
+# ---------------------------------------------------------------------------
+
+
+def create_twin(
+    s3_client: object,
+    bucket: str,
+    pair: dict[str, str],
+) -> str:
+    """Create the correctly-named twin for *pair* and verify it.
+
+    *pair* must have keys ``mislabel_key``, ``twin_key``,
+    ``metadata_hash``, ``twin_status``. Only ``twin_status == "missing"``
+    pairs are processed; all other statuses return a status code without
+    side effects so the caller's counters stay aligned with the
+    enumeration.
+
+    Returns one of these status strings:
+      * ``"created"``           — pre-HEAD confirmed twin missing, ``copy_object``
+                                  called, post-HEAD verified the new twin is
+                                  correctly-labelled.
+      * ``"already_exists"``    — pre-HEAD found the twin already exists and
+                                  is correctly-labelled (idempotent re-run, or
+                                  another writer materialised the twin between
+                                  enumerate and create). No ``copy_object``
+                                  call.
+      * ``"collision_skipped"`` — pre-HEAD found the twin exists but is itself
+                                  mislabeled (filename hash != metadata hash).
+                                  Operator intervention required; no
+                                  ``copy_object`` call.
+      * ``"verify_failed"``     — ``copy_object`` succeeded but post-HEAD
+                                  showed the new twin is NOT correctly-labelled.
+                                  Logs an error; does not raise.
+      * ``"error"``             — ``copy_object`` raised a non-404 ``ClientError``,
+                                  or the pre-HEAD raised a non-404 ``ClientError``.
+                                  Logs the error; does not raise.
+      * ``"skipped_non_missing"``— pair's ``twin_status`` was ``valid`` or
+                                  ``invalid`` at enumeration time. No work
+                                  performed (separate code paths handle these).
+
+    The function never raises on S3 errors; it logs them and returns
+    ``"error"`` so the caller's per-county loop can keep running.
+    """
+    twin_status_at_enum = pair.get("twin_status")
+    if twin_status_at_enum != "missing":
+        # Defensive: the caller already filters to missing, but gate here too
+        # so the pure helper contract is unambiguous.
+        return "skipped_non_missing"
+
+    mislabel_key = pair["mislabel_key"]
+    twin_key = pair["twin_key"]
+    expected_metadata_hash = pair["metadata_hash"]
+
+    # Pre-HEAD the twin: handle the case where another writer materialised
+    # the twin between enumerate and create (idempotence on re-runs, race
+    # safety on concurrent writers).
+    try:
+        pre_metadata_hash = head_object_metadata_hash(s3_client, bucket, twin_key)
+    except ClientError as exc:
+        logger.error(
+            "create_twin: pre-HEAD failed for twin %s (mislabel %s): %s",
+            twin_key,
+            mislabel_key,
+            exc,
+        )
+        return "error"
+
+    if pre_metadata_hash is not None:
+        # Twin already exists. Decide based on whether its filename matches
+        # its own metadata hash.
+        twin_parsed = parse_flat_hash_key(twin_key)
+        assert twin_parsed is not None  # build_twin_key always produces a parseable key
+        if twin_parsed["hash"] == pre_metadata_hash:
+            logger.info(
+                "create_twin: twin %s already exists and is correctly-labelled "
+                "(idempotent skip; mislabel %s)",
+                twin_key,
+                mislabel_key,
+            )
+            return "already_exists"
+        logger.error(
+            "create_twin: twin %s exists but is itself mislabeled "
+            "(filename=%s metadata=%s; mislabel=%s) — operator must resolve",
+            twin_key,
+            twin_parsed["hash"],
+            pre_metadata_hash,
+            mislabel_key,
+        )
+        return "collision_skipped"
+
+    # Twin is missing — copy from mislabel.
+    try:
+        s3_client.copy_object(
+            Bucket=bucket,
+            CopySource={"Bucket": bucket, "Key": mislabel_key},
+            Key=twin_key,
+        )
+    except ClientError as exc:
+        logger.error(
+            "create_twin: copy_object failed for %s -> %s: %s",
+            mislabel_key,
+            twin_key,
+            exc,
+        )
+        return "error"
+
+    # Post-HEAD verification: confirm the new twin is correctly-labelled.
+    try:
+        post_metadata_hash = head_object_metadata_hash(s3_client, bucket, twin_key)
+    except ClientError as exc:
+        logger.error(
+            "create_twin: post-HEAD failed for new twin %s (mislabel %s): %s",
+            twin_key,
+            mislabel_key,
+            exc,
+        )
+        return "error"
+
+    twin_parsed = parse_flat_hash_key(twin_key)
+    assert twin_parsed is not None
+    if (
+        post_metadata_hash != expected_metadata_hash
+        or post_metadata_hash != twin_parsed["hash"]
+    ):
+        logger.error(
+            "create_twin: post-HEAD verification FAILED for new twin %s "
+            "(filename=%s expected_metadata=%s observed_metadata=%s; mislabel=%s)",
+            twin_key,
+            twin_parsed["hash"],
+            expected_metadata_hash,
+            post_metadata_hash,
+            mislabel_key,
+        )
+        return "verify_failed"
+
+    logger.info(
+        "create_twin: created twin %s from mislabel %s (verified)",
+        twin_key,
+        mislabel_key,
+    )
+    return "created"
+
+
+def create_twins_for_county(
+    s3_client: object,
+    pairs: Iterable[dict[str, str]],
+    *,
+    county: str,
+    bucket: str,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Create twins for the missing-twin pairs in *pairs*.
+
+    Filters to ``twin_status == "missing"`` and accumulates per-status
+    counters. Logs a per-county summary at the end. Returns a dict with
+    keys: ``planned``, ``created``, ``already_exists``,
+    ``collision_skipped``, ``verify_failed``, ``errors``,
+    ``skipped_invalid``, ``skipped_valid``.
+    """
+    pairs_list = list(pairs)
+    missing = [p for p in pairs_list if p.get("twin_status") == "missing"]
+    skipped_valid = sum(1 for p in pairs_list if p.get("twin_status") == "valid")
+    skipped_invalid = sum(1 for p in pairs_list if p.get("twin_status") == "invalid")
+
+    counters = {
+        "planned": len(missing),
+        "created": 0,
+        "already_exists": 0,
+        "collision_skipped": 0,
+        "verify_failed": 0,
+        "errors": 0,
+        "skipped_invalid": skipped_invalid,
+        "skipped_valid": skipped_valid,
+    }
+
+    if not missing:
+        logger.info(
+            "[%s] No missing-twin mislabels (planned=0, valid=%d, invalid=%d)",
+            county,
+            skipped_valid,
+            skipped_invalid,
+        )
+        return counters
+
+    if dry_run:
+        logger.info(
+            "[%s] DRY-RUN: would create %d twin(s) (valid=%d, invalid=%d)",
+            county,
+            len(missing),
+            skipped_valid,
+            skipped_invalid,
+        )
+        for p in missing[:SAMPLE_SIZE]:
+            logger.info(
+                "  %s -> %s",
+                p["mislabel_key"],
+                p["twin_key"],
+            )
+        if len(missing) > SAMPLE_SIZE:
+            logger.info("  ... and %d more", len(missing) - SAMPLE_SIZE)
+        return counters
+
+    for p in missing:
+        result = create_twin(s3_client, bucket, p)
+        if result == "created":
+            counters["created"] += 1
+        elif result == "already_exists":
+            counters["already_exists"] += 1
+        elif result == "collision_skipped":
+            counters["collision_skipped"] += 1
+        elif result == "verify_failed":
+            counters["verify_failed"] += 1
+        elif result == "error":
+            counters["errors"] += 1
+        # "skipped_non_missing" is an internal-only return; the filter
+        # above means it should never fire in practice.
+
+    logger.info(
+        "[%s] Done. created=%d, already_exists=%d, collision_skipped=%d, "
+        "verify_failed=%d, errors=%d (planned=%d)",
+        county,
+        counters["created"],
+        counters["already_exists"],
+        counters["collision_skipped"],
+        counters["verify_failed"],
+        counters["errors"],
+        counters["planned"],
+    )
+    return counters
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def report_enumeration(by_county: dict[str, list[dict[str, str]]]) -> dict[str, int]:
+    """Log per-county counts; return summary totals (valid/missing/invalid)."""
+    totals: dict[str, int] = defaultdict(int)
+    for county in sorted(by_county.keys()):
+        records = by_county[county]
+        valid = sum(1 for r in records if r.get("twin_status") == "valid")
+        missing = sum(1 for r in records if r.get("twin_status") == "missing")
+        invalid = sum(1 for r in records if r.get("twin_status") == "invalid")
+        totals["valid"] += valid
+        totals["missing"] += missing
+        totals["invalid"] += invalid
+        totals["total"] += len(records)
+        logger.info(
+            "%s: %d mislabel(s) — %d valid twin(s), %d missing, %d invalid",
+            county,
+            len(records),
+            valid,
+            missing,
+            invalid,
+        )
+
+    print()
+    print("=" * 72)
+    print("Mislabel enumeration summary (Path A target = `missing` column)")
+    print("=" * 72)
+    print(
+        f"  {'county':<24s} {'total':>8s} {'valid':>8s} {'missing':>8s} {'invalid':>8s}"
+    )
+    for county in sorted(by_county.keys()):
+        records = by_county[county]
+        valid = sum(1 for r in records if r.get("twin_status") == "valid")
+        missing = sum(1 for r in records if r.get("twin_status") == "missing")
+        invalid = sum(1 for r in records if r.get("twin_status") == "invalid")
+        print(
+            f"  {county:<24s} {len(records):>8d} {valid:>8d} {missing:>8d} {invalid:>8d}"
+        )
+    print(
+        f"  {'TOTAL':<24s} {totals['total']:>8d} {totals['valid']:>8d} "
+        f"{totals['missing']:>8d} {totals['invalid']:>8d}"
+    )
+    return dict(totals)
+
+
+def report_creation(
+    by_county_counters: dict[str, dict[str, int]],
+) -> dict[str, int]:
+    """Log per-county creation counters; return aggregate totals."""
+    totals: dict[str, int] = defaultdict(int)
+    for county in sorted(by_county_counters.keys()):
+        counters = by_county_counters[county]
+        for k, v in counters.items():
+            totals[k] += v
+
+    print()
+    print("=" * 96)
+    print("Twin creation summary")
+    print("=" * 96)
+    print(
+        f"  {'county':<24s} {'planned':>8s} {'created':>8s} {'exists':>8s} "
+        f"{'collide':>8s} {'verify!':>8s} {'errors':>8s}"
+    )
+    for county in sorted(by_county_counters.keys()):
+        c = by_county_counters[county]
+        print(
+            f"  {county:<24s} {c['planned']:>8d} {c['created']:>8d} "
+            f"{c['already_exists']:>8d} {c['collision_skipped']:>8d} "
+            f"{c['verify_failed']:>8d} {c['errors']:>8d}"
+        )
+    print(
+        f"  {'TOTAL':<24s} {totals['planned']:>8d} {totals['created']:>8d} "
+        f"{totals['already_exists']:>8d} {totals['collision_skipped']:>8d} "
+        f"{totals['verify_failed']:>8d} {totals['errors']:>8d}"
+    )
+    return dict(totals)
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestration
+# ---------------------------------------------------------------------------
+
+
+def run_create(
+    s3_client: object,
+    *,
+    bucket: str,
+    state: str,
+    county: str | None,
+    dry_run: bool,
+) -> dict[str, int]:
+    """Run the two-pass create. Returns a dict with summary counts.
+
+    Summary keys: ``mislabels_found``, ``valid_twins``, ``missing_twins``,
+    ``invalid_twins``, ``planned``, ``created``, ``already_exists``,
+    ``collision_skipped``, ``verify_failed``, ``errors``.
+    """
+    if county:
+        prefix = f"{state}/{county}/"
+    else:
+        prefix = f"{state}/"
+
+    logger.info(
+        "Mode: %s | Bucket: %s | Prefix: %s",
+        "DRY-RUN" if dry_run else "APPLY",
+        bucket,
+        prefix,
+    )
+
+    # Pass 1: enumerate.
+    by_county = enumerate_mislabel_pairs(s3_client, bucket, prefix)
+    enum_totals = report_enumeration(by_county)
+
+    if enum_totals.get("total", 0) == 0:
+        logger.info("No mislabels found. Nothing to do.")
+        return {
+            "mislabels_found": 0,
+            "valid_twins": 0,
+            "missing_twins": 0,
+            "invalid_twins": 0,
+            "planned": 0,
+            "created": 0,
+            "already_exists": 0,
+            "collision_skipped": 0,
+            "verify_failed": 0,
+            "errors": 0,
+        }
+
+    # Pass 2: create per county.
+    by_county_counters: dict[str, dict[str, int]] = {}
+    for county_name in sorted(by_county.keys()):
+        by_county_counters[county_name] = create_twins_for_county(
+            s3_client,
+            by_county[county_name],
+            county=county_name,
+            bucket=bucket,
+            dry_run=dry_run,
+        )
+
+    create_totals = report_creation(by_county_counters)
+
+    return {
+        "mislabels_found": enum_totals.get("total", 0),
+        "valid_twins": enum_totals.get("valid", 0),
+        "missing_twins": enum_totals.get("missing", 0),
+        "invalid_twins": enum_totals.get("invalid", 0),
+        "planned": create_totals.get("planned", 0),
+        "created": create_totals.get("created", 0),
+        "already_exists": create_totals.get("already_exists", 0),
+        "collision_skipped": create_totals.get("collision_skipped", 0),
+        "verify_failed": create_totals.get("verify_failed", 0),
+        "errors": create_totals.get("errors", 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create correctly-labelled twin S3 objects for missing-twin "
+            "mislabels (Path A from issue #4446). Two-pass: enumerate "
+            "(mislabel, twin) pairs, then CopyObject the missing twins "
+            "into existence. CopyObject's default MetadataDirective: COPY "
+            "preserves the source metadata content-hash, so the new twin "
+            "is correctly-labelled by construction."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Enumerate pairs and show planned creates; do not write (default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run the per-county CopyObject calls.",
+    )
+    parser.add_argument(
+        "--county",
+        default=None,
+        help="Restrict to a single county prefix (e.g. santa_clara, orange).",
+    )
+    parser.add_argument(
+        "--state",
+        default="ca",
+        help="State prefix to scan (default: ca).",
+    )
+    parser.add_argument(
+        "--bucket",
+        default=DEFAULT_BUCKET,
+        help=f"S3 bucket to scan (default: ${{S3_BUCKET}} or {DEFAULT_BUCKET}).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    # --apply overrides --dry-run.
+    dry_run = not args.apply
+
+    s3_client = boto3.client("s3")
+
+    result = run_create(
+        s3_client,
+        bucket=args.bucket,
+        state=args.state,
+        county=args.county,
+        dry_run=dry_run,
+    )
+
+    # Apply mode: surface verify failures and errors as exit code 1 so the
+    # operator can detect partial success without parsing logs.
+    if not dry_run and (result.get("errors", 0) or result.get("verify_failed", 0)):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_create_missing_twins_4446.py
+++ b/scripts/tests/test_create_missing_twins_4446.py
@@ -1,0 +1,996 @@
+"""Tests for create_missing_twins_4446 script.
+
+Tests cover:
+- parse_flat_hash_key for valid, malformed, edge-case keys
+- is_mislabel for matching/mismatching/missing-metadata cases
+- build_twin_key for valid + non-parseable inputs
+- head_object_metadata_hash with mocked S3 client (200, 404, missing field)
+- verify_twin: valid, missing, invalid twin
+- enumerate_mislabel_pairs end-to-end with mocked paginator + HEAD
+  (records valid/missing/invalid twin states)
+- create_twin: each return-status branch (created, already_exists,
+  collision_skipped, verify_failed, error, skipped_non_missing)
+- create_twins_for_county: dry-run, missing-only filter, per-status counters
+- run_create orchestration: empty, dry-run, apply with happy path + errors
+- main CLI: --dry-run default, --apply switch, error/verify_failed exit code
+- report_enumeration / report_creation smoke tests
+
+The script imports boto3 + structlog + framework.* at module level, which
+may not be installed in the CI ``scripts-tests`` environment. We use
+``tests._mock_helpers.mock_sys_modules`` (the canonical pattern as of
+#4430) to inject MagicMocks into sys.modules around the import — the
+helper restores sys.modules on exit so other tests in the same pytest run
+don't see the leaked mocks (#4426).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add scripts/ to sys.path so the script-under-test imports cleanly, and
+# scripts/tests/ to sys.path so the helper module is reachable as
+# ``tests._mock_helpers``.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tests._mock_helpers import mock_sys_modules  # noqa: E402
+
+
+# ClientError needs a real exception class so `except ClientError` works in
+# the script under test. We define a minimal subclass that mirrors the
+# botocore ClientError signature (response dict + operation_name).
+class _FakeClientError(Exception):
+    def __init__(self, response: dict, operation_name: str = "Unknown"):
+        super().__init__(f"{operation_name}: {response}")
+        self.response = response
+        self.operation_name = operation_name
+
+
+_mock_botocore = MagicMock()
+_mock_botocore_exceptions = MagicMock()
+_mock_botocore_exceptions.ClientError = _FakeClientError
+_mock_botocore.exceptions = _mock_botocore_exceptions
+
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+
+
+with mock_sys_modules(
+    {
+        "boto3": MagicMock(),
+        "botocore": _mock_botocore,
+        "botocore.exceptions": _mock_botocore_exceptions,
+        "structlog": _mock_structlog,
+        "framework": MagicMock(),
+        "framework.logging": MagicMock(),
+    }
+):
+    import create_missing_twins_4446  # noqa: E402
+
+parse_flat_hash_key = create_missing_twins_4446.parse_flat_hash_key
+is_mislabel = create_missing_twins_4446.is_mislabel
+build_twin_key = create_missing_twins_4446.build_twin_key
+head_object_metadata_hash = create_missing_twins_4446.head_object_metadata_hash
+verify_twin = create_missing_twins_4446.verify_twin
+enumerate_mislabel_pairs = create_missing_twins_4446.enumerate_mislabel_pairs
+create_twin = create_missing_twins_4446.create_twin
+create_twins_for_county = create_missing_twins_4446.create_twins_for_county
+report_enumeration = create_missing_twins_4446.report_enumeration
+report_creation = create_missing_twins_4446.report_creation
+run_create = create_missing_twins_4446.run_create
+build_parser = create_missing_twins_4446.build_parser
+main = create_missing_twins_4446.main
+ClientError = create_missing_twins_4446.ClientError
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+
+HEX64_A = "a" * 64
+HEX64_B = "b" * 64
+HEX64_C = "c" * 64
+HEX64_D = "d" * 64
+
+
+# ---------------------------------------------------------------------------
+# parse_flat_hash_key
+# ---------------------------------------------------------------------------
+
+
+class TestParseFlatHashKey:
+    def test_valid_pdf(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{HEX64_A}.pdf")
+        assert result == {
+            "state": "ca",
+            "county": "orange",
+            "court": "superior_court",
+            "hash": HEX64_A,
+            "ext": "pdf",
+        }
+
+    def test_short_hash_returns_none(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'a' * 63}.pdf")
+        assert result is None
+
+    def test_uppercase_hash_returns_none(self) -> None:
+        result = parse_flat_hash_key(f"ca/orange/superior_court/raw/{'A' * 64}.pdf")
+        assert result is None
+
+    def test_date_partitioned_key_returns_none(self) -> None:
+        result = parse_flat_hash_key("ca/orange/superior_court/raw/2026/04/01/uuid.pdf")
+        assert result is None
+
+    def test_non_raw_path_returns_none(self) -> None:
+        result = parse_flat_hash_key(
+            f"ca/orange/superior_court/transcripts/{HEX64_A}.txt"
+        )
+        assert result is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert parse_flat_hash_key("") is None
+
+
+# ---------------------------------------------------------------------------
+# is_mislabel
+# ---------------------------------------------------------------------------
+
+
+class TestIsMislabel:
+    def test_matching_hashes_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_A) is False
+
+    def test_differing_hashes_is_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, HEX64_B) is True
+
+    def test_missing_metadata_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, None) is False
+
+    def test_empty_metadata_not_mislabel(self) -> None:
+        assert is_mislabel(HEX64_A, "") is False
+
+
+# ---------------------------------------------------------------------------
+# build_twin_key
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTwinKey:
+    def test_replaces_filename_hash_preserves_rest(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = build_twin_key(mislabel, HEX64_B)
+        assert twin == f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+
+    def test_preserves_extension_html(self) -> None:
+        mislabel = f"ca/santa_clara/superior_court/raw/{HEX64_A}.html"
+        twin = build_twin_key(mislabel, HEX64_C)
+        assert twin == f"ca/santa_clara/superior_court/raw/{HEX64_C}.html"
+
+    def test_preserves_court_segment(self) -> None:
+        mislabel = f"ca/los_angeles/some_court/raw/{HEX64_A}.docx"
+        twin = build_twin_key(mislabel, HEX64_D)
+        assert twin == f"ca/los_angeles/some_court/raw/{HEX64_D}.docx"
+
+    def test_returns_none_for_non_parseable(self) -> None:
+        # Date-partitioned legacy key — does not match KEY_PATTERN.
+        assert (
+            build_twin_key("ca/orange/superior_court/raw/2026/04/01/x.pdf", HEX64_A)
+            is None
+        )
+
+    def test_returns_none_for_empty(self) -> None:
+        assert build_twin_key("", HEX64_A) is None
+
+
+# ---------------------------------------------------------------------------
+# head_object_metadata_hash
+# ---------------------------------------------------------------------------
+
+
+class TestHeadObjectMetadataHash:
+    def test_returns_hash_when_present(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        assert head_object_metadata_hash(s3, "bucket", "key") == HEX64_A
+
+    def test_returns_none_when_metadata_missing(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {}}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_metadata_field_absent(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {}
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_object_404(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_returns_none_when_no_such_key(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey"}}, "HeadObject"
+        )
+        assert head_object_metadata_hash(s3, "bucket", "key") is None
+
+    def test_propagates_other_errors(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "HeadObject"
+        )
+        with pytest.raises(ClientError):
+            head_object_metadata_hash(s3, "bucket", "key")
+
+
+# ---------------------------------------------------------------------------
+# verify_twin
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTwin:
+    def test_valid_twin_returns_true(self) -> None:
+        # Twin filename hash == twin metadata hash → valid.
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_B}}
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is True
+
+    def test_missing_twin_returns_false(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is False
+
+    def test_invalid_twin_returns_false(self) -> None:
+        # Twin exists but its filename hash != its own metadata hash → invalid.
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_C}}
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is False
+
+    def test_twin_with_no_metadata_returns_false(self) -> None:
+        s3 = MagicMock()
+        s3.head_object.return_value = {"Metadata": {}}
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        assert verify_twin(s3, "bucket", twin_key) is False
+
+    def test_non_parseable_twin_returns_false(self) -> None:
+        s3 = MagicMock()
+        # No HEAD should occur for a key that doesn't even parse.
+        assert verify_twin(s3, "bucket", "garbage") is False
+        s3.head_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# enumerate_mislabel_pairs
+# ---------------------------------------------------------------------------
+
+
+def _mock_paginator(pages: list[list[dict[str, str]]]) -> MagicMock:
+    """Build a mock S3 paginator that yields *pages*, each a list of object
+    dicts with a "Key" field."""
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Contents": page} for page in pages]
+    return paginator
+
+
+class TestEnumerateMislabelPairs:
+    def test_no_objects_returns_empty(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[]])
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_correctly_labeled_skipped(self) -> None:
+        # filename == metadata: not a mislabel, no pair recorded.
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_A}}
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert result == {}
+
+    def test_mislabel_with_valid_twin_recorded(self) -> None:
+        mislabel_key = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel_key}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel_key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin_key:
+                # Twin's filename HEX64_B == metadata HEX64_B — valid.
+                return {"Metadata": {"content-hash": HEX64_B}}
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert "orange" in result
+        assert len(result["orange"]) == 1
+        record = result["orange"][0]
+        assert record["mislabel_key"] == mislabel_key
+        assert record["twin_key"] == twin_key
+        assert record["filename_hash"] == HEX64_A
+        assert record["metadata_hash"] == HEX64_B
+        assert record["twin_status"] == "valid"
+
+    def test_mislabel_with_missing_twin_recorded(self) -> None:
+        mislabel_key = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel_key}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel_key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin_key:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert len(result["orange"]) == 1
+        assert result["orange"][0]["twin_status"] == "missing"
+
+    def test_mislabel_with_invalid_twin_recorded(self) -> None:
+        # Twin exists but its metadata disagrees with its filename → invalid.
+        mislabel_key = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin_key = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel_key}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel_key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin_key:
+                # Twin claims content is HEX64_C, not HEX64_B — itself mislabeled.
+                return {"Metadata": {"content-hash": HEX64_C}}
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert result["orange"][0]["twin_status"] == "invalid"
+
+    def test_groups_by_county(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [
+                [
+                    {"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"},
+                    {"Key": f"ca/santa_clara/superior_court/raw/{HEX64_A}.pdf"},
+                ]
+            ]
+        )
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            # Every mislabel with metadata HEX64_B; every twin valid.
+            if HEX64_A in Key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if HEX64_B in Key:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            return {"Metadata": {}}
+
+        s3.head_object.side_effect = fake_head
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert sorted(result.keys()) == ["orange", "santa_clara"]
+
+    def test_skips_non_matching_shape(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [
+                [
+                    {"Key": "ca/orange/superior_court/raw/2026/04/01/x.pdf"},
+                    {"Key": "court_directory/snapshot.json"},
+                ]
+            ]
+        )
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert result == {}
+        s3.head_object.assert_not_called()
+
+    def test_skips_objects_with_missing_metadata(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator(
+            [[{"Key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf"}]]
+        )
+        s3.head_object.return_value = {"Metadata": {}}
+        result = enumerate_mislabel_pairs(s3, "bucket", "ca/")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# create_twin
+# ---------------------------------------------------------------------------
+
+
+def _missing_pair() -> dict[str, str]:
+    return {
+        "mislabel_key": f"ca/orange/superior_court/raw/{HEX64_A}.pdf",
+        "twin_key": f"ca/orange/superior_court/raw/{HEX64_B}.pdf",
+        "filename_hash": HEX64_A,
+        "metadata_hash": HEX64_B,
+        "twin_status": "missing",
+    }
+
+
+class TestCreateTwin:
+    def test_skipped_for_non_missing_status(self) -> None:
+        s3 = MagicMock()
+        pair = dict(_missing_pair())
+        pair["twin_status"] = "valid"
+        assert create_twin(s3, "bucket", pair) == "skipped_non_missing"
+        s3.head_object.assert_not_called()
+        s3.copy_object.assert_not_called()
+
+    def test_happy_path_creates_and_verifies(self) -> None:
+        # Pre-HEAD: 404 (missing). copy_object: succeeds. Post-HEAD: matches.
+        s3 = MagicMock()
+        pair = _missing_pair()
+
+        head_calls = {"n": 0}
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls["n"] += 1
+            if head_calls["n"] == 1:
+                # Pre-HEAD: twin is missing.
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            # Post-HEAD: new twin is correctly-labelled.
+            return {"Metadata": {"content-hash": HEX64_B}}
+
+        s3.head_object.side_effect = fake_head
+        result = create_twin(s3, "bucket", pair)
+        assert result == "created"
+        s3.copy_object.assert_called_once_with(
+            Bucket="bucket",
+            CopySource={"Bucket": "bucket", "Key": pair["mislabel_key"]},
+            Key=pair["twin_key"],
+        )
+        assert s3.head_object.call_count == 2
+
+    def test_already_exists_skips_copy(self) -> None:
+        # Pre-HEAD: twin exists AND is correctly-labelled — idempotent skip.
+        s3 = MagicMock()
+        pair = _missing_pair()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_B}}
+        result = create_twin(s3, "bucket", pair)
+        assert result == "already_exists"
+        s3.copy_object.assert_not_called()
+        # Only the pre-HEAD ran.
+        assert s3.head_object.call_count == 1
+
+    def test_collision_skipped_when_twin_mislabeled(self) -> None:
+        # Pre-HEAD: twin exists but metadata != filename → another mislabel.
+        s3 = MagicMock()
+        pair = _missing_pair()
+        s3.head_object.return_value = {"Metadata": {"content-hash": HEX64_C}}
+        result = create_twin(s3, "bucket", pair)
+        assert result == "collision_skipped"
+        s3.copy_object.assert_not_called()
+
+    def test_verify_failed_when_post_head_mismatch(self) -> None:
+        # Pre-HEAD: 404. copy_object: succeeds. Post-HEAD: returns wrong hash.
+        s3 = MagicMock()
+        pair = _missing_pair()
+
+        head_calls = {"n": 0}
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls["n"] += 1
+            if head_calls["n"] == 1:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            # Post-HEAD: bytes ended up labelled wrong somehow.
+            return {"Metadata": {"content-hash": HEX64_C}}
+
+        s3.head_object.side_effect = fake_head
+        result = create_twin(s3, "bucket", pair)
+        assert result == "verify_failed"
+        s3.copy_object.assert_called_once()
+
+    def test_verify_failed_when_post_head_missing(self) -> None:
+        # Pre-HEAD: 404. copy_object: succeeds. Post-HEAD: also 404 (eventual
+        # consistency / something deleted it). Treat as verify_failed.
+        s3 = MagicMock()
+        pair = _missing_pair()
+
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        result = create_twin(s3, "bucket", pair)
+        assert result == "verify_failed"
+        s3.copy_object.assert_called_once()
+
+    def test_error_when_copy_object_raises(self) -> None:
+        # Pre-HEAD: 404. copy_object: raises non-404 ClientError.
+        s3 = MagicMock()
+        pair = _missing_pair()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "404"}}, "HeadObject"
+        )
+        s3.copy_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "CopyObject"
+        )
+        result = create_twin(s3, "bucket", pair)
+        assert result == "error"
+
+    def test_error_when_pre_head_raises_non_404(self) -> None:
+        s3 = MagicMock()
+        pair = _missing_pair()
+        s3.head_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "HeadObject"
+        )
+        result = create_twin(s3, "bucket", pair)
+        assert result == "error"
+        s3.copy_object.assert_not_called()
+
+    def test_error_when_post_head_raises_non_404(self) -> None:
+        # Pre-HEAD: 404. copy_object: succeeds. Post-HEAD: raises AccessDenied.
+        s3 = MagicMock()
+        pair = _missing_pair()
+
+        head_calls = {"n": 0}
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls["n"] += 1
+            if head_calls["n"] == 1:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            raise ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject")
+
+        s3.head_object.side_effect = fake_head
+        result = create_twin(s3, "bucket", pair)
+        assert result == "error"
+        s3.copy_object.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# create_twins_for_county
+# ---------------------------------------------------------------------------
+
+
+class TestCreateTwinsForCounty:
+    def test_no_missing_pairs_returns_zero(self) -> None:
+        s3 = MagicMock()
+        pairs = [
+            {
+                "mislabel_key": "k1",
+                "twin_key": "k1t",
+                "filename_hash": HEX64_A,
+                "metadata_hash": HEX64_B,
+                "twin_status": "valid",
+            }
+        ]
+        result = create_twins_for_county(
+            s3, pairs, county="orange", bucket="b", dry_run=False
+        )
+        assert result["planned"] == 0
+        assert result["created"] == 0
+        assert result["skipped_valid"] == 1
+        s3.head_object.assert_not_called()
+        s3.copy_object.assert_not_called()
+
+    def test_dry_run_does_not_write(self) -> None:
+        s3 = MagicMock()
+        pairs = [
+            _missing_pair(),
+            {
+                "mislabel_key": "k2",
+                "twin_key": "k2t",
+                "filename_hash": HEX64_C,
+                "metadata_hash": HEX64_D,
+                "twin_status": "invalid",
+            },
+        ]
+        result = create_twins_for_county(
+            s3, pairs, county="orange", bucket="b", dry_run=True
+        )
+        assert result["planned"] == 1
+        assert result["created"] == 0
+        assert result["skipped_invalid"] == 1
+        s3.head_object.assert_not_called()
+        s3.copy_object.assert_not_called()
+
+    def test_apply_aggregates_counters(self) -> None:
+        # Build three missing pairs and walk them through three different
+        # outcomes via head_object/copy_object stubs:
+        #   pair1 → created (pre-404, copy ok, post-match)
+        #   pair2 → already_exists (pre-HEAD shows valid twin)
+        #   pair3 → verify_failed (pre-404, copy ok, post-mismatch)
+        s3 = MagicMock()
+
+        pair1 = {
+            "mislabel_key": "ca/orange/sc/raw/" + ("1" * 64) + ".pdf",
+            "twin_key": "ca/orange/sc/raw/" + ("2" * 64) + ".pdf",
+            "filename_hash": "1" * 64,
+            "metadata_hash": "2" * 64,
+            "twin_status": "missing",
+        }
+        pair2 = {
+            "mislabel_key": "ca/orange/sc/raw/" + ("3" * 64) + ".pdf",
+            "twin_key": "ca/orange/sc/raw/" + ("4" * 64) + ".pdf",
+            "filename_hash": "3" * 64,
+            "metadata_hash": "4" * 64,
+            "twin_status": "missing",
+        }
+        pair3 = {
+            "mislabel_key": "ca/orange/sc/raw/" + ("5" * 64) + ".pdf",
+            "twin_key": "ca/orange/sc/raw/" + ("6" * 64) + ".pdf",
+            "filename_hash": "5" * 64,
+            "metadata_hash": "6" * 64,
+            "twin_status": "missing",
+        }
+
+        # Track per-key call counts so post-HEAD differs from pre-HEAD.
+        head_calls: dict[str, int] = {}
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls[Key] = head_calls.get(Key, 0) + 1
+            n = head_calls[Key]
+            if Key == pair1["twin_key"]:
+                if n == 1:
+                    raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+                # Post-HEAD: correct.
+                return {"Metadata": {"content-hash": "2" * 64}}
+            if Key == pair2["twin_key"]:
+                # Pre-HEAD: twin already exists, correctly-labelled.
+                return {"Metadata": {"content-hash": "4" * 64}}
+            if Key == pair3["twin_key"]:
+                if n == 1:
+                    raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+                # Post-HEAD: filename != metadata (mismatch).
+                return {"Metadata": {"content-hash": "f" * 64}}
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+
+        result = create_twins_for_county(
+            s3, [pair1, pair2, pair3], county="orange", bucket="b", dry_run=False
+        )
+
+        assert result["planned"] == 3
+        assert result["created"] == 1
+        assert result["already_exists"] == 1
+        assert result["verify_failed"] == 1
+        assert result["errors"] == 0
+        assert result["collision_skipped"] == 0
+
+    def test_apply_aggregates_collision_and_error(self) -> None:
+        # Aggregator-level coverage for collision_skipped + errors counters.
+        s3 = MagicMock()
+
+        # Pair1 → collision_skipped (pre-HEAD shows mislabeled twin).
+        pair1 = {
+            "mislabel_key": "ca/orange/sc/raw/" + ("1" * 64) + ".pdf",
+            "twin_key": "ca/orange/sc/raw/" + ("2" * 64) + ".pdf",
+            "filename_hash": "1" * 64,
+            "metadata_hash": "2" * 64,
+            "twin_status": "missing",
+        }
+        # Pair2 → error (pre-HEAD raises non-404).
+        pair2 = {
+            "mislabel_key": "ca/orange/sc/raw/" + ("3" * 64) + ".pdf",
+            "twin_key": "ca/orange/sc/raw/" + ("4" * 64) + ".pdf",
+            "filename_hash": "3" * 64,
+            "metadata_hash": "4" * 64,
+            "twin_status": "missing",
+        }
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == pair1["twin_key"]:
+                # Pre-HEAD: twin exists but its metadata != filename.
+                return {"Metadata": {"content-hash": "f" * 64}}
+            if Key == pair2["twin_key"]:
+                raise ClientError({"Error": {"Code": "AccessDenied"}}, "HeadObject")
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+
+        result = create_twins_for_county(
+            s3, [pair1, pair2], county="orange", bucket="b", dry_run=False
+        )
+
+        assert result["planned"] == 2
+        assert result["collision_skipped"] == 1
+        assert result["errors"] == 1
+        assert result["created"] == 0
+        s3.copy_object.assert_not_called()
+
+    def test_dry_run_truncates_sample_log(self) -> None:
+        # Drive the SAMPLE_SIZE truncation log line in the dry-run branch.
+        s3 = MagicMock()
+        pairs = [
+            {
+                "mislabel_key": f"ca/orange/sc/raw/{format(i, 'x'):>064}.pdf",
+                "twin_key": f"ca/orange/sc/raw/{format(i + 1000, 'x'):>064}.pdf",
+                "filename_hash": format(i, "x").rjust(64, "0"),
+                "metadata_hash": format(i + 1000, "x").rjust(64, "0"),
+                "twin_status": "missing",
+            }
+            for i in range(25)  # > SAMPLE_SIZE (20) to trigger the truncate log.
+        ]
+        result = create_twins_for_county(
+            s3, pairs, county="orange", bucket="b", dry_run=True
+        )
+        assert result["planned"] == 25
+        assert result["created"] == 0
+        s3.copy_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_create orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestRunCreate:
+    def test_no_mislabels_returns_clean(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[]])
+        result = run_create(s3, bucket="b", state="ca", county=None, dry_run=True)
+        assert result["mislabels_found"] == 0
+        assert result["planned"] == 0
+        assert result["created"] == 0
+
+    def test_dry_run_with_missing_twin_plans_create(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        result = run_create(s3, bucket="b", state="ca", county=None, dry_run=True)
+        assert result["mislabels_found"] == 1
+        assert result["missing_twins"] == 1
+        assert result["planned"] == 1
+        assert result["created"] == 0
+        s3.copy_object.assert_not_called()
+
+    def test_county_scoping_uses_specific_prefix(self) -> None:
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[]])
+        run_create(s3, bucket="b", state="ca", county="orange", dry_run=True)
+        s3.get_paginator.return_value.paginate.assert_called_with(
+            Bucket="b", Prefix="ca/orange/"
+        )
+
+    def test_apply_happy_path_creates_twin(self) -> None:
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel}]])
+
+        # head_object call sequence:
+        #   1. enumerate: HEAD on mislabel → metadata = HEX64_B
+        #   2. enumerate: HEAD on twin → 404 (missing)
+        #   3. create_twin pre-HEAD on twin → 404 (still missing)
+        #   4. create_twin post-HEAD on twin → metadata = HEX64_B (verified)
+        head_calls: list[tuple[str, str]] = []
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls.append((Bucket, Key))
+            if Key == mislabel:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            # Twin: first two HEADs are missing; third HEAD is post-create
+            # verification — return correctly-labelled metadata.
+            twin_count = sum(1 for _, k in head_calls if k == twin)
+            if twin_count <= 2:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            return {"Metadata": {"content-hash": HEX64_B}}
+
+        s3.head_object.side_effect = fake_head
+        result = run_create(s3, bucket="b", state="ca", county=None, dry_run=False)
+        assert result["planned"] == 1
+        assert result["created"] == 1
+        assert result["errors"] == 0
+        assert result["verify_failed"] == 0
+        s3.copy_object.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_default_is_dry_run(self) -> None:
+        args = build_parser().parse_args([])
+        assert args.dry_run is True
+        assert args.apply is False
+
+    def test_apply_flag(self) -> None:
+        args = build_parser().parse_args(["--apply"])
+        assert args.apply is True
+
+    def test_county_flag(self) -> None:
+        args = build_parser().parse_args(["--county", "santa_clara"])
+        assert args.county == "santa_clara"
+
+    def test_state_default(self) -> None:
+        args = build_parser().parse_args([])
+        assert args.state == "ca"
+
+    def test_bucket_override(self) -> None:
+        args = build_parser().parse_args(["--bucket", "my-bucket"])
+        assert args.bucket == "my-bucket"
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_dry_run_returns_0(self) -> None:
+        with patch.object(create_missing_twins_4446, "boto3") as boto3_mock:
+            s3 = MagicMock()
+            s3.get_paginator.return_value = _mock_paginator([[]])
+            boto3_mock.client.return_value = s3
+            assert main(["--dry-run"]) == 0
+
+    def test_apply_with_errors_returns_1(self) -> None:
+        # One missing-twin pair where copy_object raises AccessDenied.
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel}]])
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            if Key == mislabel:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            if Key == twin:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            raise AssertionError(f"unexpected HEAD on {Key}")
+
+        s3.head_object.side_effect = fake_head
+        s3.copy_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied"}}, "CopyObject"
+        )
+
+        with patch.object(create_missing_twins_4446, "boto3") as boto3_mock:
+            boto3_mock.client.return_value = s3
+            assert main(["--apply"]) == 1
+
+    def test_apply_with_verify_failed_returns_1(self) -> None:
+        # One missing-twin pair: copy succeeds but post-HEAD shows mismatch.
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel}]])
+
+        head_calls: list[tuple[str, str]] = []
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls.append((Bucket, Key))
+            if Key == mislabel:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            twin_count = sum(1 for _, k in head_calls if k == twin)
+            if twin_count <= 2:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            # Post-HEAD: wrong metadata.
+            return {"Metadata": {"content-hash": HEX64_C}}
+
+        s3.head_object.side_effect = fake_head
+
+        with patch.object(create_missing_twins_4446, "boto3") as boto3_mock:
+            boto3_mock.client.return_value = s3
+            assert main(["--apply"]) == 1
+
+    def test_apply_happy_path_returns_0(self) -> None:
+        # One missing-twin pair: pre-404, copy ok, post-verified.
+        mislabel = f"ca/orange/superior_court/raw/{HEX64_A}.pdf"
+        twin = f"ca/orange/superior_court/raw/{HEX64_B}.pdf"
+        s3 = MagicMock()
+        s3.get_paginator.return_value = _mock_paginator([[{"Key": mislabel}]])
+
+        head_calls: list[tuple[str, str]] = []
+
+        def fake_head(*, Bucket: str, Key: str) -> dict:
+            head_calls.append((Bucket, Key))
+            if Key == mislabel:
+                return {"Metadata": {"content-hash": HEX64_B}}
+            twin_count = sum(1 for _, k in head_calls if k == twin)
+            if twin_count <= 2:
+                raise ClientError({"Error": {"Code": "404"}}, "HeadObject")
+            return {"Metadata": {"content-hash": HEX64_B}}
+
+        s3.head_object.side_effect = fake_head
+
+        with patch.object(create_missing_twins_4446, "boto3") as boto3_mock:
+            boto3_mock.client.return_value = s3
+            assert main(["--apply"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# report_enumeration / report_creation (smoke tests)
+# ---------------------------------------------------------------------------
+
+
+class TestReportEnumeration:
+    def test_returns_totals(self, capsys: pytest.CaptureFixture[str]) -> None:
+        by_county = {
+            "orange": [
+                {
+                    "mislabel_key": "k1",
+                    "twin_key": "k1t",
+                    "filename_hash": HEX64_A,
+                    "metadata_hash": HEX64_B,
+                    "twin_status": "valid",
+                },
+                {
+                    "mislabel_key": "k2",
+                    "twin_key": "k2t",
+                    "filename_hash": HEX64_C,
+                    "metadata_hash": HEX64_D,
+                    "twin_status": "missing",
+                },
+            ],
+            "santa_clara": [
+                {
+                    "mislabel_key": "k3",
+                    "twin_key": "k3t",
+                    "filename_hash": HEX64_A,
+                    "metadata_hash": HEX64_B,
+                    "twin_status": "invalid",
+                }
+            ],
+        }
+        totals = report_enumeration(by_county)
+        assert totals["total"] == 3
+        assert totals["valid"] == 1
+        assert totals["missing"] == 1
+        assert totals["invalid"] == 1
+        captured = capsys.readouterr()
+        assert "orange" in captured.out
+        assert "santa_clara" in captured.out
+        assert "TOTAL" in captured.out
+
+
+class TestReportCreation:
+    def test_aggregates_per_county(self, capsys: pytest.CaptureFixture[str]) -> None:
+        by_county_counters = {
+            "orange": {
+                "planned": 5,
+                "created": 4,
+                "already_exists": 1,
+                "collision_skipped": 0,
+                "verify_failed": 0,
+                "errors": 0,
+                "skipped_invalid": 0,
+                "skipped_valid": 0,
+            },
+            "santa_clara": {
+                "planned": 3,
+                "created": 2,
+                "already_exists": 0,
+                "collision_skipped": 0,
+                "verify_failed": 1,
+                "errors": 0,
+                "skipped_invalid": 0,
+                "skipped_valid": 0,
+            },
+        }
+        totals = report_creation(by_county_counters)
+        assert totals["planned"] == 8
+        assert totals["created"] == 6
+        assert totals["already_exists"] == 1
+        assert totals["verify_failed"] == 1
+        captured = capsys.readouterr()
+        assert "orange" in captured.out
+        assert "santa_clara" in captured.out
+        assert "TOTAL" in captured.out


### PR DESCRIPTION
## Summary

Implements **Path A** from issue #4446: a new ECS oneshot script `scripts/create_missing_twins_4446.py` that materialises the 970 missing twins by `s3.copy_object`-ing each missing-twin mislabel to its correctly-named twin location. `CopyObject`'s default `MetadataDirective: COPY` preserves the source `content-hash` metadata, so the resulting twin satisfies `filename hex64 == metadata content-hash` by construction. After this runs and `repoint_mislabeled_documents_4439.py --apply` finishes, the cleanup script `cleanup_mislabeled_s3_2661.py` (unchanged) can complete (#2661).

Closes #4446

## Design notes

- **Two-pass design** (mirrors `repoint_mislabeled_documents_4439.py`): enumerate mislabels + classify `twin_status` as `valid`/`missing`/`invalid`, then for each `missing` pair pre-HEAD (idempotence + collision detection) → `s3.copy_object` → post-HEAD verification.
- **Per-county counters**: `created`, `already_exists` (idempotent re-run skip), `collision_skipped` (twin slot occupied by sibling mislabel), `verify_failed` (post-HEAD mismatch), `errors` (non-404 ClientError). Apply mode exits 1 when `errors > 0` OR `verify_failed > 0`.
- **No DB connection** — explicitly does not import psycopg. The companion repoint script handles DB repoints after twins are materialised.
- **No changes to `cleanup_mislabeled_s3_2661.py`** — Path A's invariant matches the cleanup script's existing DB-safety check.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh scripts/create_missing_twins_4446.py -- --dry-run --county santa_clara` on dev — confirm enumeration matches the issue's table (75 missing-twins for santa_clara). **Verified live: enumeration returned `190 mislabel(s) — 115 valid twin(s), 75 missing, 0 invalid` (exact match).**
- [ ] Run `scripts/ecs-run-task.sh scripts/create_missing_twins_4446.py -- --apply --county santa_clara` on dev — confirm `created` counter ~75 and `errors`/`verify_failed` are 0. *(Operator-driven follow-on — commits 75 CopyObject calls; not autonomous /task scope.)*
- [ ] Run `scripts/ecs-run-task.sh scripts/repoint_mislabeled_documents_4439.py -- --apply --county santa_clara` on dev — confirm DB rows now point at twins. *(Operator-driven follow-on after the --apply step above.)*
- [ ] Run `scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --dry-run --county santa_clara` on dev — confirm output reports `DB safety check: 0 mislabeled key(s) still referenced`. *(Operator-driven follow-on after the chain completes.)*
- [x] Verification evidence posted on issue #4446 (see A.8). Live dry-run output captured in the issue comment.

Note: orange (518) + riverside (377) missing-twin runs are operator-driven follow-ons after santa_clara validates the chain.
