### PR TITLE
feat(dx): auto-close parent meta-tasks when all Path-C sub-tasks close (#4499)

### DIFF
--- a/scripts/_sweep_completed_parents.py
+++ b/scripts/_sweep_completed_parents.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Helper for sweep-completed-parents.sh — auto-close meta-tasks (#4499).
+
+Not meant to be run directly. Called by ``sweep-completed-parents.sh`` with
+environment variables: REPO, DRY_RUN, GRACE_HOURS, CHILDREN_FILE,
+WORK_TMPDIR, SCRIPT_DIR.
+
+Algorithm
+---------
+1. Read ``CHILDREN_FILE`` — a JSON array of {number, state, closedAt, body}
+   produced by ``gh issue list --search 'in:body "Parent: #"' --state all``.
+2. For each child, parse the canonical ``Parent: #<N>`` line out of its
+   body (regex shared with daemon's ``_parse_parent_issue``).
+3. Group children by parent number. The PARENT SET is the unique set of
+   parent numbers extracted in step 2.
+4. For each candidate parent:
+   a. Fetch the parent's state, closedAt, and updatedAt via ``gh issue
+      view`` (one ``--json`` call). Skip if the parent is already CLOSED.
+   b. Verify ALL children of this parent (from step 3's grouping) are
+      CLOSED. Skip if any are OPEN.
+   c. Verify no child was closed via ``--reason not_planned``. We query
+      via ``gh issue view --json stateReason`` per child the first time we
+      see one closed without a confirmed reason. (Rare; cached.)
+   d. Compute the most-recent ``closedAt`` across all children. Require
+      it to be ``>= grace_hours`` ago. Skip otherwise.
+   e. Fetch parent comments newer than the most-recent child closedAt.
+      Skip if any non-bot comments exist (suggests human follow-up).
+   f. Otherwise: post the auto-close comment, ``gh issue close --reason
+      completed``, and ``scripts/unblock-dependents.sh <parent>``.
+
+Run via ``scripts/sweep-completed-parents.sh`` (the bash front end populates
+the env vars and the children JSON file). The helper is intentionally
+side-effect-free until step (f) — every short-circuit short-skip is
+visible in the ``[skip]`` log lines so the dry-run output reads as a
+candidate list without action.
+"""
+
+# permanent: true
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+# Canonical regex for the ``Parent: #N`` body reference. Matches the daemon's
+# ``DispatcherDaemon._parse_parent_issue`` (#3 of dispatcher/daemon.py:7559).
+_PARENT_RE = re.compile(r"(?im)^\s*parent\s*:\s*#(\d+)\s*$")
+
+# Bot-author logins whose comments are filtered out of the
+# "comments-since-last-child-closed" check. A trailing ``[bot]`` segment is
+# also recognized via :func:`_is_bot_author` so any future bot integrations
+# inherit the skip without code change.
+_BOT_AUTHORS = frozenset(
+    {
+        "github-actions",
+        "judgemind-agent",
+        "judgeminder",
+    }
+)
+
+# Auto-close comment template — names the children, the date, and the
+# script that closed it for audit-trail purposes. The wording mirrors what
+# the issue #4499 body proposes verbatim so future readers have an obvious
+# breadcrumb back to the design.
+_AUTOCLOSE_TEMPLATE = (
+    "Auto-closing as completed — all sub-tasks ({child_list}) closed on "
+    "or before {last_close_date}. If the parent's acceptance criteria "
+    "were not fully met by the sub-tasks, please reopen and link the "
+    "residual follow-up.\n\n"
+    "_Closed by `scripts/sweep-completed-parents.sh` (#4499). "
+    "Grace window: {grace_hours}h._"
+)
+
+
+@dataclass(frozen=True)
+class _Child:
+    """Single sub-task entry parsed from the children-list JSON."""
+
+    number: int
+    state: str  # OPEN / CLOSED
+    closed_at: datetime | None  # Always present when state == CLOSED
+    state_reason: str | None  # Filled lazily — populated by _state_reason_for
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+    """Parse a GitHub-formatted ISO 8601 timestamp into a UTC datetime."""
+    if not value:
+        return None
+    # GitHub returns 'Z' for UTC; Python <3.11 doesn't accept it directly.
+    cleaned = value.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _is_bot_author(login: str | None) -> bool:
+    """Return True if ``login`` looks like a bot account.
+
+    Recognises explicit names in ``_BOT_AUTHORS`` plus any GitHub App login
+    ending in ``[bot]`` (the suffix GitHub stamps onto bot logins).
+    """
+    if not login:
+        return False
+    if login in _BOT_AUTHORS:
+        return True
+    return login.endswith("[bot]")
+
+
+def parse_parent_number(body: str) -> int | None:
+    """Extract the first ``Parent: #N`` reference from an issue body."""
+    match = _PARENT_RE.search(body or "")
+    return int(match.group(1)) if match else None
+
+
+def group_children_by_parent(
+    children: list[dict],
+) -> dict[int, list[_Child]]:
+    """Group raw children-list JSON entries by their parent issue number."""
+    grouped: dict[int, list[_Child]] = defaultdict(list)
+    for entry in children:
+        body = entry.get("body") or ""
+        parent = parse_parent_number(body)
+        if parent is None:
+            continue
+        grouped[parent].append(
+            _Child(
+                number=int(entry["number"]),
+                state=str(entry.get("state", "UNKNOWN")).upper(),
+                closed_at=_parse_iso8601(entry.get("closedAt")),
+                state_reason=None,
+            )
+        )
+    return dict(grouped)
+
+
+def _gh_json(*args: str) -> dict | list | None:
+    """Run ``gh`` and parse stdout as JSON; return None on error."""
+    try:
+        r = subprocess.run(  # noqa: S603 — args are well-typed
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except FileNotFoundError:
+        print("  ERROR: gh CLI not found", file=sys.stderr)
+        return None
+    if r.returncode != 0:
+        print(f"  gh error: {r.stderr.strip()[:200]}", file=sys.stderr)
+        return None
+    out = (r.stdout or "").strip()
+    if not out:
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        print(f"  gh JSON parse failure: {out[:200]}", file=sys.stderr)
+        return None
+
+
+def _gh_run(*args: str) -> tuple[int, str, str]:
+    """Run a non-JSON ``gh`` command (e.g. close, edit, comment)."""
+    try:
+        r = subprocess.run(  # noqa: S603 — args are well-typed
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except FileNotFoundError:
+        return 127, "", "gh CLI not found"
+    return r.returncode, (r.stdout or "").strip(), (r.stderr or "").strip()
+
+
+def is_parent_closeable(
+    parent_state: str,
+    children: list[_Child],
+    *,
+    now: datetime,
+    grace: timedelta,
+) -> tuple[bool, str]:
+    """Return (closeable, reason) for one parent + its children.
+
+    Pure function — no I/O. Used directly by the integration code below
+    AND by the unit tests in ``scripts/tests/test_sweep_completed_parents.py``
+    so the gating logic is verifiable without mocking ``gh``.
+
+    Closeable iff:
+      * Parent is OPEN.
+      * At least one child exists.
+      * Every child is CLOSED.
+      * No child has ``state_reason == "not_planned"``.
+      * Most-recent child ``closed_at`` is older than ``grace``.
+    """
+    if parent_state.upper() != "OPEN":
+        return False, f"parent is {parent_state}"
+    if not children:
+        return False, "no children grouped under this parent"
+    open_children = [c.number for c in children if c.state != "CLOSED"]
+    if open_children:
+        return False, f"open children: {open_children}"
+    not_planned = [c.number for c in children if c.state_reason == "not_planned"]
+    if not_planned:
+        return False, f"closed-not-planned children: {not_planned}"
+    closed_ats = [c.closed_at for c in children if c.closed_at is not None]
+    if not closed_ats:
+        return False, "no children carry closedAt timestamps"
+    most_recent = max(closed_ats)
+    age = now - most_recent
+    if age < grace:
+        return False, (
+            f"most-recent child closed {age.total_seconds() / 3600.0:.1f}h ago "
+            f"(< grace {grace.total_seconds() / 3600.0:.1f}h)"
+        )
+    return True, "all children closed; outside grace window"
+
+
+def has_human_comments_since(
+    comments: list[dict],
+    cutoff: datetime,
+) -> tuple[bool, list[int]]:
+    """Return (has_human, comment_count_after_cutoff).
+
+    A "human" comment is any comment authored by a non-bot login (see
+    :func:`_is_bot_author`) and posted strictly after ``cutoff``.
+    """
+    after = [
+        c
+        for c in comments
+        if (created := _parse_iso8601(c.get("createdAt"))) is not None
+        and created > cutoff
+    ]
+    human_after = [
+        c for c in after if not _is_bot_author((c.get("author") or {}).get("login"))
+    ]
+    return bool(human_after), [c.get("id") for c in after]
+
+
+def _fetch_parent_info(repo: str, parent: int) -> dict | None:
+    """Fetch parent issue state, comments, closedAt via one ``gh`` call."""
+    return _gh_json(
+        "issue",
+        "view",
+        str(parent),
+        "--repo",
+        repo,
+        "--json",
+        "number,state,closedAt,updatedAt,comments,labels",
+    )
+
+
+def _resolve_state_reason(repo: str, child: _Child) -> _Child:
+    """Populate ``state_reason`` for a CLOSED child (one extra ``gh`` call)."""
+    if child.state != "CLOSED" or child.state_reason is not None:
+        return child
+    info = _gh_json(
+        "issue",
+        "view",
+        str(child.number),
+        "--repo",
+        repo,
+        "--json",
+        "stateReason",
+    )
+    reason: str | None = None
+    if isinstance(info, dict):
+        # gh's stateReason field is one of: COMPLETED, NOT_PLANNED, REOPENED, null.
+        # Normalise to lower-case for the comparison in is_parent_closeable.
+        raw = info.get("stateReason")
+        if isinstance(raw, str):
+            reason = raw.lower()
+    return _Child(
+        number=child.number,
+        state=child.state,
+        closed_at=child.closed_at,
+        state_reason=reason,
+    )
+
+
+def _build_autoclose_comment(
+    children: list[_Child],
+    grace_hours: int,
+) -> str:
+    """Render the auto-close comment body."""
+    sorted_children = sorted(children, key=lambda c: c.number)
+    child_list = ", ".join(f"#{c.number}" for c in sorted_children)
+    closed_ats = [c.closed_at for c in children if c.closed_at is not None]
+    last = max(closed_ats) if closed_ats else datetime.now(timezone.utc)
+    return _AUTOCLOSE_TEMPLATE.format(
+        child_list=child_list,
+        last_close_date=last.strftime("%Y-%m-%d"),
+        grace_hours=grace_hours,
+    )
+
+
+def _close_parent(
+    repo: str,
+    parent: int,
+    children: list[_Child],
+    grace_hours: int,
+    tmpdir: str,
+    script_dir: str,
+) -> bool:
+    """Post comment, close parent, run unblock-dependents.sh. Return True on success."""
+    comment_path = os.path.join(tmpdir, f"_sweep_autoclose_{parent}.txt")
+    body = _build_autoclose_comment(children, grace_hours)
+    with open(comment_path, "w") as f:
+        f.write(body + "\n")
+
+    # 1. Comment.
+    rc, _out, err = _gh_run(
+        "issue",
+        "comment",
+        str(parent),
+        "--repo",
+        repo,
+        "--body-file",
+        comment_path,
+    )
+    if rc != 0:
+        print(f"  ERROR posting comment on #{parent}: {err[:200]}", file=sys.stderr)
+        return False
+
+    # 2. Close.
+    rc, _out, err = _gh_run(
+        "issue",
+        "close",
+        str(parent),
+        "--repo",
+        repo,
+        "--reason",
+        "completed",
+    )
+    if rc != 0:
+        print(f"  ERROR closing #{parent}: {err[:200]}", file=sys.stderr)
+        return False
+
+    # 3. Unblock dependents (best-effort; failure here is logged but does
+    #    not roll back the close).
+    unblock = os.path.join(script_dir, "unblock-dependents.sh")
+    try:
+        r = subprocess.run(  # noqa: S603 — args are well-typed
+            [unblock, str(parent)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        if r.returncode != 0:
+            print(
+                f"  WARN unblock-dependents.sh exited {r.returncode} for #{parent}: "
+                f"{(r.stderr or '')[:200]}",
+                file=sys.stderr,
+            )
+    except FileNotFoundError:
+        print(
+            f"  WARN unblock-dependents.sh missing at {unblock}",
+            file=sys.stderr,
+        )
+
+    return True
+
+
+def main() -> int:
+    repo = os.environ.get("REPO", "judgemind/judgemind")
+    dry_run = os.environ.get("DRY_RUN", "false") == "true"
+    grace_hours = int(os.environ.get("GRACE_HOURS", "24"))
+    children_file = os.environ.get("CHILDREN_FILE", "")
+    tmpdir = os.environ.get("WORK_TMPDIR", ".")
+    script_dir = os.environ.get("SCRIPT_DIR", os.path.dirname(__file__))
+
+    if not children_file or not os.path.exists(children_file):
+        print(
+            f"Error: CHILDREN_FILE not set or missing: {children_file!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(children_file) as f:
+        try:
+            children_raw: list[dict] = json.load(f)
+        except json.JSONDecodeError as exc:
+            print(f"Error: malformed children JSON: {exc}", file=sys.stderr)
+            return 1
+
+    if not children_raw:
+        print("No children with 'Parent: #' references found — nothing to do.")
+        return 0
+
+    grouped = group_children_by_parent(children_raw)
+    print(
+        f"Found {len(grouped)} candidate parent(s) across "
+        f"{len(children_raw)} child issue(s)."
+    )
+    print()
+
+    grace = timedelta(hours=grace_hours)
+    now = datetime.now(timezone.utc)
+
+    closed_count = 0
+    skipped_count = 0
+    error_count = 0
+
+    for parent, children in sorted(grouped.items()):
+        print(f"Parent #{parent} (children: {[c.number for c in children]}):")
+
+        # Fetch parent state.
+        info = _fetch_parent_info(repo, parent)
+        if not isinstance(info, dict):
+            print(f"  [skip] could not fetch parent #{parent} state")
+            skipped_count += 1
+            print()
+            continue
+
+        parent_state = str(info.get("state", "UNKNOWN")).upper()
+        if parent_state != "OPEN":
+            print(f"  [skip] parent state is {parent_state}")
+            skipped_count += 1
+            print()
+            continue
+
+        # Verify each closed child's state_reason — only resolve lazily on
+        # the first child for which we lack the field.
+        resolved: list[_Child] = [_resolve_state_reason(repo, c) for c in children]
+
+        closeable, reason = is_parent_closeable(
+            parent_state,
+            resolved,
+            now=now,
+            grace=grace,
+        )
+        if not closeable:
+            print(f"  [skip] {reason}")
+            skipped_count += 1
+            print()
+            continue
+
+        # Comment-since-last-child-closed check. Skip if a non-bot comment
+        # exists after the most-recent child close — suggests a human is
+        # working on residual follow-up and we should not auto-close.
+        closed_ats = [c.closed_at for c in resolved if c.closed_at is not None]
+        most_recent = max(closed_ats)
+        comments = info.get("comments") or []
+        has_human, ids_after = has_human_comments_since(comments, most_recent)
+        if has_human:
+            print(
+                f"  [skip] {len(ids_after)} comment(s) since last child close "
+                f"({most_recent.isoformat()}) — possible human follow-up"
+            )
+            skipped_count += 1
+            print()
+            continue
+
+        if dry_run:
+            print(
+                f"  [DRY RUN] would close parent #{parent}; children all closed by "
+                f"{most_recent.isoformat()}"
+            )
+            closed_count += 1
+            print()
+            continue
+
+        ok = _close_parent(
+            repo,
+            parent,
+            resolved,
+            grace_hours,
+            tmpdir,
+            script_dir,
+        )
+        if ok:
+            print(f"  closed #{parent} (auto-close completed).")
+            closed_count += 1
+        else:
+            print(f"  ERROR — auto-close of #{parent} failed mid-flight.")
+            error_count += 1
+        print()
+
+    print("---")
+    if dry_run:
+        print(
+            f"[DRY RUN] would have closed {closed_count} parent(s); "
+            f"skipped {skipped_count}; errors {error_count}."
+        )
+    else:
+        print(
+            f"Closed {closed_count} parent(s); skipped {skipped_count}; "
+            f"errors {error_count}."
+        )
+    return 0 if error_count == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -27546,6 +27546,82 @@ class DispatcherDaemon:
             "skipped_open_target": skipped_open_target,
         }
 
+    def _housekeeping_sweep_completed_parents(self) -> dict[str, Any]:
+        """Auto-close parent meta-tasks whose Path-C sub-tasks all closed (#4499).
+
+        Invokes ``scripts/sweep-completed-parents.sh`` as a subprocess. The
+        bash entry point + Python helper read open issues that carry
+        ``Parent: #<N>`` in their bodies, group them by parent, and close
+        any parent whose children are ALL closed for >= 24 hours with no
+        human follow-up comment. The invocation is bounded by the same
+        ``GH_POLL_SUBPROCESS_TIMEOUT_SECONDS`` budget the orphan-PR GC
+        uses, since both call ``gh issue ...`` repeatedly under the hood.
+
+        Failures are caught by the caller (:meth:`_housekeeping_tick`).
+        Returns a small dict for observability: ``exit_code`` + a one-line
+        ``summary_tail`` so the structured log captures the script's
+        ``Closed N; skipped M; errors K`` final line. The script is
+        intentionally chatty on stdout so a passing dry-run reads as a
+        candidate list — we do not bound that output here.
+
+        Pattern matches :meth:`_housekeeping_close_orphan_prs` (#3852) so
+        operators reading the code see the same shape for both "close
+        leftover open thing" healers.
+        """
+        # Use _git_parent_root() for the production Fargate path (baseline
+        # clone) and the local-dev/test fallback (cwd) — same selector the
+        # diagnoser and worktree-creation paths use.
+        repo_root = self._git_parent_root()
+        script_path = repo_root / "scripts" / "sweep-completed-parents.sh"
+        if not script_path.exists():
+            self._log.warning(
+                "daemon.sweep_completed_parents_missing",
+                extra={
+                    "event": "sweep_completed_parents_missing",
+                    "run_id": self._run_id,
+                    "script_path": str(script_path),
+                },
+            )
+            return {"exit_code": 127, "summary_tail": "script missing"}
+
+        cmd = [str(script_path)]
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="sweep_completed_parents",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        if not outcome["ok"]:
+            self._log.warning(
+                "daemon.sweep_completed_parents_failed",
+                extra={
+                    "event": "sweep_completed_parents_failed",
+                    "run_id": self._run_id,
+                    "reason": outcome.get("reason"),
+                    "exit_code": outcome.get("exit_code"),
+                    "stderr_tail": outcome.get("stderr_tail"),
+                },
+            )
+            return {
+                "exit_code": int(outcome.get("exit_code") or 1),
+                "summary_tail": str(outcome.get("stderr_tail") or "").splitlines()[-1:],
+            }
+
+        result = outcome["result"]
+        # Tail the last non-empty stdout line — it carries the
+        # ``Closed N; skipped M; errors K`` summary the helper emits.
+        summary_lines = [ln for ln in (result.stdout or "").splitlines() if ln.strip()]
+        summary_tail = summary_lines[-1] if summary_lines else ""
+        self._log.info(
+            "daemon.housekeeping_sweep_completed_parents",
+            extra={
+                "event": "housekeeping_sweep_completed_parents",
+                "run_id": self._run_id,
+                "summary_tail": summary_tail,
+                "exit_code": result.returncode,
+            },
+        )
+        return {"exit_code": result.returncode, "summary_tail": summary_tail}
+
     def _housekeeping_tick(self) -> dict[str, int]:
         """Run one housekeeping tick. Prunes stale rows from dispatcher tables.
 
@@ -27708,6 +27784,26 @@ class DispatcherDaemon:
                 "daemon.housekeeping_orphan_pr_gc_failed",
                 extra={
                     "event": "housekeeping_orphan_pr_gc_failed",
+                    "run_id": self._run_id,
+                },
+            )
+
+        # Issue #4499: auto-close parent meta-tasks whose Path-C sub-tasks
+        # have all closed >= 24h ago. Path C decomposition writes only
+        # ``Parent: #N`` (hierarchy, not dependency), so the existing
+        # unblock-dependents.sh flow does not auto-close the parent — and
+        # the parent stays in ``status/in-progress`` for days, re-entering
+        # the agent/ready queue to be verify-and-closed manually. This
+        # sweep invokes ``scripts/sweep-completed-parents.sh`` to close
+        # that loop. Runs in its own try/except so a gh flake here does
+        # not break the prune loop or sibling healers.
+        try:
+            self._housekeeping_sweep_completed_parents()
+        except Exception:
+            self._log.exception(
+                "daemon.housekeeping_sweep_completed_parents_failed",
+                extra={
+                    "event": "housekeeping_sweep_completed_parents_failed",
                     "run_id": self._run_id,
                 },
             )

--- a/scripts/dispatcher/tests/test_daemon_housekeeping.py
+++ b/scripts/dispatcher/tests/test_daemon_housekeeping.py
@@ -1699,6 +1699,14 @@ class TestHousekeepingTickWiresInOrphanPRGC:
         )
         monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0, raising=True)
         monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0, raising=True)
+        # Issue #4499: sibling sweep is also called from _housekeeping_tick;
+        # neutralize so this test stays focused on the orphan-PR helper.
+        monkeypatch.setattr(
+            d,
+            "_housekeeping_sweep_completed_parents",
+            lambda: {"exit_code": 0, "summary_tail": ""},
+            raising=True,
+        )
 
         d._housekeeping_tick()
 
@@ -1723,6 +1731,14 @@ class TestHousekeepingTickWiresInOrphanPRGC:
         )
         monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0, raising=True)
         monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0, raising=True)
+        # Issue #4499: neutralize the sibling sweep so this test stays
+        # focused on the orphan-PR helper's exception path.
+        monkeypatch.setattr(
+            d,
+            "_housekeeping_sweep_completed_parents",
+            lambda: {"exit_code": 0, "summary_tail": ""},
+            raising=True,
+        )
 
         target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
         conn.cursor_instance.fetch_queue = [None] * target_count
@@ -1731,6 +1747,216 @@ class TestHousekeepingTickWiresInOrphanPRGC:
         result = d._housekeeping_tick()
 
         failure_events = handler.events("housekeeping_orphan_pr_gc_failed")
+        assert len(failure_events) == 1
+        assert "queue_snapshots" in result
+        assert d._housekeeping_ticks == 1
+
+
+# --------------------------------------------------------------------------
+# _housekeeping_sweep_completed_parents (#4499)
+# --------------------------------------------------------------------------
+
+
+class TestHousekeepingSweepCompletedParents:
+    """``_housekeeping_sweep_completed_parents`` invokes the sweep script (#4499).
+
+    The bash + Python helpers are exercised separately in
+    ``scripts/tests/test_sweep_completed_parents.py``; the daemon-side
+    helper just shells out to the script via ``_subprocess_with_retry``.
+    These tests cover only the daemon's responsibilities: missing-script
+    fallback, success-path summary log, and subprocess-failure handling.
+    """
+
+    def test_logs_summary_tail_on_success(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """Happy path: subprocess returns 0, helper logs the summary tail."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        # Place a fake script under tmp_path so the existence check passes.
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "sweep-completed-parents.sh").write_text("#!/bin/bash\nexit 0\n")
+        monkeypatch.setattr(d, "_git_parent_root", lambda: tmp_path)
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            captured_cmds.append(cmd)
+            assert event_name == "sweep_completed_parents"
+            return _ok_outcome(
+                "Sweeping completed-parent candidates in judgemind/judgemind\n"
+                "Found 0 candidate parent(s)\n"
+                "Closed 1 parent(s); skipped 2; errors 0.\n"
+            )
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        result = d._housekeeping_sweep_completed_parents()
+
+        assert result["exit_code"] == 0
+        assert result["summary_tail"] == "Closed 1 parent(s); skipped 2; errors 0."
+
+        # Subprocess invoked exactly once with the resolved script path.
+        assert len(captured_cmds) == 1
+        assert captured_cmds[0][0].endswith("sweep-completed-parents.sh")
+
+        # Structured log captures the summary tail.
+        events = handler.events("housekeeping_sweep_completed_parents")
+        assert len(events) == 1
+        assert events[0].summary_tail == "Closed 1 parent(s); skipped 2; errors 0."
+        assert events[0].exit_code == 0
+        assert events[0].run_id == "test-run-id"
+
+    def test_returns_127_when_script_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """No script on disk: helper logs and returns exit_code=127 (no subprocess)."""
+        d, _conn, handler = _make_daemon_with_capture()
+        # Empty tmp_path — no scripts/ subdir → script_path does not exist.
+        monkeypatch.setattr(d, "_git_parent_root", lambda: tmp_path)
+
+        called = {"count": 0}
+
+        def fail_subprocess(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            called["count"] += 1
+            return _ok_outcome("")
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fail_subprocess)
+
+        result = d._housekeeping_sweep_completed_parents()
+
+        assert result["exit_code"] == 127
+        assert called["count"] == 0  # subprocess never invoked
+        events = handler.events("sweep_completed_parents_missing")
+        assert len(events) == 1
+
+    def test_logs_warning_on_subprocess_failure(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        """When the subprocess returns non-zero, the daemon logs and surfaces it."""
+        d, _conn, handler = _make_daemon_with_capture()
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "sweep-completed-parents.sh").write_text("#!/bin/bash\nexit 2\n")
+        monkeypatch.setattr(d, "_git_parent_root", lambda: tmp_path)
+
+        def fail_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            return _fail_outcome(reason="nonzero_exit", exit_code=2)
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fail_subprocess)
+
+        result = d._housekeeping_sweep_completed_parents()
+
+        assert result["exit_code"] == 2
+        events = handler.events("sweep_completed_parents_failed")
+        assert len(events) == 1
+        assert events[0].exit_code == 2
+
+    def test_tick_invokes_sweep_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The hourly tick must call ``_housekeeping_sweep_completed_parents`` exactly once.
+
+        Regression: an accidental decouple would silently stop the sweep
+        from running without any test failure in the unit-level helper
+        tests above. Mirrors the orphan-PR GC tick-wiring test (#3852).
+        """
+        d, _conn, handler = _make_daemon_with_capture()
+
+        called: dict[str, int] = {"count": 0}
+
+        def fake_sweep() -> dict[str, Any]:
+            called["count"] += 1
+            return {"exit_code": 0, "summary_tail": ""}
+
+        # Neutralize sibling helpers so the test focuses on the new wiring.
+        monkeypatch.setattr(
+            d,
+            "_housekeeping_close_orphan_prs",
+            lambda: {
+                "closed": 0,
+                "scanned": 0,
+                "skipped_non_agent": 0,
+                "skipped_no_target": 0,
+                "skipped_open_target": 0,
+            },
+            raising=True,
+        )
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0, raising=True)
+        monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0, raising=True)
+        monkeypatch.setattr(
+            d,
+            "_housekeeping_sweep_completed_parents",
+            fake_sweep,
+            raising=True,
+        )
+
+        d._housekeeping_tick()
+
+        assert called["count"] == 1
+        # Tick still completes cleanly with no sweep-failure log line.
+        assert handler.events("housekeeping_sweep_completed_parents_failed") == []
+
+    def test_tick_catches_sweep_helper_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the sweep helper raises, the tick logs and continues."""
+        d, conn, handler = _make_daemon_with_capture()
+
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("gh unavailable")
+
+        # Other healers must not raise — they would mask the sweep
+        # exception in the assertion below.
+        monkeypatch.setattr(
+            d,
+            "_housekeeping_close_orphan_prs",
+            lambda: {
+                "closed": 0,
+                "scanned": 0,
+                "skipped_non_agent": 0,
+                "skipped_no_target": 0,
+                "skipped_open_target": 0,
+            },
+            raising=True,
+        )
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0, raising=True)
+        monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0, raising=True)
+        monkeypatch.setattr(
+            d,
+            "_housekeeping_sweep_completed_parents",
+            boom,
+            raising=True,
+        )
+
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        # Must not propagate.
+        result = d._housekeeping_tick()
+
+        failure_events = handler.events("housekeeping_sweep_completed_parents_failed")
         assert len(failure_events) == 1
         assert "queue_snapshots" in result
         assert d._housekeeping_ticks == 1

--- a/scripts/sweep-completed-parents.sh
+++ b/scripts/sweep-completed-parents.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# sweep-completed-parents.sh — Auto-close parent meta-tasks whose Path-C
+# sub-tasks all closed >= 24h ago.
+#
+# When an issue is decomposed via Path C into N sub-tasks (each carrying
+# `Parent: #<N>` in the body, per docs/agent/task-dependencies.md §Sub-tasks),
+# closing all sub-tasks does NOT auto-close the parent — `Parent:` is hierarchy,
+# not a `Blocked by` dependency, so `unblock-dependents.sh` does not act on it.
+# Result: the parent stays open with `status/in-progress` and re-enters the
+# `agent/ready` queue days later, where a fresh agent runs a verify-and-close
+# pivot to do what should have happened automatically.
+#
+# This script closes that loop. For every open issue whose body lists
+# `Parent: #<N>` children:
+#   1. Find every open or closed child via the `Parent: #<N>` body search.
+#   2. Require >=1 child exists and ALL of them are CLOSED with
+#      state_reason != "not_planned".
+#   3. Require the most-recent child `closedAt` is >= 24 hours ago (grace
+#      window — gives humans time to reopen if the parent's ACs weren't
+#      really covered).
+#   4. Skip if the parent has comments newer than the most-recent child
+#      `closedAt` (suggests human follow-up is still in flight).
+#   5. Otherwise: post an auto-close comment, close the parent with
+#      `--reason completed`, and run `unblock-dependents.sh` on it so any
+#      issues that were `Blocked by #<parent>` get unblocked too.
+#
+# Issue #4499 — see issue body for the full motivation and #4097 as the
+# canonical recurrence (closed via verify-and-close 3 days late).
+#
+# Usage:
+#   scripts/sweep-completed-parents.sh
+#   scripts/sweep-completed-parents.sh --dry-run
+#   scripts/sweep-completed-parents.sh --grace-hours 48
+#   scripts/sweep-completed-parents.sh --help
+#
+# Options:
+#   --dry-run           Show what would be done without making changes.
+#   --grace-hours <H>   Override the 24-hour grace window (default: 24).
+#   --limit <N>         Cap the number of candidate parents inspected (default: 200).
+#   --help              Show this help message.
+#
+# Exit codes:
+#   0 — completed without error (zero or more parents auto-closed).
+#   1 — argument or environment error.
+#   2 — gh CLI invocation failed (rate limit, auth, transient).
+
+set -euo pipefail
+
+DRY_RUN=false
+GRACE_HOURS=24
+LIMIT=200
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --grace-hours)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --grace-hours requires an integer argument" >&2
+                exit 1
+            fi
+            GRACE_HOURS="$2"
+            shift 2
+            ;;
+        --limit)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --limit requires an integer argument" >&2
+                exit 1
+            fi
+            LIMIT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option: $1" >&2
+            echo "Run 'scripts/sweep-completed-parents.sh --help' for usage." >&2
+            exit 1
+            ;;
+        *)
+            echo "Error: Unexpected positional argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate numeric args.
+if ! [[ "$GRACE_HOURS" =~ ^[0-9]+$ ]]; then
+    echo "Error: --grace-hours must be a non-negative integer" >&2
+    exit 1
+fi
+if ! [[ "$LIMIT" =~ ^[0-9]+$ ]] || [[ "$LIMIT" -lt 1 ]]; then
+    echo "Error: --limit must be a positive integer" >&2
+    exit 1
+fi
+
+REPO="${REPO:-judgemind/judgemind}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK_TMPDIR="${SCRIPT_DIR}/../tmp"
+mkdir -p "$WORK_TMPDIR"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[DRY RUN] Sweeping completed-parent candidates in $REPO (grace=${GRACE_HOURS}h)"
+else
+    echo "Sweeping completed-parent candidates in $REPO (grace=${GRACE_HOURS}h)"
+fi
+
+# Find open issues whose body contains "Parent: #<N>" — these are CHILDREN of
+# some parent. The parent set is derived from the children's Parent: lines.
+# We bound the result at $LIMIT candidate children.
+echo "Listing open + closed sub-task children with 'Parent: #' in body..."
+
+CHILDREN_JSON_OPEN="$WORK_TMPDIR/_sweep_children_open.json"
+CHILDREN_JSON_CLOSED="$WORK_TMPDIR/_sweep_children_closed.json"
+
+# We need both open and closed children for accurate "all closed?" checks.
+# Search for the literal `Parent: ` in the body — narrow enough that GitHub
+# search returns only sub-tasks. Broaden via two queries (open + closed).
+gh issue list --repo "$REPO" \
+    --state all \
+    --search 'in:body "Parent: #"' \
+    --json number,state,closedAt,body \
+    --limit "$LIMIT" > "$CHILDREN_JSON_OPEN" 2>/dev/null || {
+    echo "Error: gh issue list failed (search for 'Parent: #' children)" >&2
+    rm -f "$CHILDREN_JSON_OPEN" "$CHILDREN_JSON_CLOSED"
+    exit 2
+}
+
+# Delegate the rest (parent grouping, child-state checks, comment-since-close
+# checks, action) to the Python helper. Keep the bash entry point small.
+# `export` rather than `VAR=val cmd` form so the python3 path expansion below
+# uses the parent's $SCRIPT_DIR (shellcheck SC2097/SC2098 false-positive
+# avoidance — the prefix-assignment form would technically work but reads
+# as ambiguous).
+export REPO
+export DRY_RUN
+export GRACE_HOURS
+export CHILDREN_FILE="$CHILDREN_JSON_OPEN"
+export WORK_TMPDIR
+export SCRIPT_DIR
+set +e
+python3 "$SCRIPT_DIR/_sweep_completed_parents.py"
+RC=$?
+set -e
+
+rm -f "$CHILDREN_JSON_OPEN" "$CHILDREN_JSON_CLOSED"
+exit "$RC"

--- a/scripts/tests/test_sweep_completed_parents.py
+++ b/scripts/tests/test_sweep_completed_parents.py
@@ -1,0 +1,309 @@
+"""Unit tests for ``scripts/_sweep_completed_parents.py`` (#4499).
+
+Exercises the pure-function gating logic without invoking the GitHub CLI:
+
+* ``parse_parent_number`` — extracts the canonical ``Parent: #N`` line and
+  ignores spurious matches.
+* ``group_children_by_parent`` — collapses a flat children list into a
+  parent-keyed mapping.
+* ``is_parent_closeable`` — the closeability gate with grace-window /
+  state / state-reason short-circuits.
+* ``has_human_comments_since`` — the post-close comment guard, including
+  the bot-author filter for ``judgemind-agent`` and ``[bot]`` suffixes.
+
+Run with::
+
+    python3 -m pytest scripts/tests/test_sweep_completed_parents.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Add scripts/ to path so we can import the helper module directly.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# noqa: E402 — sys.path mutation above
+from _sweep_completed_parents import (
+    _Child,
+    group_children_by_parent,
+    has_human_comments_since,
+    is_parent_closeable,
+    parse_parent_number,
+)
+
+
+class TestParseParentNumber(unittest.TestCase):
+    def test_canonical_form(self) -> None:
+        self.assertEqual(parse_parent_number("Parent: #4097"), 4097)
+
+    def test_with_surrounding_text(self) -> None:
+        body = (
+            "## Summary\n\nDoes a thing.\n\n## Out of Scope\n\nNothing.\n\n"
+            "Parent: #42\n"
+        )
+        self.assertEqual(parse_parent_number(body), 42)
+
+    def test_lowercase_parent(self) -> None:
+        # The regex is case-insensitive (matches the daemon's parser).
+        self.assertEqual(parse_parent_number("parent: #100"), 100)
+
+    def test_extra_whitespace(self) -> None:
+        self.assertEqual(parse_parent_number("   Parent:    #7   "), 7)
+
+    def test_inline_does_not_match(self) -> None:
+        # The regex anchors to a line start (^) — inline mentions are
+        # ignored to avoid false positives.
+        self.assertIsNone(parse_parent_number("See Parent: #5 in another doc"))
+
+    def test_no_parent_line(self) -> None:
+        self.assertIsNone(parse_parent_number("## Summary\nNo parent here.\n"))
+
+    def test_empty_body(self) -> None:
+        self.assertIsNone(parse_parent_number(""))
+
+    def test_takes_first_match(self) -> None:
+        # Multiple Parent: lines in the body — the parser takes the first.
+        body = "Parent: #1\nFiller\nParent: #2\n"
+        self.assertEqual(parse_parent_number(body), 1)
+
+
+class TestGroupChildrenByParent(unittest.TestCase):
+    def test_groups_by_parent(self) -> None:
+        children = [
+            {
+                "number": 4137,
+                "state": "CLOSED",
+                "closedAt": "2026-05-06T06:21:36Z",
+                "body": "Parent: #4097\n",
+            },
+            {
+                "number": 4138,
+                "state": "CLOSED",
+                "closedAt": "2026-05-06T08:00:00Z",
+                "body": "Parent: #4097\n",
+            },
+            {
+                "number": 4139,
+                "state": "CLOSED",
+                "closedAt": "2026-05-06T10:43:00Z",
+                "body": "Parent: #4097\n",
+            },
+        ]
+        grouped = group_children_by_parent(children)
+        self.assertEqual(set(grouped.keys()), {4097})
+        self.assertEqual(
+            sorted(c.number for c in grouped[4097]),
+            [4137, 4138, 4139],
+        )
+
+    def test_skips_children_without_parent(self) -> None:
+        children = [
+            {"number": 1, "state": "OPEN", "closedAt": None, "body": "no parent"},
+            {
+                "number": 2,
+                "state": "CLOSED",
+                "closedAt": "2026-05-01T00:00:00Z",
+                "body": "Parent: #99\n",
+            },
+        ]
+        grouped = group_children_by_parent(children)
+        self.assertEqual(set(grouped.keys()), {99})
+        self.assertEqual([c.number for c in grouped[99]], [2])
+
+    def test_multiple_parents(self) -> None:
+        children = [
+            {
+                "number": 1,
+                "state": "CLOSED",
+                "closedAt": "2026-05-01T00:00:00Z",
+                "body": "Parent: #10\n",
+            },
+            {
+                "number": 2,
+                "state": "CLOSED",
+                "closedAt": "2026-05-02T00:00:00Z",
+                "body": "Parent: #20\n",
+            },
+        ]
+        grouped = group_children_by_parent(children)
+        self.assertEqual(set(grouped.keys()), {10, 20})
+
+
+class TestIsParentCloseable(unittest.TestCase):
+    def setUp(self) -> None:
+        self.now = datetime(2026, 5, 9, 12, 0, tzinfo=timezone.utc)
+        self.grace = timedelta(hours=24)
+
+    def _child(
+        self,
+        n: int,
+        state: str = "CLOSED",
+        closed_at: datetime | None = None,
+        state_reason: str | None = None,
+    ) -> _Child:
+        return _Child(
+            number=n,
+            state=state,
+            closed_at=closed_at,
+            state_reason=state_reason,
+        )
+
+    def test_all_children_closed_outside_grace(self) -> None:
+        # Most-recent child closed 36h before now — outside the 24h grace.
+        children = [
+            self._child(1, closed_at=self.now - timedelta(hours=72)),
+            self._child(2, closed_at=self.now - timedelta(hours=36)),
+            self._child(3, closed_at=self.now - timedelta(hours=48)),
+        ]
+        ok, reason = is_parent_closeable(
+            "OPEN", children, now=self.now, grace=self.grace
+        )
+        self.assertTrue(ok, msg=f"unexpected skip reason: {reason}")
+
+    def test_inside_grace_window_is_skipped(self) -> None:
+        # Most-recent child closed only 6h ago — inside the 24h grace.
+        children = [
+            self._child(1, closed_at=self.now - timedelta(hours=72)),
+            self._child(2, closed_at=self.now - timedelta(hours=6)),
+        ]
+        ok, reason = is_parent_closeable(
+            "OPEN", children, now=self.now, grace=self.grace
+        )
+        self.assertFalse(ok)
+        self.assertIn("grace", reason)
+
+    def test_open_child_blocks_close(self) -> None:
+        children = [
+            self._child(1, closed_at=self.now - timedelta(hours=72)),
+            self._child(2, state="OPEN", closed_at=None),
+        ]
+        ok, reason = is_parent_closeable(
+            "OPEN", children, now=self.now, grace=self.grace
+        )
+        self.assertFalse(ok)
+        self.assertIn("open children", reason)
+
+    def test_not_planned_child_blocks_close(self) -> None:
+        children = [
+            self._child(1, closed_at=self.now - timedelta(hours=72)),
+            self._child(
+                2,
+                closed_at=self.now - timedelta(hours=72),
+                state_reason="not_planned",
+            ),
+        ]
+        ok, reason = is_parent_closeable(
+            "OPEN", children, now=self.now, grace=self.grace
+        )
+        self.assertFalse(ok)
+        self.assertIn("not-planned", reason)
+
+    def test_closed_parent_is_skipped(self) -> None:
+        children = [
+            self._child(1, closed_at=self.now - timedelta(hours=72)),
+        ]
+        ok, reason = is_parent_closeable(
+            "CLOSED", children, now=self.now, grace=self.grace
+        )
+        self.assertFalse(ok)
+        self.assertIn("CLOSED", reason)
+
+    def test_no_children_is_skipped(self) -> None:
+        ok, reason = is_parent_closeable("OPEN", [], now=self.now, grace=self.grace)
+        self.assertFalse(ok)
+        self.assertIn("no children", reason)
+
+    def test_no_closed_at_timestamps_is_skipped(self) -> None:
+        children = [self._child(1, state="CLOSED", closed_at=None)]
+        ok, reason = is_parent_closeable(
+            "OPEN", children, now=self.now, grace=self.grace
+        )
+        self.assertFalse(ok)
+        self.assertIn("closedAt", reason)
+
+    def test_completed_state_reason_does_not_block(self) -> None:
+        # ``state_reason="completed"`` is fine — only ``not_planned`` blocks.
+        children = [
+            self._child(
+                1,
+                closed_at=self.now - timedelta(hours=72),
+                state_reason="completed",
+            ),
+        ]
+        ok, _reason = is_parent_closeable(
+            "OPEN", children, now=self.now, grace=self.grace
+        )
+        self.assertTrue(ok)
+
+
+class TestHasHumanCommentsSince(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cutoff = datetime(2026, 5, 6, 10, 0, tzinfo=timezone.utc)
+
+    def _comment(
+        self,
+        login: str,
+        created: str,
+        cid: str = "id",
+    ) -> dict:
+        return {
+            "id": cid,
+            "createdAt": created,
+            "author": {"login": login},
+        }
+
+    def test_human_comment_after_cutoff_returns_true(self) -> None:
+        comments = [
+            self._comment("drewthaler", "2026-05-07T00:00:00Z", "h1"),
+        ]
+        has_human, ids = has_human_comments_since(comments, self.cutoff)
+        self.assertTrue(has_human)
+        self.assertEqual(ids, ["h1"])
+
+    def test_bot_comment_after_cutoff_returns_false(self) -> None:
+        # judgemind-agent is in the explicit allowlist.
+        comments = [
+            self._comment("judgemind-agent", "2026-05-07T00:00:00Z", "b1"),
+        ]
+        has_human, _ids = has_human_comments_since(comments, self.cutoff)
+        self.assertFalse(has_human)
+
+    def test_github_actions_bot_is_filtered(self) -> None:
+        comments = [
+            self._comment("github-actions[bot]", "2026-05-07T00:00:00Z"),
+        ]
+        has_human, _ids = has_human_comments_since(comments, self.cutoff)
+        self.assertFalse(has_human)
+
+    def test_arbitrary_bot_suffix_is_filtered(self) -> None:
+        comments = [
+            self._comment("dependabot[bot]", "2026-05-07T00:00:00Z"),
+        ]
+        has_human, _ids = has_human_comments_since(comments, self.cutoff)
+        self.assertFalse(has_human)
+
+    def test_comments_at_or_before_cutoff_are_ignored(self) -> None:
+        # Strict > (greater-than), not >=. Equal timestamps don't count.
+        comments = [
+            self._comment("drewthaler", "2026-05-06T10:00:00Z"),
+            self._comment("drewthaler", "2026-05-06T09:59:00Z"),
+        ]
+        has_human, ids = has_human_comments_since(comments, self.cutoff)
+        self.assertFalse(has_human)
+        self.assertEqual(ids, [])
+
+    def test_mixed_human_and_bot_returns_true(self) -> None:
+        comments = [
+            self._comment("github-actions[bot]", "2026-05-07T00:00:00Z"),
+            self._comment("drewthaler", "2026-05-07T01:00:00Z"),
+        ]
+        has_human, _ids = has_human_comments_since(comments, self.cutoff)
+        self.assertTrue(has_human)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `scripts/sweep-completed-parents.sh` (bash entry point) + Python helper `scripts/_sweep_completed_parents.py` that auto-closes parent meta-tasks whose Path-C sub-tasks have all closed >= 24h ago, and wires it into the dispatcher daemon's hourly `_housekeeping_tick` alongside the orphan-PR GC (#3852).

The sweep finds children via `gh issue list --search 'in:body "Parent: #"'`, groups them by parent, requires every child CLOSED with `state_reason != not_planned`, requires the most-recent close >= 24h ago (grace window), skips parents with non-bot comments after the last child close, and posts an auto-close comment + `gh issue close --reason completed` + `scripts/unblock-dependents.sh <parent>` so any `Blocked by #<parent>` dependents auto-unblock.

Dry-run against today's repo state flags `parent #2840; children all closed by 2026-04-29T05:07:48+00:00` — an open issue whose 3 sub-tasks (#3764, #3765, #3768) all closed 9 days ago. The pattern matches what #4097 needed (closed via verify-and-close 3 days late).

Closes #4499

## Test plan

### Automated checks
- [x] Lint passes (ruff check, ruff format)
- [x] Format check passes
- [x] Tests pass (25 unit tests in `scripts/tests/test_sweep_completed_parents.py`, 5 in `scripts/dispatcher/tests/test_daemon_housekeeping.py::TestHousekeepingSweepCompletedParents`, 55 total in housekeeping suite)
- [x] shellcheck clean on `scripts/sweep-completed-parents.sh`
- [x] check-bash-compat.sh / check-bash-set-u-empty-array.sh clean
- [x] check-script-headers.py clean (one-off/permanent markers OK)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component before next dispatcher rollout, but the daemon-side hook will exercise on the first hourly housekeeping tick post-deploy. Verify post-deploy: a CloudWatch Insights query against `/ecs/judgemind-dispatcher-dev` for `event = "housekeeping_sweep_completed_parents"` returns at least one row in the next hour.
- [ ] Verification evidence posted on issue (see A.8)
