### PR TITLE
feat(dx): --fix mode for check-bash-set-u-empty-array.sh (#4492)

### DIFF
--- a/scripts/check-bash-set-u-empty-array.sh
+++ b/scripts/check-bash-set-u-empty-array.sh
@@ -154,20 +154,89 @@
 #
 # Usage
 # -----
-#   scripts/check-bash-set-u-empty-array.sh          # scan repo's scripts/
-#   scripts/check-bash-set-u-empty-array.sh [dir]    # scan a specific directory
+#   scripts/check-bash-set-u-empty-array.sh                # scan repo's scripts/
+#   scripts/check-bash-set-u-empty-array.sh [dir]          # scan a specific directory
+#   scripts/check-bash-set-u-empty-array.sh --fix [dir]    # apply length-guard wrap to shape (B) violations
+#   scripts/check-bash-set-u-empty-array.sh --fix --dry-run [dir]
+#                                                          # print the patch to stdout, do NOT modify files
+#
+# --fix mode (#4492)
+# ------------------
+# Applies the canonical length-guard wrap to shape (B) violations:
+#
+#     for v in "${arr[@]}"; do  ───►  if [ "${#arr[@]}" -gt 0 ]; then
+#         echo "$v"                       for v in "${arr[@]}"; do
+#     done                                    echo "$v"
+#                                         done
+#                                     fi
+#
+# Same shape as ruff's ``--fix`` mode for Python lints. Without
+# ``--fix`` the script behaves exactly as today (report-only). With
+# ``--fix --dry-run`` the patch is printed to stdout but no file is
+# modified. With ``--fix`` (no ``--dry-run``) the patch is applied
+# in-place AND the diff is printed to stdout.
+#
+# Shape (A) violations are not auto-fixed — the canonical fix is a
+# one-character edit (``declare -a <name>`` → ``<name>=()``) and is
+# left to the operator. ``--fix`` mode only acts on shape (B).
 #
 # Exit codes
 # ----------
-#   0 — No violations found.
+#   0 — No violations found, OR ``--fix`` (without ``--dry-run``)
+#       successfully patched every shape (B) violation.
 #   1 — One or more shell scripts trip shape (A) or shape (B). The
 #       offending lines are printed with file:line:content plus the
-#       suggested fix.
+#       suggested fix. Also returned by ``--fix --dry-run`` (the
+#       patch is printed but the violations are still outstanding).
+#       Also returned by ``--fix`` when one or more shape (A)
+#       violations remain unfixed (shape (A) is operator-fixed only).
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Argument parsing ────────────────────────────────────────────────────
+# Accept ``--fix`` and ``--dry-run`` as flags, in any order, before or
+# after a positional ``[dir]`` argument. Unknown flags exit 2 with a
+# usage hint.
+FIX_MODE=0
+DRY_RUN=0
+SCAN_DIR=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fix)
+            FIX_MODE=1
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '155,189p' "${BASH_SOURCE[0]}"
+            exit 0
+            ;;
+        --*)
+            echo "check-bash-set-u-empty-array: unknown flag '$1'" >&2
+            echo "Usage: $0 [--fix [--dry-run]] [dir]" >&2
+            exit 2
+            ;;
+        *)
+            if [[ -z "$SCAN_DIR" ]]; then
+                SCAN_DIR="$1"
+                shift
+            else
+                echo "check-bash-set-u-empty-array: unexpected extra argument '$1'" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+if [[ $DRY_RUN -eq 1 && $FIX_MODE -eq 0 ]]; then
+    echo "check-bash-set-u-empty-array: --dry-run requires --fix" >&2
+    exit 2
+fi
+SCAN_DIR="${SCAN_DIR:-$REPO_ROOT}"
 
 # ─── Files that legitimately mention the forbidden pattern ───────────────
 # The check script and its test must spell the pattern literally.
@@ -212,6 +281,24 @@ fi
 # ─── Per-file scan ───────────────────────────────────────────────────────
 violations=0
 report_lines=()
+
+# Shape (A) violation count — tracked separately because --fix mode
+# does not act on shape (A) (the fix is a one-character ``declare -a
+# <name>`` → ``<name>=()`` edit left to the operator).
+shape_a_violations=0
+
+# Parallel arrays of shape (B) violation data. Each index i describes
+# one violation:
+#
+#   fix_files[i]      — absolute path to the offending shell file
+#   fix_inames[i]     — array name (e.g. ``LABELS``)
+#   fix_iter_lines[i] — 1-based line number of the iteration read
+#
+# Populated in Pass B below. Consumed by the --fix block at the
+# bottom of the script.
+fix_files=()
+fix_inames=()
+fix_iter_lines=()
 
 # Match any ``set`` invocation that turns on nounset:
 #   set -u
@@ -346,6 +433,7 @@ for file in "${sh_files[@]}"; do
                 report_lines+=("    $file:$verdict_line: $verdict_content")
                 report_lines+=("    fix: replace 'declare -a $name' with '$name=()'")
                 violations=$((violations + 1))
+                shape_a_violations=$((shape_a_violations + 1))
             fi
         fi
 
@@ -691,6 +779,10 @@ for file in "${sh_files[@]}"; do
                 report_lines+=("    fix: guard with 'if [ \"\${#$iname[@]}\" -gt 0 ]; then ... fi'")
                 report_lines+=("         or pre-populate '$iname' before iterating")
                 violations=$((violations + 1))
+                # Stash data for --fix mode (shape B only).
+                fix_files+=("$file")
+                fix_inames+=("$iname")
+                fix_iter_lines+=("$iverdict_line")
             fi
         fi
 
@@ -698,35 +790,280 @@ for file in "${sh_files[@]}"; do
     done
 done
 
-if (( violations > 0 )); then
-    echo "ERROR: bash + set -u empty-array footgun(s) detected in scripts/**/*.sh."
-    echo ""
-    echo "  Shape (A) — 'declare -a <name>' declares an indexed array"
-    echo "  but does NOT assign it. On bash 3.2 (macOS) reading"
-    echo "  \${#<name>[@]} returns 0 cleanly; on bash 5.x (Linux CI)"
-    echo "  under 'set -u' the same read trips '<name>: unbound"
-    echo "  variable'. Fix: replace 'declare -a <name>' with"
-    echo "  '<name>=()' so the variable is bound to an empty array at"
-    echo "  declaration time."
-    echo ""
-    echo "  Shape (B) — '<name>=()' initialises the array empty, but"
-    echo "  iterating \"\${<name>[@]}\" / \"\${<name>[*]}\" while it is"
-    echo "  still empty trips 'unbound variable' on bash 3.2 (the"
-    echo "  inverse-direction skew of shape A). Fix: guard iteration"
-    echo "  with 'if [ \"\${#<name>[@]}\" -gt 0 ]; then ... fi', or"
-    echo "  pre-populate the array before iterating."
-    echo ""
-    for line in "${report_lines[@]}"; do
-        echo "$line"
-    done
-    echo ""
-    echo "  Total violations: $violations"
-    echo ""
-    echo "  See: scripts/check-bash-set-u-empty-array.sh header for the"
-    echo "  full rationale, #4143 / PR #4140 for shape (A), and"
-    echo "  #4332 / #4336 for shape (B)."
-    exit 1
+if (( violations == 0 )); then
+    echo "check-bash-set-u-empty-array: ${#sh_files[@]} shell script(s) scanned — all clean."
+    exit 0
 fi
 
-echo "check-bash-set-u-empty-array: ${#sh_files[@]} shell script(s) scanned — all clean."
-exit 0
+# ─── --fix mode (#4492) ────────────────────────────────────────────────
+# When --fix is set, walk the shape (B) violations recorded above and
+# wrap the offending iteration line (and its enclosing for-loop body,
+# if applicable) in an ``if [ "${#<name>[@]}" -gt 0 ]; then ... fi``
+# block. Print the unified diff to stdout for every file modified.
+#
+# Algorithm per violation:
+#   1. Read the file into an array of lines.
+#   2. Locate the iteration line by 1-based line number.
+#   3. If the iteration line is the opener of a multi-line ``for ... do``
+#      block (matches ``^[[:space:]]*for[[:space:]].*do[[:space:]]*$``),
+#      find the matching ``done`` at the same line-prefix indentation.
+#      Otherwise the iteration is a single-line read (``echo "${arr[@]}"``)
+#      and only that single line is wrapped.
+#   4. Insert ``<indent>if [ "${#<name>[@]}" -gt 0 ]; then`` immediately
+#      before the iteration line and ``<indent>fi`` immediately after
+#      the block's closing line. Inner content keeps its existing
+#      indentation (per AC#1: "with preserved indentation").
+#
+# Multiple violations in the same file are processed back-to-front so
+# earlier line numbers stay valid as later edits are applied.
+if (( FIX_MODE )); then
+    # Group violations by file so each file is opened, edited, and
+    # diffed exactly once. We process files in the order they appear
+    # in fix_files[]; for each file we collect the indices of every
+    # violation belonging to that file, then apply the edits back-
+    # to-front so earlier line numbers remain valid.
+    files_seen=()
+    nfix=${#fix_files[@]}
+    fi_loop_idx=0
+    while (( fi_loop_idx < nfix )); do
+        cur_file="${fix_files[$fi_loop_idx]}"
+
+        # Skip if we've already processed this file.
+        already_seen=0
+        for seen in "${files_seen[@]+"${files_seen[@]}"}"; do
+            if [[ "$seen" == "$cur_file" ]]; then
+                already_seen=1
+                break
+            fi
+        done
+        if (( already_seen )); then
+            fi_loop_idx=$((fi_loop_idx + 1))
+            continue
+        fi
+        files_seen+=("$cur_file")
+
+        # Collect every (iname, iter_line) pair for this file.
+        per_file_inames=()
+        per_file_iter_lines=()
+        gather_idx=0
+        while (( gather_idx < nfix )); do
+            if [[ "${fix_files[$gather_idx]}" == "$cur_file" ]]; then
+                per_file_inames+=("${fix_inames[$gather_idx]}")
+                per_file_iter_lines+=("${fix_iter_lines[$gather_idx]}")
+            fi
+            gather_idx=$((gather_idx + 1))
+        done
+
+        # Sort the (iter_line, iname) pairs by iter_line DESCENDING so
+        # we apply edits back-to-front. Bash 3.2 has no associative
+        # arrays; use a simple O(n²) selection sort over the parallel
+        # arrays.
+        nper=${#per_file_iter_lines[@]}
+        sort_i=0
+        while (( sort_i < nper )); do
+            sort_max=$sort_i
+            sort_j=$((sort_i + 1))
+            while (( sort_j < nper )); do
+                if (( ${per_file_iter_lines[$sort_j]} > ${per_file_iter_lines[$sort_max]} )); then
+                    sort_max=$sort_j
+                fi
+                sort_j=$((sort_j + 1))
+            done
+            if (( sort_max != sort_i )); then
+                tmp_line="${per_file_iter_lines[$sort_i]}"
+                tmp_name="${per_file_inames[$sort_i]}"
+                per_file_iter_lines[$sort_i]="${per_file_iter_lines[$sort_max]}"
+                per_file_inames[$sort_i]="${per_file_inames[$sort_max]}"
+                per_file_iter_lines[$sort_max]="$tmp_line"
+                per_file_inames[$sort_max]="$tmp_name"
+            fi
+            sort_i=$((sort_i + 1))
+        done
+
+        # Read the file into an array of lines.
+        edit_lines=()
+        while IFS= read -r el || [[ -n "$el" ]]; do
+            edit_lines+=("$el")
+        done < "$cur_file"
+        edit_nlines=${#edit_lines[@]}
+
+        # Apply each violation's wrap, back-to-front.
+        edit_i=0
+        while (( edit_i < nper )); do
+            ename="${per_file_inames[$edit_i]}"
+            eline="${per_file_iter_lines[$edit_i]}"
+            edit_idx=$((eline - 1))
+            iter_text="${edit_lines[$edit_idx]}"
+
+            # Compute leading-whitespace prefix of the iteration line.
+            indent=""
+            ws_i=0
+            ws_n=${#iter_text}
+            while (( ws_i < ws_n )); do
+                ws_ch="${iter_text:$ws_i:1}"
+                if [[ "$ws_ch" == " " || "$ws_ch" == $'\t' ]]; then
+                    indent="${indent}${ws_ch}"
+                    ws_i=$((ws_i + 1))
+                else
+                    break
+                fi
+            done
+
+            # Trim leading whitespace (cheap parameter expansion).
+            iter_trimmed="$iter_text"
+            while [[ "$iter_trimmed" == [[:space:]]* ]]; do
+                iter_trimmed="${iter_trimmed# }"
+                iter_trimmed="${iter_trimmed#	}"
+            done
+
+            # Determine block end: multi-line ``for ... do`` opener vs
+            # single-line read. The opener pattern matches:
+            #   for X in "${arr[@]}"; do
+            #   for X in "${arr[*]}"; do
+            # with optional trailing comment / whitespace.
+            block_end_idx=$edit_idx
+            if [[ "$iter_trimmed" =~ ^for[[:space:]].*do([[:space:]]|$|\;) ]]; then
+                # Multi-line for loop: find the matching ``done`` at
+                # the same indentation. We scan forward, tracking the
+                # nested for/while/until depth (these all close with
+                # ``done``).
+                fdepth=1
+                scan_j=$((edit_idx + 1))
+                while (( scan_j < edit_nlines )); do
+                    sl="${edit_lines[$scan_j]}"
+                    sl_trimmed="$sl"
+                    while [[ "$sl_trimmed" == [[:space:]]* ]]; do
+                        sl_trimmed="${sl_trimmed# }"
+                        sl_trimmed="${sl_trimmed#	}"
+                    done
+                    # Skip comments.
+                    if [[ "$sl_trimmed" == \#* || -z "$sl_trimmed" ]]; then
+                        scan_j=$((scan_j + 1))
+                        continue
+                    fi
+                    # One-liner ``for X; do Y; done`` would close on
+                    # the same line; we only enter this branch when
+                    # the opener was multi-line, so a one-liner here
+                    # is just a nested complete construct that nets
+                    # to zero.
+                    if [[ "$sl_trimmed" =~ ^(for|while|until)([[:space:]]|$) ]]; then
+                        if [[ "$sl_trimmed" =~ \;[[:space:]]*done([[:space:]]|\;|$) ]] || \
+                           [[ "$sl_trimmed" =~ [[:space:]]done([[:space:]]|\;|$) ]]; then
+                            :  # nested one-liner, no net change
+                        else
+                            fdepth=$((fdepth + 1))
+                        fi
+                    elif [[ "$sl_trimmed" =~ ^done([[:space:]]|\;|$) ]]; then
+                        fdepth=$((fdepth - 1))
+                        if (( fdepth == 0 )); then
+                            block_end_idx=$scan_j
+                            break
+                        fi
+                    fi
+                    scan_j=$((scan_j + 1))
+                done
+                if (( fdepth != 0 )); then
+                    echo "check-bash-set-u-empty-array: --fix could not find matching 'done' for '$ename' iteration at $cur_file:$eline; skipping" >&2
+                    edit_i=$((edit_i + 1))
+                    continue
+                fi
+            fi
+
+            # Build the wrapped block.
+            if_line="${indent}if [ \"\${#${ename}[@]}\" -gt 0 ]; then"
+            fi_line="${indent}fi"
+
+            # Splice into edit_lines: insert if_line BEFORE edit_idx,
+            # leave the iter line and any block body unchanged, insert
+            # fi_line AFTER block_end_idx.
+            # Bash 3.2-safe array splice via rebuild-into-new-array.
+            new_lines=()
+            ri=0
+            while (( ri < edit_nlines )); do
+                if (( ri == edit_idx )); then
+                    new_lines+=("$if_line")
+                fi
+                new_lines+=("${edit_lines[$ri]}")
+                if (( ri == block_end_idx )); then
+                    new_lines+=("$fi_line")
+                fi
+                ri=$((ri + 1))
+            done
+            edit_lines=("${new_lines[@]}")
+            edit_nlines=${#edit_lines[@]}
+            edit_i=$((edit_i + 1))
+        done
+
+        # Emit the unified diff. Use ``diff -u`` against a temporary
+        # file holding the new contents. The diff command exits 1 when
+        # the files differ (that's the expected case), so we capture
+        # its rc explicitly.
+        tmp_new="$cur_file.--fix.tmp.$$"
+        # Rebuild the file contents, preserving newline at EOF.
+        : > "$tmp_new"
+        write_i=0
+        while (( write_i < edit_nlines )); do
+            printf '%s\n' "${edit_lines[$write_i]}" >> "$tmp_new"
+            write_i=$((write_i + 1))
+        done
+
+        diff_rc=0
+        diff -u "$cur_file" "$tmp_new" || diff_rc=$?
+
+        if (( DRY_RUN )); then
+            rm -f "$tmp_new"
+        else
+            # Preserve the original file's mode bits — ``mv`` on top
+            # of an existing file keeps the destination's mode on
+            # Linux + macOS, so write the new bytes via a copy + mv
+            # idiom that overwrites in place without changing perms.
+            cat "$tmp_new" > "$cur_file"
+            rm -f "$tmp_new"
+        fi
+
+        fi_loop_idx=$((fi_loop_idx + 1))
+    done
+
+    # Exit codes for --fix mode:
+    #   --fix --dry-run : exit 1 (violations still outstanding)
+    #   --fix           : exit 0 if all violations were shape (B) and
+    #                     thus auto-fixed; exit 1 if any shape (A)
+    #                     violations remain (operator must hand-edit).
+    if (( DRY_RUN )); then
+        exit 1
+    fi
+    if (( shape_a_violations > 0 )); then
+        echo "check-bash-set-u-empty-array: --fix applied $((violations - shape_a_violations)) shape (B) wrap(s); $shape_a_violations shape (A) violation(s) remain (manual fix required)." >&2
+        exit 1
+    fi
+    exit 0
+fi
+
+echo "ERROR: bash + set -u empty-array footgun(s) detected in scripts/**/*.sh."
+echo ""
+echo "  Shape (A) — 'declare -a <name>' declares an indexed array"
+echo "  but does NOT assign it. On bash 3.2 (macOS) reading"
+echo "  \${#<name>[@]} returns 0 cleanly; on bash 5.x (Linux CI)"
+echo "  under 'set -u' the same read trips '<name>: unbound"
+echo "  variable'. Fix: replace 'declare -a <name>' with"
+echo "  '<name>=()' so the variable is bound to an empty array at"
+echo "  declaration time."
+echo ""
+echo "  Shape (B) — '<name>=()' initialises the array empty, but"
+echo "  iterating \"\${<name>[@]}\" / \"\${<name>[*]}\" while it is"
+echo "  still empty trips 'unbound variable' on bash 3.2 (the"
+echo "  inverse-direction skew of shape A). Fix: guard iteration"
+echo "  with 'if [ \"\${#<name>[@]}\" -gt 0 ]; then ... fi', or"
+echo "  pre-populate the array before iterating. Use --fix to apply"
+echo "  the wrap automatically."
+echo ""
+for line in "${report_lines[@]}"; do
+    echo "$line"
+done
+echo ""
+echo "  Total violations: $violations"
+echo ""
+echo "  See: scripts/check-bash-set-u-empty-array.sh header for the"
+echo "  full rationale, #4143 / PR #4140 for shape (A), and"
+echo "  #4332 / #4336 for shape (B)."
+exit 1

--- a/scripts/tests/test_check_bash_set_u_empty_array.sh
+++ b/scripts/tests/test_check_bash_set_u_empty_array.sh
@@ -600,6 +600,178 @@ else
     rm -f "$FIXTURE_OUT_FILE"
 fi
 
+# ─── Tests F1-F6 (#4492): --fix mode ─────────────────────────────────────
+# The --fix flag wraps shape (B) violations in a length-guard
+# (``if [ "${#<name>[@]}" -gt 0 ]; then ... fi``). Same shape as
+# ruff's --fix mode.
+
+# ─── Test F1: --fix --dry-run prints patch, does NOT modify file ─────────
+TESTS=$((TESTS + 1))
+F1_DIR="$TMPDIR_TEST/f1_root"
+mkdir -p "$F1_DIR/scripts"
+cat > "$F1_DIR/scripts/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+arr=()
+for x in "${arr[@]}"; do
+    echo "$x"
+done
+EOF
+chmod +x "$F1_DIR/scripts/probe.sh"
+F1_BEFORE_HASH="$(shasum "$F1_DIR/scripts/probe.sh" | awk '{print $1}')"
+F1_OUT="$TMPDIR_TEST/f1_out.txt"
+"$CHECK_SCRIPT" --fix --dry-run "$F1_DIR" > "$F1_OUT" 2>&1 && f1_rc=0 || f1_rc=$?
+F1_AFTER_HASH="$(shasum "$F1_DIR/scripts/probe.sh" | awk '{print $1}')"
+if [[ "$f1_rc" -ne 1 ]]; then
+    echo "FAIL: F1 --fix --dry-run — expected exit 1 (violations outstanding), got $f1_rc"
+    FAILURES=$((FAILURES + 1))
+elif [[ "$F1_BEFORE_HASH" != "$F1_AFTER_HASH" ]]; then
+    echo "FAIL: F1 --fix --dry-run — file was modified despite --dry-run"
+    FAILURES=$((FAILURES + 1))
+elif ! grep -qE '\+if \[ "\$\{#arr\[@\]\}" -gt 0 \]; then' "$F1_OUT"; then
+    echo "FAIL: F1 --fix --dry-run — patch did not show added 'if' guard line"
+    cat "$F1_OUT"
+    FAILURES=$((FAILURES + 1))
+elif ! grep -qE '^\+fi$' "$F1_OUT"; then
+    echo "FAIL: F1 --fix --dry-run — patch did not show added 'fi' closer"
+    cat "$F1_OUT"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: F1 --fix --dry-run prints unified diff with added if/fi wrapper, file unchanged, exit 1"
+fi
+rm -rf "$F1_DIR" "$F1_OUT"
+
+# ─── Test F2: --fix applies the wrap and exits 0 ────────────────────────
+TESTS=$((TESTS + 1))
+F2_DIR="$TMPDIR_TEST/f2_root"
+mkdir -p "$F2_DIR/scripts"
+cat > "$F2_DIR/scripts/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+arr=()
+for x in "${arr[@]}"; do
+    echo "$x"
+done
+EOF
+chmod +x "$F2_DIR/scripts/probe.sh"
+F2_OUT="$TMPDIR_TEST/f2_out.txt"
+"$CHECK_SCRIPT" --fix "$F2_DIR" > "$F2_OUT" 2>&1 && f2_rc=0 || f2_rc=$?
+if [[ "$f2_rc" -ne 0 ]]; then
+    echo "FAIL: F2 --fix — expected exit 0 after fixing all violations, got $f2_rc"
+    cat "$F2_OUT"
+    FAILURES=$((FAILURES + 1))
+elif ! grep -qE 'if \[ "\$\{#arr\[@\]\}" -gt 0 \]; then' "$F2_DIR/scripts/probe.sh"; then
+    echo "FAIL: F2 --fix — file does not contain the inserted 'if' guard"
+    cat "$F2_DIR/scripts/probe.sh"
+    FAILURES=$((FAILURES + 1))
+elif ! "$CHECK_SCRIPT" "$F2_DIR" > /dev/null 2>&1; then
+    echo "FAIL: F2 --fix — file still trips the check after the wrap"
+    cat "$F2_DIR/scripts/probe.sh"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: F2 --fix applies the wrap, file passes the default check afterward, exit 0"
+fi
+rm -rf "$F2_DIR" "$F2_OUT"
+
+# ─── Test F3: --fix wrap preserves the body's original indentation ──────
+# AC#1 Verify line: "with preserved indentation". The wrapped body
+# keeps its original indentation; only the if/fi lines are added at
+# the iteration line's indentation level.
+TESTS=$((TESTS + 1))
+F3_DIR="$TMPDIR_TEST/f3_root"
+mkdir -p "$F3_DIR/scripts"
+cat > "$F3_DIR/scripts/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+LABELS=()
+    for label in "${LABELS[@]}"; do
+        echo "$label"
+    done
+EOF
+chmod +x "$F3_DIR/scripts/probe.sh"
+"$CHECK_SCRIPT" --fix "$F3_DIR" > /dev/null 2>&1 || true
+# The 'if' line should have the same 4-space leading indentation as
+# the original 'for' line, and 'fi' likewise.
+F3_FILE="$F3_DIR/scripts/probe.sh"
+if grep -qE '^    if \[ "\$\{#LABELS\[@\]\}" -gt 0 \]; then$' "$F3_FILE" && \
+   grep -qE '^    fi$' "$F3_FILE" && \
+   grep -qE '^    for label in "\$\{LABELS\[@\]\}"; do$' "$F3_FILE" && \
+   grep -qE '^        echo "\$label"$' "$F3_FILE"; then
+    echo "PASS: F3 --fix preserves the body's original indentation; if/fi added at iter-line indent"
+else
+    echo "FAIL: F3 --fix indentation preservation broken"
+    cat "$F3_FILE"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -rf "$F3_DIR"
+
+# ─── Test F4: --fix on single-line read (no for-loop body) ──────────────
+# A bare ``echo "${arr[@]}"`` outside a for loop is also flagged. The
+# --fix wrap should target just that single line.
+TESTS=$((TESTS + 1))
+F4_DIR="$TMPDIR_TEST/f4_root"
+mkdir -p "$F4_DIR/scripts"
+cat > "$F4_DIR/scripts/probe.sh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+xs=()
+echo "${xs[@]}"
+EOF
+chmod +x "$F4_DIR/scripts/probe.sh"
+F4_OUT="$TMPDIR_TEST/f4_out.txt"
+"$CHECK_SCRIPT" --fix "$F4_DIR" > "$F4_OUT" 2>&1 && f4_rc=0 || f4_rc=$?
+if [[ "$f4_rc" -ne 0 ]]; then
+    echo "FAIL: F4 --fix single-line read — expected exit 0, got $f4_rc"
+    cat "$F4_OUT"
+    FAILURES=$((FAILURES + 1))
+elif ! "$CHECK_SCRIPT" "$F4_DIR" > /dev/null 2>&1; then
+    echo "FAIL: F4 --fix single-line read — file still trips the check"
+    cat "$F4_DIR/scripts/probe.sh"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: F4 --fix wraps a single-line iteration read"
+fi
+rm -rf "$F4_DIR" "$F4_OUT"
+
+# ─── Test F5: --dry-run without --fix → exit 2 (usage error) ───────────
+TESTS=$((TESTS + 1))
+F5_OUT="$TMPDIR_TEST/f5_out.txt"
+"$CHECK_SCRIPT" --dry-run "$TMPDIR_TEST" > "$F5_OUT" 2>&1 && f5_rc=0 || f5_rc=$?
+if [[ "$f5_rc" -eq 2 ]]; then
+    echo "PASS: F5 --dry-run without --fix exits 2 (usage error)"
+else
+    echo "FAIL: F5 --dry-run without --fix — expected exit 2, got $f5_rc"
+    cat "$F5_OUT"
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$F5_OUT"
+
+# ─── Test F6: --fix on the AC#1 fixture matches the expected wrap ──────
+# Reproduce AC#1 verbatim against a copy of the repo fixture: the
+# diff shows the added if/fi wrapper around the line-33 iteration,
+# and the post-fix file passes the default check.
+TESTS=$((TESTS + 1))
+F6_DIR="$TMPDIR_TEST/f6_root"
+mkdir -p "$F6_DIR/scripts"
+cp "$REPO_ROOT/tests/fixtures/conditional_array_assign/scripts/conditional_array_assign.sh" \
+    "$F6_DIR/scripts/conditional_array_assign.sh"
+F6_OUT="$TMPDIR_TEST/f6_out.txt"
+"$CHECK_SCRIPT" --fix "$F6_DIR" > "$F6_OUT" 2>&1 && f6_rc=0 || f6_rc=$?
+if [[ "$f6_rc" -ne 0 ]]; then
+    echo "FAIL: F6 --fix on conditional_array_assign fixture — expected exit 0, got $f6_rc"
+    cat "$F6_OUT"
+    FAILURES=$((FAILURES + 1))
+elif ! grep -qE '^if \[ "\$\{#LABELS\[@\]\}" -gt 0 \]; then$' "$F6_DIR/scripts/conditional_array_assign.sh"; then
+    echo "FAIL: F6 --fix — wrap was not applied to fixture"
+    FAILURES=$((FAILURES + 1))
+elif ! "$CHECK_SCRIPT" "$F6_DIR" > /dev/null 2>&1; then
+    echo "FAIL: F6 --fix — fixture still trips the check after wrap"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: F6 --fix on conditional_array_assign fixture wraps line-33 iteration; post-fix check passes"
+fi
+rm -rf "$F6_DIR" "$F6_OUT"
+
 # ─── Test 15: Self-scan — real repo scripts/ tree → passes ─────────────
 TESTS=$((TESTS + 1))
 if "$CHECK_SCRIPT" "$REPO_ROOT" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Adds `--fix` and `--fix --dry-run` modes to
`scripts/check-bash-set-u-empty-array.sh`. The flag wraps each
shape (B) iteration violation (`name=()` followed by an unguarded
`"${name[@]}"` / `"${name[*]}"` read) in
`if [ "${#name[@]}" -gt 0 ]; then ... fi` with preserved body
indentation. Same shape as ruff's `--fix` mode for Python lints.

`--fix --dry-run` prints the unified diff and leaves files
untouched (exit 1, violations still outstanding). `--fix` applies
the patch in place AND prints the diff to stdout (exit 0 if every
violation was shape (B); exit 1 if any shape (A) violations remain
since those require a one-character `declare -a` → `=()` hand
edit). Multi-line `for X in "${arr[@]}"; do ... done` blocks are
wrapped end-to-end; single-line reads (`echo "${arr[@]}"`) are
wrapped on their own line. Multiple violations per file are
applied back-to-front so earlier line numbers stay valid as later
edits land.

Closes #4492.

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (`scripts/tests/test_check_bash_set_u_empty_array.sh` — 41/41 with 6 new tests for `--fix`)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (DX/tooling shell script only). The
  script runs locally (operator laptop) and in CI's
  `Verify scripts initialise indexed arrays before reading under nounset`
  step. The CI step continues to invoke the default report-only
  mode; `--fix` is operator/agent convenience for bulk fix-up.
