### PR TITLE
fix(scraping): handle CourtListener docket.court URL query string (#4310)

### DIFF
--- a/packages/scraper-framework/src/courts/federal/courtlistener.py
+++ b/packages/scraper-framework/src/courts/federal/courtlistener.py
@@ -586,8 +586,12 @@ class CourtListenerScraper(BaseScraper):
 
         # Extract court identifier — prefer the resolved docket sub-resource
         # because cluster.court is empty in every CourtListener API response
-        # we capture today (#4247).  Fall back to cluster.court for
-        # backward compatibility with old envelopes / future API shapes.
+        # we capture today (#4247).  ``_resolve_court_id`` reads
+        # ``docket.court_id`` (the bare short-id) first, then parses the URL
+        # form in ``docket.court`` -- which contains a ``?format=json``
+        # query string and previously produced ``?format=json`` as the
+        # court id (#4310).  Falls back to cluster fields for backward
+        # compatibility with old envelopes / future API shapes.
         court_id = _resolve_court_id(cluster, docket)
 
         # Resolve jurisdiction from court_id mapping.
@@ -644,33 +648,55 @@ def _resolve_court_id(
 ) -> str:
     """Resolve the CourtListener court short-id from a cluster + docket pair.
 
-    Resolution order (#4247):
-      1. ``docket.court`` if the docket sub-resource is present and the field is truthy.
-      2. ``cluster.court`` as backward-compat fallback.
+    Resolution order (#4247, expanded by #4310):
+      1. ``docket.court_id`` -- the canonical bare short-id on the resolved docket.
+      2. ``docket.court`` -- a URL pointing at the court resource, parsed for the short-id.
+      3. ``cluster.court_id`` -- fallback for envelopes lacking a docket sub-resource.
+      4. ``cluster.court`` -- backward-compat fallback (typically empty in real responses).
 
-    The "court" field is typically a URL path like ``/api/rest/v4/courts/scotus/``;
-    the short-id is extracted from the last path segment.  Bare short-ids
-    (no slashes) are returned verbatim.
+    On real CourtListener responses, ``docket.court`` is a full URL with a
+    query string -- e.g. ``https://www.courtlistener.com/api/rest/v4/courts/dcd/?format=json``
+    -- not the relative path ``/api/rest/v4/courts/dcd/`` the previous parser
+    expected. The previous implementation produced ``?format=json`` as the
+    "court id" for every doc and every CourtListener capture landed in
+    ``(Unknown, Unknown)`` jurisdiction (#4310). Reading ``docket.court_id``
+    directly avoids URL parsing entirely; the URL-parser path remains as a
+    fallback for older responses that omit ``court_id``.
 
-    Returns an empty string when neither source has a usable reference.
+    The "court" URL parser:
+      * strips any ``?...`` query string before splitting,
+      * handles trailing-slash and no-trailing-slash variants,
+      * returns the bare short-id (last path segment).
+
+    Bare short-ids (no slashes) are returned verbatim, which matches what
+    ``court_id`` already returns on most modern responses.
+
+    Returns an empty string when no source has a usable reference.
     The caller decides what to do on empty (today: fall back to config defaults).
 
     Why docket-first: ``cluster.court`` is empty in every CourtListener API
     response we capture today, so reading it first produces Federal/Federal
-    misclassification on every doc.  ``docket.court`` is reliably populated
-    on the resolved docket sub-resource.
+    misclassification on every doc. The docket sub-resource is reliably
+    populated.
     """
     candidates: list[str] = []
     if docket:
+        # Prefer the bare short-id when available; the URL form is a fallback.
+        candidates.append(str(docket.get("court_id") or ""))
         candidates.append(str(docket.get("court") or ""))
+    candidates.append(str(cluster.get("court_id") or ""))
     candidates.append(str(cluster.get("court") or ""))
     for raw in candidates:
         if not raw:
             continue
-        if "/" in raw:
-            parts = raw.rstrip("/").split("/")
+        # Strip any ?... query string before path-splitting -- real responses
+        # ship URLs like ``.../courts/dcd/?format=json`` and the previous
+        # implementation emitted ``?format=json`` as the court id (#4310).
+        without_query = raw.split("?", 1)[0]
+        if "/" in without_query:
+            parts = without_query.rstrip("/").split("/")
             return parts[-1] if parts and parts[-1] else raw
-        return raw
+        return without_query
     return ""
 
 

--- a/packages/scraper-framework/tests/courts/test_courtlistener.py
+++ b/packages/scraper-framework/tests/courts/test_courtlistener.py
@@ -536,6 +536,49 @@ class TestDataMapping:
         assert _resolve_court_id({"court": ""}, {"court": "texapp14"}) == "texapp14"
         assert _resolve_court_id({"court": "scotus"}, None) == "scotus"
 
+    def test_resolve_court_id_handles_full_url_with_query_string(self) -> None:
+        """Regression for #4310: docket.court is a full URL with ?format=json
+        query string (e.g. ``https://www.courtlistener.com/api/rest/v4/courts/dcd/?format=json``).
+
+        The previous implementation split the raw URL on ``/`` and took the last
+        segment, which produced ``?format=json`` — every CourtListener doc landed
+        in ``(Unknown, Unknown)`` jurisdiction.
+
+        The fix must extract ``dcd`` (the court short-id) from the URL even
+        when a query string is present.
+        """
+        cluster = {"court": None}
+        docket = {"court": "https://www.courtlistener.com/api/rest/v4/courts/dcd/?format=json"}
+        assert _resolve_court_id(cluster, docket) == "dcd"
+
+    def test_resolve_court_id_prefers_docket_court_id_short_form(self) -> None:
+        """#4310: docket.court_id is the canonical bare short-id, prefer it
+        over the URL form in docket.court when both are present.
+
+        On real CourtListener responses, ``docket.court`` is the URL
+        ``https://www.courtlistener.com/api/rest/v4/courts/dcd/?format=json``
+        and ``docket.court_id`` is the bare short-id ``"dcd"``. Reading
+        ``court_id`` directly avoids URL parsing entirely.
+        """
+        cluster = {"court": None}
+        docket = {
+            "court": "https://www.courtlistener.com/api/rest/v4/courts/dcd/?format=json",
+            "court_id": "dcd",
+        }
+        assert _resolve_court_id(cluster, docket) == "dcd"
+
+    def test_resolve_court_id_handles_full_url_without_trailing_slash(self) -> None:
+        """Belt-and-suspenders: a URL that omits the trailing slash before
+        the query string still yields the right short-id."""
+        cluster = {"court": None}
+        docket = {"court": "https://www.courtlistener.com/api/rest/v4/courts/scotus?format=json"}
+        assert _resolve_court_id(cluster, docket) == "scotus"
+
+    def test_resolve_court_id_falls_back_to_cluster_court_id(self) -> None:
+        """When docket is absent, cluster.court_id is preferred over cluster.court."""
+        cluster = {"court": None, "court_id": "ca9"}
+        assert _resolve_court_id(cluster, None) == "ca9"
+
     def test_extract_docket_number(self) -> None:
         """Extract docket number from cluster."""
         cluster = _make_cluster(docket_number="22-1234")

--- a/scripts/audit_scraper_field_population.py
+++ b/scripts/audit_scraper_field_population.py
@@ -145,11 +145,15 @@ REGISTRY: tuple[ScraperFieldSpec, ...] = (
     ScraperFieldSpec(
         scraper_id="federal-courtlistener-opinions",
         envelope_format="json",
-        field_paths=("docket.court",),
+        field_paths=("docket.court_id",),
         rationale=(
-            "docket.court is the canonical jurisdiction signal after "
-            "#4247.  cluster.court (the previous source-of-truth) is "
-            "empty in every CourtListener API response we capture."
+            "docket.court_id is the canonical bare short-id (e.g. "
+            "'dcd', 'scotus', 'texapp1') after #4247 / #4310. "
+            "cluster.court / cluster.court_id are empty in every "
+            "CourtListener API response we capture; docket.court is a "
+            "URL with a ?format=json query string and previously parsed "
+            "to '?format=json' (#4310).  docket.court_id is the bare "
+            "short-id directly and avoids URL parsing entirely."
         ),
     ),
     ScraperFieldSpec(
@@ -475,7 +479,7 @@ def synthetic_drift_result() -> AuditResult:
     assert spec is not None, "registry must contain courtlistener"
     drifted = FieldResult(
         scraper_id=spec.scraper_id,
-        field_path="docket.court",
+        field_path="docket.court_id",
         populated=0,
         sampled=10,
         sample_keys=[

--- a/scripts/tests/test_audit_scraper_field_population.py
+++ b/scripts/tests/test_audit_scraper_field_population.py
@@ -79,8 +79,12 @@ class TestRegistry:
     def test_courtlistener_is_registered(self) -> None:
         spec = get_spec("federal-courtlistener-opinions")
         assert spec is not None
-        # Per #4247: docket.court is the canonical jurisdiction signal.
-        assert "docket.court" in spec.field_paths
+        # Per #4310: docket.court_id is the canonical bare short-id.  docket.court
+        # is a URL with a ?format=json query string and was previously the
+        # registered field, but parsing it produced "?format=json" as the court
+        # id (#4310).  docket.court_id is the bare short-id directly and avoids
+        # URL parsing entirely.
+        assert "docket.court_id" in spec.field_paths
 
     def test_sf_civil_is_registered(self) -> None:
         spec = get_spec("ca-sf-civil-tentatives")
@@ -280,14 +284,16 @@ class TestAuditOneScraper:
         assert skip["reason"] == "no_sample_keys"
 
     def test_drift_when_field_empty_in_all_samples(self) -> None:
-        """The motivating bug class: docket.court empty in 10/10 samples."""
+        """The motivating bug class (#4247 / #4310): docket.court_id empty
+        in 10/10 samples.  Now keyed on docket.court_id (the bare short-id)
+        rather than docket.court (the URL form) -- see #4310."""
         keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
-        # Simulates the #4247 scenario: cluster present, docket missing court.
+        # Simulates the #4310 scenario: docket present but court_id empty.
         envelopes = {
             k: {
                 "cluster": {"id": i, "case_name": "X v. Y"},
                 "opinion": {"id": i, "plain_text": "text"},
-                "docket": {"id": i, "court": ""},  # empty -- the bug!
+                "docket": {"id": i, "court_id": ""},  # empty -- the bug!
             }
             for i, k in enumerate(keys)
         }
@@ -312,7 +318,7 @@ class TestAuditOneScraper:
         assert skip is None
         assert len(results) == 1
         assert results[0].scraper_id == "federal-courtlistener-opinions"
-        assert results[0].field_path == "docket.court"
+        assert results[0].field_path == "docket.court_id"
         assert results[0].populated == 0
         assert results[0].sampled == 10
         assert results[0].drifted is True
@@ -320,14 +326,14 @@ class TestAuditOneScraper:
     def test_healthy_when_field_populated_in_at_least_one(self) -> None:
         """1/N populated is enough to clear -- the audit's floor is 'at least one'."""
         keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
-        # Only one sample has docket.court populated; the audit clears.
+        # Only one sample has docket.court_id populated; the audit clears.
         envelopes = {}
         for i, k in enumerate(keys):
-            court = "ca9" if i == 0 else ""
+            court_id = "ca9" if i == 0 else ""
             envelopes[k] = {
                 "cluster": {},
                 "opinion": {},
-                "docket": {"court": court},
+                "docket": {"court_id": court_id},
             }
         conn = _make_conn(
             {"federal-courtlistener-opinions": 100},
@@ -358,7 +364,7 @@ class TestAuditOneScraper:
         keys = ["k1", "k2", "k3"]
         envelopes = {
             "k1": b"not json at all",  # parse fail
-            "k2": {"docket": {"court": "ca9"}},  # OK
+            "k2": {"docket": {"court_id": "ca9"}},  # OK
             "k3": b"[1, 2, 3]",  # JSON but not a dict
         }
         conn = _make_conn(
@@ -454,11 +460,11 @@ class TestRunAudit:
 
 class TestSyntheticDriftResult:
     def test_synthetic_is_unhealthy(self) -> None:
-        """The synthetic scenario simulates the #4247 bug class."""
+        """The synthetic scenario simulates the #4247 / #4310 bug class."""
         result = synthetic_drift_result()
         assert result.healthy is False
         assert result.drift_count == 1
-        assert result.field_results[0].field_path == "docket.court"
+        assert result.field_results[0].field_path == "docket.court_id"
         assert result.field_results[0].drifted is True
 
 
@@ -472,7 +478,7 @@ class TestBuildIssueBody:
         result = synthetic_drift_result()
         body = build_issue_body(result)
         assert "federal-courtlistener-opinions" in body
-        assert "docket.court" in body
+        assert "docket.court_id" in body
         # Markdown table delimiter present.
         assert "| Scraper |" in body
 
@@ -503,7 +509,7 @@ class TestMainDryRun:
         assert out.exists()
         text = out.read_text()
         assert "Scraper Field-Mapping Drift Alert" in text
-        assert "docket.court" in text
+        assert "docket.court_id" in text
 
     def test_dry_run_returns_1_when_unhealthy(self) -> None:
         rc = _script.main(["--dry-run"])


### PR DESCRIPTION
## Summary

`docket.court` is a full URL with a `?format=json` query string — not the relative path the previous parser expected — so every CourtListener doc resolved to court_id `'?format=json'` and landed in `(Unknown, Unknown)` jurisdiction. CloudWatch confirms 198/198 occurrences of the resulting `Unknown CourtListener court_id` warning in the most recent run. Fix `_resolve_court_id` to prefer the bare `docket.court_id` short-id, strip the query string when parsing the URL form, and update the audit registry to track `docket.court_id` (the more stable canonical field).

Closes #4310

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (4 new regression tests in `test_courtlistener.py`; audit-script test updates)
- [x] CI green

### Post-deploy verification
- [x] After `deploy-scraper.yml` runs, monitor `/ecs/judgemind-scraper-dev` for absence of `Unknown CourtListener court_id — courtlistener_court_id='?format=json'` warnings on the next CourtListener scraper run
- [x] Verify a fresh CourtListener capture's envelope now contains the `docket` key with populated `docket.court_id` (e.g. `'ca6'`) — verified via S3 sample after one-off scraper run
- [x] Verification evidence posted on issue (see comment on #4310)
