### PR TITLE
feat(dx): probe AC's literal Verify: clauses against origin/main (#4472)

### DIFF
--- a/scripts/_check_shipped_pr_summary.py
+++ b/scripts/_check_shipped_pr_summary.py
@@ -47,6 +47,17 @@ def main() -> int:
         "candidate_files": candidate_files,
     }
 
+    # Verify-clause channel (#4472). When the wrapper resolved the match
+    # via _check_shipped_pr_verify_probe.py rather than path-overlap, the
+    # canonical Verify clause that fired is passed through this env var
+    # so the JSON summary can name it. Empty string → no verify-channel
+    # match → field is omitted (preserves pre-#4472 JSON shape for
+    # path-overlap-driven matches that downstream consumers may already
+    # parse).
+    verify_clause = os.environ.get("CHECK_SHIPPED_VERIFY_CLAUSE", "")
+    if verify_clause:
+        summary["verify_clause"] = verify_clause
+
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/_check_shipped_pr_verify_probe.py
+++ b/scripts/_check_shipped_pr_verify_probe.py
@@ -1,0 +1,534 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_verify_probe.py — Content-channel "shipped" probe for
+# scripts/check-shipped-pr.sh.
+#
+# venv: none
+# permanent: true
+#
+# Purpose (issue #4472):
+#   The path-overlap heuristic in check-shipped-pr.sh fires when an issue
+#   body cites the same file paths a merged PR touched. That works when
+#   the AC author guesses the right filename, but breaks for the canonical
+#   pre-#3994 zombie shape where the AC names a *test-content invariant*
+#   (e.g. "frozenset ALLOWED_CLAUDE_FLAGS containing -p, --max-turns,
+#   --model") and the actual PR uses a different filename than the issue
+#   body's prose. The path channel returns zero overlap, so the issue
+#   stays `agent/ready` indefinitely.
+#
+#   Concrete case: issue #2828 ↔ PR #3215. Issue body cited
+#   ``scripts/dispatcher/tests/test_daemon_phase3a.py`` as a *guess*; the
+#   PR landed at ``test_daemon_phase_argv_allowlist.py``. Path-overlap
+#   sees zero hits. But the AC's literal Verify clause —
+#   ``grep "ALLOWED_CLAUDE_FLAGS" scripts/dispatcher/tests/`` — matches
+#   on origin/main today. A second-axis content probe that runs the AC's
+#   Verify line catches this case in <1s, independent of filename.
+#
+# Reads `gh issue view --json body,title` JSON on stdin. Emits one of:
+#
+#   - On match: a single line ``shipped:<pr-number>\t<clause>`` to stdout
+#     and exit 0. ``<clause>`` is the canonicalized Verify command that
+#     fired (for diagnostic logs / JSON summary).
+#   - On no match: empty stdout and exit 1. Caller falls through to the
+#     path-overlap channel.
+#   - On error / malformed input: empty stdout and exit 2.
+#
+# Supported Verify clause shapes (issue #4472 Proposal):
+#
+#   1. ``Verify: grep <pattern> <path>``
+#      → run grep against the worktree, ≥1 match → shipped. Resolve PR
+#        via ``git log -S <pattern> -- <path>`` (most-recent matching
+#        squash-merge). Read-only; safe to execute.
+#
+#   2. ``Verify: pytest -k <test_name>`` or ``Verify: pytest <args> -k <test_name>``
+#      → run ``pytest --collect-only -q -k <test_name>`` against the
+#        worktree, ≥1 collected test → shipped. The ``--collect-only``
+#        rewrite is enforced regardless of how the AC author wrote it,
+#        so test side-effects (DB writes, network calls, file mutations)
+#        are never triggered by a probe. Resolve PR via
+#        ``git log -S <test_name>`` against the test files identified
+#        by collection.
+#
+# DELIBERATELY UNSUPPORTED — script-execution clauses
+# (``Verify: ./scripts/foo.sh ...`` / ``Verify: bash scripts/foo.sh``):
+#   The issue's original proposal called for a third shape — "run the
+#   probe and check exit-0". Two reasons we don't:
+#     - **Safety.** Many scripts in this repo carry side effects (gh
+#       writes, DB writes, AWS calls, secret reads). The probe runs
+#       autonomously inside check-shipped-pr.sh; arbitrary script
+#       execution is not appropriate.
+#     - **Precision.** A pure-existence check ("the script is present
+#       in the worktree") is too weak a signal. Most issues that cite a
+#       script in a Verify clause are either (a) extending an EXISTING
+#       script with new behavior — exactly the audit/extension shape
+#       the script-existence channel would false-positive on, since
+#       the script existed all along; or (b) asking for a new script
+#       that the path-overlap channel already catches via
+#       ``changeType: ADDED`` overlap on the script path.
+#   We considered (and rejected) a "freshly added" filter — only fire
+#   when the script's introducing commit post-dates the issue's
+#   ``createdAt``. That's exactly what the path-overlap channel already
+#   computes; folding it into the verify-channel as a second
+#   implementation would not add precision over the existing path. The
+#   verify-channel's purpose is to catch cases the path channel CAN'T
+#   catch (filename guesses that don't match the actual PR's filename),
+#   not to re-implement what the path channel already does.
+#
+# Safety contract:
+#   - Only ``grep`` and ``pytest --collect-only`` are executed. No other
+#     verb is invoked.
+#   - All execution paths take a wall-clock timeout (default 30s per
+#     subprocess) so a runaway grep / pytest cannot wedge the wrapper.
+#   - The helper never writes to disk, never calls gh, never touches the
+#     network outside of what pytest's collection step already does
+#     (which is bounded by the repo's pytest config).
+#   - Issue body content that doesn't match one of the two supported
+#     shapes is silently ignored — the helper falls through to exit 1
+#     and the path-overlap channel takes over.
+#
+# Why this is its own helper rather than inline shell:
+#   - Multi-line regex parsing of Verify clauses is awkward in bash.
+#   - The ``git log -S`` PR-resolution step needs careful argument
+#     escaping that is less error-prone in Python than in bash heredocs.
+#   - The classifier is unit-testable in isolation (see
+#     ``scripts/tests/test_check_shipped_pr_verify_probe.py``).
+#
+# Environment variables (all optional, for testing hooks):
+#   CHECK_SHIPPED_VERIFY_REPO_ROOT — repo root to run probes against
+#       (defaults to ``git rev-parse --show-toplevel`` from the helper's
+#       cwd when the env var is unset). Tests pass a fixture root.
+#   CHECK_SHIPPED_VERIFY_TIMEOUT_SEC — per-subprocess timeout in seconds
+#       (default 30). Tests pin this lower for fast failures.
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+# ─── Verify clause extraction ──────────────────────────────────────────────
+
+# A Verify clause is a line that starts with ``Verify:`` (optionally
+# preceded by markdown bullet markers, indentation, or a bold-emphasis
+# wrapper ``**Verify:**``). The capture group grabs everything AFTER the
+# colon (with the leading whitespace stripped). Empirically the AC
+# authors use these forms:
+#
+#   - ``- Verify: grep foo bar/``                        # bullet
+#   - ``  Verify: pytest -k test_x``                     # indented continuation
+#   - ``  - **Verify:** `grep foo bar/```                # bold + backticks
+#   - ``Verify: ./scripts/probe.sh``                     # bare line
+#
+# The leading bullet/whitespace and the optional ``**`` bold wrapper are
+# both consumed by the regex prefix. A trailing ``**`` from the bold
+# closer is stripped from the captured remainder before parsing.
+VERIFY_LINE_RE = re.compile(
+    r"^[\s>*\-]*(?:\*\*)?Verify:?\*?\*?\s*(.*?)\s*$",
+    re.IGNORECASE,
+)
+
+# A clause MAY embed a backtick-wrapped command (``Verify: `grep foo
+# bar` returns a match``). When the FIRST backtick appears at column 0
+# of the post-Verify text, the convention is "the load-bearing command
+# is wrapped in backticks; trailing prose is informational." We extract
+# the first backtick-balanced span as the actual command. This is a
+# non-greedy match — ``Verify: `grep x y` returns a match; adding `--z`
+# breaks it`` returns ``grep x y``, NOT ``grep x y` returns a match;
+# adding `--z`` (which the greedy version would emit).
+INLINE_BACKTICK_RE = re.compile(r"^`([^`]+)`")
+
+
+def _extract_verify_clauses(body: str) -> list[str]:
+    """Yield raw Verify clause command strings from ``body``.
+
+    Each returned string is the post-``Verify:`` portion of the line,
+    with leading/trailing whitespace and surrounding backticks stripped.
+    Bullet markers, bold-emphasis wrappers, and indentation are consumed
+    by ``VERIFY_LINE_RE``; only the actual command remains.
+
+    Multi-clause lines (rare — most AC authors use one clause per line)
+    are not split here. The grep/pytest/script classifiers each parse
+    their own clause shape, so a clause that only contains prose
+    ("Verify: reviewer confirms on read-through") simply fails all three
+    classifiers and is silently skipped.
+
+    Note on the bold-wrapped form (``**Verify:**``): the regex is
+    intentionally lax about the trailing ``**`` because the line shape
+    varies — the closer can appear immediately after the colon
+    (``**Verify:**`` followed by a space and the command) or be absent
+    entirely (a bullet that opens with ``**Verify:`` and forgets the
+    closer). The regex consumes both forms by making the trailing
+    ``**`` optional.
+    """
+    out: list[str] = []
+    for line in body.splitlines():
+        m = VERIFY_LINE_RE.match(line)
+        if not m:
+            continue
+        raw = m.group(1).strip()
+        if not raw:
+            continue
+        # Strip a trailing ``**`` if the bold closer landed at end-of-line.
+        if raw.endswith("**"):
+            raw = raw[:-2].rstrip()
+        # Strip a leading ``**`` if the bold opener wrapped the value
+        # (rare but observed: ``Verify: **grep foo bar**``).
+        if raw.startswith("**"):
+            raw = raw[2:].lstrip()
+        # If the clause is wrapped in single backticks, unwrap it. Keep
+        # any post-backtick prose appended (e.g. ``Verify: `grep x y`
+        # returns a match`` — the ``returns a match`` is informational
+        # narrative, not part of the command).
+        bt = INLINE_BACKTICK_RE.match(raw)
+        if bt:
+            raw = bt.group(1).strip()
+        if raw:
+            out.append(raw)
+    return out
+
+
+# ─── Clause classifiers ────────────────────────────────────────────────────
+
+# A grep clause is the canonical shape ``grep [flags] <pattern> <path>``.
+# We accept any flags between ``grep`` and the pattern, and the pattern
+# may be quoted (single or double) or bare. The path is everything after
+# the pattern up to end-of-string.
+GREP_CLAUSE_RE = re.compile(
+    r"^grep\s+",
+    re.IGNORECASE,
+)
+
+# A pytest clause starts with ``pytest`` (or ``python -m pytest``) and
+# names a test selector via ``-k <expr>`` somewhere in its arguments.
+# We only execute the ``--collect-only`` rewrite — the AC author may have
+# written a full ``pytest -k ...`` invocation, but we never actually run
+# the tests. The ``-k <expr>`` is the load-bearing identifier we resolve
+# back to a PR via ``git log -S``.
+PYTEST_CLAUSE_RE = re.compile(
+    r"^(?:python(?:3)?\s+-m\s+)?pytest\s+",
+    re.IGNORECASE,
+)
+
+
+def _classify_clause(clause: str) -> tuple[str, list[str]] | None:
+    """Classify ``clause`` and return (shape, argv) or None on no-match.
+
+    ``shape`` is one of ``"grep"`` or ``"pytest"``. ``argv`` is the
+    post-``shlex.split`` token list for the matched verb (with the verb
+    itself preserved as ``argv[0]`` so the executor can re-emit it).
+
+    Script-execution clauses (``./scripts/foo.sh`` /
+    ``bash scripts/foo.sh``) are intentionally NOT classified — see the
+    "DELIBERATELY UNSUPPORTED" header at the top of this file. They
+    fall through to None and the wrapper falls back to the path-overlap
+    channel.
+    """
+    try:
+        argv = shlex.split(clause)
+    except ValueError:
+        # Clause has unbalanced quotes — not parseable. Bail.
+        return None
+    if not argv:
+        return None
+    if GREP_CLAUSE_RE.match(clause):
+        return ("grep", argv)
+    if PYTEST_CLAUSE_RE.match(clause):
+        return ("pytest", argv)
+    return None
+
+
+# ─── Probe executors ───────────────────────────────────────────────────────
+
+
+def _run(
+    cmd: list[str], *, cwd: Path, timeout_sec: int
+) -> subprocess.CompletedProcess[str]:
+    """Run ``cmd`` synchronously, capturing stdout+stderr.
+
+    Always returns a CompletedProcess (timeouts are caught and converted
+    into a returncode=124 result with empty stdout). The helper never
+    raises — every probe path is defensive against subprocess errors so
+    a malformed clause cannot wedge check-shipped-pr.sh.
+    """
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=str(cwd),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=124, stdout="", stderr="timeout"
+        )
+    except (FileNotFoundError, PermissionError, OSError) as e:
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=126, stdout="", stderr=str(e)
+        )
+
+
+def _extract_grep_pattern(argv: list[str]) -> str | None:
+    """Recover the grep pattern from ``argv``.
+
+    grep argv shape: ``grep [flags...] <pattern> [path...]``. Flags start
+    with ``-``; the first non-flag token is the pattern. We do NOT
+    attempt to handle ``grep -e <pattern>`` here — that's vanishingly
+    rare in AC clauses and the simple "first non-flag token" heuristic
+    covers every observed case.
+    """
+    if not argv or argv[0].lower() != "grep":
+        return None
+    for tok in argv[1:]:
+        if tok.startswith("-"):
+            continue
+        return tok
+    return None
+
+
+def _extract_pytest_k_expr(argv: list[str]) -> str | None:
+    """Recover the ``-k <expr>`` selector from a pytest argv.
+
+    Returns None when no ``-k`` appears (the clause is then unsupported —
+    we don't probe by file path because that's already the path-overlap
+    channel). Both ``-k expr`` (separate token) and ``-k=expr`` (joined)
+    are supported, plus ``--keyword expr`` / ``--keyword=expr``.
+    """
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in ("-k", "--keyword"):
+            if i + 1 < len(argv):
+                return argv[i + 1]
+            return None
+        if tok.startswith("-k="):
+            return tok[3:]
+        if tok.startswith("--keyword="):
+            return tok[len("--keyword=") :]
+        i += 1
+    return None
+
+
+def _resolve_pr_for_pattern(
+    repo_root: Path, pattern: str, path: str | None, *, timeout_sec: int
+) -> int | None:
+    """Find the most-recent squash-merge PR that introduced ``pattern``.
+
+    Uses ``git log -S <pattern>`` (the "pickaxe" search) to find commits
+    where the count of occurrences of ``pattern`` changed. Optionally
+    constrains to a path. Returns the PR number parsed from the most
+    recent matching commit's subject line (the ``(#N)`` token), or None
+    when no candidate is found.
+
+    The pickaxe search is exact-string by default; we don't pass ``-G``
+    (regex) because AC patterns are typically string literals (frozenset
+    names, function names, magic strings).
+    """
+    cmd = ["git", "log", "-S", pattern, "--oneline", "--max-count=10"]
+    if path:
+        cmd.extend(["--", path])
+    proc = _run(cmd, cwd=repo_root, timeout_sec=timeout_sec)
+    if proc.returncode != 0:
+        return None
+    # Each line is ``<sha> <subject>``. Walk in newest-first order (git
+    # log default) and return the FIRST line whose subject ends in
+    # ``(#N)`` — that's the squash-merge PR.
+    for line in proc.stdout.splitlines():
+        # Match the LAST ``(#N)`` token on the subject — handles both
+        # the conventional ``feat(x): foo (#1234)`` and the chained
+        # ``fix(ci): squash (#2837) (#3170)`` shape (#4214 lesson —
+        # always pick the trailing token, never the first).
+        m = re.search(r"\(#(\d+)\)\s*$", line)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def _probe_grep(
+    argv: list[str], *, repo_root: Path, timeout_sec: int
+) -> tuple[int, str] | None:
+    """Run a grep clause against ``repo_root`` and resolve the PR on match.
+
+    Returns (pr_number, canonical_clause) on hit, None on miss.
+    """
+    pattern = _extract_grep_pattern(argv)
+    if not pattern:
+        return None
+    # Reconstruct the path argument(s). After the pattern token, every
+    # remaining non-flag token is a path argument.
+    paths: list[str] = []
+    seen_pattern = False
+    for tok in argv[1:]:
+        if tok.startswith("-"):
+            continue
+        if not seen_pattern:
+            seen_pattern = True
+            continue
+        paths.append(tok)
+    # Run grep against the worktree. The ``-r`` flag is added so a
+    # directory path (like ``scripts/dispatcher/tests/``) recurses into
+    # files; grep with a directory but no -r errors out on most BSD/GNU
+    # implementations. ``-l`` (list-only) is added to keep output bounded.
+    grep_cmd = ["grep", "-rln", pattern]
+    if paths:
+        grep_cmd.extend(paths)
+    else:
+        # No path → search the whole repo (matches the AC author's intent
+        # when they wrote ``Verify: grep foo`` with no path argument).
+        grep_cmd.append(".")
+    proc = _run(grep_cmd, cwd=repo_root, timeout_sec=timeout_sec)
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    # Found at least one match — resolve the introducing PR. Prefer the
+    # first matching path as the PR-resolution scope (constrains the
+    # pickaxe search to the relevant subtree). When multiple paths match,
+    # pick the first one's parent directory as the scope.
+    first_match_line = proc.stdout.strip().splitlines()[0]
+    # ``grep -ln`` output: ``<path>:<linenum>:<text>`` — but ``-l`` mode
+    # emits just ``<path>``. Combined with -n, the format is the full
+    # ``<path>:<line>:<match>``. Take the path portion (everything before
+    # the first colon) as the scope hint.
+    scope_path = (
+        first_match_line.split(":", 1)[0]
+        if ":" in first_match_line
+        else first_match_line
+    )
+    pr = _resolve_pr_for_pattern(
+        repo_root, pattern, scope_path, timeout_sec=timeout_sec
+    )
+    if pr is None:
+        # Fallback: pickaxe search without path constraint.
+        pr = _resolve_pr_for_pattern(repo_root, pattern, None, timeout_sec=timeout_sec)
+    if pr is None:
+        return None
+    canonical = f"grep {shlex.quote(pattern)} " + " ".join(
+        shlex.quote(p) for p in paths
+    )
+    return (pr, canonical.rstrip())
+
+
+def _probe_pytest(
+    argv: list[str], *, repo_root: Path, timeout_sec: int
+) -> tuple[int, str] | None:
+    """Run a pytest clause in --collect-only mode against ``repo_root``.
+
+    Returns (pr_number, canonical_clause) on collection-hit, None on miss.
+    Side-effect-free: pytest collection imports test modules but does not
+    run their bodies.
+    """
+    expr = _extract_pytest_k_expr(argv)
+    if not expr:
+        return None
+    # Locate pytest. Prefer python -m pytest from the active interpreter
+    # so we don't depend on a global ``pytest`` binary on PATH. The
+    # active venv's pytest (if any) is what's on the helper's path.
+    pytest_cmd = [sys.executable, "-m", "pytest", "--collect-only", "-q", "-k", expr]
+    proc = _run(pytest_cmd, cwd=repo_root, timeout_sec=timeout_sec)
+    # pytest --collect-only -q exits 0 with output of the form:
+    #   <file>::<test_name>
+    #   <file>::<test_name>
+    #
+    #   <N> tests collected in <T>s
+    # Exit 5 means "no tests collected" — which is exactly the miss
+    # case we want to drop. Any non-zero non-5 exit is treated as
+    # "collection failed for an unrelated reason" — fall through to miss.
+    if proc.returncode == 5:
+        return None
+    if proc.returncode != 0:
+        return None
+    # Parse out at least one ``<file>::<test>`` line. If pytest's output
+    # does not contain such a line (e.g. quiet mode collected zero
+    # tests), treat as miss.
+    test_lines = [
+        line for line in proc.stdout.splitlines() if "::" in line and "[" not in line
+    ]
+    if not test_lines:
+        return None
+    # Resolve the PR via pickaxe search on the test name. Constrain to
+    # the first collected test's file for tighter PR resolution.
+    test_path = test_lines[0].split("::", 1)[0]
+    pr = _resolve_pr_for_pattern(repo_root, expr, test_path, timeout_sec=timeout_sec)
+    if pr is None:
+        pr = _resolve_pr_for_pattern(repo_root, expr, None, timeout_sec=timeout_sec)
+    if pr is None:
+        return None
+    canonical = f"pytest --collect-only -q -k {shlex.quote(expr)}"
+    return (pr, canonical)
+
+
+# ─── Main entrypoint ───────────────────────────────────────────────────────
+
+
+def probe(body: str, *, repo_root: Path, timeout_sec: int) -> tuple[int, str] | None:
+    """Run all Verify clauses in ``body`` against the worktree.
+
+    Returns the FIRST hit as (pr_number, canonical_clause), or None when
+    no clause matches. Clauses are evaluated in source order so the AC
+    author's first verify line takes precedence — that's typically the
+    most direct expression of "what the AC actually pins."
+    """
+    for clause in _extract_verify_clauses(body):
+        cls = _classify_clause(clause)
+        if cls is None:
+            continue
+        shape, argv = cls
+        result: tuple[int, str] | None = None
+        if shape == "grep":
+            result = _probe_grep(argv, repo_root=repo_root, timeout_sec=timeout_sec)
+        elif shape == "pytest":
+            result = _probe_pytest(argv, repo_root=repo_root, timeout_sec=timeout_sec)
+        if result is not None:
+            return result
+    return None
+
+
+def _resolve_repo_root() -> Path:
+    """Resolve the worktree root the probes should run against.
+
+    Precedence:
+      1. ``CHECK_SHIPPED_VERIFY_REPO_ROOT`` env var (tests pass a fixture).
+      2. ``git rev-parse --show-toplevel`` from the helper's cwd.
+      3. The current working directory (last-resort fallback).
+    """
+    env_root = os.environ.get("CHECK_SHIPPED_VERIFY_REPO_ROOT")
+    if env_root:
+        return Path(env_root)
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return Path(proc.stdout.strip())
+    return Path.cwd()
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 2
+    body = data.get("body") or ""
+    if not body:
+        return 1
+    try:
+        timeout_sec = int(os.environ.get("CHECK_SHIPPED_VERIFY_TIMEOUT_SEC", "30"))
+    except ValueError:
+        timeout_sec = 30
+    repo_root = _resolve_repo_root()
+    hit = probe(body, repo_root=repo_root, timeout_sec=timeout_sec)
+    if hit is None:
+        return 1
+    pr, clause = hit
+    print(f"shipped:{pr}\t{clause}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -16,31 +16,49 @@
 #
 # Algorithm:
 #   1. Fetch the issue body via `gh issue view`.
-#   2. Extract candidate file paths from the body using a fixed regex
-#      that covers the four conventional repo roots
-#      (scripts/, packages/, docs/, infra/) plus `.github/`. Each path
-#      is classified as either *target-context* (narrative / Proposal /
-#      AC text — load-bearing change targets) or *search-context*
-#      (cited only inside Verify: / grep / pytest / aws / curl / rg
-#      invocations or fenced shell-output blocks — search arguments,
-#      not change targets). #4340.
-#   3. For each unique file path, query the commits API on `main` to find
-#      commits that touched it (`gh api /repos/.../commits?path=<file>`),
-#      and parse the squash-merge PR number from each commit headline
-#      (the trailing `(#N)` token).
-#   4. For each candidate PR, fetch its merge metadata and changed files
-#      via `gh pr view --json mergedAt,baseRefName,files`. Drop the
-#      candidate if `mergedAt` is null or `baseRefName != main`.
-#   5. Compute overlap of the candidate PR's changed files vs the
-#      candidate paths. Apply the high-confidence threshold AGAINST THE
-#      TARGET-CONTEXT SUBSET ONLY — search-context overlaps don't trip
-#      a shipped match by themselves (#4340). Threshold: ≥1 added
-#      target-context overlap OR ≥2 total target-context overlaps. The
-#      "added" classification uses changeType:"ADDED" (or status:
-#      "added" from the raw GitHub REST API), falling back to a
-#      deletions==0 heuristic when neither authoritative signal is
-#      present.
-#   6. On match: print a `shipped:` line and a JSON summary to stdout,
+#   2. **Verify-clause content probe (#4472).** Before falling through to
+#      the path-overlap channel, run the AC's literal Verify: clauses
+#      against the worktree via _check_shipped_pr_verify_probe.py. The
+#      probe supports three shapes — `grep <pattern> <path>` (read-only,
+#      executed verbatim), `pytest -k <test>` (rewritten to
+#      --collect-only for safety), and `./scripts/<probe>.sh` (NOT
+#      executed; checks file existence + git log). On match, the probe
+#      resolves the introducing PR via `git log -S` and emits a
+#      `shipped:` line, short-circuiting the path-overlap pipeline.
+#      This catches the canonical pre-#3994 zombie shape where the AC
+#      pins a content invariant (frozenset name, magic string, test
+#      name) and the actual PR uses a different filename than the
+#      issue body's prose — issue #2828 ↔ PR #3215 is the worked
+#      example.
+#   3. **Fallback — path-overlap channel.** When step 2 returns no
+#      match, fall through to the original heuristic:
+#        a. Extract candidate file paths from the body using a fixed
+#           regex that covers the four conventional repo roots
+#           (scripts/, packages/, docs/, infra/) plus `.github/`. Each
+#           path is classified as either *target-context* (narrative /
+#           Proposal / AC text — load-bearing change targets) or
+#           *search-context* (cited only inside Verify: / grep / pytest
+#           / aws / curl / rg invocations or fenced shell-output blocks
+#           — search arguments, not change targets). #4340.
+#        b. For each unique file path, query the commits API on `main`
+#           to find commits that touched it
+#           (`gh api /repos/.../commits?path=<file>`), and parse the
+#           squash-merge PR number from each commit headline (the
+#           trailing `(#N)` token).
+#        c. For each candidate PR, fetch its merge metadata and changed
+#           files via `gh pr view --json mergedAt,baseRefName,files`.
+#           Drop the candidate if `mergedAt` is null or
+#           `baseRefName != main`.
+#        d. Compute overlap of the candidate PR's changed files vs the
+#           candidate paths. Apply the high-confidence threshold
+#           AGAINST THE TARGET-CONTEXT SUBSET ONLY — search-context
+#           overlaps don't trip a shipped match by themselves (#4340).
+#           Threshold: ≥1 added target-context overlap OR ≥2 total
+#           target-context overlaps. The "added" classification uses
+#           changeType:"ADDED" (or status: "added" from the raw GitHub
+#           REST API), falling back to a deletions==0 heuristic when
+#           neither authoritative signal is present.
+#   4. On match: print a `shipped:` line and a JSON summary to stdout,
 #      exit 0. On no match: print a `not-shipped:` line, exit 1. On
 #      error: print an `error:` line to stderr, exit 2.
 #
@@ -96,6 +114,67 @@ issue_json=""
 if ! issue_json=$("$GH_BIN" issue view "$issue_num" --repo "$REPO" --json body,title,createdAt 2>/dev/null); then
     echo "error: failed to fetch issue #${issue_num} from ${REPO} (exit 2)" >&2
     exit 2
+fi
+
+# ─── Verify-clause content probe (#4472) ──────────────────────────────────
+#
+# Before the path-overlap channel, run the AC's literal `Verify:` clauses
+# against the worktree. This catches the canonical pre-#3994 zombie shape
+# where the AC pins a content invariant (frozenset name, magic string,
+# test name) and the actual PR used a different filename than the issue
+# body's prose. Concrete case: issue #2828 ↔ PR #3215 — the AC's
+# `grep "ALLOWED_CLAUDE_FLAGS" scripts/dispatcher/tests/` matches in
+# origin/main today, even though the issue's body cited
+# `scripts/dispatcher/tests/test_daemon_phase3a.py` as a guess (the PR
+# landed at `test_daemon_phase_argv_allowlist.py`).
+#
+# Exit codes from the helper:
+#   0 — match. Stdout: ``shipped:<pr-number>\t<canonical-clause>``.
+#   1 — no match. Stdout empty. Caller falls through to path-overlap.
+#   2 — error / malformed input. Stdout empty. Caller falls through too.
+#
+# The helper is opt-out via env var so callers can suppress the new
+# channel when running against a shallow / non-git fixture (some unit
+# tests with bash mocks cannot satisfy the `git rev-parse --show-toplevel`
+# precondition; setting CHECK_SHIPPED_VERIFY_DISABLE=1 bypasses the
+# probe entirely while leaving the path-overlap channel intact).
+verify_probe_disabled="${CHECK_SHIPPED_VERIFY_DISABLE:-}"
+if [[ -z "$verify_probe_disabled" ]]; then
+    verify_probe_out=""
+    verify_probe_exit=0
+    verify_probe_out=$(printf '%s' "$issue_json" | python3 \
+        "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_verify_probe.py" \
+        2>/dev/null) || verify_probe_exit=$?
+    if [[ "$verify_probe_exit" -eq 0 && "$verify_probe_out" == shipped:* ]]; then
+        # Parse `shipped:<pr>\t<clause>` — split on the first tab.
+        verify_probe_pr="${verify_probe_out%%$'\t'*}"
+        verify_probe_pr="${verify_probe_pr#shipped:}"
+        verify_probe_clause=""
+        if [[ "$verify_probe_out" == *$'\t'* ]]; then
+            verify_probe_clause="${verify_probe_out#*$'\t'}"
+        fi
+        if [[ "$verify_probe_pr" =~ ^[0-9]+$ ]]; then
+            # Emit a `shipped:` line in the same shape the path-overlap
+            # channel uses, plus a minimal JSON summary. Downstream
+            # consumers (.claude/skills/task/SKILL.md §4a.2.1) parse
+            # `shipped_pr` from the JSON, which is enough to drive the
+            # verify-and-close pivot.
+            summary_json=$(CHECK_SHIPPED_ISSUE="$issue_num" \
+                            CHECK_SHIPPED_PR="$verify_probe_pr" \
+                            CHECK_SHIPPED_OVERLAP_COUNT="0" \
+                            CHECK_SHIPPED_OVERLAP_FILES="" \
+                            CHECK_SHIPPED_ADDED_FILES="" \
+                            CHECK_SHIPPED_CANDIDATE_FILES="" \
+                            CHECK_SHIPPED_VERIFY_CLAUSE="$verify_probe_clause" \
+                            python3 "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_summary.py" \
+                            2>/dev/null) || summary_json=""
+            echo "shipped: PR #${verify_probe_pr} matches issue #${issue_num} via Verify-clause probe (${verify_probe_clause}) (exit 0)"
+            if [[ -n "$summary_json" ]]; then
+                echo "$summary_json"
+            fi
+            exit 0
+        fi
+    fi
 fi
 
 # Extract candidate file paths from the issue body via Python (so the regex

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -53,6 +53,15 @@ MOCK_BIN_DIR=$(mktemp -d)
 register_temp_dir "$MOCK_BIN_DIR"
 export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
 
+# Disable the Verify-clause content probe (#4472) for the path-overlap
+# integration tests below. The verify-channel runs the AC's literal
+# Verify clauses against the actual worktree (grep, pytest --collect-only,
+# git log -S), which the bash mocks here cannot influence — the worktree
+# content is real and the mocks only intercept gh. Tests in this file
+# specifically exercise the path-overlap channel; the verify-channel has
+# its own dedicated unit tests in test_check_shipped_pr_verify_probe.py.
+export CHECK_SHIPPED_VERIFY_DISABLE=1
+
 # Path to the mock gh script that test cases overwrite.
 MOCK_GH="$MOCK_BIN_DIR/gh"
 
@@ -1262,6 +1271,121 @@ if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3319"* ]
 else
     fail "audit-class mixed ADDED+MODIFIED clears threshold (regression #4501)" "exit=$exit_code output=$output"
 fi
+
+# ─── Test 30: Verify-clause content probe matches #2828 ↔ PR #3215 (#4472) ─
+
+# AC1 of #4472: extending check-shipped-pr.sh with a content-channel
+# probe that runs the AC's literal Verify clause against origin/main
+# must catch the canonical case from issue #2828. Issue body cites
+# `scripts/dispatcher/tests/test_daemon_phase3a.py` as a *guess* at the
+# new test file's path — the actual PR (#3215) landed at
+# `test_daemon_phase_argv_allowlist.py`. Path-overlap returns zero hits
+# because the issue's path guess and the PR's actual filename don't
+# match. The AC's literal Verify line —
+#   `grep "ALLOWED_CLAUDE_FLAGS" scripts/dispatcher/tests/`
+# — matches in origin/main today, and `git log -S 'ALLOWED_CLAUDE_FLAGS'`
+# resolves the introducing commit's PR as #3215.
+#
+# This test runs WITHOUT the CHECK_SHIPPED_VERIFY_DISABLE opt-out so the
+# verify-channel actually executes. It runs grep + git log against the
+# real worktree (the worktree this test executes from) — both are
+# read-only, so no side effects. The mock gh is only used to feed the
+# issue body to the wrapper.
+unset CHECK_SHIPPED_VERIFY_DISABLE
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            # Issue #2828 body — abbreviated to the AC bullet that
+            # carries the load-bearing Verify clause.
+            cat << 'JSON'
+{"body": "## Acceptance criteria\n\n- [ ] Unit test asserts all flags in the phase-subprocess argv are in an explicit allowlist.\n  **Verify:** `grep \"ALLOWED_CLAUDE_FLAGS\" scripts/dispatcher/tests/` returns a match.\n- [ ] Allowlist contains -p, --max-turns, --model.\n", "title": "test(dispatcher): lock claude -p argv flags to an allowlist", "createdAt": "2026-04-19T15:49:13Z"}
+JSON
+            exit 0
+        fi
+        ;;
+    api|pr)
+        # The verify-channel short-circuits before the wrapper reaches
+        # the path-overlap section; these handlers should not be called.
+        # Return empty / error to avoid masking a regression in the
+        # short-circuit path.
+        exit 1
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2828 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3215"* && "$output" == *"Verify-clause probe"* ]]; then
+    pass "verify-channel probe resolves #2828 ↔ PR #3215 via grep clause (regression #4472, AC1)"
+else
+    fail "verify-channel probe resolves #2828 ↔ PR #3215 via grep clause (regression #4472, AC1)" "exit=$exit_code output=$output"
+fi
+
+# Re-disable for any remaining tests (defensive — this is the last test
+# before the summary, but make the env state explicit for future
+# extensions).
+export CHECK_SHIPPED_VERIFY_DISABLE=1
+
+# ─── Test 31: Verify-channel falls through when no Verify clause (#4472) ──
+
+# AC5 of #4472: an issue body with NO literal `Verify:` clause must NOT
+# be affected by the new probe — the wrapper falls through to the path-
+# overlap channel as before. Locks in that the probe is purely additive:
+# issues that the path-overlap channel already classifies correctly
+# (exit 0 / shipped or exit 1 / not-shipped) keep classifying the same
+# way. This guards against the failure mode where a poorly-targeted
+# verify probe over-fires on incidental text.
+#
+# We re-use the high-confidence shipped fixture from Test 3 — issue
+# body cites `scripts/foo.sh`, no Verify line at all, mock PR #3229
+# added the file. Expectation: shipped (via path-overlap), with the
+# verify-channel exiting 1 (no match) on a body that has no Verify
+# clauses to probe.
+unset CHECK_SHIPPED_VERIFY_DISABLE
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            # Body has NO `Verify:` clauses — verify-channel must miss.
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Closes the widget loop (#3229)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0, "changeType": "ADDED"}], "mergedAt": "2026-04-24T15:39:47Z", "number": 3229, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+# Path-overlap channel must fire (note: NOT the verify-channel — the
+# `Verify-clause probe` substring must NOT appear).
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3229"* && "$output" != *"Verify-clause probe"* ]]; then
+    pass "no-Verify-clause issue still resolves via path-overlap channel (regression #4472, AC5)"
+else
+    fail "no-Verify-clause issue still resolves via path-overlap channel (regression #4472, AC5)" "exit=$exit_code output=$output"
+fi
+
+export CHECK_SHIPPED_VERIFY_DISABLE=1
 
 # Restore PATH for cleanup
 export PATH="$ORIG_PATH_SAVE"

--- a/scripts/tests/test_check_shipped_pr_verify_probe.py
+++ b/scripts/tests/test_check_shipped_pr_verify_probe.py
@@ -1,0 +1,593 @@
+# venv: none
+"""Tests for ``scripts/_check_shipped_pr_verify_probe.py``.
+
+The verify-probe helper (issue #4472) is the content-channel companion
+to check-shipped-pr.sh's path-overlap heuristic. It extracts literal
+``Verify:`` clauses from an issue body, classifies them by shape (grep
+/ pytest / script-execution), and runs a safe subset against the
+worktree to resolve the introducing PR.
+
+These tests cover three layers:
+
+  1. **Clause extraction** — the ``_extract_verify_clauses()`` parser.
+     Verify lines come in many shapes — bare bullet, bold-emphasis
+     (``**Verify:**``), backtick-wrapped command, indented continuation.
+     The parser must extract the load-bearing command in each case
+     without confusing trailing prose for command tokens.
+
+  2. **Clause classification** — the ``_classify_clause()`` shape
+     dispatcher. Decides whether a clause is grep / pytest / script /
+     unsupported. Unsupported clauses are silently dropped (the helper
+     must NOT execute arbitrary verbs like aws / curl / sql).
+
+  3. **Probe execution + PR resolution** — end-to-end via a fixture
+     git repository. Each test builds a temp git repo with deterministic
+     content + commit history (subject lines carrying ``(#<n>)`` so the
+     PR resolver can find them), runs the probe against it, and asserts
+     the resolved PR number.
+
+Loads the helper module via ``importlib.util.spec_from_file_location``
+because the filename starts with an underscore — the standard
+``import scripts._check_...`` path doesn't apply (``scripts/`` is not
+a package).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "_check_shipped_pr_verify_probe.py"
+
+
+def _import_probe_module():
+    """Load the verify-probe helper as ``check_shipped_pr_verify_probe``."""
+    spec = importlib.util.spec_from_file_location(
+        "check_shipped_pr_verify_probe", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_shipped_pr_verify_probe"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def probe_module():
+    return _import_probe_module()
+
+
+# ─── Layer 1: Verify clause extraction ────────────────────────────────────
+
+
+def test_extract_bullet_form(probe_module):
+    """Plain bullet ``- Verify: <command>`` is extracted with bullet stripped."""
+    body = (
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] Foo bar baz.\n"
+        "  Verify: grep widget scripts/foo.sh\n"
+    )
+    clauses = probe_module._extract_verify_clauses(body)
+    assert clauses == ["grep widget scripts/foo.sh"]
+
+
+def test_extract_bold_form(probe_module):
+    """``**Verify:**`` (bold-emphasis) is consumed by the prefix regex."""
+    body = "  - **Verify:** pytest -k test_foo\n"
+    clauses = probe_module._extract_verify_clauses(body)
+    assert clauses == ["pytest -k test_foo"]
+
+
+def test_extract_backtick_wrapped(probe_module):
+    """Backtick-wrapped command is unwrapped — trailing prose is dropped."""
+    body = (
+        '  - **Verify:** `grep "WIDGET" scripts/foo/` returns a match; '
+        "adding `--cwd` makes it fail.\n"
+    )
+    clauses = probe_module._extract_verify_clauses(body)
+    # The backtick unwrap is non-greedy — captures the FIRST balanced
+    # span. Trailing ``returns a match; adding --cwd makes it fail`` is
+    # informational narrative, not part of the command.
+    assert clauses == ['grep "WIDGET" scripts/foo/']
+
+
+def test_extract_multiple_clauses(probe_module):
+    """Multiple Verify lines in the same body each yield a clause."""
+    body = (
+        "- [ ] A\n"
+        "  Verify: grep alpha scripts/a.sh\n"
+        "- [ ] B\n"
+        "  **Verify:** `pytest -k test_b`\n"
+    )
+    clauses = probe_module._extract_verify_clauses(body)
+    assert clauses == ["grep alpha scripts/a.sh", "pytest -k test_b"]
+
+
+def test_extract_ignores_lines_without_verify(probe_module):
+    """Body lines that are not Verify clauses are skipped."""
+    body = (
+        "## Description\n"
+        "Some prose about the feature.\n"
+        "\n"
+        "## Acceptance criteria\n"
+        "\n"
+        "- [ ] Foo.\n"
+        "  Verify: grep x y\n"
+        "- [ ] Bar (manual).\n"
+    )
+    clauses = probe_module._extract_verify_clauses(body)
+    assert clauses == ["grep x y"]
+
+
+def test_extract_handles_case_insensitive(probe_module):
+    """``verify:`` (lowercase) is extracted same as ``Verify:``."""
+    body = "  verify: grep foo bar/\n"
+    clauses = probe_module._extract_verify_clauses(body)
+    assert clauses == ["grep foo bar/"]
+
+
+def test_extract_strips_trailing_bold_closer(probe_module):
+    """``Verify: <cmd>**`` (rare malformed bold) drops the closer."""
+    body = "  Verify: grep foo bar/**\n"
+    clauses = probe_module._extract_verify_clauses(body)
+    assert clauses == ["grep foo bar/"]
+
+
+# ─── Layer 2: Clause classification ───────────────────────────────────────
+
+
+def test_classify_grep_clause(probe_module):
+    """``grep ...`` is classified as a grep clause (issue #4472 AC3)."""
+    cls = probe_module._classify_clause(
+        "grep ALLOWED_CLAUDE_FLAGS scripts/dispatcher/tests/"
+    )
+    assert cls is not None
+    shape, argv = cls
+    assert shape == "grep"
+    assert argv[0] == "grep"
+    assert argv[1] == "ALLOWED_CLAUDE_FLAGS"
+
+
+def test_classify_grep_clause_with_flags(probe_module):
+    """``grep -n -r <pattern> <path>`` keeps the flags in argv."""
+    cls = probe_module._classify_clause('grep -n -r "WIDGET" scripts/foo/')
+    assert cls is not None
+    shape, argv = cls
+    assert shape == "grep"
+    # The flags are preserved in argv; the pattern extractor walks past
+    # them. Quoted "WIDGET" arrives as an unquoted token after shlex.
+    assert argv[0] == "grep"
+    assert "-n" in argv
+    assert "-r" in argv
+
+
+def test_classify_pytest_clause(probe_module):
+    """``pytest -k <test_name>`` is classified as a pytest clause (AC4)."""
+    cls = probe_module._classify_clause("pytest -k test_phase_constants_cover_all")
+    assert cls is not None
+    shape, argv = cls
+    assert shape == "pytest"
+    assert "-k" in argv
+
+
+def test_classify_pytest_via_python_module(probe_module):
+    """``python -m pytest -k <test>`` is also classified as pytest."""
+    cls = probe_module._classify_clause("python -m pytest -k test_x")
+    assert cls is not None
+    shape, _ = cls
+    assert shape == "pytest"
+
+
+def test_classify_pytest3_via_python3_module(probe_module):
+    """``python3 -m pytest`` (concrete interpreter) is also pytest."""
+    cls = probe_module._classify_clause("python3 -m pytest -k test_x")
+    assert cls is not None
+    shape, _ = cls
+    assert shape == "pytest"
+
+
+def test_classify_script_dotslash_clause_drops(probe_module):
+    """``./scripts/<probe>.sh`` is INTENTIONALLY unsupported (#4472).
+
+    The verify-channel does not support script-execution clauses — see
+    the "DELIBERATELY UNSUPPORTED" header in the helper module. Two
+    reasons: arbitrary script execution is unsafe, and a pure-existence
+    check is too weak a signal (issues that ask for an existing script
+    to be EXTENDED would all false-positive). The path-overlap channel
+    catches the cases this would have caught.
+    """
+    cls = probe_module._classify_clause("./scripts/check-foo.sh --flag value")
+    assert cls is None
+
+
+def test_classify_script_bash_clause_drops(probe_module):
+    """``bash scripts/<probe>.sh`` is INTENTIONALLY unsupported (#4472)."""
+    cls = probe_module._classify_clause("bash scripts/check-foo.sh")
+    assert cls is None
+
+
+def test_classify_unsupported_verbs_drop(probe_module):
+    """Verbs we don't execute (aws, curl, gh, sql) classify as None.
+
+    Safety contract — the helper executes ONLY grep and pytest --collect-only.
+    Any other verb must fall through and the probe must return None,
+    causing the wrapper to fall back to the path-overlap channel rather
+    than executing arbitrary commands.
+    """
+    assert probe_module._classify_clause("aws ecs describe-clusters") is None
+    assert probe_module._classify_clause("curl https://example.org/api") is None
+    assert probe_module._classify_clause("gh issue view 42") is None
+    assert (
+        probe_module._classify_clause(
+            "SELECT COUNT(*) FROM derived.rulings WHERE judge_id IS NULL"
+        )
+        is None
+    )
+    assert probe_module._classify_clause("reviewer confirms on read-through") is None
+
+
+def test_classify_empty_clause_drops(probe_module):
+    """Empty / whitespace-only clauses return None."""
+    assert probe_module._classify_clause("") is None
+
+
+def test_classify_unbalanced_quotes_drop(probe_module):
+    """Unparseable clauses (unbalanced quotes) return None gracefully."""
+    # shlex.split raises on unbalanced quotes; the classifier must
+    # catch this and return None rather than crashing.
+    result = probe_module._classify_clause('grep "unclosed quote scripts/foo')
+    assert result is None
+
+
+# ─── Layer 2b: argv accessors ─────────────────────────────────────────────
+
+
+def test_extract_grep_pattern_basic(probe_module):
+    """First non-flag token is the pattern."""
+    assert (
+        probe_module._extract_grep_pattern(["grep", "ALLOWED_CLAUDE_FLAGS", "scripts/"])
+        == "ALLOWED_CLAUDE_FLAGS"
+    )
+
+
+def test_extract_grep_pattern_skips_flags(probe_module):
+    """Flags before the pattern are skipped."""
+    assert (
+        probe_module._extract_grep_pattern(["grep", "-n", "-r", "WIDGET", "src/"])
+        == "WIDGET"
+    )
+
+
+def test_extract_grep_pattern_returns_none_when_only_flags(probe_module):
+    """argv with only flags returns None (no pattern recoverable)."""
+    assert probe_module._extract_grep_pattern(["grep", "-n", "-r"]) is None
+
+
+def test_extract_pytest_k_separate_token(probe_module):
+    """``-k expr`` (separate tokens) is extracted."""
+    assert (
+        probe_module._extract_pytest_k_expr(["pytest", "-k", "test_foo"]) == "test_foo"
+    )
+
+
+def test_extract_pytest_k_joined_token(probe_module):
+    """``-k=expr`` (joined) is extracted."""
+    assert probe_module._extract_pytest_k_expr(["pytest", "-k=test_foo"]) == "test_foo"
+
+
+def test_extract_pytest_keyword_long_form(probe_module):
+    """``--keyword expr`` (long form) is extracted."""
+    assert (
+        probe_module._extract_pytest_k_expr(["pytest", "--keyword", "test_foo"])
+        == "test_foo"
+    )
+
+
+def test_extract_pytest_keyword_long_form_joined(probe_module):
+    """``--keyword=expr`` (long form joined) is extracted."""
+    assert (
+        probe_module._extract_pytest_k_expr(["pytest", "--keyword=test_foo"])
+        == "test_foo"
+    )
+
+
+def test_extract_pytest_k_missing_returns_none(probe_module):
+    """argv without -k returns None — the clause is unsupported."""
+    assert probe_module._extract_pytest_k_expr(["pytest", "tests/"]) is None
+
+
+# ─── Layer 3: End-to-end probes against a fixture git repo ────────────────
+
+
+def _git_init_repo(tmp_path: Path) -> Path:
+    """Initialize a tmp git repo with deterministic config.
+
+    Sets a fixed user name + email so commits don't depend on the agent's
+    global git config. Returns the repo root.
+    """
+    repo = tmp_path / "fixture_repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet", "--initial-branch=main", "."],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test Author"],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "false"],
+        cwd=repo,
+        check=True,
+    )
+    return repo
+
+
+def _git_commit(repo: Path, *, message: str, files: dict[str, str]) -> None:
+    """Write ``files`` and commit them with ``message``."""
+    for rel_path, content in files.items():
+        full = repo / rel_path
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content)
+        subprocess.run(["git", "add", rel_path], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "--quiet", "-m", message], cwd=repo, check=True)
+
+
+def test_probe_grep_clause_e2e(probe_module, tmp_path):
+    """Grep clause on a fixture worktree resolves the introducing PR.
+
+    Mirrors the canonical #4472 case: the AC's literal Verify clause is
+    a grep for a content invariant, the worktree contains a file with
+    the matching content, and the introducing commit's subject ends in
+    ``(#<n>)``. The probe must return that PR number.
+    """
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="WIP: ralph output (#3215)",
+        files={
+            "scripts/dispatcher/tests/test_argv_allowlist.py": (
+                "ALLOWED_CLAUDE_FLAGS = frozenset({'-p', '--max-turns', '--model'})\n"
+            ),
+        },
+    )
+    body = (
+        "- [ ] Allowlist exists.\n"
+        '  **Verify:** `grep "ALLOWED_CLAUDE_FLAGS" scripts/dispatcher/tests/`'
+        " returns a match.\n"
+    )
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=15)
+    assert hit is not None
+    pr_num, clause = hit
+    assert pr_num == 3215
+    assert "ALLOWED_CLAUDE_FLAGS" in clause
+
+
+def test_probe_grep_clause_no_match_returns_none(probe_module, tmp_path):
+    """When the worktree has no match for the grep pattern, probe misses."""
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="initial (#1)",
+        files={"scripts/foo.sh": "echo hello\n"},
+    )
+    body = "  Verify: grep ABSENT_TOKEN scripts/foo.sh\n"
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=15)
+    assert hit is None
+
+
+def test_probe_pytest_clause_e2e(probe_module, tmp_path):
+    """Pytest clause on a fixture worktree resolves the introducing PR.
+
+    The fixture commits a single test file with a parametrized test name;
+    the probe runs ``pytest --collect-only -q -k <name>`` against the
+    fixture, observes a collected test, and resolves the PR via
+    pickaxe search on the test name.
+    """
+    repo = _git_init_repo(tmp_path)
+    test_body = (
+        "def test_phase_constants_cover_all_declared_phases():\n    assert True\n"
+    )
+    _git_commit(
+        repo,
+        message="test(dispatcher): cover all declared phases (#3253)",
+        files={"scripts/dispatcher/tests/test_phase_constants.py": test_body},
+    )
+    body = (
+        "- [ ] Test exists.\n"
+        "  Verify: pytest -k test_phase_constants_cover_all_declared_phases\n"
+    )
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=30)
+    assert hit is not None
+    pr_num, clause = hit
+    assert pr_num == 3253
+    # The canonical clause carries the rewritten --collect-only flag (AC4).
+    assert "--collect-only" in clause
+
+
+def test_probe_pytest_clause_no_match_returns_none(probe_module, tmp_path):
+    """Pytest probe with no test matching ``-k`` expr returns None."""
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="initial (#1)",
+        files={
+            "scripts/dispatcher/tests/test_other.py": "def test_other():\n    assert True\n"
+        },
+    )
+    body = "  Verify: pytest -k test_absent_test_name_definitely_not_present\n"
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=15)
+    assert hit is None
+
+
+def test_probe_script_clause_drops_silently(probe_module, tmp_path):
+    """Script-execution Verify clauses must NOT match — even when the script exists.
+
+    Issue #4472 design decision: the verify-channel does not support
+    script-execution clauses. A body whose only Verify clause is a
+    ``./scripts/foo.sh`` invocation — even when the script exists in
+    the worktree and was added by a prior PR — must miss the verify-
+    channel and fall through to the path-overlap channel. This locks in
+    the safety + precision rationale documented in the helper's
+    "DELIBERATELY UNSUPPORTED" header.
+
+    Concrete failure mode this prevents: when /task picks up an
+    AC-extension issue (e.g. issue #4472 itself, asking to extend
+    ``scripts/check-shipped-pr.sh``), the script EXISTS but the
+    extension hasn't shipped. A naive script-existence probe would
+    false-positive against the script's introducing PR.
+    """
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="dx: add foo helper (#4001)",
+        files={"scripts/foo-helper.sh": "#!/usr/bin/env bash\necho hi\n"},
+    )
+    body = "  Verify: ./scripts/foo-helper.sh exits 0\n"
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=15)
+    assert hit is None
+
+
+def test_probe_first_clause_wins(probe_module, tmp_path):
+    """When multiple Verify clauses match, the first one in source order fires."""
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="first (#100)",
+        files={
+            "scripts/a.sh": "FIRST_TOKEN_HERE\n",
+            "scripts/b.sh": "SECOND_TOKEN_HERE\n",
+        },
+    )
+    body = (
+        "- [ ] A.\n"
+        "  Verify: grep FIRST_TOKEN_HERE scripts/a.sh\n"
+        "- [ ] B.\n"
+        "  Verify: grep SECOND_TOKEN_HERE scripts/b.sh\n"
+    )
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=15)
+    assert hit is not None
+    pr_num, clause = hit
+    # Either clause would resolve to PR #100 (single commit), so we
+    # check the clause text to distinguish: the first one in source
+    # order should win.
+    assert pr_num == 100
+    assert "FIRST_TOKEN_HERE" in clause
+
+
+def test_probe_unsupported_clause_silently_skipped(probe_module, tmp_path):
+    """Unsupported clauses (aws / curl / sql / prose) don't trip the probe.
+
+    AC5: an issue body whose Verify clauses are all unsupported shapes
+    must miss — the wrapper falls through to the path-overlap channel.
+    """
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="initial (#1)",
+        files={"scripts/foo.sh": "WIDGET_TOKEN\n"},
+    )
+    body = (
+        "- [ ] A.\n"
+        "  Verify: aws ecs describe-clusters --include SETTINGS\n"
+        "- [ ] B.\n"
+        "  Verify: SELECT COUNT(*) FROM derived.rulings\n"
+        "- [ ] C.\n"
+        "  Verify: reviewer confirms on read-through\n"
+    )
+    hit = probe_module.probe(body, repo_root=repo, timeout_sec=15)
+    assert hit is None
+
+
+def test_probe_empty_body_returns_none(probe_module, tmp_path):
+    """Empty body → no clauses → no match."""
+    repo = _git_init_repo(tmp_path)
+    hit = probe_module.probe("", repo_root=repo, timeout_sec=15)
+    assert hit is None
+
+
+# ─── stdin-driven main entrypoint ─────────────────────────────────────────
+
+
+def test_main_emits_shipped_line_on_match(probe_module, tmp_path, monkeypatch, capsys):
+    """The CLI entrypoint emits ``shipped:<pr>\\t<clause>`` on a match."""
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="add helper (#9001)",
+        files={"scripts/helper.sh": "WIDGET_TOKEN\n"},
+    )
+    monkeypatch.setenv("CHECK_SHIPPED_VERIFY_REPO_ROOT", str(repo))
+    monkeypatch.setenv("CHECK_SHIPPED_VERIFY_TIMEOUT_SEC", "15")
+
+    issue_json = (
+        '{"body": "- [ ] Foo.\\n  Verify: grep WIDGET_TOKEN scripts/helper.sh\\n", '
+        '"title": "feat: foo"}'
+    )
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        type("S", (), {"read": staticmethod(lambda: issue_json)})(),
+    )
+    # json.load wants a file-like object — patch it to a stringio-ish
+    # wrapper.
+    import io
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(issue_json))
+
+    rc = probe_module.main()
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith("shipped:9001\t")
+    assert "WIDGET_TOKEN" in out
+
+
+def test_main_returns_1_on_no_match(probe_module, tmp_path, monkeypatch):
+    """The CLI returns exit 1 with empty stdout on no Verify-channel match."""
+    repo = _git_init_repo(tmp_path)
+    _git_commit(
+        repo,
+        message="initial (#1)",
+        files={"scripts/foo.sh": "echo hi\n"},
+    )
+    monkeypatch.setenv("CHECK_SHIPPED_VERIFY_REPO_ROOT", str(repo))
+    monkeypatch.setenv("CHECK_SHIPPED_VERIFY_TIMEOUT_SEC", "15")
+
+    import io
+
+    issue_json = '{"body": "Pure prose with no Verify clause.", "title": "x"}'
+    monkeypatch.setattr(sys, "stdin", io.StringIO(issue_json))
+
+    rc = probe_module.main()
+    assert rc == 1
+
+
+def test_main_returns_2_on_malformed_json(probe_module, monkeypatch):
+    """The CLI returns exit 2 on malformed JSON input."""
+    import io
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{not json"))
+    rc = probe_module.main()
+    assert rc == 2
+
+
+def test_main_returns_1_on_empty_body(probe_module, monkeypatch):
+    """A JSON object with empty body returns exit 1 (no match), not exit 2."""
+    import io
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO('{"body": "", "title": "x"}'))
+    rc = probe_module.main()
+    assert rc == 1


### PR DESCRIPTION
## Summary

Adds a content-channel "shipped" probe to `check-shipped-pr.sh` that runs the AC's literal `Verify: grep ...` and `Verify: pytest -k ...` clauses against the worktree before the path-overlap heuristic. Catches the canonical pre-#3994 zombie shape where the AC pins a content invariant (frozenset name, magic string, test name) and the actual PR used a different filename than the issue body's prose — issue #2828 ↔ PR #3215 is the worked example. Intentionally drops the third clause shape from the original proposal (`Verify: ./scripts/foo.sh`) for safety + precision; see the "DELIBERATELY UNSUPPORTED" header in the new helper for the rationale.

Closes #4472

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` clean on the three changed Python files).
- [x] Format check passes (`ruff format --check` clean).
- [x] Tests pass — `pytest scripts/tests/test_check_shipped_pr_verify_probe.py` 37/37 PASS, plus `pytest scripts/tests/test_check_shipped_pr_*.py` 119/119 PASS overall, plus `bash scripts/tests/test_check_shipped_pr.sh` 36/36 PASS (28 path-overlap regressions + 2 new verify-channel regressions, all isolated via `CHECK_SHIPPED_VERIFY_DISABLE`).
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling; runs locally / in /task agents only).
- [x] Verification evidence posted on issue (process summary at #4472, A.8 evidence comment after merge per `/task` SKILL.md A.8 §3).
