### PR TITLE
fix(dx): strip line-range suffixes in check-shipped-pr extractor (#4462)

### DIFF
--- a/scripts/_check_shipped_pr_extract_files.py
+++ b/scripts/_check_shipped_pr_extract_files.py
@@ -63,6 +63,15 @@ PATH_REGEX = re.compile(r"(?:scripts/|packages/|docs/|infra/|\.github/)[^\s\]\)`
 # often follows an inline file reference but is not part of the path).
 TRAILING_STRIP = ".,:;"
 
+# Strip a trailing line-range suffix like ``:47`` or ``:47-62`` from a hit
+# (#4462). Issue bodies frequently cite a file with a line range to point
+# at a specific block — e.g. ``packages/foo/bar.py:132-141`` — but the
+# downstream ``gh api /repos/.../commits?path=<path>`` query rejects line
+# ranges. Stripping the suffix collapses ``foo.py:132-141`` and ``foo.py``
+# into a single deduped path so the overlap helper sees one canonical
+# candidate.
+LINE_RANGE_SUFFIX_RE = re.compile(r":[0-9]+(?:-[0-9]+)?$")
+
 # Search-context detector. A line is search-context if it carries a
 # ``Verify:`` marker OR a shell-invocation verb followed by a space.
 # The verbs listed cover the conventional shapes the AC author uses to
@@ -156,6 +165,14 @@ def _path_hits_per_line(line: str) -> list[str]:
         # Strip trailing punctuation
         while path and path[-1] in TRAILING_STRIP:
             path = path[:-1]
+        # Strip trailing line-range suffix (#4462). Run AFTER the
+        # punctuation strip so a cite like ``foo.py:47-62.`` (with a
+        # trailing sentence period) loses the ``.`` first, then loses
+        # the ``:47-62``. A second punctuation pass after the line-
+        # range strip is unnecessary because ``LINE_RANGE_SUFFIX_RE``
+        # is anchored at end-of-string and does not consume trailing
+        # punctuation.
+        path = LINE_RANGE_SUFFIX_RE.sub("", path)
         if "*" in path or "?" in path:
             continue
         if path.endswith("/"):

--- a/scripts/tests/test_check_shipped_pr_extract_files.py
+++ b/scripts/tests/test_check_shipped_pr_extract_files.py
@@ -311,3 +311,108 @@ def test_classify_files_path_in_both_promotes_to_target(extract_module):
     target, search = extract_module.classify_files(body)
     assert target == ["scripts/foo.sh"]
     assert search == []
+
+
+# ─── Line-range suffix stripping (issue #4462) ────────────────────────
+
+
+def test_line_range_suffix_stripped_dedupes_with_bare_path(extract_module):
+    """Issue bodies often cite a file both with a line range
+    (``foo.py:47-62``) and bare (``foo.py``). The downstream
+    ``gh api /repos/.../commits?path=<path>`` query rejects line ranges,
+    so the line-ranged variant resolves to no commits and the threshold
+    is unreachable. Strip the trailing ``:N`` / ``:N-M`` suffix BEFORE
+    dedupe so both cite forms collapse to one canonical entry.
+
+    Regression for #4462. Canonical case from issue #3310 — body cited
+    ``infra/terraform/modules/iam_agent/main.tf:47-62`` and
+    ``infra/terraform/modules/iam_agent/main.tf:132-141`` in narrative
+    plus the bare path in a fenced block; pre-fix the extractor emitted
+    three separate entries.
+    """
+    body = (
+        "see infra/terraform/foo/main.tf:47-62 and "
+        "infra/terraform/foo/main.tf for the fix"
+    )
+    out = extract_module.extract_files(body)
+    assert out == ["infra/terraform/foo/main.tf"]
+
+
+def test_line_range_suffix_single_line_stripped(extract_module):
+    """Bare-line citations (``foo.py:42``, no range) also strip. The
+    suffix regex matches ``:N`` as well as ``:N-M``.
+    """
+    body = (
+        "Bug at scripts/check-shipped-pr.sh:42 — see also scripts/check-shipped-pr.sh."
+    )
+    out = extract_module.extract_files(body)
+    assert out == ["scripts/check-shipped-pr.sh"]
+
+
+def test_line_range_suffix_three_cite_forms_collapse(extract_module):
+    """Three cite forms — single line, line range, bare — all dedupe
+    to one entry. Mirrors the worked example from issue #4462.
+    """
+    body = (
+        "infra/terraform/modules/iam_agent/main.tf:47-62 and "
+        "infra/terraform/modules/iam_agent/main.tf:132 plus "
+        "infra/terraform/modules/iam_agent/main.tf bare."
+    )
+    out = extract_module.extract_files(body)
+    assert out == ["infra/terraform/modules/iam_agent/main.tf"]
+
+
+def test_line_range_suffix_with_trailing_punctuation(extract_module):
+    """A cite like ``foo.py:47-62.`` (sentence period after the line
+    range) must still strip the line range. The implementation runs
+    the punctuation strip BEFORE the line-range strip — the period
+    falls off first, then the ``:47-62`` falls off cleanly.
+    """
+    body = (
+        "Bug lives at scripts/check-shipped-pr.sh:47-62. "
+        "Reading scripts/check-shipped-pr.sh."
+    )
+    out = extract_module.extract_files(body)
+    assert out == ["scripts/check-shipped-pr.sh"]
+
+
+def test_line_range_suffix_target_wins_over_search(extract_module):
+    """When the bare path appears in narrative (target-context) and the
+    line-ranged variant appears in a Verify line, both collapse to the
+    bare path — and the precedence rule still tags it as target-context.
+    Locks in that the line-range strip runs before classification.
+    """
+    body = (
+        "Update `scripts/check-shipped-pr.sh` to handle the new shape.\n"
+        "Verify: `grep -n widget scripts/check-shipped-pr.sh:42`\n"
+    )
+    target, search = extract_module.classify_files(body)
+    # Narrative cite (bare) is target; Verify cite (line-ranged) strips
+    # to bare and then promotes to target via the precedence rule.
+    assert target == ["scripts/check-shipped-pr.sh"]
+    assert search == []
+
+
+def test_line_range_suffix_only_in_search_context_stays_search(extract_module):
+    """If the path appears only with a line-range suffix inside a
+    Verify line (no narrative cite), the stripped path is search-
+    context — line-range stripping happens at the path-extraction
+    layer, not at the classification layer.
+    """
+    body = "Verify: `grep -n widget packages/api/src/index.ts:42-99`\n"
+    target, search = extract_module.classify_files(body)
+    assert target == []
+    assert search == ["packages/api/src/index.ts"]
+
+
+def test_line_range_suffix_does_not_strip_non_numeric(extract_module):
+    """The suffix regex matches ONLY ``:<digits>`` or ``:<digits>-<digits>``
+    at end-of-string. A path with a non-numeric trailing token after the
+    colon (rare, but defensive) is not affected.
+    """
+    # Trailing colon alone is already stripped by TRAILING_STRIP.
+    # A path like ``foo.py:abc`` is not a real cite — defensive: don't
+    # strip anything past the colon.
+    body = "See packages/api/src/index.ts (the entry point)."
+    out = extract_module.extract_files(body)
+    assert out == ["packages/api/src/index.ts"]


### PR DESCRIPTION
## Summary

Strip trailing `:N` / `:N-M` line-range suffixes from extracted file paths in `scripts/_check_shipped_pr_extract_files.py` so cite forms like `foo.py:47-62`, `foo.py:132`, and bare `foo.py` collapse to a single canonical entry before dedupe + target/search classification. Pre-fix, the extractor emitted three separate entries for the same physical file, and the line-ranged variants resolved to no commits via `gh api /repos/.../commits?path=<path>` (line ranges are not valid path arguments) — making the downstream threshold unreachable on the very common `path:line-range` cite pattern.

Closes #4462

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (tooling script + tests only)
- [ ] Verification evidence posted on issue (see A.8)

## Notes on AC #2

Issue #4462 lists two ACs. AC #1 (the unit-test path) is fully met — 8 new pytest cases lock in the strip behaviour. AC #2 ("`scripts/check-shipped-pr.sh 3310` returns exit 0 naming PR #3319") is left unmet by this PR by design and is documented in the process-summary comment on the issue. The line-range fix moves #3310's overlap from 0 to 1 modified target overlap on `infra/terraform/modules/iam_agent/main.tf`, but the existing threshold (≥1 added target overlap OR ≥2 total target overlaps) still doesn't fire because the only added file in PR #3319 (`scripts/iam-agent-phase-b-smoke.sh`) lives in search-context (only on a `Verify:` line). Threshold tuning is structurally adjacent to #4223 (also touching the check-shipped-pr threshold for a sibling FP class) and is left for a follow-up. The line-range fix is a prerequisite for any threshold tuning that lands on top.

No file overlap with #4223 (this PR touches `scripts/_check_shipped_pr_extract_files.py`; #4223 will touch `scripts/_check_shipped_pr_overlap.py`).
