### PR TITLE
feat(dx): gh-comment-with-retry falls back to REST on GraphQL exhaustion (#4503)

### DIFF
--- a/scripts/gh-comment-with-retry.sh
+++ b/scripts/gh-comment-with-retry.sh
@@ -1,23 +1,40 @@
 #!/usr/bin/env bash
 # permanent: true
-# gh-comment-with-retry.sh — Post a `gh issue comment` and tolerate the
-# 504-after-success failure mode.
+# gh-comment-with-retry.sh — Post a `gh issue comment` and tolerate two
+# distinct flaky failure modes (504-after-success + GraphQL-quota
+# exhaustion).
 #
 # Why this helper exists
 # ----------------------
-# `gh issue comment <N> --body-file <file>` periodically returns a
-# `504 Gateway Timeout` (with a multi-KB HTML "Unicorn!" error page in
-# stderr) **after the comment has already posted**. A naive retry
-# creates a duplicate comment. Treating it as a hard failure misleads
-# the agent about pipeline state.
+# `gh issue comment <N> --body-file <file>` has two flaky failure modes
+# that the bare `gh` call does not handle:
 #
-# This is the comment-post analogue of the `gh pr merge` 5xx case
-# documented in `.claude/skills/task/SKILL.md` §A.7 (#4231): the API
-# already accepted the request, only the response failed. Recipe:
-# re-fetch state and treat already-posted-with-matching-body as
-# success.
+#   1. **504-after-success (#4478):** the request periodically returns a
+#      `504 Gateway Timeout` (with a multi-KB HTML "Unicorn!" error page
+#      in stderr) **after the comment has already posted**. A naive
+#      retry creates a duplicate; treating it as a hard failure
+#      misleads the agent about pipeline state. Recipe: re-fetch the
+#      issue's recent comments, treat already-posted-with-matching-body
+#      as success.
 #
-# Tracking: issue #4478.
+#   2. **GraphQL-quota-exhausted (#4503):** `gh issue comment` posts
+#      the comment via GitHub's GraphQL API, which has a separate
+#      5,000-req/hr quota from the REST core API. Long agent sessions
+#      (dispatcher, multi-PR /task runs) regularly exhaust GraphQL —
+#      consumed by `gh pr view`, `gh pr merge`, `gh issue view --json`,
+#      etc. — while the REST core quota stays healthy. Recipe: fall
+#      back to `gh api -X POST /repos/<owner>/<repo>/issues/<N>/comments
+#      -F body=@<file>`. The REST endpoint is the same logical
+#      operation and `-F body=@<file>` accepts the body the same way
+#      `--body-file` does.
+#
+# Both failure modes share the same shape — the API can accept the
+# request, the wrapper just needs the right fallback path. See
+# `.claude/skills/task/SKILL.md` §A.7 for the `gh pr merge` 5xx
+# analogue (#4231).
+#
+# Tracking: issues #4478 (504-after-success) and #4503 (GraphQL-quota
+# REST fallback).
 #
 # Usage
 # -----
@@ -30,7 +47,15 @@
 #   1. Calls ``gh issue comment <N> --repo <repo> --body-file <path>``.
 #   2. On exit 0: prints the returned comment URL to stdout, exits 0.
 #   3. On non-zero exit AND the captured stderr matches
-#      ``504 Gateway Timeout`` or ``<title>Unicorn!``:
+#      ``GraphQL: API rate limit already exceeded`` (#4503):
+#      - Falls back to ``gh api -X POST /repos/<owner>/<repo>/issues/<N>/comments
+#        -F body=@<path>``.
+#      - On REST success: prints "comment posted (REST fallback): <url>"
+#        and exits 0.
+#      - On REST failure: prints both stderrs (gh + REST, truncated to
+#        5 KB each) and exits non-zero with the REST exit code.
+#   4. On non-zero exit AND the captured stderr matches
+#      ``504 Gateway Timeout`` or ``<title>Unicorn!`` (#4478):
 #      - Re-fetches the issue's recent comments via
 #        ``gh api /repos/<repo>/issues/<N>/comments?per_page=100&sort=created&direction=desc``.
 #      - Filters to comments by the current ``gh`` user
@@ -41,15 +66,27 @@
 #        and exits 0.
 #      - If they don't match: prints the captured stderr (truncated to
 #        first 5 KB) and exits non-zero.
-#   4. On any other non-zero exit (auth failure, rate limit, etc.):
+#   5. On any other non-zero exit (auth failure, generic 5xx, etc.):
 #      prints the captured stderr and exits with the original code.
+#
+# Decision rules for the REST fallback (#4503)
+# --------------------------------------------
+# - Trigger ONLY on the explicit GraphQL-rate-limit-exceeded marker.
+#   Generic 5xx failures hit the existing 504 path.
+# - Do NOT trigger on 403 / authentication errors — those need
+#   operator intervention and the REST endpoint will reject for the
+#   same reason.
+# - The REST endpoint (`POST /repos/.../issues/N/comments`) consumes
+#   from the REST core 5,000-req/hr quota, which is rarely exhausted
+#   even in long sessions.
 #
 # Rate-budget hygiene
 # -------------------
 # Stays well within the 5,000 reqs/hr GitHub API budget — at most one
 # extra ``GET /repos/.../issues/<N>/comments`` and one ``GET /user``
-# per 504. No exponential backoff retries: a single confirm-or-fail
-# round trip is enough to disambiguate the 504-after-success case.
+# per 504, or one ``POST /repos/.../issues/<N>/comments`` per
+# GraphQL-quota-exhaustion. No exponential backoff retries: a single
+# confirm-or-fail round trip is enough.
 #
 # Integration
 # -----------
@@ -192,9 +229,58 @@ if [[ "$GH_EXIT" -eq 0 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# Step 2 — Non-zero exit. Inspect stderr for the 504-after-success signature.
+# Step 2 — Non-zero exit. Inspect stderr for known recoverable signatures.
 # ---------------------------------------------------------------------------
 
+# Step 2a — GraphQL-rate-limit-exceeded (#4503).
+#
+# `gh issue comment` posts via GitHub's GraphQL API. The GraphQL quota
+# is a separate 5,000-req/hr bucket from the REST core quota and is
+# routinely exhausted on long agent sessions. The explicit marker is:
+#   "GraphQL: API rate limit already exceeded for user ID <N>."
+# When we see it, fall back to the REST endpoint (which draws from the
+# core quota) instead of failing the whole post.
+if grep -qE "GraphQL: API rate limit already exceeded" "$STDERR_FILE"; then
+    echo "gh-comment-with-retry: GraphQL rate-limit exhausted, falling back to REST API..." >&2
+
+    # Split owner / repo for the REST URL. The wrapper validates REPO
+    # as `<owner>/<repo>` upstream by passing `--repo` to gh; the
+    # default is judgemind/judgemind. We don't need additional parsing
+    # — the slash form is what the REST endpoint expects.
+    REST_STDERR_FILE=$(mktemp)
+    REST_STDOUT_FILE=$(mktemp)
+    # shellcheck disable=SC2064  # cleanup paths fixed at trap-install time.
+    trap "rm -f '$STDERR_FILE' '$STDOUT_FILE' '$REST_STDERR_FILE' '$REST_STDOUT_FILE'" EXIT
+
+    set +e
+    gh api -X POST "/repos/$REPO/issues/$ISSUE/comments" \
+        -F "body=@$BODY_FILE" \
+        --jq '.html_url' \
+        > "$REST_STDOUT_FILE" 2> "$REST_STDERR_FILE"
+    REST_EXIT=$?
+    set -e
+
+    if [[ "$REST_EXIT" -eq 0 ]]; then
+        REST_URL=$(cat "$REST_STDOUT_FILE")
+        echo "comment posted (REST fallback): $REST_URL"
+        exit 0
+    fi
+
+    # REST also failed. Surface both stderrs so the operator can
+    # diagnose (likely cause: the REST core quota is also exhausted,
+    # or the body file changed mid-flight).
+    echo "ERROR: GraphQL rate-limit fallback to REST also failed (gh exit $REST_EXIT)." >&2
+    echo "  --- gh issue comment stderr (first 5 KB) ---" >&2
+    head -c 5120 "$STDERR_FILE" >&2
+    echo "" >&2
+    echo "  --- gh api POST stderr (first 5 KB) ---" >&2
+    head -c 5120 "$REST_STDERR_FILE" >&2
+    echo "" >&2
+    exit "$REST_EXIT"
+fi
+
+# Step 2b — 504-after-success (#4478).
+#
 # Two markers are diagnostic of the GitHub 504 / Unicorn page:
 #   - Literal "504 Gateway Timeout" (HTTP status line gh sometimes echoes)
 #   - "<title>Unicorn!" (HTML error page GitHub renders for 5xx)

--- a/scripts/tests/test_gh_comment_with_retry.sh
+++ b/scripts/tests/test_gh_comment_with_retry.sh
@@ -117,6 +117,10 @@ STDERR_EOF
             echo "error: authentication required" >&2
             exit 4
             ;;
+        graphql_rate_limit)
+            echo "GraphQL: API rate limit already exceeded for user ID 3708633." >&2
+            exit 1
+            ;;
         *)
             echo "mock gh: unknown MOCK_COMMENT_MODE=$mode" >&2
             exit 99
@@ -130,7 +134,32 @@ if [[ "${1:-}" == "api" && "${2:-}" == "/user" ]]; then
     exit 0
 fi
 
-# ── gh api /repos/.../issues/<N>/comments?... ──────────────────────────────
+# ── gh api -X POST /repos/.../issues/<N>/comments (REST fallback path) ────
+# Distinct from the GET-comments path below: the wrapper invokes this
+# only after a GraphQL-rate-limit-exceeded stderr match. Behavior
+# controlled by ``MOCK_REST_POST_MODE`` env var:
+#   - "success" : exit 0, print html_url on stdout (default).
+#   - "fail"    : exit 1, print "error: secondary failure" on stderr.
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "POST" \
+        && "${4:-}" =~ ^/repos/.*/issues/[0-9]+/comments$ ]]; then
+    rest_mode="${MOCK_REST_POST_MODE:-success}"
+    case "$rest_mode" in
+        success)
+            echo "https://github.com/judgemind/judgemind/issues/100#issuecomment-rest-77"
+            exit 0
+            ;;
+        fail)
+            echo "error: secondary REST failure (rate limit or auth)" >&2
+            exit 1
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_REST_POST_MODE=$rest_mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api /repos/.../issues/<N>/comments?... (GET — 504 recovery path) ────
 if [[ "${1:-}" == "api" && "${2:-}" =~ ^/repos/.*/issues/[0-9]+/comments ]]; then
     if [[ -n "${MOCK_COMMENTS_FILE:-}" && -f "${MOCK_COMMENTS_FILE}" ]]; then
         cat "${MOCK_COMMENTS_FILE}"
@@ -441,6 +470,140 @@ if [[ "$recovery_calls" == "0" ]]; then
     pass "D: auth-fail makes no recovery API calls"
 else
     fail "D: auth-fail makes no recovery API calls" "found $recovery_calls api calls"
+fi
+
+# ── Test F — GraphQL rate-limit exhaustion → REST fallback (#4503) ────────
+
+# F.1 — gh issue comment hits GraphQL quota; REST fallback succeeds.
+BODY_FILE_F1=$(mktemp)
+register_temp_file "$BODY_FILE_F1"
+echo "test body F.1 — GraphQL exhausted, REST should rescue" > "$BODY_FILE_F1"
+
+INVOCATIONS_F1="$MOCK_BIN_DIR/invocations_f1.txt"
+: > "$INVOCATIONS_F1"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_F1" \
+    MOCK_COMMENT_MODE=graphql_rate_limit \
+    MOCK_REST_POST_MODE=success \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_F1" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "F.1: GraphQL rate-limit + REST success exits 0"
+else
+    fail "F.1: GraphQL rate-limit + REST success exits 0" "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"REST fallback"* ]]; then
+    pass "F.1: stdout names 'REST fallback' on the recovery path"
+else
+    fail "F.1: stdout names 'REST fallback' on the recovery path" "got: $stdout_output"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/issues/100#issuecomment-rest-77"* ]]; then
+    pass "F.1: stdout includes the REST-posted comment URL"
+else
+    fail "F.1: stdout includes the REST-posted comment URL" "got: $stdout_output"
+fi
+
+# Verify the wrapper actually invoked `gh api -X POST /repos/.../issues/100/comments`
+# with a body=@<file> form arg. Both signals must be present in the recorded invocations.
+if grep -qE "^api -X POST /repos/.*/issues/100/comments( |$)" "$INVOCATIONS_F1"; then
+    pass "F.1: wrapper invoked 'gh api -X POST /repos/.../issues/100/comments'"
+else
+    fail "F.1: wrapper invoked 'gh api -X POST /repos/.../issues/100/comments'" \
+        "invocations: $(cat "$INVOCATIONS_F1")"
+fi
+
+if grep -qE "body=@.*$(basename "$BODY_FILE_F1")" "$INVOCATIONS_F1"; then
+    pass "F.1: wrapper passed -F body=@<body-file> to gh api"
+else
+    fail "F.1: wrapper passed -F body=@<body-file> to gh api" \
+        "invocations: $(cat "$INVOCATIONS_F1")"
+fi
+
+# Verify the 504-recovery path was NOT taken — there should be no GET on
+# /repos/.../comments and no /user lookup (those are 504-path artifacts).
+graphql_path_only_calls=$(awk '/^api \/repos\/.*\/comments\?/ {n++} /^api \/user/ {n++} END {print n+0}' "$INVOCATIONS_F1")
+if [[ "$graphql_path_only_calls" == "0" ]]; then
+    pass "F.1: 504-recovery path was NOT exercised (no GET comments / no /user)"
+else
+    fail "F.1: 504-recovery path was NOT exercised (no GET comments / no /user)" \
+        "found $graphql_path_only_calls 504-recovery calls"
+fi
+
+# F.2 — gh issue comment hits GraphQL quota; REST fallback ALSO fails.
+BODY_FILE_F2=$(mktemp)
+register_temp_file "$BODY_FILE_F2"
+echo "test body F.2 — both paths fail" > "$BODY_FILE_F2"
+
+INVOCATIONS_F2="$MOCK_BIN_DIR/invocations_f2.txt"
+: > "$INVOCATIONS_F2"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_F2" \
+    MOCK_COMMENT_MODE=graphql_rate_limit \
+    MOCK_REST_POST_MODE=fail \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_F2" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "F.2: GraphQL rate-limit + REST fail exits non-zero"
+else
+    fail "F.2: GraphQL rate-limit + REST fail exits non-zero" "expected non-zero, got $exit_code"
+fi
+
+if [[ "$err_output" == *"REST also failed"* ]]; then
+    pass "F.2: stderr names 'REST also failed' to disambiguate from gh failure"
+else
+    fail "F.2: stderr names 'REST also failed' to disambiguate from gh failure" "got: $err_output"
+fi
+
+if [[ "$err_output" == *"GraphQL: API rate limit"* ]]; then
+    pass "F.2: stderr surfaces the original GraphQL rate-limit error for context"
+else
+    fail "F.2: stderr surfaces the original GraphQL rate-limit error for context" "got: $err_output"
+fi
+
+if [[ "$err_output" == *"secondary REST failure"* ]]; then
+    pass "F.2: stderr surfaces the REST-side failure too"
+else
+    fail "F.2: stderr surfaces the REST-side failure too" "got: $err_output"
+fi
+
+# F.3 — Generic GraphQL error (NOT rate-limit) should NOT trigger REST fallback.
+# We piggyback on the existing 'auth' mode which produces a non-rate-limit error.
+# Already covered indirectly by Test D, but verify the explicit
+# trigger-only-on-rate-limit-marker decision rule with a positive assertion.
+BODY_FILE_F3=$(mktemp)
+register_temp_file "$BODY_FILE_F3"
+echo "test body F.3" > "$BODY_FILE_F3"
+
+INVOCATIONS_F3="$MOCK_BIN_DIR/invocations_f3.txt"
+: > "$INVOCATIONS_F3"
+
+exit_code=0
+MOCK_INVOCATIONS="$INVOCATIONS_F3" \
+    MOCK_COMMENT_MODE=auth \
+    "$WRAPPER" 100 --body-file "$BODY_FILE_F3" >/dev/null 2>&1 || exit_code=$?
+
+# Auth failure should still pass through (exit 4) — REST fallback NOT invoked.
+if [[ "$exit_code" -eq 4 ]]; then
+    pass "F.3: auth-fail does NOT trigger REST fallback (passthrough preserved)"
+else
+    fail "F.3: auth-fail does NOT trigger REST fallback (passthrough preserved)" \
+        "expected 4, got $exit_code"
+fi
+
+rest_post_calls=$(awk '/^api -X POST / {n++} END {print n+0}' "$INVOCATIONS_F3")
+if [[ "$rest_post_calls" == "0" ]]; then
+    pass "F.3: auth-fail makes no REST POST calls"
+else
+    fail "F.3: auth-fail makes no REST POST calls" \
+        "found $rest_post_calls REST POST calls"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a REST-API fallback to `scripts/gh-comment-with-retry.sh` for the GraphQL-quota-exhausted failure mode. `gh issue comment` posts via GraphQL, which has a separate 5,000-req/hr quota from REST core; long agent sessions routinely exhaust it. Previously the wrapper would fail the post entirely — fully merged PRs were blocked at the verification-evidence step because the agent couldn't post a single comment. The new Step 2a branch detects the explicit `GraphQL: API rate limit already exceeded` stderr marker and falls back to `gh api -X POST /repos/<owner>/<repo>/issues/<N>/comments -F body=@<file>`.

The fix dogfooded itself live during this task — the claim comment for #4503 hit GraphQL exhaustion, and I worked around it manually with the exact REST call the new fallback now makes automatically. The process-summary comment on #4503 was posted by the patched wrapper itself (see "Verification Evidence" below).

Closes #4503

## Test plan

### Automated checks
- [x] Lint passes (shellcheck clean on the modified script; pre-existing warnings unchanged)
- [x] Format check passes (no formatter applies to bash)
- [x] Tests pass (`scripts/tests/test_gh_comment_with_retry.sh` — 31/31 passed: 19 existing + 12 new)
- [x] CI green (57/57 checks passed, ci-passed=success)

### Post-deploy verification
- [x] N/A — no deployed component (tooling script with shell-mocked test suite). The fix is exercised every time any subsequent `/task` agent posts a comment after GraphQL exhaustion. Already exercised in this PR's own process-summary post on issue #4503 (see issue comments).

### Decision rules (documented in script header)

- Triggers ONLY on the explicit `GraphQL: API rate limit already exceeded` marker.
- Generic 5xx and `<title>Unicorn!` continue to hit the existing 504-after-success path.
- 403 / auth errors pass through unchanged (operator intervention required).
- F.3 test asserts auth failures do NOT trigger REST fallback.
