### PR TITLE
test(scripts): add shell tests for block-issue.sh and block-on-new-issue.sh (#4051)

### DIFF
--- a/scripts/block-on-new-issue.sh
+++ b/scripts/block-on-new-issue.sh
@@ -160,11 +160,19 @@ fi
 
 # Build the gh issue create invocation.
 CREATE_ARGS=(issue create --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE")
-for label in "${LABELS[@]}"; do
-    if [ -n "$label" ]; then
-        CREATE_ARGS+=(--label "$label")
-    fi
-done
+# bash 3.2 (macOS) trips ``unbound variable`` on ``"${LABELS[@]}"`` when
+# LABELS=() and no --label / --priority was supplied — the conditional
+# ``LABELS+=(...)`` inside the arg-parse loop is invisible to the static
+# `check-bash-set-u-empty-array.sh` linear scan. Length-guard the iteration
+# so the loop body is skipped when LABELS is still empty. Surfaced by
+# tests/test_block_on_new_issue.sh "I: happy path" (#4051 regression test).
+if [ "${#LABELS[@]}" -gt 0 ]; then
+    for label in "${LABELS[@]}"; do
+        if [ -n "$label" ]; then
+            CREATE_ARGS+=(--label "$label")
+        fi
+    done
+fi
 
 echo "Creating new tracker issue in $REPO..." >&2
 NEW_URL="$(gh "${CREATE_ARGS[@]}")"

--- a/scripts/tests/test_block_issue.sh
+++ b/scripts/tests/test_block_issue.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# test_block_issue.sh — Tests for scripts/block-issue.sh.
+#
+# Companion to test_block_on_new_issue.sh, closing the test-coverage gap
+# called out by issue #4051. Argument-validation paths run before the first
+# `gh` call, so they need no network. The body-edit / label-flip behavior is
+# exercised against a PATH-mocked `gh` binary (same pattern as
+# test_unblock_issue.sh, #4343).
+#
+# Test cases:
+#   A — Wrong arg count (0, 1, 3) exits 1.
+#   B — Non-numeric <issue> or <blocker> exits 1.
+#   C — Leading '#' on either arg is stripped (numeric validation passes).
+#   D — Body without ## Dependencies: writer creates section + Blocked by line.
+#   E — Body with ## Dependencies but no matching Blocked by: writer appends
+#       the line under the existing heading.
+#   F — Body that already has 'Blocked by #N': no body update; labels still
+#       added (exit 0, idempotent).
+#   G — Label flip: --add-label status/blocked + --remove-label agent/ready
+#       always invoked.
+#
+# Usage:
+#   scripts/tests/test_block_issue.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/block-issue.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+ORIG_PATH_SAVE=""
+restore_path() {
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+register_cleanup_hook restore_path
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Test A — Wrong arg count exits 1 ───────────────────────────────────────
+
+# 0 args
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "A: 0 args exits 1"
+else
+    fail "A: 0 args exits 1" "expected exit 1, got $exit_code"
+fi
+
+# 1 arg
+exit_code=0
+"$WRAPPER" 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "A: 1 arg exits 1"
+else
+    fail "A: 1 arg exits 1" "expected exit 1, got $exit_code"
+fi
+
+# 3 args
+exit_code=0
+"$WRAPPER" 100 200 300 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "A: 3 args exits 1"
+else
+    fail "A: 3 args exits 1" "expected exit 1, got $exit_code"
+fi
+
+# ── Test B — Non-numeric args exit 1 ───────────────────────────────────────
+
+exit_code=0
+err_output=$("$WRAPPER" abc 100 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "B: non-numeric <issue> exits 1"
+else
+    fail "B: non-numeric <issue> exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"must be issue numbers"* ]]; then
+    pass "B: non-numeric error names the validation"
+else
+    fail "B: non-numeric error names the validation" "expected 'must be issue numbers', got: $err_output"
+fi
+
+exit_code=0
+"$WRAPPER" 100 abc > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "B: non-numeric <blocker> exits 1"
+else
+    fail "B: non-numeric <blocker> exits 1" "expected exit 1, got $exit_code"
+fi
+
+# ── Set up a mock gh CLI on PATH for the body/label tests ─────────────────
+
+MOCK_BIN_DIR=$(mktemp -d)
+register_temp_dir "$MOCK_BIN_DIR"
+ORIG_PATH_SAVE="$PATH"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+# Helper — render a fresh mock gh that:
+#   - On `gh issue view <N> --json body -q .body`, prints the staged body
+#     for issue N (one body per N, picked from $BODY_FOR_<N> env vars).
+#   - On `gh issue edit <N> ... --body-file <path>`, copies the body file to
+#     $WRITTEN_BODY_<N>.
+#   - On `gh issue edit <N> ... --add-label ...`, records the full call to
+#     $INVOCATIONS.
+#   - Records every call to $INVOCATIONS regardless.
+write_gh_mock() {
+    local invocations="$1"
+    cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$invocations"
+
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    ISSUE_NUM="\${3:-}"
+    body_var="BODY_FOR_\$ISSUE_NUM"
+    body_value="\${!body_var:-}"
+    # Print body; if -q is present we pass through raw, else JSON.
+    has_q=0
+    for arg in "\$@"; do
+        if [[ "\$arg" == "-q" || "\$arg" == "--jq" ]]; then
+            has_q=1
+        fi
+    done
+    if [[ "\$has_q" == "1" ]]; then
+        printf '%s' "\$body_value"
+    else
+        printf '%s' "\$body_value"
+    fi
+    exit 0
+fi
+
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "edit" ]]; then
+    ISSUE_NUM="\${3:-}"
+    # If --body-file is present, capture the written body to a per-issue file.
+    prev=""
+    for arg in "\$@"; do
+        if [[ "\$prev" == "--body-file" ]]; then
+            cp "\$arg" "$MOCK_BIN_DIR/written_body_\$ISSUE_NUM.txt"
+        fi
+        prev="\$arg"
+    done
+    exit 0
+fi
+
+exit 0
+MOCKEOF
+    chmod +x "$MOCK_BIN_DIR/gh"
+}
+
+# ── Test C — Leading '#' is stripped ───────────────────────────────────────
+
+INVOCATIONS_C="$MOCK_BIN_DIR/invocations_c.txt"
+write_gh_mock "$INVOCATIONS_C"
+export BODY_FOR_500="## Summary
+
+Stub body."
+
+exit_code=0
+"$WRAPPER" "#500" "#600" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "C: leading '#' on both args passes validation"
+else
+    fail "C: leading '#' on both args passes validation" "expected exit 0, got $exit_code"
+fi
+
+# Confirm the body update went to issue 500 (not "#500").
+if grep -qE "^issue (view|edit) 500" "$INVOCATIONS_C" 2>/dev/null; then
+    pass "C: '#500' resolves to issue number 500"
+else
+    fail "C: '#500' resolves to issue number 500" "no 'issue view 500' or 'issue edit 500' in: $(cat "$INVOCATIONS_C")"
+fi
+
+unset BODY_FOR_500
+
+# ── Test D — Body without ## Dependencies → section is created ─────────────
+
+INVOCATIONS_D="$MOCK_BIN_DIR/invocations_d.txt"
+write_gh_mock "$INVOCATIONS_D"
+export BODY_FOR_700="## Summary
+
+No dependencies yet."
+
+exit_code=0
+"$WRAPPER" 700 800 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "D: body without ## Dependencies — exits 0"
+else
+    fail "D: body without ## Dependencies — exits 0" "expected exit 0, got $exit_code"
+fi
+
+WRITTEN_D="$MOCK_BIN_DIR/written_body_700.txt"
+if [[ -f "$WRITTEN_D" ]] && grep -q "^## Dependencies" "$WRITTEN_D" && grep -q "^Blocked by #800" "$WRITTEN_D"; then
+    pass "D: writer creates ## Dependencies section + 'Blocked by #800'"
+else
+    fail "D: writer creates ## Dependencies section + 'Blocked by #800'" "written body: $(cat "$WRITTEN_D" 2>/dev/null || echo '<not written>')"
+fi
+
+unset BODY_FOR_700
+
+# ── Test E — Body with ## Dependencies → line appended under heading ───────
+
+INVOCATIONS_E="$MOCK_BIN_DIR/invocations_e.txt"
+write_gh_mock "$INVOCATIONS_E"
+export BODY_FOR_710="## Summary
+
+Stub.
+
+## Dependencies
+
+Blocked by #999"
+
+exit_code=0
+"$WRAPPER" 710 800 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "E: body with existing ## Dependencies — exits 0"
+else
+    fail "E: body with existing ## Dependencies — exits 0" "expected exit 0, got $exit_code"
+fi
+
+WRITTEN_E="$MOCK_BIN_DIR/written_body_710.txt"
+if [[ -f "$WRITTEN_E" ]] && grep -q "^Blocked by #800" "$WRITTEN_E" && grep -q "^Blocked by #999" "$WRITTEN_E"; then
+    pass "E: writer keeps existing 'Blocked by #999' and adds 'Blocked by #800'"
+else
+    fail "E: writer keeps existing 'Blocked by #999' and adds 'Blocked by #800'" "written body: $(cat "$WRITTEN_E" 2>/dev/null || echo '<not written>')"
+fi
+
+# Should have exactly one ## Dependencies heading (no duplication).
+heading_count=$(grep -c "^## Dependencies" "$WRITTEN_E" 2>/dev/null || echo 0)
+if [[ "$heading_count" == "1" ]]; then
+    pass "E: writer does not duplicate the ## Dependencies heading"
+else
+    fail "E: writer does not duplicate the ## Dependencies heading" "found $heading_count headings; written body: $(cat "$WRITTEN_E" 2>/dev/null || echo '<not written>')"
+fi
+
+unset BODY_FOR_710
+
+# ── Test F — Body already has 'Blocked by #N' → no body write, labels still set ─
+
+INVOCATIONS_F="$MOCK_BIN_DIR/invocations_f.txt"
+write_gh_mock "$INVOCATIONS_F"
+export BODY_FOR_720="## Summary
+
+Stub.
+
+## Dependencies
+
+Blocked by #800"
+
+exit_code=0
+stdout_output=$("$WRAPPER" 720 800 2>&1) || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "F: idempotent — already 'Blocked by #800', exits 0"
+else
+    fail "F: idempotent — already 'Blocked by #800', exits 0" "expected exit 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"already has 'Blocked by #800'"* ]] || [[ "$stdout_output" == *"skipping body update"* ]]; then
+    pass "F: idempotent — log line confirms body update skipped"
+else
+    fail "F: idempotent — log line confirms body update skipped" "stdout: $stdout_output"
+fi
+
+# Body file write must NOT have happened (no written_body_720.txt).
+WRITTEN_F="$MOCK_BIN_DIR/written_body_720.txt"
+if [[ ! -f "$WRITTEN_F" ]]; then
+    pass "F: idempotent — no body file was written"
+else
+    fail "F: idempotent — no body file was written" "found written body: $(cat "$WRITTEN_F" 2>/dev/null || echo '<empty>')"
+fi
+
+# Labels must STILL have been set even though the body was skipped.
+if grep -q -- "--add-label" "$INVOCATIONS_F" 2>/dev/null && grep -q "status/blocked" "$INVOCATIONS_F" 2>/dev/null; then
+    pass "F: idempotent — labels (status/blocked) still applied"
+else
+    fail "F: idempotent — labels (status/blocked) still applied" "invocations: $(cat "$INVOCATIONS_F" 2>/dev/null)"
+fi
+
+unset BODY_FOR_720
+
+# ── Test G — Label flip always fires ───────────────────────────────────────
+#
+# Re-uses Test D's scenario (body without ## Dependencies, fresh mock state)
+# but checks the label-flip line specifically.
+
+INVOCATIONS_G="$MOCK_BIN_DIR/invocations_g.txt"
+write_gh_mock "$INVOCATIONS_G"
+export BODY_FOR_730="## Summary
+
+Stub."
+
+"$WRAPPER" 730 800 > /dev/null 2>&1 || true
+
+# Find the label-edit invocation: should contain --add-label status/blocked
+# and --remove-label agent/ready in a single call.
+label_line=$(grep "issue edit 730" "$INVOCATIONS_G" 2>/dev/null | grep -- "--add-label" || true)
+if [[ -n "$label_line" ]] \
+    && [[ "$label_line" == *"status/blocked"* ]] \
+    && [[ "$label_line" == *"--remove-label"* ]] \
+    && [[ "$label_line" == *"agent/ready"* ]]; then
+    pass "G: label-flip call sets +status/blocked, -agent/ready"
+else
+    fail "G: label-flip call sets +status/blocked, -agent/ready" "label-edit line: $label_line; full invocations: $(cat "$INVOCATIONS_G" 2>/dev/null)"
+fi
+
+unset BODY_FOR_730
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_block_on_new_issue.sh
+++ b/scripts/tests/test_block_on_new_issue.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# test_block_on_new_issue.sh — Tests for scripts/block-on-new-issue.sh.
+#
+# Closes the gap surfaced by #4051: scripts/block-on-new-issue.sh and its
+# companion scripts/block-issue.sh shipped in #4035 / PR #4045 with zero test
+# coverage. The argument-validation paths were sanity-checked manually before
+# the PR went out, but a future refactor of the arg parser could silently
+# regress and the next agent that hits an upstream blocker would discover it
+# the hard way (failed `gh issue create` invocation mid-flight, dependent
+# issue never blocked, repeat-investigation cycle that #4035 just closed
+# re-opens).
+#
+# Coverage model — all argument-validation paths exercise without network
+# because block-on-new-issue.sh's parser runs to completion before the first
+# `gh` call. The tests that DO need to reach the gh-call layer use a
+# PATH-mocked gh binary (same pattern as test_unblock_issue.sh, #4343) so the
+# real GitHub API is never touched.
+#
+# Test cases:
+#   A — `--help` exits 0 with usage text on stdout (here: stderr; usage()
+#       prints to stderr per the script).
+#   B — Missing <dependent-issue> exits 1.
+#   C — Non-numeric <dependent-issue> exits 1 with explicit error message.
+#   D — Missing --title exits 1.
+#   E — Missing --body-file exits 1.
+#   F — --body-file points to a path that does not exist exits 1.
+#   G — --priority p9 (invalid) exits 1; --priority p0|p1|p2|p3 are accepted.
+#   H — Unknown flag exits 1.
+#   I — Happy path with a mocked `gh` records a `gh issue create` call AND a
+#       `gh issue edit` call (via block-issue.sh) on the dependent issue.
+#   J — --priority p1 sugar adds priority/p1 to the gh issue create labels.
+#
+# Usage:
+#   scripts/tests/test_block_on_new_issue.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/block-on-new-issue.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+# Cleanup of temp dirs/files + PATH restore via the shared helper (#4343).
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+ORIG_PATH_SAVE=""
+restore_path() {
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+register_cleanup_hook restore_path
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# Stage a body file used by every test that gets past the body-file check.
+BODY_DIR=$(mktemp -d)
+register_temp_dir "$BODY_DIR"
+BODY_FILE="$BODY_DIR/body.md"
+echo "stub body for tests" > "$BODY_FILE"
+
+# ── Test A — --help exits 0 ────────────────────────────────────────────────
+
+exit_code=0
+"$WRAPPER" --help > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "A: --help exits 0"
+else
+    fail "A: --help exits 0" "expected exit 0, got $exit_code"
+fi
+
+# --help prints usage containing 'block-on-new-issue.sh' (usage prints to
+# stderr per the script).
+help_output=$("$WRAPPER" --help 2>&1 >/dev/null) || true
+if [[ "$help_output" == *"block-on-new-issue.sh"* ]]; then
+    pass "A: --help prints usage line"
+else
+    fail "A: --help prints usage line" "expected 'block-on-new-issue.sh' in output, got: $help_output"
+fi
+
+# ── Test B — Missing <dependent-issue> exits 1 ─────────────────────────────
+
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "B: missing <dependent-issue> exits 1"
+else
+    fail "B: missing <dependent-issue> exits 1" "expected exit 1, got $exit_code"
+fi
+
+# ── Test C — Non-numeric <dependent-issue> exits 1 ─────────────────────────
+
+exit_code=0
+err_output=$("$WRAPPER" "abc" --title "x" --body-file "$BODY_FILE" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "C: non-numeric <dependent-issue> exits 1"
+else
+    fail "C: non-numeric <dependent-issue> exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"must be an issue number"* ]]; then
+    pass "C: non-numeric error names the validation"
+else
+    fail "C: non-numeric error names the validation" "expected 'must be an issue number', got: $err_output"
+fi
+
+# Leading-# form is accepted (gets stripped) — check by piping into a path
+# that fails *after* validation (no --title) so we know validation passed.
+exit_code=0
+err_output=$("$WRAPPER" "#42" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]] && [[ "$err_output" == *"--title is required"* ]]; then
+    pass "C: leading-# form (#42) passes numeric validation"
+else
+    fail "C: leading-# form (#42) passes numeric validation" "expected '--title is required' (i.e. validation passed), got exit=$exit_code output: $err_output"
+fi
+
+# ── Test D — Missing --title exits 1 ───────────────────────────────────────
+
+exit_code=0
+err_output=$("$WRAPPER" 42 --body-file "$BODY_FILE" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "D: missing --title exits 1"
+else
+    fail "D: missing --title exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"--title is required"* ]]; then
+    pass "D: missing --title error mentions --title"
+else
+    fail "D: missing --title error mentions --title" "expected '--title is required', got: $err_output"
+fi
+
+# ── Test E — Missing --body-file exits 1 ───────────────────────────────────
+
+exit_code=0
+err_output=$("$WRAPPER" 42 --title "x" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "E: missing --body-file exits 1"
+else
+    fail "E: missing --body-file exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"--body-file is required"* ]]; then
+    pass "E: missing --body-file error mentions --body-file"
+else
+    fail "E: missing --body-file error mentions --body-file" "expected '--body-file is required', got: $err_output"
+fi
+
+# ── Test F — --body-file points to a non-existent path exits 1 ─────────────
+
+exit_code=0
+err_output=$("$WRAPPER" 42 --title "x" --body-file "$BODY_DIR/does-not-exist.md" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "F: --body-file with non-existent path exits 1"
+else
+    fail "F: --body-file with non-existent path exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"does not exist"* ]]; then
+    pass "F: --body-file non-existent error names the missing path"
+else
+    fail "F: --body-file non-existent error names the missing path" "expected 'does not exist', got: $err_output"
+fi
+
+# ── Test G — --priority validation ─────────────────────────────────────────
+
+# Invalid priority exits 1 BEFORE attempting any gh call.
+exit_code=0
+err_output=$("$WRAPPER" 42 --title "x" --body-file "$BODY_FILE" --priority p9 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "G: --priority p9 (invalid) exits 1"
+else
+    fail "G: --priority p9 (invalid) exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"--priority must be one of"* ]]; then
+    pass "G: --priority p9 error names valid choices"
+else
+    fail "G: --priority p9 error names valid choices" "expected '--priority must be one of', got: $err_output"
+fi
+
+# Valid priorities (p0..p3) pass validation. We can't run the script all the
+# way through without a gh mock, so we verify each priority is accepted by
+# making the call fail at a *later* point — by setting PATH so gh is missing,
+# which causes the script to fail in CREATE_ARGS execution (gh: command not
+# found), AFTER having passed --priority validation. We detect that by the
+# absence of the priority error text in the output.
+EMPTY_BIN=$(mktemp -d)
+register_temp_dir "$EMPTY_BIN"
+ORIG_PATH_SAVE="$PATH"
+export PATH="$EMPTY_BIN"   # gh not available
+
+for prio in p0 p1 p2 p3; do
+    exit_code=0
+    err_output=$("$WRAPPER" 42 --title "x" --body-file "$BODY_FILE" --priority "$prio" 2>&1 >/dev/null) || exit_code=$?
+    # Priority validation must NOT have triggered.
+    if [[ "$err_output" == *"--priority must be one of"* ]]; then
+        fail "G: --priority $prio is accepted" "got --priority error: $err_output"
+    else
+        pass "G: --priority $prio is accepted (passed validation)"
+    fi
+done
+
+# Restore PATH for subsequent gh-mock tests.
+export PATH="$ORIG_PATH_SAVE"
+
+# ── Test H — Unknown flag exits 1 ──────────────────────────────────────────
+
+exit_code=0
+err_output=$("$WRAPPER" 42 --title "x" --body-file "$BODY_FILE" --bogus-flag value 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "H: unknown flag exits 1"
+else
+    fail "H: unknown flag exits 1" "expected exit 1, got $exit_code"
+fi
+
+if [[ "$err_output" == *"unknown argument"* ]]; then
+    pass "H: unknown flag error names 'unknown argument'"
+else
+    fail "H: unknown flag error names 'unknown argument'" "expected 'unknown argument', got: $err_output"
+fi
+
+# ── Set up a mock gh CLI on PATH for tests I and J ─────────────────────────
+
+MOCK_BIN_DIR=$(mktemp -d)
+register_temp_dir "$MOCK_BIN_DIR"
+ORIG_PATH_SAVE="$PATH"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+# ── Test I — Happy path: mocked gh records create + edit ───────────────────
+#
+# Scenario: file a new tracker for issue #500.
+# Mock gh records every invocation. block-on-new-issue.sh should:
+#   1. Call `gh issue create ... --title "tracker for X"` and capture the URL.
+#   2. Hand off to block-issue.sh which calls `gh issue view 500` (body
+#      fetch), `gh issue edit 500 --body-file ...` (body update), and
+#      `gh issue edit 500 --add-label status/blocked --remove-label
+#      agent/ready` (label flip).
+
+INVOCATIONS_I="$MOCK_BIN_DIR/invocations_i.txt"
+
+cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+# Record every invocation so the test can assert against them.
+echo "\$@" >> "$INVOCATIONS_I"
+
+# gh issue create — emit a fake URL so the wrapper can parse the new number.
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "create" ]]; then
+    echo "https://github.com/judgemind/judgemind/issues/9999"
+    exit 0
+fi
+
+# gh issue view <N> --json body -q .body  (block-issue.sh body fetch)
+# Match the -q form regardless of how the tool quotes it.
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    # Emit a body with no ## Dependencies section so block-issue.sh creates
+    # one. The -q '.body' flag means we return raw body text, not JSON.
+    has_q=0
+    for arg in "\$@"; do
+        if [[ "\$arg" == "-q" || "\$arg" == "--jq" ]]; then
+            has_q=1
+        fi
+    done
+    if [[ "\$has_q" == "1" ]]; then
+        echo "## Summary"
+        echo ""
+        echo "Stub body, no dependencies yet."
+    else
+        # JSON form (block-issue.sh uses -q so this branch is unused, but
+        # included for safety / future-proofing).
+        printf '%s' '{"body":"## Summary\n\nStub body, no dependencies yet."}'
+    fi
+    exit 0
+fi
+
+# gh issue edit — body update or label flip. Always succeed.
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "edit" ]]; then
+    exit 0
+fi
+
+# Default: succeed silently.
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 500 --title "tracker for X" --body-file "$BODY_FILE" > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "I: happy path exits 0"
+else
+    fail "I: happy path exits 0" "expected exit 0, got $exit_code; invocations: $(cat "$INVOCATIONS_I" 2>/dev/null || echo '<none>')"
+fi
+
+if grep -q "issue create" "$INVOCATIONS_I" 2>/dev/null; then
+    pass "I: happy path calls 'gh issue create'"
+else
+    fail "I: happy path calls 'gh issue create'" "no 'issue create' in invocations: $(cat "$INVOCATIONS_I" 2>/dev/null || echo '<none>')"
+fi
+
+# block-issue.sh adds the status/blocked label — confirm the dependent (500)
+# was edited.
+if grep -q "issue edit 500" "$INVOCATIONS_I" 2>/dev/null; then
+    pass "I: happy path calls 'gh issue edit 500' (block-issue.sh handoff)"
+else
+    fail "I: happy path calls 'gh issue edit 500' (block-issue.sh handoff)" "no 'issue edit 500' in invocations: $(cat "$INVOCATIONS_I" 2>/dev/null || echo '<none>')"
+fi
+
+if grep -q "status/blocked" "$INVOCATIONS_I" 2>/dev/null; then
+    pass "I: happy path adds status/blocked label"
+else
+    fail "I: happy path adds status/blocked label" "no 'status/blocked' in invocations"
+fi
+
+# ── Test J — --priority p1 sugar adds priority/p1 to gh issue create ───────
+
+INVOCATIONS_J="$MOCK_BIN_DIR/invocations_j.txt"
+
+cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$INVOCATIONS_J"
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "create" ]]; then
+    echo "https://github.com/judgemind/judgemind/issues/8888"
+    exit 0
+fi
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    echo "## Summary"
+    echo ""
+    echo "Stub."
+    exit 0
+fi
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 600 --title "p1 tracker" --body-file "$BODY_FILE" --priority p1 > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "J: --priority p1 happy path exits 0"
+else
+    fail "J: --priority p1 happy path exits 0" "expected exit 0, got $exit_code"
+fi
+
+# Find the line for gh issue create and confirm it includes 'priority/p1'.
+create_line=$(grep "^issue create" "$INVOCATIONS_J" 2>/dev/null || true)
+if [[ -n "$create_line" && "$create_line" == *"priority/p1"* ]]; then
+    pass "J: --priority p1 adds 'priority/p1' label to gh issue create"
+else
+    fail "J: --priority p1 adds 'priority/p1' label to gh issue create" "create line: $create_line"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds the missing test coverage for `scripts/block-issue.sh` and `scripts/block-on-new-issue.sh` (the two block-* helpers shipped in #4035 / PR #4045 with no automated regression guard). Tests use the PATH-mocked `gh` pattern from `test_unblock_issue.sh` (#4343) so they are network-free and auto-discovered by `scripts/run-scripts-tests.sh` — no `ci.yml` edit needed.

While writing the happy-path test, surfaced a real bash 3.2 / `set -u` footgun in `block-on-new-issue.sh`: the empty `LABELS=()` array is iterated as `"${LABELS[@]}"` when no `--label`/`--priority` was supplied, tripping `unbound variable` on macOS bash 3.2. Fixed in the same PR with the canonical length-guard. The conditional `LABELS+=(...)` inside the arg-parse loop was invisible to `scripts/check-bash-set-u-empty-array.sh`'s linear scan, so the bug had been latent since #4035.

Closes #4051

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass — including the two new `test_block_*.sh` files (auto-discovered by `scripts/run-scripts-tests.sh`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test files + a one-line bug fix in a script that runs inside `/task` agents only; no production service touches `block-on-new-issue.sh`).
