### PR TITLE
feat(dx): catch conditional += iteration in check-bash-set-u-empty-array (#4479)

### DIFF
--- a/scripts/check-bash-set-u-empty-array.sh
+++ b/scripts/check-bash-set-u-empty-array.sh
@@ -77,25 +77,52 @@
 #      i.e. an indexed-array initialiser where the parens are empty
 #      (whitespace-only between ``(`` and ``)``). Record the line
 #      number and the array name. For each (name, decl_line) pair:
-#      scan from ``decl_line + 1`` to EOF looking for either:
-#        - an assignment ``<name>=(`` or ``<name>+=(`` (the bug is
-#          cleared the moment any element appends or a fresh
-#          assignment lands), OR
-#        - an iteration-form read ``"${<name>[@]}"`` or
-#          ``"${<name>[*]}"`` (i.e. element expansion, NOT the size
-#          form ``${#<name>[@]}`` which is bash-3.2-safe — flags the
-#          bug).
-#      Same first-wins verdict logic.
+#      scan from ``decl_line + 1`` to EOF, tracking control-flow
+#      depth, looking for either:
+#        - an *unconditional* assignment ``<name>=(`` or
+#          ``<name>+=(`` — i.e. one at the same control-flow depth
+#          as the ``<name>=()`` line, NOT inside a deeper ``if`` /
+#          ``case`` / ``while`` / ``until`` / ``for`` block. This
+#          unconditionally binds the array; verdict: safe.
+#        - an *iteration-form* read ``"${<name>[@]}"`` or
+#          ``"${<name>[*]}"`` (element expansion, NOT the size form
+#          ``${#<name>[@]}``) — verdict: flag.
+#      Reads inside an explicit length-guard block — ``if [
+#      "${#<name>[@]}" -gt 0 ]; then ... fi`` (or the ``[[ ... ]]`` /
+#      ``-ge 1`` / ``-ne 0`` / ``!= 0`` variants) — are exempt: the
+#      iteration only fires when the array is non-empty. A closed
+#      ``if [[ ${#<name>[@]} -eq 0 ]]; then ... exit|return ...; fi``
+#      block before any iteration also short-circuits to "safe": the
+#      array is guaranteed non-empty after the early-exit check.
+#      Conditional assignments — ``<name>+=(...)`` inside a deeper
+#      block — are NOT treated as binding (#4479): the prior
+#      first-``+=``-wins logic missed bugs like ``block-on-new-
+#      issue.sh`` where the ``+=`` was inside a ``case`` arm of an
+#      arg-parse loop and never executed when the user didn't pass
+#      the relevant flag.
 #
 # What it does NOT flag
 # ---------------------
 #   - ``declare -a <name>=()`` — the inline form is fine.
-#   - ``<name>=()`` followed by ``<name>+=(...)`` BEFORE any iteration
-#     read — append-then-iterate is bash-3.2-safe because the array is
-#     no longer empty by the time iteration runs.
+#   - ``<name>=()`` followed by an *unconditional* ``<name>+=(...)``
+#     (at the same control-flow depth as the declaration) BEFORE any
+#     iteration read — append-then-iterate is bash-3.2-safe because
+#     the array is no longer empty by the time iteration runs.
+#   - ``<name>=()`` whose iteration is wrapped in an explicit length-
+#     guard block: ``if [ "${#<name>[@]}" -gt 0 ]; then for x in
+#     "${<name>[@]}"; do ...; done; fi`` (or ``[[ ... ]]`` / ``-ge 1``
+#     / ``-ne 0`` / ``!= 0`` variants). The iteration only fires when
+#     the array is non-empty.
+#   - ``<name>=()`` followed by an early-exit-on-empty guard — ``if
+#     [[ ${#<name>[@]} -eq 0 ]]; then exit|return ...; fi`` (or ``-lt
+#     1`` / ``-le 0`` / ``== 0`` variants) — *before* the iteration.
+#     The array is guaranteed non-empty after the check.
 #   - ``<name>=()`` whose only subsequent reads are size form
 #     ``${#<name>[@]}`` / ``${#<name>[*]}`` — bash 3.2 handles size
 #     reads of empty initialised arrays cleanly.
+#   - ``<name>=()`` whose iteration uses the parameter-expansion
+#     guard ``${<name>[@]+"${<name>[@]}"}`` — the leading ``[@]+...``
+#     substitutes nothing on empty.
 #   - ``<name>=("a" "b")`` with content — not bare-empty, not flagged.
 #   - ``declare -a <name>`` followed by ``<name>+=(...)`` BEFORE any
 #     ``${#<name>[@]}`` read — append-then-read is bash 3.2 / 5.x
@@ -103,6 +130,19 @@
 #   - Files without any ``set -u`` / ``set -o nounset`` directive — no
 #     nounset, no bug.
 #   - Comment lines (first non-whitespace is ``#``).
+#
+# What it DOES flag (since #4479)
+# -------------------------------
+#   - ``<name>=()`` whose only subsequent ``+=`` is *conditional* —
+#     i.e. inside an ``if`` / ``case`` / ``while`` / ``until`` /
+#     ``for`` block at deeper control-flow depth than the
+#     declaration — followed by an iteration read that is NOT
+#     wrapped in a length-guard or preceded by an early-exit guard.
+#     This was the ``block-on-new-issue.sh`` shape from #4051: the
+#     ``LABELS+=(...)`` inside the arg-parse ``case`` arm only ran
+#     when the user supplied ``--label``; with no flag, the
+#     subsequent ``for label in "${LABELS[@]}"; do`` tripped
+#     ``unbound variable`` on bash 3.2.
 #
 # Sibling check: ``scripts/check-bash-compat.sh`` covers the bash-4+
 # constructs that simply don't exist on bash 3.2 (mapfile, declare
@@ -312,13 +352,173 @@ for file in "${sh_files[@]}"; do
         decl_idx=$((decl_idx + 1))
     done
 
-    # Pass 3: find bare-empty ``<name>=()`` lines and check for an
-    # iteration-form read (``"${<name>[@]}"`` / ``"${<name>[*]}"``)
-    # that fires *before* any intervening ``<name>+=(...)`` or
-    # ``<name>=(...)``-with-content assignment. Same first-wins
-    # verdict logic as Pass 2 but with a different declaration
-    # matcher and a stricter read regex (size form ``${#<name>[@]}``
-    # is not flagged — it is bash-3.2-safe).
+    # Pass 3 — bare-empty ``<name>=()`` + iteration-empty footgun
+    # ----------------------------------------------------------
+    # Find every ``<name>=()`` line. For each, scan forward looking
+    # for whichever of these comes first:
+    #
+    #   (a) an *unconditional* assignment ``<name>=(...)`` /
+    #       ``<name>+=(...)`` — this binds the array, the scan
+    #       short-circuits with verdict "assigned" (safe).
+    #   (b) an iteration-form read ``${<name>[@]}`` / ``${<name>[*]}``
+    #       (NOT the size form ``${#<name>[@]}``, NOT the guarded
+    #       form ``${<name>[@]+...}``) — verdict "read" (flag).
+    #
+    # "Unconditional" means: the assignment is at the same control-
+    # flow depth as the ``<name>=()`` declaration. An assignment at
+    # depth > base is *conditional* — it only binds the array on
+    # some code paths, so the scan continues forward looking for
+    # either an unconditional bind or an iteration read. This is
+    # the fix for #4479: the prior linear scan stopped at the
+    # *first* ``<name>+=`` it saw, even if that ``+=`` was inside an
+    # ``if`` / ``case`` / ``while`` branch that may not execute.
+    # The post-#4051 ``block-on-new-issue.sh`` is the canonical
+    # example: ``LABELS=()`` then ``LABELS+=("$2")`` inside a
+    # ``case`` arm of an arg-parse loop, then unguarded ``for label
+    # in "${LABELS[@]}"; do ...`` — runtime-broken on bash 3.2 when
+    # no ``--label`` was supplied, but the pre-#4479 check missed it.
+    #
+    # Length-guard recognition (#4479 AC#2 — keep current scripts/
+    # tree clean): an iteration read inside an ``if [ "${#<name>[@]}"
+    # -gt 0 ]; then ... fi`` (or ``[[ ... ]]`` / ``-ne 0`` / ``!= 0``
+    # / ``-ge 1``) block is exempt from the flag. The block is at
+    # depth = base_depth + 1 and the matching ``fi`` is the first
+    # ``fi`` at depth = base_depth on the line walk after the
+    # opening ``if``.
+    #
+    # Early-exit-on-empty recognition: a closed ``if [[
+    # ${#<name>[@]} -eq 0 ]]; then ... exit|return ...; fi`` block
+    # before any iteration read marks the array as "guaranteed
+    # non-empty after this point" — verdict short-circuits to
+    # "assigned" the moment the closing ``fi`` is processed. This
+    # covers the ``check-shard-coverage.sh`` style "early-exit if
+    # we found nothing, then iterate".
+
+    # ─── Pass A: precompute control-flow depth at each line ───
+    # We track TWO depth counters:
+    #
+    #   depth_at_line[i]      — total nesting depth after line i.
+    #                           Used for length-guard / early-exit
+    #                           block scoping (``if [ ... ]; then
+    #                           ... fi`` blocks).
+    #   branch_depth_at_line[i] — depth counting ONLY ``if`` / ``case``
+    #                           branches (not ``while`` / ``until`` /
+    #                           ``for`` loop bodies). Used to decide
+    #                           whether a ``<name>+=(...)`` is
+    #                           branch-conditional (and thus does
+    #                           NOT bind unconditionally) versus
+    #                           inside a loop body (which we treat
+    #                           as binding — the loop body runs zero
+    #                           or more times, but for the static
+    #                           scan we accept the loop-binding
+    #                           pattern that real codebases use,
+    #                           e.g. ``arr=(); while read line; do
+    #                           arr+=("$line"); done; for x in
+    #                           "${arr[@]}"...``). The runtime risk
+    #                           there — empty input → empty array →
+    #                           bash-3.2 trip — is a separate bug
+    #                           class. The #4479 fix targets the
+    #                           ``if``/``case`` arm shape that #4051
+    #                           hit (conditional ``+=`` inside an
+    #                           arg-parse ``case``).
+    #
+    # One-liners (``if X; then Y; fi`` / ``for X; do Y; done``) net
+    # to 0 — detected by presence of the matching closer on the
+    # same line.
+    depth_at_line=()
+    branch_depth_at_line=()
+    cur_depth=0
+    cur_branch_depth=0
+    li=0
+    while (( li < nlines )); do
+        dline_text="${lines[$li]}"
+
+        # Strip leading whitespace cheaply via parameter expansion
+        # plus a regex peel — bash 3.2-safe (no ${var/#pattern/}
+        # tricks needed beyond what 3.2 supports).
+        trimmed="$dline_text"
+        while [[ "$trimmed" == [[:space:]]* ]]; do
+            trimmed="${trimmed# }"
+            trimmed="${trimmed#	}"
+        done
+
+        # Skip comments and blank lines for depth tracking.
+        if [[ -z "$trimmed" || "$trimmed" == \#* ]]; then
+            depth_at_line+=("$cur_depth")
+            branch_depth_at_line+=("$cur_branch_depth")
+            li=$((li + 1))
+            continue
+        fi
+
+        # Detect openers / closers. Pattern matching uses bash
+        # regex (``[[ =~ ]]``) rather than ``case`` because the
+        # bare word ``case`` is a reserved keyword and cannot
+        # appear as a glob alternation pattern in a ``case``
+        # statement.
+        #
+        # An "opener" is one of ``if`` / ``while`` / ``until`` /
+        # ``for`` / ``case`` at start-of-trimmed-line. A "one-
+        # liner" (e.g. ``if X; then Y; fi``) carries its matching
+        # closer on the same line and contributes no net depth
+        # change. ``elif`` is treated as continuation (no depth
+        # change) of an already-open ``if`` block.
+        line_delta=0
+        branch_delta=0
+        if [[ "$trimmed" =~ ^elif([[:space:]]|$) ]]; then
+            :  # continuation, no depth change
+        elif [[ "$trimmed" =~ ^(if|while|until|for)([[:space:]]|$) ]]; then
+            # Opener of an if/while/until/for block. Look for a
+            # matching closer on the same line — one-liner.
+            opener="${BASH_REMATCH[1]}"
+            closer="fi"
+            case "$opener" in
+                while|until|for) closer="done" ;;
+            esac
+            if [[ "$trimmed" =~ \;[[:space:]]*${closer}([[:space:]]|\;|$) ]] || \
+               [[ "$trimmed" =~ [[:space:]]${closer}([[:space:]]|\;|$) ]]; then
+                :  # one-liner, no net change
+            else
+                line_delta=1
+                if [[ "$opener" == "if" ]]; then
+                    branch_delta=1
+                fi
+            fi
+        elif [[ "$trimmed" =~ ^case([[:space:]]|$) ]]; then
+            # ``case`` opener — this counts as a branch.
+            if [[ "$trimmed" =~ \;[[:space:]]*esac([[:space:]]|\;|$) ]] || \
+               [[ "$trimmed" =~ [[:space:]]esac([[:space:]]|\;|$) ]]; then
+                :
+            else
+                line_delta=1
+                branch_delta=1
+            fi
+        elif [[ "$trimmed" =~ ^fi([[:space:]]|\;|$) ]]; then
+            line_delta=-1
+            branch_delta=-1
+        elif [[ "$trimmed" =~ ^esac([[:space:]]|\;|$) ]]; then
+            line_delta=-1
+            branch_delta=-1
+        elif [[ "$trimmed" =~ ^done([[:space:]]|\;|$) ]]; then
+            line_delta=-1
+        fi
+
+        # Apply the delta. Note: for closers, depth_at_line[i]
+        # records the depth *after* the close — i.e. the depth
+        # the next line opens at.
+        cur_depth=$((cur_depth + line_delta))
+        if (( cur_depth < 0 )); then
+            cur_depth=0  # defensive: malformed file shouldn't crash us
+        fi
+        cur_branch_depth=$((cur_branch_depth + branch_delta))
+        if (( cur_branch_depth < 0 )); then
+            cur_branch_depth=0
+        fi
+        depth_at_line+=("$cur_depth")
+        branch_depth_at_line+=("$cur_branch_depth")
+        li=$((li + 1))
+    done
+
+    # ─── Pass B: per-name forward scan ───
     init_idx=0
     while (( init_idx < nlines )); do
         iline="${lines[$init_idx]}"
@@ -331,47 +531,51 @@ for file in "${sh_files[@]}"; do
 
         if [[ "$iline" =~ $EMPTY_INIT_REGEX ]]; then
             iname="${BASH_REMATCH[1]}"
+            # base_branch_depth is the ``if``/``case`` nesting at
+            # the ``<name>=()`` line — used to decide whether a
+            # later ``+=`` is at the same branch depth (binding)
+            # or deeper (branch-conditional, not binding).
+            base_branch_depth="${branch_depth_at_line[$init_idx]}"
 
-            # Build name-specific patterns. Same assignment regex as
-            # Pass 2 — ``<name>=(`` or ``<name>+=(`` clears the bug
-            # by binding the array with at least one (or about to be
-            # one) element.
-            #
-            # The read regex is *stricter* than Pass 2's: it matches
-            # the bare element-expansion forms ``${<name>[@]}`` and
-            # ``${<name>[*]}`` only — i.e. ``[@]`` or ``[*]``
-            # IMMEDIATELY followed by ``}``. It deliberately does
-            # NOT match the size form ``${#<name>[@]}`` (bash-3.2-
-            # safe on an empty initialised array; flagging it here
-            # would over-report).
-            #
-            # Anchoring rationale: same as Pass 2 — leading
-            # ``[^A-Za-z0-9_]`` (or start-of-line) before the name
-            # ensures a substring like ``foo_bar=`` does not match
-            # when the array is ``foo``.
-            #
-            # Guarded-form exemption: lines containing the defensive
-            # parameter-expansion guard ``${<name>[@]+"${<name>[@]}"}``
-            # (or the ``[*]`` variant) are exempted in the scan
-            # below before the read regex is applied. The leading
-            # ``[@]+...`` substitutes nothing when the array is
-            # unset OR empty — the canonical bash-3.2-safe idiom for
-            # "iterate this maybe-empty array under set -u" — and
-            # the inner ``${<name>[@]}`` only evaluates when the
-            # array is non-empty, so it is not a footgun. We detect
-            # the guarded form via a substring presence check
-            # (``[@]+`` or ``[*]+`` after ``${<name>``) and skip
-            # the line.
+            # Name-specific regexes. Anchoring rationale: see
+            # the assign / read / guarded-form notes preserved
+            # below from the prior implementation.
             iassign_regex="(^|[^A-Za-z0-9_])${iname}\\+?=\\("
             iread_regex="\\\$\\{${iname}\\[[@*]\\]\\}"
             iguarded_regex="\\\$\\{${iname}\\[[@*]\\]\\+"
+            # Length-guard openers. Match both ``[ ... ]`` and
+            # ``[[ ... ]]`` test forms, with optional double-quotes
+            # around the size expression, and either ``-gt 0`` /
+            # ``-ge 1`` / ``-ne 0`` / ``!= 0`` for "non-empty".
+            ilen_guard_open_regex="^[[:space:]]*if[[:space:]]+\\[\\[?[[:space:]]+\"?\\\$\\{#${iname}\\[[@*]\\]\\}\"?[[:space:]]+(-gt[[:space:]]+0|-ge[[:space:]]+1|-ne[[:space:]]+0|!=[[:space:]]+0)[[:space:]]+\\]\\]?[[:space:]]*\\;?[[:space:]]*then"
+            # Early-exit openers — same shape but checking == 0.
+            iearly_exit_open_regex="^[[:space:]]*if[[:space:]]+\\[\\[?[[:space:]]+\"?\\\$\\{#${iname}\\[[@*]\\]\\}\"?[[:space:]]+(-eq[[:space:]]+0|-lt[[:space:]]+1|-le[[:space:]]+0|==[[:space:]]+0)[[:space:]]+\\]\\]?[[:space:]]*\\;?[[:space:]]*then"
+            # Stop statement (exit / return) inside an early-exit block.
+            istop_regex="^[[:space:]]*(exit|return)([[:space:]]|$)"
 
             iscan_idx=$((init_idx + 1))
             iverdict=""
             iverdict_line=0
             iverdict_content=""
+
+            # Length-guard tracking: when we open an
+            # ``if [ "${#name[@]}" -gt 0 ]`` block, record the
+            # depth at which it opened. Reads inside that block
+            # (depth > open_depth) are exempt. The block closes
+            # when depth drops back to open_depth.
+            len_guard_open_depth=-1
+
+            # Early-exit-on-empty tracking: when we see an
+            # ``if [[ ${#name[@]} -eq 0 ]]; then ... exit|return ;
+            # fi`` block close cleanly, mark the array as
+            # guaranteed non-empty going forward.
+            in_early_exit_block=0
+            early_exit_open_depth=-1
+            early_exit_has_stop=0
+
             while (( iscan_idx < nlines )); do
                 isline="${lines[$iscan_idx]}"
+                idepth="${depth_at_line[$iscan_idx]}"
 
                 # Skip comments inside the scan.
                 if [[ "$isline" =~ ^[[:space:]]*# ]]; then
@@ -379,25 +583,98 @@ for file in "${sh_files[@]}"; do
                     continue
                 fi
 
-                # Check assignment first — it is the safe outcome.
+                # ── Length-guard block close detection ──
+                # If we were inside a length-guard block and depth
+                # has dropped back to the open-depth, the block
+                # has just closed — clear the tracker.
+                if (( len_guard_open_depth >= 0 )) && (( idepth <= len_guard_open_depth )); then
+                    len_guard_open_depth=-1
+                fi
+
+                # ── Length-guard block open detection ──
+                # An ``if [ "${#name[@]}" -gt 0 ]; then`` line
+                # opens a block at depth = idepth. Reads of
+                # ``name`` inside this block are exempt.
+                if [[ "$isline" =~ $ilen_guard_open_regex ]]; then
+                    # idepth has already been incremented by Pass A
+                    # for this opener line, so we record idepth - 1
+                    # as the "outside" depth.
+                    len_guard_open_depth=$((idepth - 1))
+                fi
+
+                # ── Early-exit-on-empty block tracking ──
+                # If we were tracking an early-exit candidate and
+                # depth has dropped back, the block has just
+                # closed. If a stop statement was seen inside it,
+                # short-circuit verdict to "assigned".
+                if (( in_early_exit_block )) && (( idepth <= early_exit_open_depth )); then
+                    if (( early_exit_has_stop )); then
+                        iverdict="assigned"
+                        break
+                    fi
+                    in_early_exit_block=0
+                    early_exit_open_depth=-1
+                    early_exit_has_stop=0
+                fi
+
+                # Open a fresh early-exit candidate?
+                if [[ "$isline" =~ $iearly_exit_open_regex ]]; then
+                    in_early_exit_block=1
+                    early_exit_open_depth=$((idepth - 1))
+                    early_exit_has_stop=0
+                fi
+
+                # Stop statement inside the early-exit candidate?
+                if (( in_early_exit_block )) && (( idepth > early_exit_open_depth )); then
+                    if [[ "$isline" =~ $istop_regex ]]; then
+                        early_exit_has_stop=1
+                    fi
+                fi
+
+                # ── Check assignment ──
+                # An assignment ``<name>=(`` or ``<name>+=(`` is
+                # treated as binding (verdict "assigned") UNLESS
+                # it is inside an ``if`` / ``case`` branch deeper
+                # than the declaration's branch depth. That is,
+                # we accept loop-body bindings (``while`` / ``for``
+                # / ``until``) as binding because real codebases
+                # use ``arr=(); while read line; do arr+=...; done;
+                # for x in "${arr[@]}"; do ...`` and the runtime
+                # risk (empty input → empty array → bash-3.2 trip)
+                # is a separate, lower-severity bug class than the
+                # ``if``/``case``-arm conditional that #4051 hit.
+                # The ``branch_depth`` check is what distinguishes
+                # the two.
+                ibranch_depth="${branch_depth_at_line[$iscan_idx]}"
                 if [[ "$isline" =~ $iassign_regex ]]; then
-                    iverdict="assigned"
-                    break
+                    if (( ibranch_depth <= base_branch_depth )); then
+                        iverdict="assigned"
+                        break
+                    fi
+                    # else: branch-conditional assignment (inside
+                    # an ``if`` / ``case`` arm) — does NOT bind
+                    # the array unconditionally. Continue scanning.
                 fi
 
                 # Skip lines using the guarded ``${name[@]+...}``
                 # parameter-expansion idiom. The line is bash-3.2-
                 # safe even when the array is empty, so do not
                 # treat it as a flagged read. The scan continues
-                # past the guarded line — the array is still empty
-                # afterward, so a later unguarded iteration would
-                # still be flagged.
+                # past the guarded line — the array may still be
+                # empty afterward.
                 if [[ "$isline" =~ $iguarded_regex ]]; then
                     iscan_idx=$((iscan_idx + 1))
                     continue
                 fi
 
+                # ── Check iteration read ──
                 if [[ "$isline" =~ $iread_regex ]]; then
+                    # If we're inside an active length-guard
+                    # block for this name, the read is safe.
+                    if (( len_guard_open_depth >= 0 )) && (( idepth > len_guard_open_depth )); then
+                        iscan_idx=$((iscan_idx + 1))
+                        continue
+                    fi
                     iverdict="read"
                     iverdict_line=$((iscan_idx + 1))
                     iverdict_content="$isline"

--- a/scripts/check-brand-md-tokens.sh
+++ b/scripts/check-brand-md-tokens.sh
@@ -208,17 +208,22 @@ check_tuple_in_config() {
 
     IFS=':' read -r token subkey expected_val <<< "$tuple"
 
-    # Find matching tuple in config_tuples
+    # Find matching tuple in config_tuples. Length-guard: bash 3.2
+    # trips on ``"${config_tuples[@]}"`` when the array is empty
+    # (tailwind.config.ts restructured to drop the colors block).
+    # See #4479.
     local found_val=""
     local t
-    for t in "${config_tuples[@]}"; do
-        local ct cs cv
-        IFS=':' read -r ct cs cv <<< "$t"
-        if [[ "$ct" == "$token" && "$cs" == "$subkey" ]]; then
-            found_val="$cv"
-            break
-        fi
-    done
+    if [ "${#config_tuples[@]}" -gt 0 ]; then
+        for t in "${config_tuples[@]}"; do
+            local ct cs cv
+            IFS=':' read -r ct cs cv <<< "$t"
+            if [[ "$ct" == "$token" && "$cs" == "$subkey" ]]; then
+                found_val="$cv"
+                break
+            fi
+        done
+    fi
 
     if [[ -z "$found_val" ]]; then
         if [[ $violations -eq 0 ]]; then
@@ -240,16 +245,24 @@ check_tuple_in_config() {
     fi
 }
 
-# Check code-block tuples
-for tuple in "${brand_tuples[@]}"; do
-    check_tuple_in_config "$tuple" "Tailwind Token Mapping block"
-done
+# Check code-block tuples. Length-guard the iteration: bash 3.2
+# trips ``unbound variable`` on ``"${arr[@]}"`` when arr=() and no
+# elements ever got appended (e.g. BRAND.md restructured to drop
+# the §Tailwind Token Mapping block). See #4479 for the static
+# check that catches this shape.
+if [ "${#brand_tuples[@]}" -gt 0 ]; then
+    for tuple in "${brand_tuples[@]}"; do
+        check_tuple_in_config "$tuple" "Tailwind Token Mapping block"
+    done
+fi
 
 # Check Accent table tuples (may overlap with code block — that's fine,
 # the cross-check is the point)
-for tuple in "${accent_tuples[@]}"; do
-    check_tuple_in_config "$tuple" "Accent table"
-done
+if [ "${#accent_tuples[@]}" -gt 0 ]; then
+    for tuple in "${accent_tuples[@]}"; do
+        check_tuple_in_config "$tuple" "Accent table"
+    done
+fi
 
 if [[ $violations -gt 0 ]]; then
     echo ""

--- a/scripts/check-dispatcher-execution-mode-aware.sh
+++ b/scripts/check-dispatcher-execution-mode-aware.sh
@@ -140,10 +140,16 @@ if (( violations > 0 )); then
     echo ""
     echo "  Sites missing coverage:"
     echo ""
-    for line in "${missing[@]}"; do
-        snippet="$(sed -n "${line}p" "$TARGET_FILE")"
-        echo "    $TARGET_FILE:${line}: ${snippet}"
-    done
+    # Length-guard the iteration — bash 3.2 trips on ``"${arr[@]}"``
+    # when arr=() and the conditional ``missing+=`` inside the
+    # earlier loop never fired (e.g. all SQL sites are covered, but
+    # ``violations`` was incremented by some other path). See #4479.
+    if [ "${#missing[@]}" -gt 0 ]; then
+        for line in "${missing[@]}"; do
+            snippet="$(sed -n "${line}p" "$TARGET_FILE")"
+            echo "    $TARGET_FILE:${line}: ${snippet}"
+        done
+    fi
     echo ""
     echo "  Fix: add an execution_mode branch, OR annotate the site:"
     echo ""

--- a/scripts/check-git-gh-retries.sh
+++ b/scripts/check-git-gh-retries.sh
@@ -187,10 +187,13 @@ if (( violations > 0 )); then
     echo ""
     echo "  Sites missing an annotation:"
     echo ""
-    for line in "${missing[@]}"; do
-        snippet="$(sed -n "${line}p" "$TARGET_FILE")"
-        echo "    $TARGET_FILE:${line}: ${snippet}"
-    done
+    # Length-guard the iteration — see #4479.
+    if [ "${#missing[@]}" -gt 0 ]; then
+        for line in "${missing[@]}"; do
+            snippet="$(sed -n "${line}p" "$TARGET_FILE")"
+            echo "    $TARGET_FILE:${line}: ${snippet}"
+        done
+    fi
     echo ""
     echo "  Fix: add a comment above the call such as"
     echo ""

--- a/scripts/check-hardcoded-models.sh
+++ b/scripts/check-hardcoded-models.sh
@@ -93,72 +93,81 @@ fi
 # ─── Scan the codebase ────────────────────────────────────────────────
 violations=0
 
-for target in "${scan_targets[@]}"; do
-    [[ -e "$target" ]] || continue
+# Defensive length-guard: each ``scan_targets+=`` above runs in
+# exactly one branch of the if/else, so the array is always
+# populated at runtime — but the #4479 static check treats branch-
+# conditional ``+=`` as non-binding. The guard makes the check
+# happy AND defends against the pathological case where neither
+# branch fired (e.g. SCAN_DIR is REPO_ROOT but no packages/*/src/
+# exists yet on a fresh clone before the first build).
+if [ "${#scan_targets[@]}" -gt 0 ]; then
+    for target in "${scan_targets[@]}"; do
+        [[ -e "$target" ]] || continue
 
-    matches=$(grep -rnE "$PATTERN" "$target" "${exclude_args[@]}" 2>/dev/null || true)
+        matches=$(grep -rnE "$PATTERN" "$target" "${exclude_args[@]}" 2>/dev/null || true)
 
-    [[ -z "$matches" ]] && continue
+        [[ -z "$matches" ]] && continue
 
-    while IFS= read -r line; do
-        # Check if this match is in an excluded file
-        skip=false
-        for excl in "${EXCLUDE_FILES[@]}"; do
-            if [[ "$line" == *"$excl"* ]]; then
-                skip=true
-                break
+        while IFS= read -r line; do
+            # Check if this match is in an excluded file
+            skip=false
+            for excl in "${EXCLUDE_FILES[@]}"; do
+                if [[ "$line" == *"$excl"* ]]; then
+                    skip=true
+                    break
+                fi
+            done
+            "$skip" && continue
+
+            # Check excluded path patterns (tests, eval)
+            for pat in "${EXCLUDE_PATH_PATTERNS[@]}"; do
+                # shellcheck disable=SC2254
+                case "$line" in
+                    *$pat*) skip=true; break ;;
+                esac
+            done
+            "$skip" && continue
+
+            # Skip comment lines:
+            #   Python/shell comments: lines where the match is after a #
+            #   SQL comments: lines containing --
+            #   Docstring examples: lines containing e.g. or ``
+            # Extract the file:lineno:content and check the content portion.
+            content="${line#*:}"   # strip filename
+            content="${content#*:}"  # strip line number
+            # Trim leading whitespace
+            trimmed="${content#"${content%%[![:space:]]*}"}"
+
+            # Skip lines that are pure comments
+            if [[ "$trimmed" == "#"* ]]; then
+                continue
             fi
-        done
-        "$skip" && continue
+            # Skip SQL comment lines
+            if [[ "$trimmed" == "--"* ]]; then
+                continue
+            fi
+            # Skip docstring-style documentation lines (contain `` or "e.g.")
+            if [[ "$content" == *'``'* ]] || [[ "$content" == *'e.g.'* ]]; then
+                continue
+            fi
 
-        # Check excluded path patterns (tests, eval)
-        for pat in "${EXCLUDE_PATH_PATTERNS[@]}"; do
-            # shellcheck disable=SC2254
-            case "$line" in
-                *$pat*) skip=true; break ;;
-            esac
-        done
-        "$skip" && continue
+            if [[ $violations -eq 0 ]]; then
+                echo "ERROR: Found hardcoded Claude model identifier(s) in the codebase."
+                echo ""
+                echo "  Model identifiers should be centralized in judgemind-config."
+                echo "  Import from judgemind_config instead of hardcoding the string:"
+                echo ""
+                echo "    from judgemind_config import DEFAULT_HAIKU_MODEL"
+                echo ""
+                echo "  Violations:"
+                echo ""
+            fi
 
-        # Skip comment lines:
-        #   Python/shell comments: lines where the match is after a #
-        #   SQL comments: lines containing --
-        #   Docstring examples: lines containing e.g. or ``
-        # Extract the file:lineno:content and check the content portion.
-        content="${line#*:}"   # strip filename
-        content="${content#*:}"  # strip line number
-        # Trim leading whitespace
-        trimmed="${content#"${content%%[![:space:]]*}"}"
-
-        # Skip lines that are pure comments
-        if [[ "$trimmed" == "#"* ]]; then
-            continue
-        fi
-        # Skip SQL comment lines
-        if [[ "$trimmed" == "--"* ]]; then
-            continue
-        fi
-        # Skip docstring-style documentation lines (contain `` or "e.g.")
-        if [[ "$content" == *'``'* ]] || [[ "$content" == *'e.g.'* ]]; then
-            continue
-        fi
-
-        if [[ $violations -eq 0 ]]; then
-            echo "ERROR: Found hardcoded Claude model identifier(s) in the codebase."
-            echo ""
-            echo "  Model identifiers should be centralized in judgemind-config."
-            echo "  Import from judgemind_config instead of hardcoding the string:"
-            echo ""
-            echo "    from judgemind_config import DEFAULT_HAIKU_MODEL"
-            echo ""
-            echo "  Violations:"
-            echo ""
-        fi
-
-        echo "    $line"
-        violations=$((violations + 1))
-    done <<< "$matches"
-done
+            echo "    $line"
+            violations=$((violations + 1))
+        done <<< "$matches"
+    done
+fi
 
 if [[ $violations -gt 0 ]]; then
     echo ""

--- a/scripts/check-migration-files.sh
+++ b/scripts/check-migration-files.sh
@@ -106,9 +106,17 @@ for num in "${sorted_numbers[@]}"; do
             "Fix for duplicate migration number $num:"
             "  Two files claim sequence number $num:"
         )
-        for c in "${colliding[@]}"; do
-            fix_blocks+=("    - $c")
-        done
+        # Length-guard: ``colliding`` was just populated above by
+        # the inner ``for f in migration_files`` filter loop. In
+        # practice the duplicate-num condition guarantees at least
+        # one match (we got here because two files share the same
+        # number), but the #4479 static check treats branch-
+        # conditional ``+=`` as non-binding.
+        if [ "${#colliding[@]}" -gt 0 ]; then
+            for c in "${colliding[@]}"; do
+                fix_blocks+=("    - $c")
+            done
+        fi
         fix_blocks+=(
             "  Keep the older one (whichever was merged to main first) at"
             "  '$num' and rename the newer to '${next_free}_<topic>.sql':"
@@ -162,10 +170,17 @@ for num in "${sorted_numbers[@]}"; do
 done
 
 if [[ $errors -gt 0 ]]; then
-    # Emit the accumulated Fix blocks.
-    for line in "${fix_blocks[@]}"; do
-        echo "$line"
-    done
+    # Emit the accumulated Fix blocks. Length-guard the iteration —
+    # bash 3.2 trips on ``"${fix_blocks[@]}"`` when arr=() and the
+    # ``+=`` only ran inside conditional branches that produced
+    # error-counter increments without populating ``fix_blocks``
+    # (defensive: in practice ``errors > 0`` implies fix_blocks is
+    # populated, but the static check #4479 can't prove that).
+    if [ "${#fix_blocks[@]}" -gt 0 ]; then
+        for line in "${fix_blocks[@]}"; do
+            echo "$line"
+        done
+    fi
     echo ""
     echo "Migration file validation: $errors error(s) found."
     exit 1

--- a/scripts/check-placeholder-gates.sh
+++ b/scripts/check-placeholder-gates.sh
@@ -73,6 +73,15 @@ if [[ "$SCAN_DIR" == "$REPO_ROOT" ]]; then
 else
     scan_targets+=("$SCAN_DIR")
 fi
+# Defensive: each ``scan_targets+=`` above runs in exactly one
+# branch of the if/else, so the array is always populated at
+# runtime — but the #4479 static check treats branch-conditional
+# ``+=`` as non-binding. Catch the pathological case (no
+# packages/*/src/ exists yet on a fresh clone) explicitly.
+if [ "${#scan_targets[@]}" -eq 0 ]; then
+    echo "check-placeholder-gates: no scan targets resolved — nothing to check."
+    exit 0
+fi
 
 # ─── Helper: check if a grep output line should be skipped ───────────
 should_skip() {

--- a/scripts/check-subprocess-timeouts.sh
+++ b/scripts/check-subprocess-timeouts.sh
@@ -238,9 +238,15 @@ if (( violations_total > 0 )); then
     echo ""
     echo "  Violations:"
     echo ""
-    for vline in "${violation_lines[@]}"; do
-        echo "    $vline"
-    done
+    # Length-guard the iteration — see #4479. ``violation_lines+=``
+    # only runs inside conditional branches, so the static check
+    # treats the array as potentially empty even though
+    # ``violations_total > 0`` guarantees at least one entry.
+    if [ "${#violation_lines[@]}" -gt 0 ]; then
+        for vline in "${violation_lines[@]}"; do
+            echo "    $vline"
+        done
+    fi
     echo ""
     echo "  Fix: add timeout=<seconds> to each call. Choose a value appropriate"
     echo "  to the operation (e.g. timeout=30 for local git ops, timeout=120 for"

--- a/scripts/check-terminal-routing-comments.sh
+++ b/scripts/check-terminal-routing-comments.sh
@@ -159,11 +159,14 @@ if (( violations > 0 )); then
     echo "  Sites missing a ROUTING (#N) comment in the ${ROUTING_WINDOW_LINES}"
     echo "  lines above the call:"
     echo ""
-    for line in "${missing[@]}"; do
-        # Show the offending line in context for fast triage.
-        snippet="$(sed -n "${line}p" "$TARGET_FILE")"
-        echo "    $TARGET_FILE:${line}: ${snippet}"
-    done
+    # Length-guard the iteration — see #4479.
+    if [ "${#missing[@]}" -gt 0 ]; then
+        for line in "${missing[@]}"; do
+            # Show the offending line in context for fast triage.
+            snippet="$(sed -n "${line}p" "$TARGET_FILE")"
+            echo "    $TARGET_FILE:${line}: ${snippet}"
+        done
+    fi
     echo ""
     echo "  Fix: add a comment above the call such as"
     echo ""

--- a/scripts/check-terraform-ecs-entrypoint.sh
+++ b/scripts/check-terraform-ecs-entrypoint.sh
@@ -71,6 +71,16 @@ while IFS= read -r -d '' f; do
     fi
 done < <(find "$REPO_ROOT/infra/terraform" -name "main.tf" -print0 2>/dev/null)
 
+# Defensive: ``TF_FILES+=`` only fires inside the ``if ! "$skip"``
+# arm of the while-read loop, so the static check #4479 treats the
+# array as potentially empty. In practice the find expression
+# always returns at least one main.tf in a non-fresh checkout, but
+# bail cleanly on the pathological case.
+if [ "${#TF_FILES[@]}" -eq 0 ]; then
+    echo "check-terraform-ecs-entrypoint: no main.tf files under infra/terraform — nothing to check."
+    exit 0
+fi
+
 if [[ "$LIST_MODE" == true ]]; then
     for f in "${TF_FILES[@]}"; do
         echo "$f"

--- a/scripts/check-terraform-empty-resource-risk.sh
+++ b/scripts/check-terraform-empty-resource-risk.sh
@@ -60,6 +60,15 @@ while IFS= read -r -d '' f; do
     fi
 done < <(find "$REPO_ROOT/infra/terraform" -name "main.tf" -print0 2>/dev/null)
 
+# Defensive: ``TF_FILES+=`` only fires inside the ``if ! "$skip"``
+# arm of the while-read loop, so the static check #4479 treats the
+# array as potentially empty. Bail cleanly on the pathological
+# case (no main.tf files anywhere).
+if [ "${#TF_FILES[@]}" -eq 0 ]; then
+    echo "check-terraform-empty-resource-risk: no main.tf files under infra/terraform — nothing to check."
+    exit 0
+fi
+
 if [[ "$LIST_MODE" == true ]]; then
     for f in "${TF_FILES[@]}"; do
         echo "$f"

--- a/scripts/run-ci-guards.sh
+++ b/scripts/run-ci-guards.sh
@@ -330,9 +330,14 @@ if [ "$failures" -gt 0 ]; then
     echo "" >&2
     echo "════════════════════════════════════════════════════════════════════" >&2
     echo "run-ci-guards: $failures of ${#runnable[@]} guard(s) failed:" >&2
-    for fname in "${failed_names[@]}"; do
-        echo "  - $fname" >&2
-    done
+    # Length-guard the iteration — see #4479. ``failures > 0``
+    # implies failed_names was populated, but the static check
+    # treats branch-conditional ``+=`` as non-binding.
+    if [ "${#failed_names[@]}" -gt 0 ]; then
+        for fname in "${failed_names[@]}"; do
+            echo "  - $fname" >&2
+        done
+    fi
     echo "" >&2
     echo "Fix the issues above and re-run.  These are the same guards CI" >&2
     echo "runs — catching them locally saves a full CI round trip." >&2

--- a/scripts/tests/test_check_bash_set_u_empty_array.sh
+++ b/scripts/tests/test_check_bash_set_u_empty_array.sh
@@ -318,19 +318,14 @@ EOF
 assert_passes "arr=() + reassign-with-content + iterate passes"
 reset_tmpdir
 
-# ─── Test B7: Length-guard alone (without += or [@]+ guard) → fails ─────
-# A length guard ``if [ "${#arr[@]}" -gt 0 ]; then`` is the runtime
-# fix recommended by the check's report message — it makes the
-# iteration safe at run time. But the static check cannot reason
-# about ``if`` block scopes, and the AC's static criterion is "no
-# ``arr+=(...)`` or ``arr=(...)`` assignment intervenes" (see #4336
-# AC#1). So the static check still flags this shape; users should
-# either pre-populate the array, use the ``${arr[@]+...}``
-# parameter-expansion guard (Test B8), or accept that the iteration
-# is unreachable at run time anyway. This test documents the
-# limitation so future maintainers don't accidentally weaken the
-# check trying to recognise length guards.
-write_file "bad_arr_length_guard_only.sh" <<'EOF'
+# ─── Test B7: Length-guard wrapping the iteration → passes ─────────────
+# The recommended runtime fix (``if [ "${#arr[@]}" -gt 0 ]; then
+# ... fi``) is now recognized by the static check (#4479). Reads of
+# ``arr`` inside the length-guard block are exempt: the iteration
+# only fires when the array is non-empty, so the bash 3.2 footgun
+# cannot trip. This is the canonical post-#4051 fix used in
+# ``scripts/block-on-new-issue.sh`` lines 169-175.
+write_file "good_arr_length_guard.sh" <<'EOF'
 #!/usr/bin/env bash
 set -u
 arr=()
@@ -340,7 +335,21 @@ if [ "${#arr[@]}" -gt 0 ]; then
     done
 fi
 EOF
-assert_fails "arr=() + length-guard alone (no += / [@]+ guard) still flags (static-scan limitation)"
+assert_passes "arr=() + length-guarded iteration ('if [ \"\${#arr[@]}\" -gt 0 ]') passes (#4479)"
+reset_tmpdir
+
+# ─── Test B7b: Length-guard with [[ ... ]] / -ne 0 form → passes ────────
+write_file "good_arr_length_guard_dbl.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+if [[ ${#arr[@]} -ne 0 ]]; then
+    for v in "${arr[@]}"; do
+        echo "$v"
+    done
+fi
+EOF
+assert_passes "arr=() + length-guarded iteration ('[[ -ne 0 ]]') passes (#4479)"
 reset_tmpdir
 
 # ─── Test B8: Safe — arr=() + ${arr[@]+...} guarded expansion → passes ──
@@ -435,6 +444,161 @@ else
     echo "PASS: AC#1 Verify probe — check fails with probe filename + line number"
 fi
 rm -rf "$PROBE_DIR" "$PROBE_OUT_FILE"
+
+# ─── Test C1 (#4479): Conditional ``+=`` inside ``case`` arm → fails ────
+# This is the canonical bug shape from #4051 / ``block-on-new-issue.sh``:
+# ``LABELS=()`` then ``LABELS+=("$2")`` inside a ``case`` arm of an
+# arg-parse loop, then unguarded ``for label in "${LABELS[@]}"; do``.
+# When the user supplies no ``--label`` flag, the conditional ``+=``
+# never runs, the array stays empty, and bash 3.2 trips ``unbound
+# variable`` on the iteration. The pre-#4479 linear scan stopped at
+# the first ``LABELS+=`` it saw and classified the array as "assigned"
+# regardless of nesting; the post-#4479 scan tracks branch depth and
+# treats ``+=`` inside ``if``/``case`` arms as conditional.
+write_file "bad_conditional_assign_case_arm.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LABELS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --label)
+            LABELS+=("${2:-}")
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+# Unguarded iteration — the #4051 bug shape.
+for label in "${LABELS[@]}"; do
+    echo "$label"
+done
+EOF
+assert_fails "Conditional 'LABELS+=' inside case arm + unguarded for-loop iterate triggers (#4479)"
+reset_tmpdir
+
+# ─── Test C2 (#4479): Conditional ``+=`` inside ``if`` arm → fails ──────
+# Same root cause class but the conditional gate is an ``if`` rather
+# than a ``case`` arm.
+write_file "bad_conditional_assign_if_arm.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+if [[ "${1:-}" == "--add" ]]; then
+    arr+=("$2")
+fi
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_fails "Conditional 'arr+=' inside 'if' arm + unguarded iterate triggers (#4479)"
+reset_tmpdir
+
+# ─── Test C3 (#4479): Conditional ``+=`` inside ``case`` + length-guard → passes ──
+# Mirrors the post-#4051 fix in ``scripts/block-on-new-issue.sh``:
+# the conditional ``+=`` stays where it is, but the iteration is
+# wrapped in an explicit length-guard that the static check now
+# recognizes (B7 above).
+write_file "good_conditional_assign_with_length_guard.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+LABELS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --label)
+            LABELS+=("${2:-}")
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+if [ "${#LABELS[@]}" -gt 0 ]; then
+    for label in "${LABELS[@]}"; do
+        echo "$label"
+    done
+fi
+EOF
+assert_passes "Conditional 'LABELS+=' + length-guarded iteration passes (post-#4051 fix shape)"
+reset_tmpdir
+
+# ─── Test C4 (#4479): Loop-body ``+=`` is treated as binding → passes ───
+# The static check intentionally accepts the ``arr=(); while read line;
+# do arr+=("$line"); done; for x in "${arr[@]}"; do ...`` pattern as
+# binding, even though the loop body may iterate zero times if the
+# input stream is empty. Distinguishing "loop iterates >= 1 times"
+# from "loop iterates 0 times" needs runtime semantics; the check
+# only enforces "branch-conditional ``+=`` does not bind". The
+# zero-iteration case is a separate (lower-severity) bug class —
+# real codebases routinely use this idiom and the false-positive
+# rate would be too high to ship.
+write_file "good_loop_body_assign.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+while IFS= read -r line; do
+    arr+=("$line")
+done < /dev/null
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=() + loop-body 'arr+=' (no inner if/case) treated as binding"
+reset_tmpdir
+
+# ─── Test C5 (#4479): Early-exit-on-empty + iterate → passes ────────────
+# A closed ``if [[ ${#arr[@]} -eq 0 ]]; then ... exit ...; fi`` block
+# before the iteration marks the array as "guaranteed non-empty
+# after this point". The check short-circuits to "assigned" when the
+# closing ``fi`` is processed.
+write_file "good_early_exit_on_empty.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+arr=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && arr+=("$line")
+done < /dev/null
+if [[ ${#arr[@]} -eq 0 ]]; then
+    echo "no items"
+    exit 0
+fi
+for v in "${arr[@]}"; do
+    echo "$v"
+done
+EOF
+assert_passes "arr=() + early-exit-on-empty + iterate passes (#4479)"
+reset_tmpdir
+
+# ─── Test C6 (#4479): Verify-line probe — repo-style fixture path ──────
+# AC#1 of #4479 says: ``scripts/check-bash-set-u-empty-array.sh
+# tests/fixtures/conditional_array_assign/`` exits 1 with a violation
+# report naming the iteration line. This test reproduces that
+# verbatim by pointing the check at the repo's
+# ``tests/fixtures/conditional_array_assign/`` directory and
+# asserting exit 1 + the iteration line is named.
+TESTS=$((TESTS + 1))
+FIXTURE_DIR="$REPO_ROOT/tests/fixtures/conditional_array_assign"
+if [[ ! -d "$FIXTURE_DIR" ]]; then
+    echo "FAIL: AC#1 fixture directory missing: $FIXTURE_DIR"
+    FAILURES=$((FAILURES + 1))
+else
+    FIXTURE_OUT_FILE="$TMPDIR_TEST/fixture_output.txt"
+    "$CHECK_SCRIPT" "$FIXTURE_DIR" > "$FIXTURE_OUT_FILE" 2>&1 && fixture_rc=0 || fixture_rc=$?
+    if [[ "$fixture_rc" -eq 0 ]]; then
+        echo "FAIL: AC#1 fixture probe — expected check to exit non-zero, got 0"
+        cat "$FIXTURE_OUT_FILE"
+        FAILURES=$((FAILURES + 1))
+    elif ! grep -qE "for[[:space:]]+label[[:space:]]+in.*LABELS" "$FIXTURE_OUT_FILE"; then
+        echo "FAIL: AC#1 fixture probe — output does not name the iteration line"
+        cat "$FIXTURE_OUT_FILE"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: AC#1 fixture probe — tests/fixtures/conditional_array_assign/ flagged with iteration line"
+    fi
+    rm -f "$FIXTURE_OUT_FILE"
+fi
 
 # ─── Test 15: Self-scan — real repo scripts/ tree → passes ─────────────
 TESTS=$((TESTS + 1))

--- a/tests/fixtures/conditional_array_assign/scripts/conditional_array_assign.sh
+++ b/tests/fixtures/conditional_array_assign/scripts/conditional_array_assign.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Fixture for #4479: conditional ``LABELS+=`` inside an arg-parse
+# ``case`` arm + unguarded ``for label in "${LABELS[@]}"; do``
+# iteration. Mirrors the bug shape from #4051 /
+# ``scripts/block-on-new-issue.sh`` (pre-#4476).
+#
+# Expected behavior: ``scripts/check-bash-set-u-empty-array.sh
+# tests/fixtures/conditional_array_assign/`` exits 1 and the
+# violation report names the iteration line (line 27 of this file).
+#
+# When the user invokes this script with no ``--label`` argument,
+# the conditional ``LABELS+=`` inside the ``case`` arm never runs,
+# the array stays empty, and the iteration trips ``unbound
+# variable`` on bash 3.2.
+
+set -euo pipefail
+
+LABELS=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --label)
+            LABELS+=("${2:-}")
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+# This is the iteration the static check must flag.
+for label in "${LABELS[@]}"; do
+    echo "$label"
+done


### PR DESCRIPTION
## Summary

Tightens `scripts/check-bash-set-u-empty-array.sh` Pass 3 to catch the conditional-`+=` shape that slipped past the linear scan in #4051 / PR #4476 — the canonical `block-on-new-issue.sh` bug where `LABELS=()` is followed by `LABELS+=("$2")` inside a `case` arm of an arg-parse loop, then iterated unguarded as `for label in "${LABELS[@]}"; do`. The check now precomputes per-line control-flow depth, distinguishes branch-conditional `+=` (inside `if` / `case` arms) from loop-body `+=` (treated as binding), and recognizes both length-guard (`if [ "${#name[@]}" -gt 0 ]`) and early-exit-on-empty (`if [[ ${#name[@]} -eq 0 ]]; then exit; fi`) idioms as safe.

Adds the AC-required fixture at `tests/fixtures/conditional_array_assign/`, 8 new tests (C1-C6, revised B7, B7b), and 14 defensive length-guards across 11 existing `scripts/check-*.sh` scripts that exhibited the conditional-`+=` shape.

Closes #4479

## Test plan

### Automated checks
- [x] Lint passes (shellcheck clean on all touched files; pre-push hook ran the CI-guards umbrella locally)
- [x] Format check passes
- [x] Tests pass (35/35 in `scripts/tests/test_check_bash_set_u_empty_array.sh`; pre-existing 3-test pre-push failures in `test_check_graphql_queries.sh` and `test_cleanup_worktree_review_log_mirror.sh` are unrelated and predate this PR)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (CI/tooling only; the check runs in the `Verify scripts initialise indexed arrays before reading under nounset` step of `.github/workflows/ci.yml`)
- [ ] Verification evidence posted on issue (see A.8)
