### PR TITLE
refactor(scripts): migrate create_missing_twins_4446.py to framework.s3_keys helpers (#4455)

### DIFF
--- a/scripts/create_missing_twins_4446.py
+++ b/scripts/create_missing_twins_4446.py
@@ -100,7 +100,6 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import re
 import sys
 from collections import defaultdict
 from collections.abc import Iterable
@@ -109,6 +108,12 @@ import boto3
 from botocore.exceptions import ClientError
 
 from framework.logging import configure_structlog
+from framework.s3_keys import (
+    build_twin_key,
+    head_object_metadata_hash,
+    is_mislabel,
+    parse_flat_hash_key,
+)
 
 # Canonical stdout/CloudWatch logger pattern (#4368/#4373).  Routes
 # stdlib ``logging.getLogger(__name__)`` calls through structlog's
@@ -123,96 +128,22 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
 
-# Matches content-addressed flat-hash keys: ca/{county}/{court}/raw/{hex64}.{ext}.
-# Captures county and the filename hash so the enumerate pass can group results
-# and build the twin key without re-parsing.
-KEY_PATTERN = re.compile(
-    r"^(?P<state>[a-z]{2})/(?P<county>[^/]+)/(?P<court>[^/]+)/raw/(?P<hash>[0-9a-f]{64})\.(?P<ext>\w+)$"
-)
-
 # Sample size to log per county before truncating.
 SAMPLE_SIZE = 20
 
 
 # ---------------------------------------------------------------------------
-# Pure helpers (unit-tested)
-# ---------------------------------------------------------------------------
-
-
-def parse_flat_hash_key(key: str) -> dict[str, str] | None:
-    """Parse a flat-hash content-addressed key.
-
-    Returns a dict with keys ``state``, ``county``, ``court``, ``hash``,
-    ``ext`` on match, or ``None`` if the key does not match the expected
-    shape.
-
-    Anything that does not match (e.g. date-partitioned legacy keys,
-    court_directory snapshots, non-raw paths) is silently skipped.
-
-    NOTE: this duplicates the helper in
-    ``repoint_mislabeled_documents_4439.py`` and
-    ``cleanup_mislabeled_s3_2661.py`` deliberately. ECS oneshot scripts
-    cannot import from other ``scripts/*.py`` files (per CLAUDE.md /
-    docs/agent/code-standards.md), so the small parser is copied rather
-    than shared.
-    """
-    m = KEY_PATTERN.match(key)
-    if m is None:
-        return None
-    return dict(m.groupdict())
-
-
-def is_mislabel(filename_hash: str, metadata_hash: str | None) -> bool:
-    """Return True if *filename_hash* differs from *metadata_hash*.
-
-    A missing metadata hash (``None`` or empty) does **not** count as a
-    mislabel — that is a separate problem class handled by
-    ``audit_s3_raw_mislabels.py``.
-    """
-    if not metadata_hash:
-        return False
-    return filename_hash != metadata_hash
-
-
-def build_twin_key(mislabel_key: str, metadata_hash: str) -> str | None:
-    """Build the correctly-named twin key for *mislabel_key*.
-
-    The twin key reuses the same ``state/county/court/raw/`` prefix and
-    file extension but replaces the filename hash with *metadata_hash* —
-    i.e. the location at which a correctly-named copy of the same bytes
-    would live.
-
-    Returns ``None`` if *mislabel_key* doesn't parse.
-    """
-    parsed = parse_flat_hash_key(mislabel_key)
-    if parsed is None:
-        return None
-    return (
-        f"{parsed['state']}/{parsed['county']}/{parsed['court']}/raw/"
-        f"{metadata_hash}.{parsed['ext']}"
-    )
-
-
-# ---------------------------------------------------------------------------
 # S3 enumeration
 # ---------------------------------------------------------------------------
-
-
-def head_object_metadata_hash(s3_client: object, bucket: str, key: str) -> str | None:
-    """Return the metadata ``content-hash`` for *key*, or ``None`` if missing.
-
-    Returns ``None`` for both a missing metadata field AND a 404 — callers
-    must treat both as "not a mislabel" / "no twin available."
-    """
-    try:
-        head = s3_client.head_object(Bucket=bucket, Key=key)
-    except ClientError as exc:
-        code = exc.response.get("Error", {}).get("Code", "")
-        if code in ("404", "NoSuchKey", "NotFound"):
-            return None
-        raise
-    metadata: dict[str, str] = head.get("Metadata", {}) or {}
-    return metadata.get("content-hash") or None
+#
+# ``parse_flat_hash_key``, ``is_mislabel``, ``head_object_metadata_hash``,
+# and ``build_twin_key`` (and the underlying ``KEY_PATTERN`` regex) are
+# imported from ``framework.s3_keys`` (see #4447). The ``framework.*``
+# imports are reachable inside the ECS oneshot container because the
+# helpers are bundled into the scraper-framework Docker image — same
+# precedent as the ``framework.logging`` import above. ``verify_twin``
+# stays inline as a thin wrapper that composes the framework helpers
+# (#4455).
 
 
 def verify_twin(s3_client: object, bucket: str, twin_key: str) -> bool:

--- a/scripts/tests/test_create_missing_twins_4446.py
+++ b/scripts/tests/test_create_missing_twins_4446.py
@@ -2,9 +2,13 @@
 
 Tests cover:
 - parse_flat_hash_key for valid, malformed, edge-case keys
+  (re-exported from ``framework.s3_keys`` after #4447 / #4455)
 - is_mislabel for matching/mismatching/missing-metadata cases
+  (re-exported from ``framework.s3_keys`` after #4447 / #4455)
 - build_twin_key for valid + non-parseable inputs
+  (re-exported from ``framework.s3_keys`` after #4447 / #4455)
 - head_object_metadata_hash with mocked S3 client (200, 404, missing field)
+  (re-exported from ``framework.s3_keys`` after #4447 / #4455)
 - verify_twin: valid, missing, invalid twin
 - enumerate_mislabel_pairs end-to-end with mocked paginator + HEAD
   (records valid/missing/invalid twin states)
@@ -21,10 +25,19 @@ may not be installed in the CI ``scripts-tests`` environment. We use
 #4430) to inject MagicMocks into sys.modules around the import — the
 helper restores sys.modules on exit so other tests in the same pytest run
 don't see the leaked mocks (#4426).
+
+After #4455, the small pure helpers (``parse_flat_hash_key``,
+``is_mislabel``, ``head_object_metadata_hash``, ``build_twin_key``,
+``KEY_PATTERN``) live in ``framework.s3_keys``. We load that real module
+via ``importlib`` from its source path inside the mock_sys_modules block
+so the script imports the genuine implementation rather than a MagicMock
+attribute. Mirrors the recipe in
+``test_repoint_mislabeled_documents_4439.py`` (#4447).
 """
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -58,6 +71,30 @@ _mock_structlog = MagicMock()
 _mock_structlog.get_logger.return_value = MagicMock()
 
 
+def _load_real_s3_keys() -> object:
+    """Load ``framework.s3_keys`` from source so the script-under-test
+    imports the real helpers, not a MagicMock attribute. Pure Python over
+    ``re`` and ``botocore.exceptions.ClientError``; invoked INSIDE the
+    ``mock_sys_modules`` block so s3_keys' import of ``ClientError``
+    resolves to ``_FakeClientError`` — keeping the ``except ClientError``
+    branch reachable from tests that raise ``_FakeClientError``."""
+    s3_keys_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "packages",
+        "scraper-framework",
+        "src",
+        "framework",
+        "s3_keys.py",
+    )
+    spec = importlib.util.spec_from_file_location("framework.s3_keys", s3_keys_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 with mock_sys_modules(
     {
         "boto3": MagicMock(),
@@ -66,8 +103,19 @@ with mock_sys_modules(
         "structlog": _mock_structlog,
         "framework": MagicMock(),
         "framework.logging": MagicMock(),
+        # Placeholder — replaced below with the real loaded module so the
+        # ``mock_sys_modules`` restore path cleans it up on exit.
+        "framework.s3_keys": MagicMock(),
     }
 ):
+    # Replace the placeholder with the genuine ``framework.s3_keys`` module
+    # loaded via importlib. The load happens INSIDE the mock context so the
+    # ``from botocore.exceptions import ClientError`` inside s3_keys.py
+    # resolves to ``_FakeClientError`` — keeping the ``except ClientError``
+    # branch reachable from tests that raise ``_FakeClientError``.
+    import sys as _sys
+
+    _sys.modules["framework.s3_keys"] = _load_real_s3_keys()
     import create_missing_twins_4446  # noqa: E402
 
 parse_flat_hash_key = create_missing_twins_4446.parse_flat_hash_key


### PR DESCRIPTION
## Summary

Migrate `scripts/create_missing_twins_4446.py` to import `parse_flat_hash_key`, `is_mislabel`, `build_twin_key`, `head_object_metadata_hash`, and `KEY_PATTERN` from `framework.s3_keys` instead of duplicating them inline — the same migration PR #4447 applied to `scripts/repoint_mislabeled_documents_4439.py`. `verify_twin` stays inline as a thin wrapper composing the framework helpers (option b in the AC), matching the precedent script's choice and keeping the framework module's API surface narrow.

The test file's `mock_sys_modules` block is updated to mock `framework.s3_keys` and load the real module via `importlib` from its source path, so the script-under-test exercises the genuine helpers rather than MagicMock attributes — same recipe as `test_repoint_mislabeled_documents_4439.py:72-117`.

Net diff: -84 / +63 lines.

Closes #4455

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (refactor of an ECS oneshot script; behavior unchanged. Existing tests are the regression gate; the script itself is invoked manually via `scripts/ecs-run-task.sh` when twin creation is needed and is not on a deploy pipeline.)
