### PR TITLE
dx(scripts): add gh-comment-with-retry.sh helper for 504-after-success case (#4478)

### DIFF
--- a/.claude/skills/task-v2-summary/SKILL.md
+++ b/.claude/skills/task-v2-summary/SKILL.md
@@ -309,7 +309,7 @@ Emit `{worktree}/tmp/dispatcher-output/summary.json` with all fields above. Exit
 ## What this skill does NOT do
 
 - **Does not open the PR.** Daemon does that after consuming this output.
-- **Does not post comments.** Daemon posts `process_summary_md` on the issue.
+- **Does not post comments.** Daemon posts `process_summary_md` on the issue. The daemon has its own retry envelope around the `gh issue comment` call (`_gh_issue_comment` in `scripts/dispatcher/daemon.py`, see #4231). The interactive `/task` path uses the equivalent `scripts/gh-comment-with-retry.sh` wrapper for the same 504-after-success failure mode (#4478) — neither path is exercised by this skill itself.
 - **Does not commit or push.** Daemon handles git operations. (The daemon's `push_and_pr` runs `git commit --amend -F` to rewrite ralph's placeholder commit with this skill's `commit_message` output — see #2971.)
 - **Does not read GitHub directly.** All issue + comment + diff data comes through the input JSON.
 - **Does not run tests.** Any pre-PR check reruns happen in ralph's final iteration or the daemon's pre-push hook.

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -163,9 +163,13 @@ Assign it to yourself (write — MCP auth currently blocked, stays on `gh`):
 gh issue edit <N> --repo judgemind/judgemind --add-assignee @me
 ```
 
-Write the claim comment to a temp file, then post it (write — stays on `gh`):
+Write the claim comment to a temp file, then post it via the
+`scripts/gh-comment-with-retry.sh` wrapper (write — stays on `gh`).
+The wrapper transparently handles the 504-after-success failure
+mode where `gh issue comment` returns a 5xx with a multi-KB
+"Unicorn!" HTML page even though the comment posted (#4478):
 ```
-gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/claim_comment.txt
+{worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/claim_comment.txt
 ```
 Comment content: `Picking this up in {agent-id}.` (Use the same `{agent-id}` resolved in Step 0 — i.e. `AGENT_ID` env var if set, else cwd-derived.)
 
@@ -606,9 +610,9 @@ Before committing or creating a PR, post a process summary comment on the GitHub
 <Any intentional exclusions or scope boundaries — what was NOT done and why>
 ```
 
-Post it (write — stays on `gh` until MCP writes land):
+Post it via `scripts/gh-comment-with-retry.sh` (write — stays on `gh` until MCP writes land). The wrapper transparently handles the 504-after-success failure mode (#4478) so a flaky GitHub response doesn't surface as a duplicate comment or a false-failure block on the PR push:
 ```
-gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/process_summary.txt
+{worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/process_summary.txt
 ```
 
 **GATE CHECK:** If any acceptance criterion is "not met" and the reason is NOT "requires post-deploy verification" or "not applicable," do NOT proceed to A.3. Go back to A.2 and address the gap first. The process summary is a self-check — if it reveals unmet criteria, the implementation is not complete.
@@ -934,9 +938,9 @@ If functional verification **fails**: diagnose the issue. If it's a simple fix, 
 
 After verification succeeds (or after determining the change has no deployed component), you MUST post a verification evidence comment on the issue. This is a hard gate — the task cannot proceed to A.9 without this comment.
 
-Write the comment to `{worktree}/tmp/verification_evidence.txt`, then post it (write — stays on `gh` until MCP writes land):
+Write the comment to `{worktree}/tmp/verification_evidence.txt`, then post it via `scripts/gh-comment-with-retry.sh` (write — stays on `gh` until MCP writes land). The wrapper transparently handles the 504-after-success failure mode (#4478):
 ```
-gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/verification_evidence.txt
+{worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/verification_evidence.txt
 ```
 
 **For deployed changes**, the comment must include concrete evidence from the verification table above AND per-criterion verification results. Example format:

--- a/scripts/_gh_comment_with_retry_match.py
+++ b/scripts/_gh_comment_with_retry_match.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""_gh_comment_with_retry_match.py — Helper for gh-comment-with-retry.sh.
+
+Reads a GitHub issue-comments JSON list from stdin, finds the most recent
+comment by ``$GH_USER``, writes its body to ``$LATEST_BODY_FILE``, and
+prints the comment's ``html_url`` on stdout.
+
+Why a sibling helper instead of an inline ``python3 -c``
+--------------------------------------------------------
+Mirrors the ``scripts/_check_shipped_pr_*.py`` pattern: small, focused
+helpers next to the bash wrapper that uses them. Keeps the logic
+unit-testable on its own (no shell mocking required), avoids the
+operator-laptop preflight hook's friction with inline ``python -c``
+content (the hook fires on the agent's Bash tool calls; sibling .py
+files are fine), and stays under the project's "Multi-line Python
+always goes in a .py file" rule for consistency.
+
+Stdin: the raw JSON body of GET /repos/<owner>/<repo>/issues/<N>/comments
+(an array of comment objects).
+
+Env:
+    GH_USER (str): the gh user login whose comment we want to match.
+    LATEST_BODY_FILE (str): destination path for the matched comment's
+        body content (UTF-8, written verbatim from the JSON ``body``
+        field).
+
+Output:
+    On match: writes the body to ``LATEST_BODY_FILE``, prints the
+    matched comment's ``html_url`` (or empty string if missing) on
+    stdout, exits 0.
+
+    On no-match (no comment by GH_USER in the response): exits 1 with
+    no stdout output. The wrapper interprets exit 1 as
+    "no-recent-comment-by-us-found".
+
+Tracking: issue #4478.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main() -> int:
+    """Process the comments JSON from stdin, write+print on match."""
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw) if raw else []
+    except json.JSONDecodeError:
+        # The wrapper saw something that wasn't valid JSON — treat as
+        # no-match so the wrapper falls through to its real-failure
+        # passthrough. Don't echo the input on stderr; the wrapper
+        # already has the original 504 stderr to surface.
+        return 1
+
+    if not isinstance(data, list):
+        return 1
+
+    gh_user = os.environ.get("GH_USER", "")
+    body_path = os.environ.get("LATEST_BODY_FILE", "")
+    if not gh_user or not body_path:
+        return 1
+
+    # The GitHub API returns comments in chronological order by default,
+    # but the wrapper requested ``direction=desc`` so the most recent
+    # comment is first. We pick the first entry whose user.login matches
+    # GH_USER. If the API ignored ``direction=desc`` for any reason
+    # (rare), we'd still pick "first by user," which is a defensible
+    # fallback — the wrapper's match check is symmetric (sha256 of body
+    # vs body file), so a wrong-comment match is impossible.
+    for comment in data:
+        if not isinstance(comment, dict):
+            continue
+        user_obj = comment.get("user") or {}
+        login = user_obj.get("login") or "" if isinstance(user_obj, dict) else ""
+        if login != gh_user:
+            continue
+        body = comment.get("body") or ""
+        with open(body_path, "w", encoding="utf-8") as fh:
+            fh.write(body)
+        print(comment.get("html_url") or "")
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gh-comment-with-retry.sh
+++ b/scripts/gh-comment-with-retry.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+# permanent: true
+# gh-comment-with-retry.sh — Post a `gh issue comment` and tolerate the
+# 504-after-success failure mode.
+#
+# Why this helper exists
+# ----------------------
+# `gh issue comment <N> --body-file <file>` periodically returns a
+# `504 Gateway Timeout` (with a multi-KB HTML "Unicorn!" error page in
+# stderr) **after the comment has already posted**. A naive retry
+# creates a duplicate comment. Treating it as a hard failure misleads
+# the agent about pipeline state.
+#
+# This is the comment-post analogue of the `gh pr merge` 5xx case
+# documented in `.claude/skills/task/SKILL.md` §A.7 (#4231): the API
+# already accepted the request, only the response failed. Recipe:
+# re-fetch state and treat already-posted-with-matching-body as
+# success.
+#
+# Tracking: issue #4478.
+#
+# Usage
+# -----
+#   scripts/gh-comment-with-retry.sh <issue-N> --body-file <path>
+#   scripts/gh-comment-with-retry.sh <issue-N> --body-file <path> --repo <owner/name>
+#   scripts/gh-comment-with-retry.sh --help
+#
+# Behavior
+# --------
+#   1. Calls ``gh issue comment <N> --repo <repo> --body-file <path>``.
+#   2. On exit 0: prints the returned comment URL to stdout, exits 0.
+#   3. On non-zero exit AND the captured stderr matches
+#      ``504 Gateway Timeout`` or ``<title>Unicorn!``:
+#      - Re-fetches the issue's recent comments via
+#        ``gh api /repos/<repo>/issues/<N>/comments?per_page=100&sort=created&direction=desc``.
+#      - Filters to comments by the current ``gh`` user
+#        (``gh api /user --jq .login``).
+#      - Compares SHA-256 of the most recent comment's body to SHA-256
+#        of the ``--body-file`` content.
+#      - If they match: prints "comment posted (504 swallowed): <url>"
+#        and exits 0.
+#      - If they don't match: prints the captured stderr (truncated to
+#        first 5 KB) and exits non-zero.
+#   4. On any other non-zero exit (auth failure, rate limit, etc.):
+#      prints the captured stderr and exits with the original code.
+#
+# Rate-budget hygiene
+# -------------------
+# Stays well within the 5,000 reqs/hr GitHub API budget — at most one
+# extra ``GET /repos/.../issues/<N>/comments`` and one ``GET /user``
+# per 504. No exponential backoff retries: a single confirm-or-fail
+# round trip is enough to disambiguate the 504-after-success case.
+#
+# Integration
+# -----------
+# Replaces direct ``gh issue comment ... --body-file ...`` calls in
+# ``.claude/skills/task/SKILL.md`` (Steps 2, A.2b, A.8 Step 3 — claim
+# comment, process summary, verification evidence) and the
+# documentation in ``.claude/skills/task-v2-summary/SKILL.md`` (process
+# summary post — daemon side already retries via
+# ``_gh_issue_comment``; the helper is the bash-path equivalent).
+#
+# Out of scope: ``gh pr comment`` calls share the same bug class but
+# are rarer; a follow-up issue can pick those up.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+print_help() {
+    cat << 'EOF'
+gh-comment-with-retry.sh — post `gh issue comment` with 504-swallow recovery.
+
+Usage:
+  scripts/gh-comment-with-retry.sh <issue-N> --body-file <path>
+  scripts/gh-comment-with-retry.sh <issue-N> --body-file <path> --repo <owner/name>
+  scripts/gh-comment-with-retry.sh --help | -h
+
+Arguments:
+  <issue-N>            Issue number to comment on (digits, optional leading '#').
+  --body-file <path>   Path to the comment body file.
+  --repo <owner/name>  Repository (default: judgemind/judgemind).
+  -h, --help           Show this help and exit.
+
+Exit codes:
+  0  — Comment posted successfully (including 504-after-success).
+  1  — Real failure (auth, rate limit, real server failure, etc.).
+  2  — Usage error (missing args, body-file not found).
+
+See header comment for behavior details. Tracking: #4478.
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+    print_help >&2
+    exit 2
+fi
+
+ISSUE=""
+BODY_FILE=""
+REPO="judgemind/judgemind"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        --body-file)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --body-file requires a value." >&2
+                exit 2
+            fi
+            BODY_FILE="$2"
+            shift 2
+            ;;
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --repo requires a value." >&2
+                exit 2
+            fi
+            REPO="$2"
+            shift 2
+            ;;
+        -*)
+            echo "ERROR: unknown flag: $1" >&2
+            print_help >&2
+            exit 2
+            ;;
+        *)
+            if [[ -z "$ISSUE" ]]; then
+                ISSUE="${1#\#}"
+            else
+                echo "ERROR: unexpected positional argument: $1" >&2
+                print_help >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+if [[ -z "$ISSUE" ]]; then
+    echo "ERROR: missing <issue-N> argument." >&2
+    print_help >&2
+    exit 2
+fi
+
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: <issue-N> must be a positive integer, got '$ISSUE'." >&2
+    exit 2
+fi
+
+if [[ -z "$BODY_FILE" ]]; then
+    echo "ERROR: missing --body-file argument." >&2
+    print_help >&2
+    exit 2
+fi
+
+if [[ ! -f "$BODY_FILE" ]]; then
+    echo "ERROR: --body-file does not exist: $BODY_FILE" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1 — Try the comment post, capturing stdout and stderr separately.
+# ---------------------------------------------------------------------------
+
+# Use mktemp for the captured stderr so we can both inspect (for 504 signature)
+# and replay (on real failure) without buffering megabytes in shell variables.
+STDERR_FILE=$(mktemp)
+STDOUT_FILE=$(mktemp)
+# shellcheck disable=SC2064  # cleanup paths are fixed at trap-install time.
+trap "rm -f '$STDERR_FILE' '$STDOUT_FILE'" EXIT
+
+set +e
+gh issue comment "$ISSUE" --repo "$REPO" --body-file "$BODY_FILE" \
+    > "$STDOUT_FILE" 2> "$STDERR_FILE"
+GH_EXIT=$?
+set -e
+
+if [[ "$GH_EXIT" -eq 0 ]]; then
+    # Happy path — pass through stdout (the comment URL) and exit 0.
+    cat "$STDOUT_FILE"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — Non-zero exit. Inspect stderr for the 504-after-success signature.
+# ---------------------------------------------------------------------------
+
+# Two markers are diagnostic of the GitHub 504 / Unicorn page:
+#   - Literal "504 Gateway Timeout" (HTTP status line gh sometimes echoes)
+#   - "<title>Unicorn!" (HTML error page GitHub renders for 5xx)
+# Either match triggers the re-fetch-and-compare path. Anything else is a
+# real failure that should pass through.
+if ! grep -qE "504 Gateway Timeout|<title>Unicorn!" "$STDERR_FILE"; then
+    # Real failure. Pass stderr through and exit with the original code.
+    cat "$STDERR_FILE" >&2
+    exit "$GH_EXIT"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — 504-after-success suspected. Re-fetch and compare bodies.
+# ---------------------------------------------------------------------------
+
+echo "gh-comment-with-retry: detected 504/Unicorn signature, verifying via comment list..." >&2
+
+# Compute SHA-256 of the body file we tried to post. ``shasum -a 256`` is
+# available on macOS and Linux; ``sha256sum`` is Linux-only. Prefer
+# ``shasum`` for portability with Fargate + operator macOS laptops.
+if command -v shasum >/dev/null 2>&1; then
+    LOCAL_SHA=$(shasum -a 256 "$BODY_FILE" | awk '{print $1}')
+elif command -v sha256sum >/dev/null 2>&1; then
+    LOCAL_SHA=$(sha256sum "$BODY_FILE" | awk '{print $1}')
+else
+    echo "ERROR: neither shasum nor sha256sum is available — cannot verify." >&2
+    cat "$STDERR_FILE" >&2
+    exit "$GH_EXIT"
+fi
+
+# Fetch current gh user login. Used to filter the comment list to comments
+# WE posted (avoids matching a coincidentally-identical comment from
+# someone else who happened to post moments before our attempt).
+GH_USER=$(gh api /user --jq '.login' 2>/dev/null) || GH_USER=""
+if [[ -z "$GH_USER" ]]; then
+    echo "ERROR: could not resolve gh user login — cannot verify." >&2
+    cat "$STDERR_FILE" >&2
+    exit "$GH_EXIT"
+fi
+
+# Fetch the most recent 100 comments, sorted descending by creation. The
+# helper compares the FIRST (most recent) comment by GH_USER against the
+# body file. ``per_page=100`` is enough for any plausible thread; the
+# direction=desc + first-by-user pattern is robust to other-user comments
+# that may have arrived in between.
+COMMENTS_JSON=$(gh api \
+    "/repos/$REPO/issues/$ISSUE/comments?per_page=100&sort=created&direction=desc" \
+    2>/dev/null) || {
+    echo "ERROR: could not fetch comment list for verification." >&2
+    cat "$STDERR_FILE" >&2
+    exit "$GH_EXIT"
+}
+
+# Extract the most recent comment by GH_USER as a tab-separated row:
+#   <html_url>\t<body-sha256>
+# We let jq compute the sha256 via @sha256d? Nope — jq has no sha256
+# builtin in the GitHub-shipped version. Compute it externally: jq prints
+# just the body, then we shasum it. Two-step pipeline keeps the data flow
+# simple and avoids embedding a sha256-in-jq workaround.
+LATEST_BODY_FILE=$(mktemp)
+LATEST_URL=""
+# shellcheck disable=SC2064  # cleanup paths are fixed at trap-install time.
+trap "rm -f '$STDERR_FILE' '$STDOUT_FILE' '$LATEST_BODY_FILE'" EXIT
+
+# Walk the JSON via the sibling python helper — same pattern as the
+# scripts/_check_shipped_pr_*.py family. The helper writes the matched
+# comment's body to LATEST_BODY_FILE and prints html_url on stdout.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LATEST_URL=$(
+    GH_USER="$GH_USER" \
+    LATEST_BODY_FILE="$LATEST_BODY_FILE" \
+    python3 "$SCRIPT_DIR/_gh_comment_with_retry_match.py" <<< "$COMMENTS_JSON"
+) || {
+    echo "ERROR: no recent comment by '$GH_USER' found on issue #$ISSUE — original 504 was not a swallowed-success." >&2
+    # Truncate stderr to first 5 KB before passthrough.
+    head -c 5120 "$STDERR_FILE" >&2
+    echo "" >&2
+    exit "$GH_EXIT"
+}
+
+# Compute SHA-256 of the fetched body and compare.
+if command -v shasum >/dev/null 2>&1; then
+    REMOTE_SHA=$(shasum -a 256 "$LATEST_BODY_FILE" | awk '{print $1}')
+else
+    REMOTE_SHA=$(sha256sum "$LATEST_BODY_FILE" | awk '{print $1}')
+fi
+
+if [[ "$LOCAL_SHA" == "$REMOTE_SHA" ]]; then
+    echo "comment posted (504 swallowed): $LATEST_URL"
+    exit 0
+fi
+
+# Bodies don't match — the 504 was a real failure (or our comment got
+# clobbered by a racing other-user post). Treat as failure.
+echo "ERROR: 504 detected but most recent comment by '$GH_USER' does not match body-file content." >&2
+echo "  local sha:  $LOCAL_SHA" >&2
+echo "  remote sha: $REMOTE_SHA" >&2
+echo "  remote url: $LATEST_URL" >&2
+echo "" >&2
+# Truncate stderr to first 5 KB before passthrough.
+head -c 5120 "$STDERR_FILE" >&2
+echo "" >&2
+exit "$GH_EXIT"

--- a/scripts/tests/test_gh_comment_with_retry.sh
+++ b/scripts/tests/test_gh_comment_with_retry.sh
@@ -1,0 +1,454 @@
+#!/usr/bin/env bash
+# test_gh_comment_with_retry.sh — Tests for scripts/gh-comment-with-retry.sh.
+#
+# Covers the four code paths called out in issue #4478:
+#   A — Success path: gh exits 0, helper prints URL and exits 0.
+#   B — 504 + matching last-comment: helper exits 0 with "504 swallowed" log.
+#   C — 504 + non-matching last-comment: helper exits non-zero (real failure).
+#   D — Other non-zero exit (auth fail / rate limit / etc.): pass-through.
+#   E — Usage / argument validation paths.
+#
+# All tests run against a PATH-mocked ``gh`` binary — no network. Uses the
+# same temp-cleanup helper pattern as test_block_issue.sh and friends
+# (see scripts/tests/_temp_cleanup_helpers.sh, #4343).
+#
+# Usage:
+#   scripts/tests/test_gh_comment_with_retry.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/gh-comment-with-retry.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+ORIG_PATH_SAVE=""
+restore_path() {
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+register_cleanup_hook restore_path
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Set up a mock gh CLI on PATH ──────────────────────────────────────────
+#
+# The mock supports three command shapes the wrapper exercises:
+#
+#   1. ``gh issue comment <N> --repo <repo> --body-file <path>``
+#      Behavior controlled by ``MOCK_COMMENT_MODE`` env var:
+#        - "success"  : exit 0, print URL on stdout (default).
+#        - "504"      : exit 1, print 504 + Unicorn HTML on stderr.
+#        - "auth"     : exit 4, print "authentication required" on stderr
+#                       (other-failure passthrough path).
+#
+#   2. ``gh api /user --jq .login``
+#      Always prints ``MOCK_GH_USER`` (default: "test-user") and exits 0.
+#
+#   3. ``gh api /repos/<owner>/<repo>/issues/<N>/comments?...``
+#      Prints the JSON staged in ``MOCK_COMMENTS_FILE`` and exits 0. If
+#      ``MOCK_COMMENTS_FILE`` is unset or the file is missing, prints
+#      ``[]`` (empty list) and exits 0.
+
+MOCK_BIN_DIR=$(mktemp -d)
+register_temp_dir "$MOCK_BIN_DIR"
+ORIG_PATH_SAVE="$PATH"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+# Record every invocation for assertions.
+if [[ -n "${MOCK_INVOCATIONS:-}" ]]; then
+    echo "$@" >> "$MOCK_INVOCATIONS"
+fi
+
+# ── gh issue comment <N> --repo <repo> --body-file <path> ──────────────────
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+    mode="${MOCK_COMMENT_MODE:-success}"
+    case "$mode" in
+        success)
+            echo "https://github.com/judgemind/judgemind/issues/${3:-0}#issuecomment-99999"
+            exit 0
+            ;;
+        504)
+            cat >&2 << 'STDERR_EOF'
+HTTP 504: Gateway Timeout (https://api.github.com/repos/judgemind/judgemind/issues/100/comments)
+<!DOCTYPE html>
+<html>
+<head>
+<title>Unicorn! &middot; GitHub</title>
+</head>
+<body>
+<h1>This page is taking way too long to load.</h1>
+<p>Sorry about that. Please try refreshing and contact us if the problem persists.</p>
+</body>
+</html>
+STDERR_EOF
+            exit 1
+            ;;
+        auth)
+            echo "error: authentication required" >&2
+            exit 4
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_COMMENT_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api /user --jq .login ───────────────────────────────────────────────
+if [[ "${1:-}" == "api" && "${2:-}" == "/user" ]]; then
+    echo "${MOCK_GH_USER:-test-user}"
+    exit 0
+fi
+
+# ── gh api /repos/.../issues/<N>/comments?... ──────────────────────────────
+if [[ "${1:-}" == "api" && "${2:-}" =~ ^/repos/.*/issues/[0-9]+/comments ]]; then
+    if [[ -n "${MOCK_COMMENTS_FILE:-}" && -f "${MOCK_COMMENTS_FILE}" ]]; then
+        cat "${MOCK_COMMENTS_FILE}"
+    else
+        echo "[]"
+    fi
+    exit 0
+fi
+
+# Unknown command — fail loudly so the test surfaces it.
+echo "mock gh: unhandled command: $*" >&2
+exit 127
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+# Helper to compute a body file's sha256 (for staging matching mock comments).
+sha256_of_file() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        sha256sum "$1" | awk '{print $1}'
+    fi
+}
+
+# ── Test E — Usage / argument validation paths ─────────────────────────────
+
+# E.1 — No args prints help to stderr and exits 2.
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.1: 0 args exits 2"
+else
+    fail "E.1: 0 args exits 2" "expected 2, got $exit_code"
+fi
+
+# E.2 — --help exits 0 and prints usage to stdout.
+exit_code=0
+help_output=$("$WRAPPER" --help 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 ]] && [[ "$help_output" == *"Usage:"* ]]; then
+    pass "E.2: --help exits 0 with usage on stdout"
+else
+    fail "E.2: --help exits 0 with usage on stdout" "exit=$exit_code, output: $help_output"
+fi
+
+# E.3 — Non-numeric issue exits 2.
+exit_code=0
+err_output=$("$WRAPPER" abc --body-file /tmp/whatever 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 2 ]] && [[ "$err_output" == *"must be a positive integer"* ]]; then
+    pass "E.3: non-numeric issue exits 2 with descriptive error"
+else
+    fail "E.3: non-numeric issue exits 2 with descriptive error" "exit=$exit_code, err: $err_output"
+fi
+
+# E.4 — Missing --body-file exits 2.
+exit_code=0
+"$WRAPPER" 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.4: missing --body-file exits 2"
+else
+    fail "E.4: missing --body-file exits 2" "expected 2, got $exit_code"
+fi
+
+# E.5 — Body-file does not exist exits 2.
+exit_code=0
+err_output=$("$WRAPPER" 100 --body-file /nonexistent/path/here 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 2 ]] && [[ "$err_output" == *"does not exist"* ]]; then
+    pass "E.5: missing body-file exits 2 with descriptive error"
+else
+    fail "E.5: missing body-file exits 2 with descriptive error" "exit=$exit_code, err: $err_output"
+fi
+
+# E.6 — Leading '#' on issue arg is stripped.
+BODY_FILE_E=$(mktemp)
+register_temp_file "$BODY_FILE_E"
+echo "test body for E.6" > "$BODY_FILE_E"
+INVOCATIONS_E="$MOCK_BIN_DIR/invocations_e.txt"
+: > "$INVOCATIONS_E"
+
+exit_code=0
+MOCK_INVOCATIONS="$INVOCATIONS_E" \
+    MOCK_COMMENT_MODE=success \
+    "$WRAPPER" "#100" --body-file "$BODY_FILE_E" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]] && grep -qE "^issue comment 100\b" "$INVOCATIONS_E"; then
+    pass "E.6: leading '#' on issue arg is stripped (gh called with '100')"
+else
+    fail "E.6: leading '#' on issue arg is stripped (gh called with '100')" \
+        "exit=$exit_code, invocations: $(cat "$INVOCATIONS_E")"
+fi
+
+# ── Test A — Success path ─────────────────────────────────────────────────
+
+BODY_FILE_A=$(mktemp)
+register_temp_file "$BODY_FILE_A"
+echo "Hello from test A — process summary content here." > "$BODY_FILE_A"
+
+INVOCATIONS_A="$MOCK_BIN_DIR/invocations_a.txt"
+: > "$INVOCATIONS_A"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_A" \
+    MOCK_COMMENT_MODE=success \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_A" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "A: success path exits 0"
+else
+    fail "A: success path exits 0" "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/issues/100"* ]]; then
+    pass "A: success path prints comment URL to stdout"
+else
+    fail "A: success path prints comment URL to stdout" "got: $stdout_output"
+fi
+
+# Verify NO comment-list re-fetch happened (only the single ``gh issue comment``).
+# Use awk so a no-match (zero count) doesn't trip pipefail.
+api_calls=$(awk '/^api / {n++} END {print n+0}' "$INVOCATIONS_A")
+if [[ "$api_calls" == "0" ]]; then
+    pass "A: success path makes no extra API calls"
+else
+    fail "A: success path makes no extra API calls" "found $api_calls api calls: $(cat "$INVOCATIONS_A")"
+fi
+
+# ── Test B — 504 + matching last-comment ──────────────────────────────────
+
+BODY_FILE_B=$(mktemp)
+register_temp_file "$BODY_FILE_B"
+cat > "$BODY_FILE_B" << 'BODY_B_EOF'
+## Process Summary
+
+This body's SHA-256 must match the last comment by test-user on
+the mock issue. The wrapper should detect 504-after-success and
+exit 0 with a "504 swallowed" log line.
+BODY_B_EOF
+
+# Stage a comments JSON whose first entry is by test-user with the same body.
+COMMENTS_B=$(mktemp)
+register_temp_file "$COMMENTS_B"
+# Read the body file as a JSON-escaped string via python (consistent with how
+# the GitHub API would round-trip the body).
+python3 - "$BODY_FILE_B" "$COMMENTS_B" << 'PY_STAGE_B'
+import json
+import sys
+body = open(sys.argv[1]).read()
+comments = [
+    {
+        "html_url": "https://github.com/judgemind/judgemind/issues/100#issuecomment-99",
+        "user": {"login": "test-user"},
+        "body": body,
+        "created_at": "2026-05-08T01:00:00Z",
+    },
+    {
+        "html_url": "https://github.com/judgemind/judgemind/issues/100#issuecomment-98",
+        "user": {"login": "someone-else"},
+        "body": "an earlier unrelated comment",
+        "created_at": "2026-05-08T00:30:00Z",
+    },
+]
+with open(sys.argv[2], "w") as fh:
+    json.dump(comments, fh)
+PY_STAGE_B
+
+INVOCATIONS_B="$MOCK_BIN_DIR/invocations_b.txt"
+: > "$INVOCATIONS_B"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_B" \
+    MOCK_COMMENT_MODE=504 \
+    MOCK_GH_USER="test-user" \
+    MOCK_COMMENTS_FILE="$COMMENTS_B" \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_B" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "B: 504 + matching last-comment exits 0"
+else
+    fail "B: 504 + matching last-comment exits 0" "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"504 swallowed"* ]]; then
+    pass "B: stdout names '504 swallowed' on the recovery path"
+else
+    fail "B: stdout names '504 swallowed' on the recovery path" "got: $stdout_output"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/issues/100#issuecomment-99"* ]]; then
+    pass "B: stdout includes the matched comment URL"
+else
+    fail "B: stdout includes the matched comment URL" "got: $stdout_output"
+fi
+
+# ── Test C — 504 + non-matching last-comment (real failure) ───────────────
+
+BODY_FILE_C=$(mktemp)
+register_temp_file "$BODY_FILE_C"
+echo "intended body for test C — should NOT match the staged comment" > "$BODY_FILE_C"
+
+# Stage a comments JSON whose first test-user comment has DIFFERENT body.
+COMMENTS_C=$(mktemp)
+register_temp_file "$COMMENTS_C"
+cat > "$COMMENTS_C" << 'COMMENTS_C_EOF'
+[
+  {
+    "html_url": "https://github.com/judgemind/judgemind/issues/100#issuecomment-50",
+    "user": {"login": "test-user"},
+    "body": "an OLDER unrelated comment we posted earlier",
+    "created_at": "2026-05-08T00:00:00Z"
+  }
+]
+COMMENTS_C_EOF
+
+exit_code=0
+err_output=$(
+    MOCK_COMMENT_MODE=504 \
+    MOCK_GH_USER="test-user" \
+    MOCK_COMMENTS_FILE="$COMMENTS_C" \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_C" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "C: 504 + non-matching last-comment exits non-zero"
+else
+    fail "C: 504 + non-matching last-comment exits non-zero" "expected non-zero, got $exit_code"
+fi
+
+if [[ "$err_output" == *"does not match body-file content"* ]]; then
+    pass "C: stderr names the SHA mismatch"
+else
+    fail "C: stderr names the SHA mismatch" "got: $err_output"
+fi
+
+# ── Test C2 — 504 + no comment by current user ────────────────────────────
+
+# Edge case: stderr matched 504, but the comment list has zero comments by us.
+BODY_FILE_C2=$(mktemp)
+register_temp_file "$BODY_FILE_C2"
+echo "test body C2" > "$BODY_FILE_C2"
+
+COMMENTS_C2=$(mktemp)
+register_temp_file "$COMMENTS_C2"
+cat > "$COMMENTS_C2" << 'COMMENTS_C2_EOF'
+[
+  {
+    "html_url": "https://github.com/judgemind/judgemind/issues/100#issuecomment-1",
+    "user": {"login": "someone-else"},
+    "body": "a comment by another user",
+    "created_at": "2026-05-08T00:00:00Z"
+  }
+]
+COMMENTS_C2_EOF
+
+exit_code=0
+err_output=$(
+    MOCK_COMMENT_MODE=504 \
+    MOCK_GH_USER="test-user" \
+    MOCK_COMMENTS_FILE="$COMMENTS_C2" \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_C2" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "C2: 504 + no comment by current user exits non-zero"
+else
+    fail "C2: 504 + no comment by current user exits non-zero" "expected non-zero, got $exit_code"
+fi
+
+if [[ "$err_output" == *"no recent comment by"* ]]; then
+    pass "C2: stderr names the missing-by-user case"
+else
+    fail "C2: stderr names the missing-by-user case" "got: $err_output"
+fi
+
+# ── Test D — Other non-zero exit (auth fail) — pass-through ───────────────
+
+BODY_FILE_D=$(mktemp)
+register_temp_file "$BODY_FILE_D"
+echo "test body D" > "$BODY_FILE_D"
+
+INVOCATIONS_D="$MOCK_BIN_DIR/invocations_d.txt"
+: > "$INVOCATIONS_D"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_D" \
+    MOCK_COMMENT_MODE=auth \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_D" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 4 ]]; then
+    pass "D: auth-fail (other non-zero) passes through original exit code"
+else
+    fail "D: auth-fail (other non-zero) passes through original exit code" "expected 4, got $exit_code"
+fi
+
+if [[ "$err_output" == *"authentication required"* ]]; then
+    pass "D: auth-fail stderr is passed through"
+else
+    fail "D: auth-fail stderr is passed through" "got: $err_output"
+fi
+
+# Verify NO recovery API calls happened — auth failure doesn't trigger
+# the 504-swallow path. Use awk to avoid grep's exit-1-on-no-match tripping pipefail.
+recovery_calls=$(awk '/^api / {n++} END {print n+0}' "$INVOCATIONS_D")
+if [[ "$recovery_calls" == "0" ]]; then
+    pass "D: auth-fail makes no recovery API calls"
+else
+    fail "D: auth-fail makes no recovery API calls" "found $recovery_calls api calls"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/gh-comment-with-retry.sh` — a small wrapper around `gh issue comment ... --body-file ...` that transparently handles the GitHub `504 Gateway Timeout` / `<title>Unicorn!` HTML response failure mode where the comment has actually posted but the response failed (the comment-post analogue of the `gh pr merge` 5xx case in #4231 / `task/SKILL.md` §A.7).

On non-zero `gh` exit + 504/Unicorn signature in stderr, the wrapper re-fetches the issue's recent comments, filters to comments by the current `gh` user, and SHA-256-compares the most recent matching comment's body to the body file. Match → "504 swallowed" + exit 0. Mismatch → pass-through with truncated stderr.

The three `gh issue comment` call sites in `.claude/skills/task/SKILL.md` (claim comment, process summary, verification evidence) now route through the wrapper. `.claude/skills/task-v2-summary/SKILL.md` references the wrapper as the bash-side equivalent of the daemon's `_gh_issue_comment` retry envelope.

JSON parsing lives in a sibling `scripts/_gh_comment_with_retry_match.py` helper (matches the `_check_shipped_pr_*.py` family). All 19 sub-tests in `scripts/tests/test_gh_comment_with_retry.sh` pass against a PATH-mocked `gh` binary.

**Dogfood verification:** the process-summary comment on issue #4478 was posted via `scripts/gh-comment-with-retry.sh 4478 --body-file ...` and returned the comment URL successfully — that's the AC1 `--help` and the wrapper-runs-end-to-end signal in one tool call.

Closes #4478

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_gh_comment_with_retry.sh` runs in the `shell-fast` shard via `scripts/run-scripts-tests.sh`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (scripts + agent SKILL.md only). The wrapper itself was dogfooded against real GitHub before the PR push: `scripts/gh-comment-with-retry.sh 4478 --body-file tmp/process_summary.txt` returned the comment URL `https://github.com/judgemind/judgemind/issues/4478#issuecomment-4412046426`.
- [x] Verification evidence posted on issue (see A.8)
