### PR TITLE
feat(dx): generalize gh-comment-with-retry to cover gh pr comment (#4484)

### DIFF
--- a/scripts/_gh_comment_with_retry_match.py
+++ b/scripts/_gh_comment_with_retry_match.py
@@ -3,9 +3,9 @@
 # permanent: true
 """_gh_comment_with_retry_match.py — Helper for gh-comment-with-retry.sh.
 
-Reads a GitHub issue-comments JSON list from stdin, finds the most recent
-comment by ``$GH_USER``, writes its body to ``$LATEST_BODY_FILE``, and
-prints the comment's ``html_url`` on stdout.
+Reads a GitHub issue/PR-comments JSON list from stdin, finds the most
+recent comment by ``$GH_USER``, writes its body to ``$LATEST_BODY_FILE``,
+and prints the comment's ``html_url`` on stdout.
 
 Why a sibling helper instead of an inline ``python3 -c``
 --------------------------------------------------------
@@ -18,7 +18,8 @@ files are fine), and stays under the project's "Multi-line Python
 always goes in a .py file" rule for consistency.
 
 Stdin: the raw JSON body of GET /repos/<owner>/<repo>/issues/<N>/comments
-(an array of comment objects).
+(an array of comment objects). The same endpoint serves both issue
+comments and PR top-level comments (#4484), so this helper handles both.
 
 Env:
     GH_USER (str): the gh user login whose comment we want to match.
@@ -35,7 +36,7 @@ Output:
     no stdout output. The wrapper interprets exit 1 as
     "no-recent-comment-by-us-found".
 
-Tracking: issue #4478.
+Tracking: issues #4478 (initial), #4484 (PR-comment generalization).
 """
 
 from __future__ import annotations

--- a/scripts/gh-comment-with-retry.sh
+++ b/scripts/gh-comment-with-retry.sh
@@ -1,62 +1,75 @@
 #!/usr/bin/env bash
 # permanent: true
-# gh-comment-with-retry.sh — Post a `gh issue comment` and tolerate two
-# distinct flaky failure modes (504-after-success + GraphQL-quota
-# exhaustion).
+# gh-comment-with-retry.sh — Post a `gh issue comment` or `gh pr comment`
+# and tolerate two distinct flaky failure modes (504-after-success +
+# GraphQL-quota exhaustion).
 #
 # Why this helper exists
 # ----------------------
-# `gh issue comment <N> --body-file <file>` has two flaky failure modes
-# that the bare `gh` call does not handle:
+# `gh issue comment <N> --body-file <file>` and `gh pr comment <N>
+# --body-file <file>` share two flaky failure modes that the bare `gh`
+# call does not handle. PR top-level comments are issue-comments under
+# the hood — both posts target the same `/repos/.../issues/<N>/comments`
+# REST endpoint via GitHub's GraphQL API, so the same flaky modes and
+# the same recovery recipes apply to both call shapes:
 #
-#   1. **504-after-success (#4478):** the request periodically returns a
-#      `504 Gateway Timeout` (with a multi-KB HTML "Unicorn!" error page
-#      in stderr) **after the comment has already posted**. A naive
-#      retry creates a duplicate; treating it as a hard failure
+#   1. **504-after-success (#4478 / #4484):** the request periodically
+#      returns a `504 Gateway Timeout` (with a multi-KB HTML "Unicorn!"
+#      error page in stderr) **after the comment has already posted**.
+#      A naive retry creates a duplicate; treating it as a hard failure
 #      misleads the agent about pipeline state. Recipe: re-fetch the
-#      issue's recent comments, treat already-posted-with-matching-body
-#      as success.
+#      issue/PR's recent comments, treat already-posted-with-matching-
+#      body as success.
 #
-#   2. **GraphQL-quota-exhausted (#4503):** `gh issue comment` posts
-#      the comment via GitHub's GraphQL API, which has a separate
-#      5,000-req/hr quota from the REST core API. Long agent sessions
-#      (dispatcher, multi-PR /task runs) regularly exhaust GraphQL —
-#      consumed by `gh pr view`, `gh pr merge`, `gh issue view --json`,
-#      etc. — while the REST core quota stays healthy. Recipe: fall
-#      back to `gh api -X POST /repos/<owner>/<repo>/issues/<N>/comments
-#      -F body=@<file>`. The REST endpoint is the same logical
-#      operation and `-F body=@<file>` accepts the body the same way
-#      `--body-file` does.
+#   2. **GraphQL-quota-exhausted (#4503 / #4484):** `gh issue comment`
+#      and `gh pr comment` post via GitHub's GraphQL API, which has a
+#      separate 5,000-req/hr quota from the REST core API. Long agent
+#      sessions (dispatcher, multi-PR /task runs) regularly exhaust
+#      GraphQL — consumed by `gh pr view`, `gh pr merge`, `gh issue
+#      view --json`, etc. — while the REST core quota stays healthy.
+#      Recipe: fall back to `gh api -X POST /repos/<owner>/<repo>/
+#      issues/<N>/comments -F body=@<file>`. The REST endpoint is the
+#      same logical operation for both shapes (PR comments are
+#      issue-comments at the API layer) and `-F body=@<file>` accepts
+#      the body the same way `--body-file` does.
 #
 # Both failure modes share the same shape — the API can accept the
 # request, the wrapper just needs the right fallback path. See
 # `.claude/skills/task/SKILL.md` §A.7 for the `gh pr merge` 5xx
 # analogue (#4231).
 #
-# Tracking: issues #4478 (504-after-success) and #4503 (GraphQL-quota
-# REST fallback).
+# Tracking: issues #4478 (504-after-success), #4503 (GraphQL-quota
+# REST fallback), and #4484 (PR-comment generalization).
 #
 # Usage
 # -----
 #   scripts/gh-comment-with-retry.sh <issue-N> --body-file <path>
-#   scripts/gh-comment-with-retry.sh <issue-N> --body-file <path> --repo <owner/name>
+#   scripts/gh-comment-with-retry.sh <pr-N> --pr --body-file <path>
+#   scripts/gh-comment-with-retry.sh <N> [--pr] --body-file <path> --repo <owner/name>
 #   scripts/gh-comment-with-retry.sh --help
+#
+# Default target is an issue comment. Pass `--pr` to post on a pull
+# request instead — the wrapper invokes `gh pr comment` and otherwise
+# behaves identically (same 504-recovery + GraphQL-rate-limit REST
+# fallback semantics, same exit codes).
 #
 # Behavior
 # --------
-#   1. Calls ``gh issue comment <N> --repo <repo> --body-file <path>``.
+#   1. Calls ``gh issue comment <N> --repo <repo> --body-file <path>``
+#      (or ``gh pr comment <N> ...`` when --pr is set).
 #   2. On exit 0: prints the returned comment URL to stdout, exits 0.
 #   3. On non-zero exit AND the captured stderr matches
 #      ``GraphQL: API rate limit already exceeded`` (#4503):
 #      - Falls back to ``gh api -X POST /repos/<owner>/<repo>/issues/<N>/comments
-#        -F body=@<path>``.
+#        -F body=@<path>`` (same endpoint for both issue and PR
+#        comments — PR comments are issue-comments at the API layer).
 #      - On REST success: prints "comment posted (REST fallback): <url>"
 #        and exits 0.
 #      - On REST failure: prints both stderrs (gh + REST, truncated to
 #        5 KB each) and exits non-zero with the REST exit code.
 #   4. On non-zero exit AND the captured stderr matches
 #      ``504 Gateway Timeout`` or ``<title>Unicorn!`` (#4478):
-#      - Re-fetches the issue's recent comments via
+#      - Re-fetches the issue/PR's recent comments via
 #        ``gh api /repos/<repo>/issues/<N>/comments?per_page=100&sort=created&direction=desc``.
 #      - Filters to comments by the current ``gh`` user
 #        (``gh api /user --jq .login``).
@@ -90,15 +103,18 @@
 #
 # Integration
 # -----------
-# Replaces direct ``gh issue comment ... --body-file ...`` calls in
+# Replaces direct ``gh issue comment ... --body-file ...`` and
+# ``gh pr comment ... --body-file ...`` calls in
 # ``.claude/skills/task/SKILL.md`` (Steps 2, A.2b, A.8 Step 3 — claim
 # comment, process summary, verification evidence) and the
 # documentation in ``.claude/skills/task-v2-summary/SKILL.md`` (process
 # summary post — daemon side already retries via
 # ``_gh_issue_comment``; the helper is the bash-path equivalent).
 #
-# Out of scope: ``gh pr comment`` calls share the same bug class but
-# are rarer; a follow-up issue can pick those up.
+# PR-comment generalization (#4484): the helper added a ``--pr`` flag
+# so a single command surface covers both shapes; the same 504 +
+# GraphQL-rate-limit recovery paths apply unchanged because PR
+# top-level comments resolve to the same REST endpoint.
 
 set -euo pipefail
 
@@ -108,25 +124,39 @@ set -euo pipefail
 
 print_help() {
     cat << 'EOF'
-gh-comment-with-retry.sh — post `gh issue comment` with 504-swallow recovery.
+gh-comment-with-retry.sh — post `gh issue comment` or `gh pr comment`
+with 504-swallow recovery and GraphQL-quota REST fallback.
 
 Usage:
   scripts/gh-comment-with-retry.sh <issue-N> --body-file <path>
-  scripts/gh-comment-with-retry.sh <issue-N> --body-file <path> --repo <owner/name>
+  scripts/gh-comment-with-retry.sh <pr-N>    --pr --body-file <path>
+  scripts/gh-comment-with-retry.sh <N> [--pr] --body-file <path> --repo <owner/name>
   scripts/gh-comment-with-retry.sh --help | -h
 
+Forms:
+  Issue comment (default): `gh issue comment <N> --body-file <path>`
+  PR comment   (--pr):     `gh pr comment <N> --body-file <path>`
+
+Both forms target the same `/repos/.../issues/<N>/comments` REST
+endpoint at the API layer (PR top-level comments are issue-comments
+under the hood), so the recovery paths are identical and the only
+behavioral difference is the underlying gh subcommand.
+
 Arguments:
-  <issue-N>            Issue number to comment on (digits, optional leading '#').
+  <N>                  Issue or PR number (digits, optional leading '#').
+  --pr                 Post a PR comment via `gh pr comment`. Default
+                       is an issue comment (`gh issue comment`).
   --body-file <path>   Path to the comment body file.
   --repo <owner/name>  Repository (default: judgemind/judgemind).
   -h, --help           Show this help and exit.
 
 Exit codes:
-  0  — Comment posted successfully (including 504-after-success).
+  0  — Comment posted successfully (including 504-after-success and
+       GraphQL-rate-limit REST fallback).
   1  — Real failure (auth, rate limit, real server failure, etc.).
   2  — Usage error (missing args, body-file not found).
 
-See header comment for behavior details. Tracking: #4478.
+See header comment for behavior details. Tracking: #4478, #4503, #4484.
 EOF
 }
 
@@ -138,12 +168,21 @@ fi
 ISSUE=""
 BODY_FILE=""
 REPO="judgemind/judgemind"
+# IS_PR controls which gh subcommand we drive: `gh pr comment` when "1",
+# `gh issue comment` (the default) when "0". The recovery paths and the
+# REST fallback URL are identical for both because PR top-level comments
+# are issue-comments at the API layer (#4484).
+IS_PR=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -h|--help)
             print_help
             exit 0
+            ;;
+        --pr)
+            IS_PR=1
+            shift
             ;;
         --body-file)
             if [[ $# -lt 2 ]]; then
@@ -184,13 +223,13 @@ done
 # ---------------------------------------------------------------------------
 
 if [[ -z "$ISSUE" ]]; then
-    echo "ERROR: missing <issue-N> argument." >&2
+    echo "ERROR: missing <N> argument (issue or PR number)." >&2
     print_help >&2
     exit 2
 fi
 
 if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
-    echo "ERROR: <issue-N> must be a positive integer, got '$ISSUE'." >&2
+    echo "ERROR: <N> must be a positive integer, got '$ISSUE'." >&2
     exit 2
 fi
 
@@ -216,8 +255,19 @@ STDOUT_FILE=$(mktemp)
 # shellcheck disable=SC2064  # cleanup paths are fixed at trap-install time.
 trap "rm -f '$STDERR_FILE' '$STDOUT_FILE'" EXIT
 
+# Route the underlying gh subcommand based on --pr. Both shapes accept
+# the same `<N> --repo <owner/name> --body-file <path>` flag set; the
+# only difference is the verb. Recovery paths downstream are identical
+# because PR top-level comments resolve to the same REST endpoint as
+# issue comments (#4484).
+if [[ "$IS_PR" -eq 1 ]]; then
+    GH_TARGET_CMD=("gh" "pr" "comment")
+else
+    GH_TARGET_CMD=("gh" "issue" "comment")
+fi
+
 set +e
-gh issue comment "$ISSUE" --repo "$REPO" --body-file "$BODY_FILE" \
+"${GH_TARGET_CMD[@]}" "$ISSUE" --repo "$REPO" --body-file "$BODY_FILE" \
     > "$STDOUT_FILE" 2> "$STDERR_FILE"
 GH_EXIT=$?
 set -e

--- a/scripts/tests/test_gh_comment_with_retry.sh
+++ b/scripts/tests/test_gh_comment_with_retry.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # test_gh_comment_with_retry.sh — Tests for scripts/gh-comment-with-retry.sh.
 #
-# Covers the four code paths called out in issue #4478:
+# Covers the code paths from #4478 and #4503, plus the PR-comment
+# generalization from #4484:
 #   A — Success path: gh exits 0, helper prints URL and exits 0.
 #   B — 504 + matching last-comment: helper exits 0 with "504 swallowed" log.
 #   C — 504 + non-matching last-comment: helper exits non-zero (real failure).
+#   C2 — 504 + no comment by current user: helper exits non-zero.
 #   D — Other non-zero exit (auth fail / rate limit / etc.): pass-through.
 #   E — Usage / argument validation paths.
+#   F — GraphQL rate-limit exhaustion → REST fallback (#4503).
+#   P — PR-comment shape via --pr flag (#4484): success, 504-recovery,
+#       GraphQL-rate-limit REST fallback, and auth passthrough — exact
+#       parity with the issue-comment paths above.
 #
 # All tests run against a PATH-mocked ``gh`` binary — no network. Uses the
 # same temp-cleanup helper pattern as test_block_issue.sh and friends
@@ -60,7 +66,7 @@ fi
 
 # ── Set up a mock gh CLI on PATH ──────────────────────────────────────────
 #
-# The mock supports three command shapes the wrapper exercises:
+# The mock supports four command shapes the wrapper exercises:
 #
 #   1. ``gh issue comment <N> --repo <repo> --body-file <path>``
 #      Behavior controlled by ``MOCK_COMMENT_MODE`` env var:
@@ -69,13 +75,21 @@ fi
 #        - "auth"     : exit 4, print "authentication required" on stderr
 #                       (other-failure passthrough path).
 #
-#   2. ``gh api /user --jq .login``
+#   2. ``gh pr comment <N> --repo <repo> --body-file <path>`` (#4484)
+#      Same MOCK_COMMENT_MODE switch as `gh issue comment`. Branding the
+#      stdout URL with ``/pull/<N>`` lets the tests assert the wrapper
+#      drove the PR shape rather than the issue shape.
+#
+#   3. ``gh api /user --jq .login``
 #      Always prints ``MOCK_GH_USER`` (default: "test-user") and exits 0.
 #
-#   3. ``gh api /repos/<owner>/<repo>/issues/<N>/comments?...``
+#   4. ``gh api /repos/<owner>/<repo>/issues/<N>/comments?...``
 #      Prints the JSON staged in ``MOCK_COMMENTS_FILE`` and exits 0. If
 #      ``MOCK_COMMENTS_FILE`` is unset or the file is missing, prints
-#      ``[]`` (empty list) and exits 0.
+#      ``[]`` (empty list) and exits 0. PR top-level comments resolve to
+#      this same endpoint at the API layer (#4484), so the GET-comments
+#      mock and the REST POST mock both serve the PR-comment paths
+#      unchanged.
 
 MOCK_BIN_DIR=$(mktemp -d)
 register_temp_dir "$MOCK_BIN_DIR"
@@ -89,12 +103,22 @@ if [[ -n "${MOCK_INVOCATIONS:-}" ]]; then
     echo "$@" >> "$MOCK_INVOCATIONS"
 fi
 
-# ── gh issue comment <N> --repo <repo> --body-file <path> ──────────────────
-if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+# ── gh issue comment <N> ... | gh pr comment <N> ... ──────────────────────
+# Both call shapes share the same flag set and the same logical recovery
+# paths; the PR shape stamps "/pull/" into the success URL so tests can
+# assert the wrapper drove the right subcommand.
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]] \
+        || [[ "${1:-}" == "pr" && "${2:-}" == "comment" ]]; then
+    target_kind="$1"   # "issue" or "pr"
+    if [[ "$target_kind" == "pr" ]]; then
+        url_path="pull"
+    else
+        url_path="issues"
+    fi
     mode="${MOCK_COMMENT_MODE:-success}"
     case "$mode" in
         success)
-            echo "https://github.com/judgemind/judgemind/issues/${3:-0}#issuecomment-99999"
+            echo "https://github.com/judgemind/judgemind/${url_path}/${3:-0}#issuecomment-99999"
             exit 0
             ;;
         504)
@@ -604,6 +628,241 @@ if [[ "$rest_post_calls" == "0" ]]; then
 else
     fail "F.3: auth-fail makes no REST POST calls" \
         "found $rest_post_calls REST POST calls"
+fi
+
+# ── Test P — --pr flag drives `gh pr comment` (#4484) ─────────────────────
+#
+# Acceptance criteria (issue #4484): test coverage parity with the
+# issue-comment path — at minimum success + 504+matching + 504+non-
+# matching + GraphQL-rate-limit + other-non-zero. The PR-comment shape
+# uses the SAME REST endpoint internally, so the recovery paths are the
+# same; we just need to confirm the wrapper drove the right gh
+# subcommand (asserted via `^pr comment ` invocation prefix and the
+# `/pull/<N>` URL path the mock stamps for the PR shape).
+
+# P.1 — Success path under --pr.
+BODY_FILE_P1=$(mktemp)
+register_temp_file "$BODY_FILE_P1"
+echo "test body P.1 — PR success path" > "$BODY_FILE_P1"
+
+INVOCATIONS_P1="$MOCK_BIN_DIR/invocations_p1.txt"
+: > "$INVOCATIONS_P1"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_P1" \
+    MOCK_COMMENT_MODE=success \
+    "$WRAPPER" --pr 200 --body-file "$BODY_FILE_P1" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "P.1: --pr success path exits 0"
+else
+    fail "P.1: --pr success path exits 0" "expected 0, got $exit_code"
+fi
+
+if grep -qE "^pr comment 200\b" "$INVOCATIONS_P1"; then
+    pass "P.1: --pr drove 'gh pr comment 200' (not 'gh issue comment')"
+else
+    fail "P.1: --pr drove 'gh pr comment 200' (not 'gh issue comment')" \
+        "invocations: $(cat "$INVOCATIONS_P1")"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/pull/200"* ]]; then
+    pass "P.1: stdout includes the PR URL (mock stamp /pull/<N>)"
+else
+    fail "P.1: stdout includes the PR URL (mock stamp /pull/<N>)" "got: $stdout_output"
+fi
+
+# P.1b — Default (no --pr) still drives `gh issue comment` — backwards-compat guard.
+BODY_FILE_P1B=$(mktemp)
+register_temp_file "$BODY_FILE_P1B"
+echo "test body P.1b — backwards-compat guard" > "$BODY_FILE_P1B"
+
+INVOCATIONS_P1B="$MOCK_BIN_DIR/invocations_p1b.txt"
+: > "$INVOCATIONS_P1B"
+
+exit_code=0
+MOCK_INVOCATIONS="$INVOCATIONS_P1B" \
+    MOCK_COMMENT_MODE=success \
+    "$WRAPPER" 200 --body-file "$BODY_FILE_P1B" >/dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]] && grep -qE "^issue comment 200\b" "$INVOCATIONS_P1B"; then
+    pass "P.1b: default (no --pr) still drives 'gh issue comment' (backwards-compat)"
+else
+    fail "P.1b: default (no --pr) still drives 'gh issue comment' (backwards-compat)" \
+        "exit=$exit_code, invocations: $(cat "$INVOCATIONS_P1B")"
+fi
+
+# P.2 — 504 + matching last-comment under --pr exits 0.
+BODY_FILE_P2=$(mktemp)
+register_temp_file "$BODY_FILE_P2"
+cat > "$BODY_FILE_P2" << 'BODY_P2_EOF'
+## PR comment — 504-after-success recovery test
+This body's SHA-256 must match the last comment by test-user on the
+mock PR. The wrapper should detect 504-after-success and exit 0.
+BODY_P2_EOF
+
+COMMENTS_P2=$(mktemp)
+register_temp_file "$COMMENTS_P2"
+python3 - "$BODY_FILE_P2" "$COMMENTS_P2" << 'PY_STAGE_P2'
+import json
+import sys
+body = open(sys.argv[1]).read()
+comments = [
+    {
+        "html_url": "https://github.com/judgemind/judgemind/pull/200#issuecomment-99",
+        "user": {"login": "test-user"},
+        "body": body,
+        "created_at": "2026-05-08T01:00:00Z",
+    },
+]
+with open(sys.argv[2], "w") as fh:
+    json.dump(comments, fh)
+PY_STAGE_P2
+
+INVOCATIONS_P2="$MOCK_BIN_DIR/invocations_p2.txt"
+: > "$INVOCATIONS_P2"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_P2" \
+    MOCK_COMMENT_MODE=504 \
+    MOCK_GH_USER="test-user" \
+    MOCK_COMMENTS_FILE="$COMMENTS_P2" \
+    "$WRAPPER" --pr 200 --body-file "$BODY_FILE_P2" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "P.2: --pr 504 + matching last-comment exits 0"
+else
+    fail "P.2: --pr 504 + matching last-comment exits 0" "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"504 swallowed"* ]]; then
+    pass "P.2: --pr stdout names '504 swallowed' on the recovery path"
+else
+    fail "P.2: --pr stdout names '504 swallowed' on the recovery path" "got: $stdout_output"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/pull/200#issuecomment-99"* ]]; then
+    pass "P.2: --pr stdout includes the matched PR comment URL"
+else
+    fail "P.2: --pr stdout includes the matched PR comment URL" "got: $stdout_output"
+fi
+
+# Confirm the wrapper invoked `gh pr comment` first (not `gh issue comment`).
+if grep -qE "^pr comment 200\b" "$INVOCATIONS_P2"; then
+    pass "P.2: --pr drove 'gh pr comment' before recovery"
+else
+    fail "P.2: --pr drove 'gh pr comment' before recovery" \
+        "invocations: $(cat "$INVOCATIONS_P2")"
+fi
+
+# P.3 — 504 + non-matching last-comment under --pr exits non-zero.
+BODY_FILE_P3=$(mktemp)
+register_temp_file "$BODY_FILE_P3"
+echo "intended body for P.3 — should NOT match staged comment" > "$BODY_FILE_P3"
+
+COMMENTS_P3=$(mktemp)
+register_temp_file "$COMMENTS_P3"
+cat > "$COMMENTS_P3" << 'COMMENTS_P3_EOF'
+[
+  {
+    "html_url": "https://github.com/judgemind/judgemind/pull/200#issuecomment-50",
+    "user": {"login": "test-user"},
+    "body": "an OLDER unrelated comment we posted earlier",
+    "created_at": "2026-05-08T00:00:00Z"
+  }
+]
+COMMENTS_P3_EOF
+
+exit_code=0
+err_output=$(
+    MOCK_COMMENT_MODE=504 \
+    MOCK_GH_USER="test-user" \
+    MOCK_COMMENTS_FILE="$COMMENTS_P3" \
+    "$WRAPPER" --pr 200 --body-file "$BODY_FILE_P3" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "P.3: --pr 504 + non-matching last-comment exits non-zero"
+else
+    fail "P.3: --pr 504 + non-matching last-comment exits non-zero" \
+        "expected non-zero, got $exit_code"
+fi
+
+if [[ "$err_output" == *"does not match body-file content"* ]]; then
+    pass "P.3: --pr stderr names the SHA mismatch"
+else
+    fail "P.3: --pr stderr names the SHA mismatch" "got: $err_output"
+fi
+
+# P.4 — Auth failure under --pr passes through original exit code.
+BODY_FILE_P4=$(mktemp)
+register_temp_file "$BODY_FILE_P4"
+echo "test body P.4" > "$BODY_FILE_P4"
+
+INVOCATIONS_P4="$MOCK_BIN_DIR/invocations_p4.txt"
+: > "$INVOCATIONS_P4"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_P4" \
+    MOCK_COMMENT_MODE=auth \
+    "$WRAPPER" --pr 200 --body-file "$BODY_FILE_P4" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 4 ]]; then
+    pass "P.4: --pr auth-fail passes through original exit code (4)"
+else
+    fail "P.4: --pr auth-fail passes through original exit code (4)" \
+        "expected 4, got $exit_code"
+fi
+
+if [[ "$err_output" == *"authentication required"* ]]; then
+    pass "P.4: --pr auth-fail stderr is passed through"
+else
+    fail "P.4: --pr auth-fail stderr is passed through" "got: $err_output"
+fi
+
+# P.5 — GraphQL rate-limit exhaustion under --pr → REST fallback success.
+BODY_FILE_P5=$(mktemp)
+register_temp_file "$BODY_FILE_P5"
+echo "test body P.5 — GraphQL exhausted on PR comment, REST should rescue" > "$BODY_FILE_P5"
+
+INVOCATIONS_P5="$MOCK_BIN_DIR/invocations_p5.txt"
+: > "$INVOCATIONS_P5"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_P5" \
+    MOCK_COMMENT_MODE=graphql_rate_limit \
+    MOCK_REST_POST_MODE=success \
+    "$WRAPPER" --pr 200 --body-file "$BODY_FILE_P5" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "P.5: --pr GraphQL rate-limit + REST success exits 0"
+else
+    fail "P.5: --pr GraphQL rate-limit + REST success exits 0" \
+        "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"REST fallback"* ]]; then
+    pass "P.5: --pr stdout names 'REST fallback' on the recovery path"
+else
+    fail "P.5: --pr stdout names 'REST fallback' on the recovery path" "got: $stdout_output"
+fi
+
+# Confirm the REST fallback hit /repos/.../issues/200/comments — PR
+# top-level comments resolve to the same endpoint as issue comments
+# (#4484), which is the structural reason the same wrapper covers both.
+if grep -qE "^api -X POST /repos/.*/issues/200/comments( |$)" "$INVOCATIONS_P5"; then
+    pass "P.5: --pr REST fallback hits /repos/.../issues/200/comments (shared endpoint)"
+else
+    fail "P.5: --pr REST fallback hits /repos/.../issues/200/comments (shared endpoint)" \
+        "invocations: $(cat "$INVOCATIONS_P5")"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Generalizes `scripts/gh-comment-with-retry.sh` to cover both `gh issue comment` and `gh pr comment` shapes via a new optional `--pr` flag (proposal option (a) — single command surface). The 504-after-success recovery and the GraphQL-rate-limit REST fallback paths are unchanged because PR top-level comments resolve to the same `/repos/.../issues/<N>/comments` REST endpoint as issue comments — only the underlying gh subcommand differs.

Closes #4484

## Test plan

### Automated checks
- [x] Lint passes (shellcheck on `scripts/gh-comment-with-retry.sh` clean; ruff check + format on `scripts/_gh_comment_with_retry_match.py` clean)
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_gh_comment_with_retry.sh` — 46/46, was 31/31 before this PR)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (developer-experience tooling only; helper is invoked by /task locally and from the dispatcher daemon, no service deploy)
- [x] Verification evidence posted on issue (see A.8) — https://github.com/judgemind/judgemind/issues/4484#issuecomment-4412470694
