### PR TITLE
perf(ci): trim test_dev_db_query.sh to ~30s via fast-poll defaults (#4497)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,13 +647,21 @@ jobs:
           # test_agent_runner_entrypoint.sh). Pre-#4067 this was the
           # `shell` shard; it observed ~21 min wall-clock dominated by
           # serial execution behind the long pole.
-          # Estimated wall-clock ~10 min today (next-largest test is
-          # test_dev_db_query.sh at ~5m25s; the rest are <1 min each).
-          # timeout-minutes:14 = ~1.4× current — adds room for setup
-          # variance + the dispatcher-tests step that runs after.
-          # See issues #3307 (original sharding) + #4067 (this split).
+          # #4497 cut test_dev_db_query.sh from ~5m25s to ~30s by baking
+          # LIST_TASKS_POLL_TIMEOUT_SECS=0 / EXEC_AGENT_POLL_TIMEOUT_SECS=0
+          # defaults into the test's run_script wrapper — the 5 tests that
+          # reach the AWS-polling stage now fail-fast on the first
+          # list-tasks "None" response instead of waiting the script's
+          # production 60-second deadline. Expected shard wall-clock is
+          # now ~6-7 min. The hard timeout-minutes:10 is the new
+          # regression gate per #4497's AC — fails the shard if a future
+          # change reintroduces a comparable long pole. Don't bump back
+          # to 14 without a follow-up issue documenting why the
+          # structural trim is no longer holding.
+          # See issues #3307 (original sharding), #4067 (this split +
+          # 14-min gate), and #4497 (structural trim + 10-min gate).
           - shard: shell-fast
-            timeout-minutes: 14
+            timeout-minutes: 10
             shard-filter: not-slow
           # Shard shell-slow (#4067): runs only paths in SLOW_TESTS so
           # the other tests in shell-fast no longer queue behind them.

--- a/scripts/tests/test_dev_db_query.sh
+++ b/scripts/tests/test_dev_db_query.sh
@@ -110,9 +110,24 @@ MOCK_AWS
 
 run_script() {
     # Args: <mock_bin> <args...>
+    #
+    # Defaults LIST_TASKS_POLL_TIMEOUT_SECS to 0 so flag-parsing / SSM-strip
+    # tests that aren't exercising polling behavior fail fast on the first
+    # list-tasks "None" response from the mock (~instant) instead of waiting
+    # the script's 60-second production default + 3-second retry loop. With
+    # =0, the deadline check on the first iteration fires immediately —
+    # 5 affected tests × ~60s each → ~5 min cut from the suite (#4497).
+    #
+    # Tests that need to exercise polling behavior (test_polls_until_task_appears,
+    # test_polls_then_gives_up_with_clear_error, test_exec_agent_probe_*)
+    # set LIST_TASKS_POLL_TIMEOUT_SECS / EXEC_AGENT_POLL_TIMEOUT_SECS on the
+    # command line and those values take precedence over these defaults via
+    # bash's standard env-var precedence.
     local mock_bin="$1"
     shift
-    PATH="$mock_bin:$PATH" "$DEV_DB_QUERY" "$@" 2>&1
+    LIST_TASKS_POLL_TIMEOUT_SECS="${LIST_TASKS_POLL_TIMEOUT_SECS:-0}" \
+        EXEC_AGENT_POLL_TIMEOUT_SECS="${EXEC_AGENT_POLL_TIMEOUT_SECS:-0}" \
+        PATH="$mock_bin:$PATH" "$DEV_DB_QUERY" "$@" 2>&1
 }
 
 # ── Tests ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Bake `LIST_TASKS_POLL_TIMEOUT_SECS=0` / `EXEC_AGENT_POLL_TIMEOUT_SECS=0` defaults into the `run_script` wrapper so flag-parsing / SSM-strip / happy-path tests fail-fast on the first list-tasks "None" response instead of waiting the production 60s deadline + 3s retry loop. Local wall-clock: **5m28s → 27s** (~12× speedup), same 22/22 PASS count. Also tightens the `scripts-tests (shell-fast)` shard timeout from 14 → 10 min as the regression gate, mirroring #4139's pattern for shell-slow.

Closes #4497

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (incl. `test_dev_db_query.sh` 22/22)
- [x] CI green — `scripts-tests (shell-fast, 10, not-slow)` 6m54s, `scripts-tests (python)` 4m8s, `scripts-tests (shell-slow, 6, slow)` 2m37s, `ci-passed` SUCCESS

### Post-deploy verification
- [x] `test_dev_db_query.sh` wall-clock ≤ 2 min (local: 27s, 12× speedup)
- [x] `scripts-tests (shell-fast)` shard `completedAt − startedAt` ≤ 7 min (CI run 25599458861: 6m54s)
- [x] Max wall-clock across the `scripts-tests` matrix ≤ 7 min (CI run 25599458861: 6m54s)
- [x] Verification evidence posted on issue
