### PR TITLE
fix(dx): classify existence-Verify clauses as target-context (#4469)

### DIFF
--- a/scripts/_check_shipped_pr_extract_files.py
+++ b/scripts/_check_shipped_pr_extract_files.py
@@ -32,14 +32,29 @@
 # A trailing punctuation strip removes `.`, `,`, `:`, `;` (sentence
 # punctuation that often follows an inline file reference).
 #
-# Search-context classifier (issue #4340):
+# Search-context classifier (issue #4340, refined #4469):
 #   A line is a *search-context line* if it matches any of:
-#     - ``Verify:`` (case-insensitive, anywhere in the line)
-#     - a shell invocation verb followed by a space — ``grep ``,
-#       ``pytest ``, ``aws ``, ``curl ``, or ``ripgrep ``/``rg ``
+#     - a shell-invocation verb followed by a space, preceded by start-
+#       of-line / whitespace / backtick — ``grep ``, ``pytest ``,
+#       ``aws ``, ``curl ``, ``ripgrep `` / ``rg ``, ``bash ``,
+#       ``python `` / ``python3 ``, or ``./`` (direct script
+#       execution)
 #   A line is also search-context if it falls inside a fenced code
 #   block (between triple backticks) AND the fenced block contains
 #   a shell-invocation verb anywhere in its body.
+#
+#   ``Verify:`` token alone DOES NOT make a line search-context (#4469).
+#   Plain-prose Verify clauses — e.g. ``Verify: <path> is committed`` —
+#   cite the path as the load-bearing target of the change, not as a
+#   search argument. Only Verify clauses that wrap an actual shell
+#   invocation (``Verify: `grep -n widget <path>` ``, ``Verify: `bash
+#   <path>` exits 0`` etc.) classify as search-context, and they do so
+#   by virtue of the verb regex, not the bare ``Verify:`` trigger.
+#
+#   The verb regex uses a backtick-aware leading boundary so a verb
+#   wrapped in inline code (``Verify: `grep ...` ``) still matches —
+#   the backtick character before the verb counts as a boundary
+#   alongside whitespace and start-of-line.
 #
 #   A path's classification is determined by ALL lines it appears in:
 #     - If the path appears at least once on a NON-search-context line,
@@ -73,15 +88,36 @@ TRAILING_STRIP = ".,:;"
 LINE_RANGE_SUFFIX_RE = re.compile(r":[0-9]+(?:-[0-9]+)?$")
 
 # Search-context detector. A line is search-context if it carries a
-# ``Verify:`` marker OR a shell-invocation verb followed by a space.
-# The verbs listed cover the conventional shapes the AC author uses to
-# write a re-run command (``Verify: pytest ...``, ``Verify: grep ...``,
-# ``Verify: aws ...``, ``Verify: curl ...``). The space after the verb
-# anchors the match to actual invocations and avoids false positives
-# on prose like "use grep when..." (which would otherwise match the
-# bare ``grep`` token).
+# shell-invocation verb followed by a space. The leading boundary
+# alternation accepts start-of-line, whitespace, OR a backtick — so
+# verbs wrapped in inline code (``Verify: `grep -n widget <path>` ``)
+# match the same way bare verbs do.
+#
+# The verb list covers the conventional shapes the AC author uses to
+# write a re-run command:
+#
+#   - ``grep`` / ``ripgrep`` / ``rg`` — search invocations.
+#   - ``pytest`` — test selectors.
+#   - ``aws`` / ``curl`` — service / HTTP probes.
+#   - ``bash`` / ``python`` / ``python3`` — explicit interpreter
+#     invocations of a script (``Verify: `bash scripts/foo.sh` ``).
+#   - ``./`` — direct script execution by relative path
+#     (``Verify: `./scripts/foo.sh` ``).
+#
+# The space after the verb anchors the match to actual invocations
+# and avoids false positives on prose like "use grep when..." (which
+# would otherwise match the bare ``grep`` token).
+#
+# Issue #4469 dropped the bare ``Verify:`` trigger that previously
+# fired this regex on every Verify line. The trigger over-matched on
+# "existence Verify" patterns — ``Verify: <path> is committed`` —
+# where the cited path IS the load-bearing target of the change, not
+# a search argument. Plain-prose Verify clauses now classify as
+# target-context; only Verify clauses that actually wrap a shell
+# invocation (matching the verb half of this regex) classify as
+# search-context.
 SEARCH_CONTEXT_LINE_REGEX = re.compile(
-    r"(?:Verify:|(?:^|\s)(?:grep|pytest|aws|curl|ripgrep|rg)\s)",
+    r"(?:^|\s|`)(?:grep|pytest|aws|curl|ripgrep|rg|bash|python3?|\./)\s",
     re.IGNORECASE,
 )
 

--- a/scripts/tests/test_check_shipped_pr_extract_files.py
+++ b/scripts/tests/test_check_shipped_pr_extract_files.py
@@ -416,3 +416,147 @@ def test_line_range_suffix_does_not_strip_non_numeric(extract_module):
     body = "See packages/api/src/index.ts (the entry point)."
     out = extract_module.extract_files(body)
     assert out == ["packages/api/src/index.ts"]
+
+
+# ─── Existence-Verify classification (issue #4469) ────────────────────
+
+
+def test_existence_verify_is_committed_classifies_as_target(extract_module):
+    """``Verify: <path> is committed`` cites ``<path>`` as the change
+    target — the predicate is "this file must exist," not "this file
+    is a search argument." Pre-#4469 the bare ``Verify:`` token put
+    every cited path into search-context; post-fix the verb regex no
+    longer triggers on plain-prose Verify clauses.
+
+    Canonical case from issue #3310 — its third AC reads
+    ``Verify: scripts/iam-agent-phase-b-smoke.sh ... is committed.``
+    The cited script IS the load-bearing file the AC requires, not a
+    grep / pytest argument.
+    """
+    body = (
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] A documented manual smoke test exists for the Phase-B write path.\n"
+        "  - Verify: `scripts/iam-agent-phase-b-smoke.sh` "
+        "(or equivalent in `infra/terraform/modules/iam_agent/tests/`) is committed.\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert "scripts/iam-agent-phase-b-smoke.sh" in target
+    assert "scripts/iam-agent-phase-b-smoke.sh" not in search
+
+
+def test_existence_verify_exists_or_created_classifies_as_target(extract_module):
+    """The existence-Verify pattern is shape-agnostic to the specific
+    predicate verb — ``is committed``, ``is created``, ``exists``,
+    ``must exist`` all behave the same. The classifier doesn't need to
+    enumerate predicate verbs; it just needs to NOT classify the line
+    as search-context when the line carries no shell-invocation verb.
+    """
+    body_a = "## AC\n  - Verify: `scripts/dispatcher/zombie_alert.py` exists.\n"
+    body_b = "## AC\n  - Verify: `docs/agent/new-runbook.md` is created.\n"
+    target_a, _ = extract_module.classify_files(body_a)
+    target_b, _ = extract_module.classify_files(body_b)
+    assert "scripts/dispatcher/zombie_alert.py" in target_a
+    assert "docs/agent/new-runbook.md" in target_b
+
+
+def test_verify_with_grep_invocation_stays_search(extract_module):
+    """Negative regression — the existence-Verify fix must not regress
+    the #4340 invariant. ``Verify: `grep -n widget <path>` `` cites
+    ``<path>`` as a grep argument; it stays search-context.
+    """
+    body = (
+        "## AC\n"
+        "  - Verify: `grep -n widget scripts/run-foo.sh packages/api/src/index.ts`\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert target == []
+    assert "scripts/run-foo.sh" in search
+    assert "packages/api/src/index.ts" in search
+
+
+def test_verify_with_bash_invocation_stays_search(extract_module):
+    """Negative regression — ``Verify: `bash <path>` exits 0`` cites
+    ``<path>`` as the script being executed, not as a target the
+    issue creates. Classify as search-context.
+
+    The verb regex was extended in #4469 to include ``bash`` so this
+    case keeps its pre-#4469 search classification after the bare
+    ``Verify:`` trigger was dropped.
+    """
+    body = "## AC\n  - Verify: `bash scripts/tests/test_check_shipped_pr.sh` exits 0.\n"
+    target, search = extract_module.classify_files(body)
+    assert target == []
+    assert "scripts/tests/test_check_shipped_pr.sh" in search
+
+
+def test_verify_with_python_invocation_stays_search(extract_module):
+    """Negative regression — ``Verify: `python3 <path>` `` and
+    ``Verify: `python <path>` `` cite the script being executed,
+    not a target the issue creates. Classify as search-context.
+
+    Locks in the ``python`` / ``python3`` verb additions from #4469.
+    """
+    body_a = (
+        "## AC\n  - Verify: `python3 scripts/check-something.py --dry-run` succeeds.\n"
+    )
+    body_b = "## AC\n  - Verify: `python scripts/dispatcher/audit.py` reports clean.\n"
+    target_a, search_a = extract_module.classify_files(body_a)
+    target_b, search_b = extract_module.classify_files(body_b)
+    assert "scripts/check-something.py" in search_a
+    assert "scripts/dispatcher/audit.py" in search_b
+
+
+def test_existence_verify_mixed_with_search_verify(extract_module):
+    """Two Verify clauses in the same body — one existence-shape, one
+    grep-shape — classify INDEPENDENTLY. The existence Verify's path
+    is target; the grep Verify's path is search.
+    """
+    body = (
+        "## AC\n"
+        "  - [ ] Smoke test exists.\n"
+        "  - Verify: `scripts/new-smoke-test.sh` is committed.\n"
+        "  - [ ] Hardcoded prefix is gone from caller.\n"
+        "  - Verify: `grep -n staging packages/api/src/legacy.py`\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert "scripts/new-smoke-test.sh" in target
+    assert "packages/api/src/legacy.py" in search
+    assert "scripts/new-smoke-test.sh" not in search
+    assert "packages/api/src/legacy.py" not in target
+
+
+def test_existence_verify_three_repo_3310_layout(extract_module):
+    """End-to-end repro of the issue #3310 body shape — narrative cites
+    ``main.tf`` (with line ranges that strip per #4462) plus a fenced
+    HCL block citing the bare ``main.tf``, plus a Verify-existence
+    clause citing ``iam-agent-phase-b-smoke.sh``. All three target
+    paths classify correctly.
+
+    Locks in #4469's worked example: post-fix, target_overlap should
+    contain BOTH ``main.tf`` and ``iam-agent-phase-b-smoke.sh``.
+    """
+    body = (
+        "## Affected files\n"
+        "\n"
+        "- `infra/terraform/modules/iam_agent/main.tf:47-62` — first issue\n"
+        "- `infra/terraform/modules/iam_agent/main.tf:132-141` — second issue\n"
+        "\n"
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] Policy is split.\n"
+        "  - Verify: `terraform plan -chdir=infra/terraform/environments/dev` "
+        "shows the new statement; `aws iam simulate-principal-policy "
+        "--policy-source-arn <arn> --action-names ecs:RegisterTaskDefinition` "
+        "returns `allowed`.\n"
+        "- [ ] A documented manual smoke test exists.\n"
+        "  - Verify: `scripts/iam-agent-phase-b-smoke.sh` "
+        "(or equivalent in `infra/terraform/modules/iam_agent/tests/`) is committed.\n"
+    )
+    target, search = extract_module.classify_files(body)
+    assert "infra/terraform/modules/iam_agent/main.tf" in target
+    assert "scripts/iam-agent-phase-b-smoke.sh" in target
+    # The aws / terraform plan Verify line cites
+    # ``infra/terraform/environments/dev`` — only on a search-context
+    # line — so it stays search.
+    assert "infra/terraform/environments/dev" in search


### PR DESCRIPTION
## Summary

Refines the search-context line classifier in `scripts/_check_shipped_pr_extract_files.py` so plain-prose Verify clauses (`Verify: <path> is committed`) classify cited paths as **target-context**, not search-context. The bare `Verify:` trigger has been dropped; the verb regex now requires an explicit shell-invocation verb (`grep`, `pytest`, `aws`, `curl`, `ripgrep`/`rg`, `bash`, `python`/`python3`, `./`) preceded by start-of-line, whitespace, or a backtick.

This closes the structural gap surfaced by issue #4462's AC #2 — the line-range strip alone was insufficient because PR #3319's only added file (`scripts/iam-agent-phase-b-smoke.sh`) was cited only on a `Verify: ... is committed` line, which the pre-#4469 classifier put in search-context. Post-fix, the path correctly classifies as target.

Closes #4469

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling under `scripts/` only)

## Notes

- AC #2 (`scripts/check-shipped-pr.sh 3310` returns exit 0) is **partially met**: the existence-Verify classification now correctly produces `target_overlap = [main.tf, iam-agent-phase-b-smoke.sh]` and `target_added_overlap = [iam-agent-phase-b-smoke.sh]`, satisfying the base threshold. However, issue #3310 is audit-class (body contains "audit" via `/audit` skill mention), and the #4223 audit-class additional rule ("every target-context overlap is ADDED") blocks the shipped match because `main.tf` is modified, not added. The issue body itself frames #4469 and #4223 as "structurally separate ... complementary tightenings," so the audit-class interaction is its own follow-up — see process summary on #4469.
- New tests cover existence-Verify (positive + negative shapes), interaction with grep / bash / python Verify shapes, mixed body, and the issue #3310 layout end-to-end. Existing 23 tests in `test_check_shipped_pr_extract_files.py` and the 33-case bash suite (`test_check_shipped_pr.sh`) all stay green.
