### PR TITLE
dx(skills): route remaining gh issue comment sites through gh-comment-with-retry.sh (#4485)

### DIFF
--- a/.claude/skills/audit-llm-carry-forward/SKILL.md
+++ b/.claude/skills/audit-llm-carry-forward/SKILL.md
@@ -114,10 +114,10 @@ Replace `FINDING_PREFIX` with the bracketed prefix from the finding's title (e.g
 
   (`N` is the finding's index in the `findings` array, 0-based.)
 
-  Then post the comment:
+  Then post the comment via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478):
 
   ```
-  gh issue comment ISSUE_NUMBER --repo judgemind/judgemind --body-file tmp/llm-carry-forward/comment-N.txt
+  scripts/gh-comment-with-retry.sh ISSUE_NUMBER --body-file tmp/llm-carry-forward/comment-N.txt
   ```
 
   Record the comment URL.
@@ -166,10 +166,10 @@ gh issue list --repo judgemind/judgemind --label source/audit-llm-carry-forward-
   tmp/llm-carry-forward/heartbeat.txt
   ```
 
-  Post:
+  Post via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478):
 
   ```
-  gh issue comment LOG_ISSUE_NUMBER --repo judgemind/judgemind --body-file tmp/llm-carry-forward/heartbeat.txt
+  scripts/gh-comment-with-retry.sh LOG_ISSUE_NUMBER --body-file tmp/llm-carry-forward/heartbeat.txt
   ```
 
 * **No matching open issue:** create the long-lived audit-log issue once. Subsequent weeks will append comments to it.

--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -270,7 +270,7 @@ You can use the full toolset of a `/task` agent or the operator's dispatcher ses
 - **Edit / Write / Read / Glob / Grep** — full filesystem access. Edit files in the failed agent's worktree (when present), write helpers to `{worktree}/tmp/diagnoser/`, read PR diffs, etc. Note: the v3 diagnoser runs in its own ECS task; it does not have the failed agent's worktree on disk by default. Use `git fetch origin pull/<PR>/head:adopt-<PR>` to materialize the agent's branch when you need to inspect or patch it.
 - **Agent (sub-skill invocation)** — call `/ralph`, `/tdd`, `/audit`, etc. when judgment requires. Sub-skills run with their own normal contracts.
 - **MCP servers** — `github`, `awslabs_cloudwatch-mcp-server`, `awslabs_ecs-mcp-server`, `plugin:telegram` (read/notify only — see Telegram Integration in `CLAUDE.md`).
-- **gh / git / aws CLI** — full operator-tier authority. You may commit and push to the failed agent's branch, file new issues, edit issue/PR bodies, add/remove labels, post comments, close issues. AWS reads (CloudWatch logs, ECS describe-tasks) plus same writes the launcher already has on the dev account.
+- **gh / git / aws CLI** — full operator-tier authority. You may commit and push to the failed agent's branch, file new issues, edit issue/PR bodies, add/remove labels, post comments (via `scripts/gh-comment-with-retry.sh` for `--body-file` posts so the 504-after-success failure mode #4478 is handled transparently), close issues. AWS reads (CloudWatch logs, ECS describe-tasks) plus same writes the launcher already has on the dev account.
 
 ---
 
@@ -304,7 +304,7 @@ remote: refusing to allow a Personal Access Token to create or update workflow `
 
 Three prior fleet decisions all blocked-on the same PAT issue (#4012). The current agent's failure is an instance of the same root cause.
 
-**Action.** Append `Blocked by #4012` to issue #3297, add `status/blocked`, post the explanatory comment.
+**Action.** Append `Blocked by #4012` to issue #3297, add `status/blocked`, post the explanatory comment via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478):
 
 ```
 gh issue view 3297 --repo judgemind/judgemind --json body --jq .body > {worktree}/tmp/diagnoser/orig_body.md
@@ -312,7 +312,7 @@ gh issue view 3297 --repo judgemind/judgemind --json body --jq .body > {worktree
 python3 {worktree}/tmp/diagnoser/append_blocked_by.py 4012 < {worktree}/tmp/diagnoser/orig_body.md > {worktree}/tmp/diagnoser/new_body.md
 gh issue edit 3297 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/new_body.md
 gh issue edit 3297 --repo judgemind/judgemind --add-label status/blocked --remove-label agent/ready
-gh issue comment 3297 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/block_comment.md
+{worktree}/scripts/gh-comment-with-retry.sh 3297 --body-file {worktree}/tmp/diagnoser/block_comment.md
 python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "\"remote: refusing to allow a Personal Access Token to create or update workflow\" — same PAT-scope cascade as #4012. Blocked-on #4012; will auto-unblock when that PR merges."
 ```
 
@@ -330,6 +330,8 @@ gh issue comment 3601 --repo judgemind/judgemind --body "AC #1 referenced 'trans
 gh issue edit 3601 --repo judgemind/judgemind --add-label agent/ready
 python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "\"AC#1 unmet: field 'transcribed_text' does not exist on Document\" — the field was renamed to transcription_html in #3204. Reissued the AC and re-added agent/ready."
 ```
+
+(Note: the `gh issue comment ... --body "..."` line above passes a short inline body, not `--body-file`, so the 504-after-success wrapper isn't needed here. The wrapper is required for `--body-file` posts; short inline bodies are unaffected by the failure mode.)
 
 ### Example 4 — duplicate-PR consolidation (#3725)
 
@@ -376,7 +378,7 @@ WHERE agent_id = $AGENT_ID;
 
 ```
 gh issue edit 3700 --repo judgemind/judgemind --add-label status/needs-human,priority/p1
-gh issue comment 3700 --repo judgemind/judgemind --body-file {worktree}/tmp/diagnoser/escalation.md
+{worktree}/scripts/gh-comment-with-retry.sh 3700 --body-file {worktree}/tmp/diagnoser/escalation.md
 python3 {worktree}/tmp/diagnoser/write_outcome.py "$AGENT_ID" "silent_hang at ralph_iter_3 — task-runner stopped emitting log events for 31 min during reviewer subagent. Third silent-hang at the same milestone on this issue. Marked needs_review; transcript ends mid-Bash call to 'gh run watch'."
 ```
 

--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -290,9 +290,9 @@ A previous agent attempted this issue and made progress before exiting.
 - If no implementation started: "No implementation progress was made. Start fresh."
 ```
 
-Post the comment:
+Post the comment via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478, so a flaky GitHub response doesn't surface as a duplicate context comment on the next agent's pickup):
 ```
-gh issue comment <N> --repo judgemind/judgemind --body-file tmp/failed_agent_context_<issue>.txt
+scripts/gh-comment-with-retry.sh <N> --body-file tmp/failed_agent_context_<issue>.txt
 ```
 
 **Determining the failure mode:**
@@ -969,7 +969,7 @@ When a `529 overloaded_error`, Anthropic/Claude-side rate-limit error, or equiva
 
 1. **Retry once with ~30s backoff.** Sleep roughly 30 seconds and reattempt the exact same operation (spawn agent, merge PR, post comment, apply terraform — whatever was overloaded). One retry is enough to ride out a transient spike; a second retry just burns API budget without improving success rate.
 2. **If the retry also fails, defer the task.** "Defer" means:
-   - Post a short comment on the affected issue: `"529 during dispatch at <ISO-8601>; deferring — retry on next dispatcher run."` Write the comment to `{worktree}/tmp/defer_comment.txt` first, then post with `gh issue comment --body-file`.
+   - Post a short comment on the affected issue: `"529 during dispatch at <ISO-8601>; deferring — retry on next dispatcher run."` Write the comment to `{worktree}/tmp/defer_comment.txt` first, then post via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478).
    - Continue processing remaining slots in the main loop. **Do not stall the whole queue** over one overloaded task.
    - If the deferred task was an agent spawn that never started, leave the issue assigned to whoever it was assigned to (the next dispatcher cycle will re-fetch and retry). If it was a PR merge, leave the PR open — the next merge pass will pick it up again.
 

--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -25,7 +25,7 @@ The original court documents are authoritative. They are the source of truth —
 5. **File issues for structural findings.** When the fix shape is non-trivial or requires a maintainer decision, file an `agent/ready` issue with root-cause-first analysis (file:line evidence, the structural fix shape, why a surface patch wouldn't work) so the dispatcher can pick it up.
 6. **No `priority/p0`.** Reserved for humans.
 
-> **MCP vs `gh`:** `mcp__github__list_issues` and `mcp__github__search_issues` for reads (full typed objects, no `--json` enumeration). `gh issue create --body-file` and `gh issue comment --body-file` for writes — the MCP write path is currently auth-blocked. See `docs/agent/github-api-access.md`.
+> **MCP vs `gh`:** `mcp__github__list_issues` and `mcp__github__search_issues` for reads (full typed objects, no `--json` enumeration). `gh issue create --body-file` and `scripts/gh-comment-with-retry.sh` (the wrapper around `gh issue comment --body-file` that handles the 504-after-success failure mode #4478) for writes — the MCP write path is currently auth-blocked. See `docs/agent/github-api-access.md`.
 
 > **MCP vs `aws` CLI:** `scripts/ecs-run-task.sh` for the oneshot Fargate launch (handles network config, log streaming, exit-code propagation — not MCP-replaceable). `aws s3 cp` for downloading the spotcheck JSON and PDF artifacts. `mcp__awslabs_ecs-mcp-server__*` and `mcp__awslabs_cloudwatch-mcp-server__*` for ad-hoc cluster + logs reads. See `docs/agent/aws-api-access.md`.
 
@@ -300,10 +300,10 @@ If the new issue is blocked by another open issue, run `scripts/block-issue.sh <
 
 ### 4c — Comment on existing issue (for new evidence)
 
-When state-awareness in Step 1 matched the finding to an existing open issue, post a comment with the new sample:
+When state-awareness in Step 1 matched the finding to an existing open issue, post a comment with the new sample. Use the `scripts/gh-comment-with-retry.sh` wrapper so the 504-after-success failure mode (#4478) doesn't surface as a duplicate comment or false-failure:
 
 ```
-gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/spotcheck/comment_N.txt
+{worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/spotcheck/comment_N.txt
 ```
 
 Comment body should add value — a fresh date, a county not previously seen, a counter-example that disambiguates, a hypothesis the issue body didn't consider. "+1, still broken" is not a comment worth posting.

--- a/.claude/skills/task-v2-operational/SKILL.md
+++ b/.claude/skills/task-v2-operational/SKILL.md
@@ -29,9 +29,9 @@ You have full authority to execute operational work:
 - **Bash** — `scripts/ecs-run-task.sh` for ECS oneshot script runs, `scripts/dev-db-query.sh` for SQL queries, `gh` for issue/label/comment operations, `aws s3` for artifact downloads, `psql` via the scripts for DB validation. Set `timeout: 1200000` on long-running commands.
 - **Read / Glob / Grep** — full filesystem access for reading issue context, scripts, and docs.
 - **MCP servers** — `mcp__github__*` for GitHub reads, `mcp__awslabs_cloudwatch-mcp-server__*` and `mcp__awslabs_ecs-mcp-server__*` for ECS + CloudWatch reads.
-- **gh CLI** — `gh issue comment`, `gh issue close`, `gh issue edit`, `gh issue view`.
+- **gh CLI** — `gh issue comment` (via `scripts/gh-comment-with-retry.sh` wrapper), `gh issue close`, `gh issue edit`, `gh issue view`.
 
-> **MCP vs `gh`:** `mcp__github__get_issue` for reads. `gh issue comment --body-file`, `gh issue close`, `gh issue edit --add-label` for writes. See `docs/agent/github-api-access.md`.
+> **MCP vs `gh`:** `mcp__github__get_issue` for reads. `scripts/gh-comment-with-retry.sh` (wrapper around `gh issue comment --body-file` that handles the 504-after-success failure mode #4478), `gh issue close`, `gh issue edit --add-label` for writes. See `docs/agent/github-api-access.md`.
 
 > **MCP vs `aws` CLI:** `scripts/ecs-run-task.sh` for ECS oneshot task launch (handles network config, log streaming, exit-code propagation). `mcp__awslabs_ecs-mcp-server__*` for cluster/task reads. See `docs/agent/aws-api-access.md`.
 
@@ -182,10 +182,10 @@ Write the evidence markdown to a temp file then post:
 # Do NOT use heredoc — write evidence to a file first, then use --body-file
 ```
 
-Write `{worktree}/tmp/dispatcher-operational/evidence.md` with a `## Verification Evidence` section, then:
+Write `{worktree}/tmp/dispatcher-operational/evidence.md` with a `## Verification Evidence` section, then post via `scripts/gh-comment-with-retry.sh` (the wrapper transparently handles the 504-after-success failure mode #4478, so a flaky GitHub response doesn't surface as a duplicate comment or false-failure verdict):
 
 ```
-gh issue comment <issue_number> --repo judgemind/judgemind --body-file {worktree}/tmp/dispatcher-operational/evidence.md
+{worktree}/scripts/gh-comment-with-retry.sh <issue_number> --body-file {worktree}/tmp/dispatcher-operational/evidence.md
 ```
 
 If the task is complete and the AC say to close the issue:

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -298,9 +298,9 @@ Evaluate:
   ```
   (Use the PR's `headRefName` from `mcp__github__get_pull_request` for `<existing-PR-branch>`.) If the existing branch name conflicts with the auto-created worktree branch, a throwaway `adopt-<N>` tracking branch is fine — the push target is the original PR's head ref, not this worktree's branch name.
 - **`state: CLOSED` (merged or declined):** MCP returned a stale hit for a PR that has since closed. Treat as no duplicate and continue to Path A / Path B normally.
-- **Ambiguous case** (e.g. the existing PR addresses a *different* sub-scope of the issue and the current task is a legitimate follow-up, or the existing PR is stalled with no clear path forward): post a comment on the issue explaining the adoption decision and exit terminal. Write the comment to `{worktree}/tmp/adoption_bail_comment.txt`, then:
+- **Ambiguous case** (e.g. the existing PR addresses a *different* sub-scope of the issue and the current task is a legitimate follow-up, or the existing PR is stalled with no clear path forward): post a comment on the issue explaining the adoption decision and exit terminal. Write the comment to `{worktree}/tmp/adoption_bail_comment.txt`, then post via `scripts/gh-comment-with-retry.sh` (the wrapper transparently handles the 504-after-success failure mode #4478):
   ```
-  gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/adoption_bail_comment.txt
+  {worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/adoption_bail_comment.txt
   gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
   ```
   The comment should name the existing PR, explain why the current agent can't adopt it (stalled, scope mismatch, author disagreement), and either re-add `agent/ready` or leave the label off for human review. Then stop — worktree cleanup is automatic.
@@ -337,10 +337,10 @@ When the issue's title or body classifies as **audit-class** — any of `audit`,
 Read the JSON summary from stdout (the `shipped_pr` field names the merged PR; `overlap_files` and `added_files` show what landed). Then:
 
 1. **Run any acceptance-criteria `Verify:` commands that look mechanical.** Walk the issue body, extract each `Verify:` line, and run only those that are concrete commands (e.g. `Verify: scripts/foo.sh exits 0`, `Verify: pytest -k test_x`, `Verify: grep -n <pattern> <file>`). Skip free-form prose verifies ("Verify: manual sanity — flip a hex...") — those need a human.
-2. **All-green path:** if every mechanical `Verify:` command exits clean, the issue is done. Post a verification-evidence comment quoting the verify commands + their output + naming the shipped PR, close the issue with `--reason completed`, run `scripts/unblock-dependents.sh <N>`, and remove `status/in-progress`. Skip Path A entirely — there is no PR to file.
+2. **All-green path:** if every mechanical `Verify:` command exits clean, the issue is done. Post a verification-evidence comment quoting the verify commands + their output + naming the shipped PR via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478), close the issue with `--reason completed`, run `scripts/unblock-dependents.sh <N>`, and remove `status/in-progress`. Skip Path A entirely — there is no PR to file.
 
    ```
-   gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/verification_evidence.txt
+   {worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/verification_evidence.txt
    gh issue close <N> --repo judgemind/judgemind --reason completed
    {worktree}/scripts/unblock-dependents.sh <N>
    gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
@@ -376,9 +376,9 @@ The verify-and-close path should be the common case when this check fires — pr
   - **Reduced docs-only PR** — when there is a residual docs delta worth producing (e.g. "document that Container Insights is enabled and cite the Terraform attribute that landed it"). The AC's intent usually has a residual of this shape; complete it as a minimal PR before proceeding to merge.
   - **Verification-only close** — when there is no remaining docs delta, which is the common case for `fix(test)` and `test(...)` issues whose acceptance criteria are exhausted by "the test passes." The AC's `Verify:` command output IS the verification evidence; post it, name the PR that landed the fix, close the issue with `--reason completed`, and run `scripts/unblock-dependents.sh <N>` if anything was blocking on it. Skip Path A entirely — there is no PR to file. The label-interlock teardown (`gh issue edit <N> --remove-label status/in-progress`) still runs at the close.
 
-  Write the comment to `{worktree}/tmp/gap_probe_comment.txt` and post it:
+  Write the comment to `{worktree}/tmp/gap_probe_comment.txt` and post it via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478):
   ```
-  gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/gap_probe_comment.txt
+  {worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/gap_probe_comment.txt
   ```
 - **Probe ambiguous** (e.g. the AWS API returns unexpected output, the grep hits unrelated files, the state is partially configured): treat as "gap real" and continue to Path A.
 
@@ -425,9 +425,9 @@ Exit codes:
   - Continue investigating to root-cause from observed symptoms (treat the issue as Path B / investigation), OR
   - Re-scope the issue: post a comment proposing the corrected hypothesis and prescribed fix, and proceed with Path A against the new scope.
 
-  Write the comment to `{worktree}/tmp/hypothesis_falsified_comment.txt` and post it:
+  Write the comment to `{worktree}/tmp/hypothesis_falsified_comment.txt` and post it via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478):
   ```
-  gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/hypothesis_falsified_comment.txt
+  {worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/hypothesis_falsified_comment.txt
   ```
 - **Probe ambiguous** (the function returns something unexpected but not clearly right or wrong; the sample input may not be representative): instrument before guessing. Add a structured log to the suspected layer that captures the raw input/output it actually saw, ship that as an instrumentation-only PR (or local probe), and re-trigger. See `docs/agent/investigation-patterns.md` §"Instrument before you guess." Don't extend the prescribed fix on top of an ambiguous probe.
 
@@ -486,9 +486,9 @@ The step runs `git fetch origin main` + `git rebase origin/main` under the hood,
     ```
     git -C {worktree} rebase --abort
     ```
-    Write a short block comment to `{worktree}/tmp/rebase_block.txt` naming the conflicting files and the competing origin/main commit(s), then (writes — stay on `gh`):
+    Write a short block comment to `{worktree}/tmp/rebase_block.txt` naming the conflicting files and the competing origin/main commit(s), then post via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478) and update labels (writes — stay on `gh`):
     ```
-    gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/rebase_block.txt
+    {worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/rebase_block.txt
     gh issue edit <N> --repo judgemind/judgemind --add-label status/blocked --remove-label status/in-progress
     ```
     Stop — do not proceed to A.1. Worktree cleanup is automatic. A follow-up agent (or a human) can pick the issue up after the conflicting PR has been triaged.
@@ -1047,9 +1047,9 @@ Post a summary comment on the investigation issue listing the findings and linki
 
 **Close the investigation issue after posting findings.** Investigation issues are fully resolved once findings are documented and follow-up issues are filed. Leaving them open causes duplicate agent work — another agent will pick up the still-open issue and re-investigate.
 
-Write the close comment to `{worktree}/tmp/close_comment.txt`, then post and close (writes — stay on `gh`; `gh issue close --reason completed` has no MCP equivalent):
+Write the close comment to `{worktree}/tmp/close_comment.txt`, then post via `scripts/gh-comment-with-retry.sh` (the wrapper handles the 504-after-success failure mode #4478) and close (writes — stay on `gh`; `gh issue close --reason completed` has no MCP equivalent):
 ```
-gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/close_comment.txt
+{worktree}/scripts/gh-comment-with-retry.sh <N> --body-file {worktree}/tmp/close_comment.txt
 gh issue close <N> --repo judgemind/judgemind --reason completed
 ```
 


### PR DESCRIPTION
## Summary

Follow-up to #4478. Routes every remaining `gh issue comment ... --body-file` invocation across `.claude/skills/` through the `scripts/gh-comment-with-retry.sh` wrapper introduced in #4481, eliminating the 504-after-success failure mode (multi-KB "Unicorn!" HTML page returned alongside a successful comment post) for these call sites.

Mechanical drop-in replacement — no logic changes. Six SKILL.md files touched:

- `task/SKILL.md` — 6 sites (adoption-bail, verify-and-close, gap-probe, hypothesis-falsified, rebase-block, investigation-close)
- `spotcheck/SKILL.md`, `dispatcher/SKILL.md`, `audit-llm-carry-forward/SKILL.md`, `task-v2-operational/SKILL.md`, `diagnose-failure/SKILL.md` — broader-scope sites the issue's `grep -rn "^gh issue comment .*--body-file" .claude/skills/` Verify clause covers.

Closes #4485

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Pre-merge verification
- [x] `grep -rn "^gh issue comment .*--body-file" .claude/skills/` returns no matches (AC #1, first verify clause).
- [x] `grep -rn "{worktree}/scripts/gh-comment-with-retry.sh" .claude/skills/task/SKILL.md` returns 9 hits (AC #1, second verify clause requires >= 8 — 3 from #4481 + 6 new).
- [x] `scripts/check-markdown-links.sh` clean.
- [x] Touched sites retain prose mentioning the wrapper purpose + #4478 reference (AC #2).

### Post-deploy verification
- [ ] N/A — no deployed component (`.claude/skills/` SKILL.md edits only, consumed by `/task`/`/dispatcher`/`/spotcheck`/etc. agents at session start).
