### PR TITLE
feat(scraping): expand _CL_COURT_ID_TO_JURISDICTION for newly-surfaced CourtListener short-ids (#4471)

### DIFF
--- a/packages/scraper-framework/src/courts/federal/courtlistener.py
+++ b/packages/scraper-framework/src/courts/federal/courtlistener.py
@@ -757,8 +757,14 @@ def _parse_date(date_str: str | None) -> datetime | None:
 
 #: Maps CourtListener short court IDs to (state, county) tuples.
 #:
-#: Federal courts map to ("Federal", "Federal").
+#: Federal courts (including federal military appellate courts like nmcca)
+#: map to ("Federal", "Federal").
 #: State high courts and appellate courts map to ("<State>", "Statewide").
+#: For appellate-court systems with both a parent record (e.g. "calctapp",
+#: "ohioctapp", "illappct") and per-district records (e.g. "calctapp1"-"6"),
+#: both are mapped explicitly to the same tuple.
+#: US territory supreme courts (prsupreme, virginislands) map to
+#: ("<Territory name>", "Statewide") — the territory is treated as the state.
 #: On a miss, the scraper defaults to ("Unknown", "Unknown") and logs a warning.
 #:
 #: Source: https://www.courtlistener.com/api/rest/v4/courts/?format=json
@@ -882,6 +888,8 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     "bap10": ("Federal", "Federal"),
     "bapme": ("Federal", "Federal"),
     "bapma": ("Federal", "Federal"),
+    # Federal military appellate courts
+    "nmcca": ("Federal", "Federal"),  # Navy-Marine Corps Court of Criminal Appeals
     # -----------------------------------------------------------------------
     # State high courts (supreme courts)
     # -----------------------------------------------------------------------
@@ -923,6 +931,8 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     "wva": ("West Virginia", "Statewide"),
     "idaho": ("Idaho", "Statewide"),
     "hi": ("Hawaii", "Statewide"),
+    # CourtListener also serves the Hawaii Supreme Court under the "haw" short-id
+    "haw": ("Hawaii", "Statewide"),
     "me": ("Maine", "Statewide"),
     "nh": ("New Hampshire", "Statewide"),
     "ri": ("Rhode Island", "Statewide"),
@@ -936,7 +946,10 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     # -----------------------------------------------------------------------
     # State appellate courts
     # -----------------------------------------------------------------------
-    # Texas Courts of Appeals (14 districts)
+    # Texas Courts of Appeals (parent + 14 districts)
+    "texapp": ("Texas", "Statewide"),  # parent record (Court of Appeals of Texas)
+    # Alternate short-id for the 11th District (Eastland), seen alongside texapp11
+    "txctapp11": ("Texas", "Statewide"),
     "texapp1": ("Texas", "Statewide"),
     "texapp2": ("Texas", "Statewide"),
     "texapp3": ("Texas", "Statewide"),
@@ -971,7 +984,8 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     "fladistctapp6": ("Florida", "Statewide"),
     # Georgia Court of Appeals
     "gactapp": ("Georgia", "Statewide"),
-    # Ohio Courts of Appeals (12 districts)
+    # Ohio Courts of Appeals (parent + 12 districts)
+    "ohioctapp": ("Ohio", "Statewide"),  # parent record
     "ohioctapp1": ("Ohio", "Statewide"),
     "ohioctapp2": ("Ohio", "Statewide"),
     "ohioctapp3": ("Ohio", "Statewide"),
@@ -984,14 +998,16 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     "ohioctapp10": ("Ohio", "Statewide"),
     "ohioctapp11": ("Ohio", "Statewide"),
     "ohioctapp12": ("Ohio", "Statewide"),
-    # California Courts of Appeal
+    # California Courts of Appeal (parent + 6 districts)
+    "calctapp": ("California", "Statewide"),  # parent record
     "calctapp1": ("California", "Statewide"),
     "calctapp2": ("California", "Statewide"),
     "calctapp3": ("California", "Statewide"),
     "calctapp4": ("California", "Statewide"),
     "calctapp5": ("California", "Statewide"),
     "calctapp6": ("California", "Statewide"),
-    # Illinois Appellate Courts
+    # Illinois Appellate Courts (parent + 5 districts)
+    "illappct": ("Illinois", "Statewide"),  # parent record
     "illappct1": ("Illinois", "Statewide"),
     "illappct2": ("Illinois", "Statewide"),
     "illappct3": ("Illinois", "Statewide"),
@@ -1004,6 +1020,10 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     "michctapp": ("Michigan", "Statewide"),
     # North Carolina Court of Appeals
     "ncctapp": ("North Carolina", "Statewide"),
+    # North Carolina Business Court (specialty trial court)
+    "ncbizct": ("North Carolina", "Statewide"),
+    # Hawaii Intermediate Court of Appeals
+    "hawapp": ("Hawaii", "Statewide"),
     # New Jersey Appellate Division
     "njsuperctappdiv": ("New Jersey", "Statewide"),
     # Virginia Court of Appeals
@@ -1039,7 +1059,8 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     # Alabama Court of Civil Appeals / Court of Criminal Appeals
     "alacivapp": ("Alabama", "Statewide"),
     "alacrimapp": ("Alabama", "Statewide"),
-    # Louisiana Courts of Appeal
+    # Louisiana Courts of Appeal (parent + 5 districts; CL uses two short-id schemes)
+    "lactapp": ("Louisiana", "Statewide"),  # parent record
     "laapp1": ("Louisiana", "Statewide"),
     "laapp2": ("Louisiana", "Statewide"),
     "laapp3": ("Louisiana", "Statewide"),
@@ -1076,6 +1097,13 @@ _CL_COURT_ID_TO_JURISDICTION: dict[str, tuple[str, str]] = {
     "montag": ("Montana", "Statewide"),
     # DC Court of Appeals (local, not federal circuit)
     "dc": ("District of Columbia", "Statewide"),
+    # -----------------------------------------------------------------------
+    # US Territories — Supreme courts
+    # -----------------------------------------------------------------------
+    # Treat the territory itself as the "state" — Puerto Rico and Virgin
+    # Islands have their own legal systems separate from any US state.
+    "prsupreme": ("Puerto Rico", "Statewide"),
+    "virginislands": ("Virgin Islands", "Statewide"),
 }
 
 

--- a/packages/scraper-framework/tests/courts/test_courtlistener.py
+++ b/packages/scraper-framework/tests/courts/test_courtlistener.py
@@ -1250,12 +1250,17 @@ class TestJurisdictionMapping:
             ("ca1", "Federal", "Federal"),
             ("cadc", "Federal", "Federal"),
             ("cafc", "Federal", "Federal"),
+            # Federal military appellate courts (#4471)
+            ("nmcca", "Federal", "Federal"),
             # State high courts
             ("tex", "Texas", "Statewide"),
             ("ny", "New York", "Statewide"),
             ("fla", "Florida", "Statewide"),
             ("cal", "California", "Statewide"),
             ("ga", "Georgia", "Statewide"),
+            ("hi", "Hawaii", "Statewide"),
+            # Hawaii alternate short-id surfaced in production logs (#4471)
+            ("haw", "Hawaii", "Statewide"),
             # State appellate courts
             ("texapp1", "Texas", "Statewide"),
             ("texapp14", "Texas", "Statewide"),
@@ -1267,6 +1272,20 @@ class TestJurisdictionMapping:
             ("fladistctapp1", "Florida", "Statewide"),
             ("gactapp", "Georgia", "Statewide"),
             ("ohioctapp1", "Ohio", "Statewide"),
+            # Appellate parent-records and alternates surfaced in production
+            # logs after the #4466 URL-parsing fix (#4471)
+            ("calctapp", "California", "Statewide"),
+            ("ohioctapp", "Ohio", "Statewide"),
+            ("illappct", "Illinois", "Statewide"),
+            ("lactapp", "Louisiana", "Statewide"),
+            ("texapp", "Texas", "Statewide"),
+            ("txctapp11", "Texas", "Statewide"),
+            ("hawapp", "Hawaii", "Statewide"),
+            # Specialty state trial court (#4471)
+            ("ncbizct", "North Carolina", "Statewide"),
+            # US Territory supreme courts (#4471)
+            ("prsupreme", "Puerto Rico", "Statewide"),
+            ("virginislands", "Virgin Islands", "Statewide"),
         ],
     )
     def test_mapping_table_entries(
@@ -1287,6 +1306,46 @@ class TestJurisdictionMapping:
     def test_unknown_court_id_not_in_mapping(self) -> None:
         """A sentinel unknown court_id is absent from the mapping table."""
         assert "zzunknownsentinel" not in _CL_COURT_ID_TO_JURISDICTION
+
+    def test_court_id_to_jurisdiction_includes_required_courts_4471(self) -> None:
+        """Regression: #4471 — the 11 distinct unmapped court_ids surfaced in the
+        post-#4466 CourtListener scraper run (CloudWatch query against
+        /ecs/judgemind-scraper-dev, 2026-05-08 → 2026-05-09) MUST all be
+        covered by _CL_COURT_ID_TO_JURISDICTION so they no longer fall
+        through to ("Unknown", "Unknown").
+
+        The IDs and their authoritative CourtListener jurisdictions
+        (verified against /api/rest/v4/courts/<id>/?format=json):
+
+        * calctapp     — California Court of Appeal (parent record)
+        * illappct     — Appellate Court of Illinois (parent record)
+        * hawapp       — Hawaii Intermediate Court of Appeals
+        * txctapp11    — Texas Court of Appeals 11th District (Eastland; alternate of texapp11)
+        * haw          — Hawaii Supreme Court (alternate of "hi")
+        * ohioctapp    — Ohio Court of Appeals (parent record)
+        * prsupreme    — Supreme Court of Puerto Rico
+        * virginislands — Supreme Court of the Virgin Islands
+        * nmcca        — Navy-Marine Corps Court of Criminal Appeals (federal military)
+        * lactapp      — Louisiana Court of Appeal (parent record)
+        * ncbizct      — North Carolina Business Court (specialty trial court)
+        """
+        required_4471_ids = {
+            "calctapp",
+            "illappct",
+            "hawapp",
+            "txctapp11",
+            "haw",
+            "ohioctapp",
+            "prsupreme",
+            "virginislands",
+            "nmcca",
+            "lactapp",
+            "ncbizct",
+        }
+        missing = required_4471_ids - set(_CL_COURT_ID_TO_JURISDICTION)
+        assert not missing, (
+            f"#4471 regression — these CourtListener court_ids must remain mapped: {missing}"
+        )
 
     @pytest.mark.parametrize(
         "court_url,expected_state,expected_county",


### PR DESCRIPTION
## Summary

After PR #4466 fixed the CourtListener `_resolve_court_id` URL parser, real bare court_ids (formerly masked as `?format=json` and falling back to scraper-config defaults) surface in production scraper warnings and land in `(Unknown, Unknown)` jurisdiction. Ran the issue's CloudWatch query against `/ecs/judgemind-scraper-dev` over the last 24h, enumerated 11 distinct unmapped ids, looked each up against the CourtListener API, and added them — plus the structurally-paired `texapp` parent — to `_CL_COURT_ID_TO_JURISDICTION`.

Closes #4471

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] CloudWatch query against `/ecs/judgemind-scraper-dev` over a fresh post-deploy scraper run shows 0 of the 11 newly-mapped court_ids appearing in `Unknown CourtListener court_id` warnings (post-deploy 08:32-09:30 UTC: 0 rows)
- [x] Verification evidence posted on issue (see https://github.com/judgemind/judgemind/issues/4471#issuecomment-4412061461)
