### PR TITLE
feat(dx): regenerable check-* hygiene-guard fix-block survey (#4349)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2202,6 +2202,22 @@ jobs:
         run: scripts/check-fix-block-coverage-complete.sh
 
   # ---------------------------------------------------------------
+  # Fix-block coverage verdict guard: every row in
+  # docs/dx/check-script-fix-block-coverage.md must carry a Verdict
+  # column matching the classifier output of
+  # scripts/check-fix-block-coverage.py --check. This is the orthogonal
+  # invariant to the row-presence check above (#4367 / #23a) — presence
+  # is necessary but not sufficient; the verdict has to track reality.
+  # See #4349.
+  # ---------------------------------------------------------------
+  dx-fix-block-coverage-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify inventory verdicts match classifier output
+        run: python3 scripts/check-fix-block-coverage.py --check
+
+  # ---------------------------------------------------------------
   # CI-guards SKIP_LIST coverage: every argument-required hygiene guard
   # under scripts/check-*.{sh,py} must be in run-ci-guards.sh's SKIP_LIST
   # or carry a `# ci-guards: skip` marker. Without this, the umbrella
@@ -2311,6 +2327,7 @@ jobs:
       - removed-exports-check
       - vitest-environment-deps-check
       - fix-block-coverage-complete-check
+      - dx-fix-block-coverage-check
       - ci-guards-skip-list-coverage-check
     if: always()
     runs-on: ubuntu-latest

--- a/docs/dx/check-script-fix-block-coverage.md
+++ b/docs/dx/check-script-fix-block-coverage.md
@@ -47,9 +47,9 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 9 | `scripts/check-brand-md-tokens.sh` | self-diagnosing (Fix block) | Emits canonical token list. |
 | 10 | `scripts/check-case-type-fallback-parity.sh` | wrapper (delegates to helper) | Wrapper for `check-case-type-fallback-parity.py`. |
 | 11 | `scripts/check-ci-job-skipped.sh` | wrapper (delegates to helper) | Wrapper for `check-ci-job-skipped.py`. |
-| 11a | `scripts/check-ci-guards-skip-list-coverage.sh` | self-diagnosing (Fix block) | Meta-check guarding `run-ci-guards.sh`'s SKIP_LIST: fails when a guard is missing from SKIP_LIST AND has no `# ci-guards: skip` marker. Detects four required-kinds — `argparse required=True` / `add_mutually_exclusive_group(required=True)`, top-level `os.environ["VAR"]` reads, shell `${1:?}` strict positional, and shell `${VAR:?}` strict env var (file-scope only). Emits per-violation `Fix:` block tagged with the detected required-kind so operators see whether the trigger was a CLI argument or an environment variable. Tracking: #4384 (env-var extension), #4379 (parent meta-check, parent: #4332). |
+| 11a | `scripts/check-ci-guards-skip-list-coverage.sh` | wrapper (delegates to helper) | Wrapper for `check-ci-guards-skip-list-coverage.py`. Meta-check guarding `run-ci-guards.sh`'s SKIP_LIST: fails when a guard is missing from SKIP_LIST AND has no `# ci-guards: skip` marker. Detects four required-kinds — `argparse required=True` / `add_mutually_exclusive_group(required=True)`, top-level `os.environ["VAR"]` reads, shell `${1:?}` strict positional, and shell `${VAR:?}` strict env var (file-scope only). The helper emits per-violation `Fix:` block tagged with the detected required-kind so operators see whether the trigger was a CLI argument or an environment variable. Tracking: #4384 (env-var extension), #4379 (parent meta-check, parent: #4332). |
 | 12 | `scripts/check-ci-passed-coverage.sh` | wrapper (delegates to helper) | Wrapper for `check-ci-passed-coverage.py`. |
-| 13 | `scripts/check-cleanup-step-continue-on-error.sh` | self-diagnosing (Fix block) | Inline Python emits "Add `continue-on-error: true` at the step level". |
+| 13 | `scripts/check-cleanup-step-continue-on-error.sh` | self-diagnosing (actionable text) | Inline Python emits "Add `continue-on-error: true` at the step level". Verdict downgraded to actionable text (#4349) — the emission is concrete imperative guidance but not a labelled `Fix:` block. |
 | 14 | `scripts/check-cloudwatch-alarm-docs.sh` | self-diagnosing (actionable text) | "Add a row to the §'CloudWatch Alarms' table with prefix, module, source metric, ...". Could be upgraded to emit a literal markdown-row patch. |
 | 14a | `scripts/check-deploy-workflow-rollout.sh` | self-diagnosing (Fix block) | Validates that every `.github/workflows/deploy-*.yml` workflow that pushes an image to ECR also rolls the running ECS service / scheduler — flags the silent-drift class behind #2772 (build-and-push job shipped without a rollout sibling, every subsequent merge silently drifts the live image from the running task). Detects `docker push` / `aws ecr put-image` as the push signal and `aws ecs update-service` / `aws scheduler update-schedule` / `aws ecs register-task-definition` / `uses: ./.github/actions/ecs-deploy` as the rollout signal. Workflows that are intentionally build-only (e.g. `deploy-dispatcher-v3.yml` — image lands now, task-def re-registers and service rollouts land in follow-up issues) opt out via the literal `# deploy-rollout-lint: build-only` comment paired with a justification. Emits a `Fix:` block naming the four canonical rollout signals plus the opt-out marker recipe. Wired by `deploy-workflow-rollout-check` in `.github/workflows/ci.yml` (gated on `detect-changes.outputs.deploy-workflows == 'true'`) and the `.githooks/pre-push` hook on `.github/workflows/deploy-*.yml` / `scripts/check-deploy-workflow-rollout.sh` changes. Tracking: #2777 (this guard), #2772 (root-cause incident). |
 | 15 | `scripts/check-deprecated-models.sh` | self-diagnosing (Fix block) | Emits literal model-name replacement table. |
@@ -63,6 +63,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 22 | `scripts/check-duplicate-functions.sh` | wrapper (delegates to helper) | Wrapper for `check-duplicate-functions.py`. |
 | 23 | `scripts/check-duplicate-pr.sh` | decision flow (no violation list) | Returns 0/1/2 with a single status line for callers (`/task` skill). No code violation. |
 | 23a | `scripts/check-fix-block-coverage-complete.sh` | self-diagnosing (Fix block) | Inventory-coverage guard: fails when a runnable hygiene guard exists in the tree without a matching row here. Emits per-violation `Fix:` block naming the doc, the verdict vocabulary, and the letter-suffix-row pattern. Mirrors `run-ci-guards.sh --list` discovery so .py companions are covered by their .sh wrapper's row. Tracking: #4367. |
+| 23b | `scripts/check-fix-block-coverage.py` | self-diagnosing (Fix block) | Verdict-correctness guard: regenerable survey for this inventory. `--check` mode (CI default) verifies the Verdict column of every row matches the classifier's output for the corresponding guard; `--regenerate` prints a fully regenerated table to stdout (verdicts only — manual Notes are intentionally lost). Classifier priority: decision flow > Fix block > operational probe > wrapper > actionable text > NEEDS UPGRADE. Emits a labelled `Fix:` block in `--check` failure mode plus per-row drift detail. Wired by `dx-fix-block-coverage-check` in `.github/workflows/ci.yml`. Tracking: #4349 (this guard), #4346 (the inventory). |
 | 24 | `scripts/check-git-gh-retries.sh` | self-diagnosing (Fix block) | Emits the `git_with_retry` / `gh_with_retry` wrapper pattern. |
 | 25 | `scripts/check-graphql-nullability-drift.sh` | wrapper (delegates to helper) | Wrapper for `check-graphql-nullability-drift.py`. |
 | 26 | `scripts/check-graphql-queries.sh` | self-diagnosing (Fix block) | Emits the `mock` / `__typename` add suggestion. |
@@ -103,11 +104,11 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 50b | `scripts/check-no-unbounded-timeouts.py` | self-diagnosing (Fix block) | Validates IO call sites under `scripts/dispatcher/` carry bounded timeouts (boto3, psycopg, requests, urllib3). Emits per-violation `Fix: add the missing kwarg, or annotate the call with ...` block. No `.sh` wrapper — invoked directly via `python3 scripts/check-no-unbounded-timeouts.py` from CI and pre-push. Tracking: #3353 (root cause), #4364/#4365 (pre-push wiring). |
 | 51 | `scripts/check-nullable-column-reads.sh` | wrapper (delegates to helper) | Wrapper for `check-nullable-column-reads.py`. |
 | 52 | `scripts/check-oneshot-imports.sh` | self-diagnosing (Fix block) | Emits "Fix: inline the helper" guidance. |
-| 53 | `scripts/check-oneshot-repo-paths.sh` | self-diagnosing (Fix block) | Emits the `Path(__file__).resolve().parent.parent` replacement. |
+| 53 | `scripts/check-oneshot-repo-paths.sh` | wrapper (delegates to helper) | Wrapper for `check_oneshot_repo_paths.py` (post-#4483 — was previously a self-contained grep guard, replaced by an AST walk). The helper emits the `Path(__file__).resolve().parent.parent` Fix-options block. |
 | 54 | `scripts/check-parse-document-reingest-safety.sh` | self-diagnosing (Fix block) | Emits required-marker substring list + canonical-example file paths. |
 | 55 | `scripts/check-per-phase-timeouts.sh` | wrapper (delegates to helper) | Wrapper for `check-per-phase-timeouts.py`. |
 | 56 | `scripts/check-placeholder-gates.sh` | self-diagnosing (Fix block) | Emits "remove the placeholder, ship the real check". |
-| 57 | `scripts/check-pr-title.sh` | self-diagnosing (actionable text) | Emits "Remediation: task-v2-summary did not run — re-trigger or amend manually". |
+| 57 | `scripts/check-pr-title.sh` | self-diagnosing (Fix block) | Emits "Remediation: task-v2-summary did not run — re-trigger or amend manually". The labelled `Remediation:` block makes this Fix-block-shaped (#4349 verdict reclassification). |
 | 58 | `scripts/check-rebase-no-silent-drop.sh` | self-diagnosing (Fix block) | Emits `git rebase --abort` + investigation steps. |
 | 59 | `scripts/check-removed-exports.sh` | self-diagnosing (Fix block) | Emits "Either restore the export or update the importers" with a file list. |
 | 60 | `scripts/check-repo-walk-exclusions-canonical.sh` | self-diagnosing (Fix block) | Emits "Required shape:" with literal `source preflight.sh` + iteration block. |
@@ -119,7 +120,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 64 | `scripts/check-shard-coverage.sh` | self-diagnosing (Fix block) | Emits the `--shard-of-N` invocation hint. |
 | 65 | `scripts/check-shipped-pr.sh` | decision flow (no violation list) | Returns shipped/not-shipped verdict for callers. No code violation. |
 | 65a | `scripts/check-short-unsubstantive-rulings.py` | operational health probe | Scheduled-cron data-quality probe — counts per-county rulings with `char_length(ruling_text) < 200 AND motion_type IS NULL AND outcome IS NULL` over the last 7 days. Fires when any county exceeds the configured threshold (signal that extraction is silently dropping useful fields). Fix is to investigate the extraction pipeline for that county; no source-code patch literal applies. Wired by `.github/workflows/short-unsubstantive-ruling-check.yml`. Tracking: #2671. |
-| 66 | `scripts/check-split-ruling-fields-propagated.sh` | wrapper (delegates to helper) | Wrapper for `check_split_ruling_fields_propagated.py` whose `_suggest_scope_entry()` emits the canonical Fix block (the reference upgrade from PR #4345). |
+| 66 | `scripts/check-split-ruling-fields-propagated.sh` | self-diagnosing (Fix block) | The wrapper itself emits a `Fix options:` block (in addition to delegating to `check_split_ruling_fields_propagated.py`, which emits the canonical per-violation Fix block — the reference upgrade from PR #4345). Verdict promoted to Fix block (#4349) — the wrapper's own emission qualifies. |
 | 66a | `scripts/check-sql-columns.py` | self-diagnosing (Fix block) | Validates qualified (`alias.column`) and unqualified column references in Python SQL string literals against `packages/api/src/data-access/schema.sql`. Emits per-violation `Fix: check the table's column definitions in schema.sql.` block. No `.sh` wrapper — invoked directly via `python3 scripts/check-sql-columns.py` from CI (`sql-column-check` job). Tracking: #1929 (qualified-drift), #4271 (unqualified-drift). |
 | 67 | `scripts/check-sql-conflicts.sh` | wrapper (delegates to helper) | Wrapper for `check-sql-conflicts.py`. |
 | 68 | `scripts/check-subprocess-timeouts.sh` | self-diagnosing (Fix block) | Emits `timeout=N` argument suggestion. |
@@ -131,7 +132,7 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 73a | `scripts/check-test-script-imports-mapped.sh` | wrapper (delegates to helper) | Wrapper for `check_test_script_imports_mapped.py`. Verifies that every top-level `scripts/*.py` imported by a test under `packages/scraper-framework/tests/` is in the `dorny/paths-filter` filter that gates the CI job which runs that test. Catches the #4452 / #4449 slip-through class — a PR that modifies only the imported `scripts/*.py` skips the test job entirely (because the path filter is scoped to `packages/scraper-framework/**`), and the regression hides until the next unrelated PR touches the package. Fix block names the missing script paths grouped by filter name (`scraper:` vs `scraper-framework:` vs `scraper-courts:`). Wired by `test-script-imports-mapped-check` in `.github/workflows/ci.yml`. Tracking: #4452 (this guard), #4449 (root-cause incident), #4421 (the PR that produced the slip). |
 | 73b | `scripts/check-test-script-imports-resolvable.sh` | wrapper (delegates to helper) | Wrapper for `check_test_script_imports_resolvable.py`. Sibling guard to `check-test-script-imports-mapped.sh` (#73a) covering the orthogonal hygiene class: a test under `packages/scraper-framework/tests/` may NOT import a `scripts/<name>.py` module that has been archived (`scripts/archive/<name>.py` or `scripts/oneoff/<name>.py`) without explicitly injecting that subtree onto `sys.path`. Catches the four AST shapes the issue body in #4464 itemized — `import X`, `from X import Y` (the headline new shape), `importlib.import_module("X")`, and `importlib.util.spec_from_file_location("X", literal Path)` (the second new shape). Suppresses violations when the test deliberately points `sys.path.insert` / `sys.path.append` at `scripts/archive/` or `scripts/oneoff/` (string literal, `Path / "scripts" / "<sub>"` chain, `os.path.join(..., "scripts", "<sub>")`, with one-shot module-level alias propagation for the production shape `_SCRIPTS_ONEOFF_DIR = os.path.join(...); sys.path.insert(0, _SCRIPTS_ONEOFF_DIR)`). Tests under `tests/archive/` are exempted entirely. Fix block proposes two options per offending file — delete the test (canonical for one-off backfills, mirrors #4459 resolution) or move it under `tests/archive/` and re-point its `sys.path.insert`. Wired by `test-script-imports-resolvable-check` in `.github/workflows/ci.yml`. Tracking: #4464 (this guard), #4452 (sibling), #4459 (the back-catalog cleanup that surfaced the gap). |
 | 74 | `scripts/check-test-statuscode-assertions.sh` | wrapper (delegates to helper) | Wrapper for `check-test-statuscode-assertions.py`. |
-| 75 | `scripts/check-tests-use-reingest-helper.sh` | self-diagnosing (Fix block) | Emits `make_reingest_cap_doc(...)` template. |
+| 75 | `scripts/check-tests-use-reingest-helper.sh` | self-diagnosing (actionable text) | Emits the `make_reingest_cap_doc(...)` template plus "tests MUST use the shared helper instead". Verdict downgraded to actionable text (#4349) — concrete imperative guidance, but not a labelled `Fix:` block. |
 | 76 | `scripts/check-transition-dispatch-vocabulary.sh` | self-diagnosing (Fix block) | Emits the canonical-vocabulary list. |
 | 77 | `scripts/check-vitest-environment-deps.sh` | self-diagnosing (Fix block) | Emits the `npm install` invocation. |
 | 78 | `scripts/check-workflow-paths-filter-coverage.sh` | wrapper (delegates to helper) | Wrapper for `check-workflow-paths-filter-coverage.py`. |
@@ -146,24 +147,26 @@ first read of the failing CI job names the fix, copy-pasteable.
 | 81 | `scripts/check_split_ruling_fields_propagated.py` | self-diagnosing (Fix block) | Reference upgrade from PR #4345 — emits per-violation Fix block with the `_DATACLASS_SCOPE` patch literal. |
 | 81a | `scripts/check_test_script_imports_mapped.py` | self-diagnosing (Fix block) | AST scanner for `scripts/check-test-script-imports-mapped.sh`. Walks `packages/scraper-framework/tests/**.py` for top-level `scripts/*.py` imports (three shapes: `import X`, `from X import ...`, `importlib.import_module("X")` including hyphen-named scripts), parses the `filters: \|` block in `.github/workflows/ci.yml`, and asserts each imported script's path appears in the filter that gates the test's CI job. Emits a per-filter copy-pasteable Fix block listing the missing script paths under each filter name (`scraper`, `scraper-framework`, `scraper-courts`). Imports of archived/missing scripts are intentionally ignored — that's a separate hygiene problem outside the path-filter mapping invariant (covered by sibling #81b). Tracking: #4452. |
 | 81b | `scripts/check_test_script_imports_resolvable.py` | self-diagnosing (Fix block) | AST scanner for `scripts/check-test-script-imports-resolvable.sh` (#73b). Orthogonal counterpart to #81a — same domain (test files under `packages/scraper-framework/tests/`), different invariant: every imported script-name candidate must resolve to a *live* `scripts/<name>.py`, not to `scripts/archive/<name>.py` or `scripts/oneoff/<name>.py`. Walks four AST shapes: `import X` / `from X import Y` (the headline new shape from #4464) / `importlib.import_module("X")` / `importlib.util.spec_from_file_location("X", <path>)` — for `spec_from_file_location` the path-arg is also classified, picking up a literal `Path / "scripts" / "<name>.py"` chain. Suppresses violations on tests that explicitly inject the archive/oneoff subtree onto `sys.path` (string literal, pathlib chain, `os.path.join(...)` with module-level alias propagation for the production `_DIR = os.path.join(..., "scripts", "oneoff")` shape). Exempts the entire `tests/archive/` subtree (the canonical place to keep tests for archived scripts). Fix block proposes per-test delete-or-move options. Tracking: #4464. |
-| 82 | `scripts/check_tests_use_reingest_helper.py` | self-diagnosing (Fix block) | Emits `<path>:<lineno>:CapturedDocument(...)` per violation; wrapper sh adds the helper-template block. |
+| 82 | `scripts/check_tests_use_reingest_helper.py` | self-diagnosing (actionable text) | Emits `<path>:<lineno>:CapturedDocument(...)` per violation; wrapper sh adds the helper-template block. Verdict downgraded to actionable text (#4349) — the effective guidance is imperative ("tests MUST use the shared helper") but not a labelled `Fix:` block. |
 | 83 | `scripts/check_tf_ecs_entrypoint.py` | self-diagnosing (Fix block) | **Upgraded #4346:** emits per-violation `Fix:` block with literal `entryPoint = ["<interpreter>"]` patch + the actual `command =` carryover, naming the resource and container. |
 | 84 | `scripts/check_tf_empty_resource.py` | self-diagnosing (Fix block) | **Upgraded #4346:** emits per-violation `Fix:` block with literal `count = length(local.compacted_<name>) > 0 ? 1 : 0` patch + a `locals { compacted_<name> = compact([...]) }` template, naming the actual variables. |
 
 ## Summary
 
-- Total guards: 112 (#14a `check-deploy-workflow-rollout.sh` added by #2777; #31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50b `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379; #50a `check-no-tmp-oneshot-file-path-derivation.py` added by #4381; #37a `check-no-basicconfig-with-extra.sh` + #78a `check_no_basicconfig_with_extra.py` added by #4376; #78b `check_fix_block_coverage_complete.py` added by #4405; #44a `check-no-logging-basicconfig.sh` added by #4400; #21a `check-dispatcher-test-imports.sh` added by #4429; #44c `check-no-manual-sys-modules-mock.sh` + #78c `check_no_manual_sys_modules_mock.py` added by #4434; #73a `check-test-script-imports-mapped.sh` + #81a `check_test_script_imports_mapped.py` added by #4452; #37b `check-no-duplicate-framework-helpers.sh` + #78d `check_no_duplicate_framework_helpers.py` added by #4456; #42a `check-no-hardcoded-llm-provider.sh` + #78e `check_no_hardcoded_llm_provider.py` added by #4050; #73b `check-test-script-imports-resolvable.sh` + #81b `check_test_script_imports_resolvable.py` added by #4464; #79a `check_oneshot_repo_paths.py` added by #4483; #37c `check-no-duplicate-parent-regex.sh` added by #4508; #37d `check-no-duplicate-blocked-by-regex.sh` added by #4514).
-- Already self-diagnosing (Fix block or actionable text) before #4346: 71.
-- Wrappers (delegate to helper): 18.
+- Total guards: 113 (#14a `check-deploy-workflow-rollout.sh` added by #2777; #31a `check-issue-verify-sql.py` added by #4358; #23a `check-fix-block-coverage-complete.sh`, #50b `check-no-unbounded-timeouts.py`, #62a `check-scraper-zero-record-runner.py`, #62b `check-scraper-zero-record-streak.py`, #65a `check-short-unsubstantive-rulings.py`, #66a `check-sql-columns.py` added by #4367; #11a `check-ci-guards-skip-list-coverage.sh` added by #4379; #50a `check-no-tmp-oneshot-file-path-derivation.py` added by #4381; #37a `check-no-basicconfig-with-extra.sh` + #78a `check_no_basicconfig_with_extra.py` added by #4376; #78b `check_fix_block_coverage_complete.py` added by #4405; #44a `check-no-logging-basicconfig.sh` added by #4400; #21a `check-dispatcher-test-imports.sh` added by #4429; #44c `check-no-manual-sys-modules-mock.sh` + #78c `check_no_manual_sys_modules_mock.py` added by #4434; #73a `check-test-script-imports-mapped.sh` + #81a `check_test_script_imports_mapped.py` added by #4452; #37b `check-no-duplicate-framework-helpers.sh` + #78d `check_no_duplicate_framework_helpers.py` added by #4456; #42a `check-no-hardcoded-llm-provider.sh` + #78e `check_no_hardcoded_llm_provider.py` added by #4050; #73b `check-test-script-imports-resolvable.sh` + #81b `check_test_script_imports_resolvable.py` added by #4464; #79a `check_oneshot_repo_paths.py` added by #4483; #37c `check-no-duplicate-parent-regex.sh` added by #4508; #37d `check-no-duplicate-blocked-by-regex.sh` added by #4514; #23b `check-fix-block-coverage.py` added by #4349).
+- Self-diagnosing (Fix block): 76.
+- Self-diagnosing (actionable text): 7.
+- Wrappers (delegate to helper): 21.
 - Operational health probes: 5.
 - Decision flows: 4.
+- NEEDS UPGRADE: 0.
 - **Upgraded by #4346: 5** (#6 `check-bash-compat.sh`, #29 `check-hyphen-underscore-collision.sh`, #35 `check-migration-files.sh`, #71 `check_tf_ecs_entrypoint.py`, #72 `check_tf_empty_resource.py`).
-- No future upgrade currently warranted: the remaining "actionable text" guards (#8, #14, #16, #33, #57) have human-readable guidance that's already concrete enough; upgrading them to literal-patch shape would add noise relative to the friction they cause.
+- No future upgrade currently warranted: the remaining "actionable text" guards have human-readable guidance that's already concrete enough; upgrading them to literal-patch shape would add noise relative to the friction they cause.
 
 ## How this list is maintained
 
-This survey was authored manually for the #4346 audit (2026-05-08). Future
-contributors:
+This survey was authored manually for the #4346 audit (2026-05-08) and made
+self-checking in #4349. Future contributors:
 
 - When you add a new `scripts/check-*.{sh,py}` guard: append a row. To
   minimise renumbering churn use a letter-suffix row number at the
@@ -171,10 +174,29 @@ contributors:
   `scripts/check-fix-block-coverage-complete.sh` CI guard (#23a) fails
   the build if you forget.
 - When you upgrade a guard's error output: update the Verdict and Notes.
+  The `scripts/check-fix-block-coverage.py --check` CI guard (#23b) fails
+  the build if the verdict column drifts from the classifier's output.
+  Run `scripts/check-fix-block-coverage.py --print` to see what the
+  classifier says about every guard, one line per guard.
 - When you delete a guard: remove the row.
+
+Two CI gates protect this inventory:
+
+1. **`fix-block-coverage-complete-check`** — every executable guard
+   under `scripts/check-*.{sh,py}` must have a row in this doc. See
+   `scripts/check-fix-block-coverage-complete.sh` (#23a) and #4367.
+2. **`dx-fix-block-coverage-check`** — every row's Verdict column must
+   match the classifier output of `scripts/check-fix-block-coverage.py
+   --check`. See #4349 (this guard) and #4346 (the inventory's parent
+   audit).
+
+To regenerate the survey table from scratch (verdicts only — manual
+Notes are intentionally lost):
+
+```
+python3 scripts/check-fix-block-coverage.py --regenerate
+```
 
 The audit's `/audit` skill (§1.9) counts top-level scripts via marker
 headers; this doc is a per-guard health check the audit can cross-reference
-against the count. The `scripts/check-fix-block-coverage-complete.sh` guard
-(wired into CI as `fix-block-coverage-complete-check`) catches drift at PR
-time — see #4367.
+against the count.

--- a/scripts/check-fix-block-coverage.py
+++ b/scripts/check-fix-block-coverage.py
@@ -1,0 +1,932 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""check-fix-block-coverage.py — Regenerable survey of `scripts/check-*` guards.
+
+Programmatically classifies every executable hygiene guard under
+``scripts/check-*.{sh,py}`` against the verdict vocabulary used by
+``docs/dx/check-script-fix-block-coverage.md``, and either:
+
+  * ``--check`` (CI mode): asserts that the inventory's verdict for every
+    guard matches the classifier output. Fails when the doc has drifted
+    from reality (e.g. a guard was upgraded but its row was not).
+  * ``--regenerate``: prints a fully regenerated survey table to stdout.
+    Manual annotations in the Notes column are intentionally lost — this
+    output is the verdict-only canonical form. Operators diff the
+    regenerated table against the checked-in doc and either accept the
+    auto-generated Notes or hand-merge their richer annotations.
+
+The classifier never tries to reproduce hand-curated Notes. Verdict
+correctness is the load-bearing invariant; Notes are operator commentary.
+
+Why this exists
+---------------
+``docs/dx/check-script-fix-block-coverage.md`` (#4346) is a hand-authored
+inventory of all ``scripts/check-*.{sh,py}`` hygiene guards. Each new
+guard or guard upgrade requires a manual edit. ``#4349`` proposed a
+regenerator script so the verdict column is self-maintaining and CI can
+catch drift before merge.
+
+A sibling guard ``scripts/check-fix-block-coverage-complete.sh`` (#23a)
+already enforces presence — every guard must have a row. This script
+adds the orthogonal invariant: presence is not enough, the verdict must
+match the classifier's output.
+
+Classification heuristic
+------------------------
+Priority order (first match wins):
+
+  1. **decision flow (no violation list)** — script emits a verdict-shaped
+     token at the start of an ``echo`` / ``print`` argument
+     (``TRUSTED:`` / ``UNTRUSTED:`` / ``DONE:`` / ``RESUME:`` / ``UNKNOWN:``
+     / ``duplicate:`` / ``ok:`` / ``shipped:`` / ``not-shipped:``).
+     Decision-flow guards return a verdict to a caller; the fix is
+     enacted by the caller.
+
+  2. **self-diagnosing (Fix block)** — error path emits a labelled block
+     marker (``Fix:`` / ``Fix options:`` / ``Remediation:`` / ``Required
+     shape:`` / ``Required:`` / ``Recovery:`` / ``Example fix:`` / ``Fix
+     recipes`` / ``Fix for ``) inside an ``echo`` / ``print`` /
+     stderr-output statement. Wrappers that emit their own Fix block
+     are caught here before the wrapper detector runs.
+
+  3. **operational health probe** — file invokes ``aws ecs`` / ``aws ssm``
+     / ``aws secretsmanager`` / ``curl http(s)://`` / ``docker build``
+     / ``docker run`` substantively (commands at line start, not inside
+     quoted strings or pattern variables), OR (for ``.py``) imports
+     ``psycopg`` / ``boto3`` / ``requests`` and queries live state.
+     Fix is judgment-driven (rotate the key, redeploy, investigate
+     the trigger).
+
+  4. **wrapper (delegates to helper)** — ``.sh`` whose primary action is
+     ``exec python3 <helper>.py "$@"`` and which has no own Fix-block
+     emission. The doc convention is to flag wrappers explicitly so
+     reviewers can immediately see where the actual Fix-block lives.
+
+  5. **self-diagnosing (actionable text)** — error path mentions ``Fix
+     by`` / ``Replace with`` / ``Use:`` / ``Add a `` / ``Add tests`` /
+     ``rename`` / ``MUST use`` / etc. but not in a labelled block.
+
+  6. **Fall-through .py-to-.sh sibling lookup** — when a discovered
+     underscore-named ``.py`` file (e.g.
+     ``check_no_basicconfig_with_extra.py``) reaches this point with no
+     direct verdict signal AND a hyphen-named ``.sh`` sibling exists,
+     classify the ``.sh`` and inherit. Standalone helper rows in the
+     inventory carry the verdict the operator actually sees on a CI
+     failure — the ``.sh`` wrapper is the canonical entry point.
+
+  7. **NEEDS UPGRADE** — guard emits only ``<file>:<line>: <message>`` or
+     similar with no actionable Fix text and no labelled block.
+
+CLI
+---
+::
+
+    # CI mode (default). Exits 0 on match, 1 on drift, 2 on error.
+    python3 scripts/check-fix-block-coverage.py --check
+
+    # Print the regenerated table (with auto-Notes) to stdout.
+    python3 scripts/check-fix-block-coverage.py --regenerate
+
+    # Print just the verdicts, one per line: ``<basename>\\t<verdict>``.
+    python3 scripts/check-fix-block-coverage.py --print
+
+Issue tracking: #4349 (this script), #4346 (the inventory), #4367
+(``check-fix-block-coverage-complete.sh`` sibling), #4322/#4345 (the
+Fix-block contract).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# ─── Verdict vocabulary ─────────────────────────────────────────────────
+
+VERDICT_DECISION_FLOW = "decision flow (no violation list)"
+VERDICT_OPERATIONAL = "operational health probe"
+VERDICT_FIX_BLOCK = "self-diagnosing (Fix block)"
+VERDICT_WRAPPER = "wrapper (delegates to helper)"
+VERDICT_ACTIONABLE = "self-diagnosing (actionable text)"
+VERDICT_NEEDS_UPGRADE = "NEEDS UPGRADE"
+
+ALL_VERDICTS = (
+    VERDICT_DECISION_FLOW,
+    VERDICT_OPERATIONAL,
+    VERDICT_FIX_BLOCK,
+    VERDICT_WRAPPER,
+    VERDICT_ACTIONABLE,
+    VERDICT_NEEDS_UPGRADE,
+)
+
+
+# ─── Fixed-shape detectors ──────────────────────────────────────────────
+
+# Fix-block markers that indicate "self-diagnosing (Fix block)" verdict.
+# The marker appears inside an emitted string — i.e. inside an
+# ``echo "..."`` / ``print(...)`` / similar. Detection is text-based
+# (the marker inside a header comment block doesn't count, because
+# ``_strip_comments`` removes header comments before this runs).
+#
+# Per-marker semantics:
+#   - The labelled-block markers (``Fix:``, ``Fix options:``,
+#     ``Remediation:``, ``Required shape:``, ``Recovery:``,
+#     ``Example fix:``) match anywhere within an emitted string. The
+#     historical doc treats e.g. ``check-bash-set-u-empty-array.sh``
+#     (which prints ``Fix: replace 'declare -a'...`` mid-line as part of
+#     a multi-echo prose block) as Fix-block-shaped — we mirror that.
+#   - ``Fix for `` is a prefix-only marker for ``check_fix_block_
+#     coverage_complete.py``-style "Fix for `<guard>`:" emissions.
+_FIX_BLOCK_MARKERS = (
+    "Fix:",
+    "Fix options:",
+    "Remediation:",
+    "Required shape:",
+    "Required: ",  # check-parse-document-reingest-safety.sh
+    "Recovery:",
+    "Example fix:",
+    "Fix recipes",  # check-no-heredoc-pipe-shadow.sh "Fix recipes:" plural
+    "Fix for ",  # check_fix_block_coverage_complete.py emits "Fix for `..`:"
+)
+
+# Actionable-text markers (case-insensitive). They appear inline in
+# string literals. The vocabulary spans the imperative-verb shapes the
+# existing inventory already classifies as actionable text.
+_ACTIONABLE_MARKERS = (
+    "Fix by",
+    "Replace with",
+    "Use:",
+    "Add a ",
+    "Add tests",
+    "Add `",
+    "Add the ",
+    "rename ",
+    "remove the ",
+    "remove one ",
+    "must emit",
+    "must include",
+    "MUST use",
+    "must use",
+    "use the shared helper",
+    "use the canonical",
+)
+
+# Operational-health-probe shell-command shapes. We require the
+# command to be invoked at the start of an executable line (after
+# leading whitespace), not embedded in a string literal or a regex
+# pattern variable. The pre-filter strips quoted strings before
+# applying these patterns.
+_OPERATIONAL_SHELL_PATTERNS = (
+    r"^\s*aws\s+ecs\s+(?:describe|list|run|register|update|wait)",
+    r"^\s*aws\s+ssm\s+(?:start|send|get|describe)",
+    r"^\s*aws\s+secretsmanager\s+(?:get|describe)",
+    r"^\s*aws\s+cloudwatch\s+(?:get|list|describe)",
+    r"^\s*curl\s+(?:-[A-Za-z]+\s+)?[\"']?https?://",
+    r"^\s*docker\s+(?:build|run|exec)\b",
+    # Subshell + assignment shapes — `var=$(aws ecs describe ...)` and
+    # `var=$(docker ...)`. These are how scripts capture command output.
+    r"=\s*[\"']?\$\(\s*aws\s+ecs",
+    r"=\s*[\"']?\$\(\s*docker\s+(?:build|run)",
+    r"=\s*[\"']?\$\(\s*curl\s+",
+)
+
+# Operational-health-probe Python signals.
+_OPERATIONAL_PY_IMPORTS = (
+    "import psycopg",
+    "from psycopg",
+    "import boto3",
+    "from boto3",
+)
+_OPERATIONAL_PY_TABLE_PATTERNS = (
+    # Live-state query against telemetry.* schema or boto3 client calls
+    # against AWS APIs.
+    r"\btelemetry\.[a-z_]+\b",
+    r"\.client\(['\"]\s*ecs\s*['\"]\)",
+    r"\.client\(['\"]\s*ssm\s*['\"]\)",
+)
+
+# Wrapper detection: "exec python3 <something>.py ..." appearing at top
+# level (not commented, not inside a function body that's never called).
+# Two shapes are recognised:
+#   (a) literal .py path:       exec python3 "$SCRIPT_DIR/check-foo.py" "$@"
+#   (b) variable + .py assign:  HELPER_PY="$SCRIPT_DIR/_check_foo.py"
+#                               ...
+#                               exec python3 "$HELPER_PY" "$@"
+# The detector accepts (a) directly, and (b) by pairing an `exec python3`
+# line with a prior shell-variable assignment whose value ends in ``.py``.
+_WRAPPER_EXEC_PATTERN_LITERAL = re.compile(
+    r"^\s*exec\s+python3\s+[\"'\$\{][^\n]+\.py[\"'\}\s]",
+    flags=re.MULTILINE,
+)
+_WRAPPER_EXEC_PATTERN_VARIABLE = re.compile(
+    r"^\s*exec\s+python3\s+\"\$\{?(?P<var>[A-Za-z_][A-Za-z0-9_]*)\}?\"",
+    flags=re.MULTILINE,
+)
+_PY_VAR_ASSIGN_RE = re.compile(
+    r"^\s*(?P<var>[A-Za-z_][A-Za-z0-9_]*)=\"\$[A-Za-z_][A-Za-z0-9_]*[^\"]*\.py\"",
+    flags=re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class Guard:
+    """One discovered hygiene guard."""
+
+    path: Path
+    basename: str
+
+    @property
+    def is_shell(self) -> bool:
+        return self.basename.endswith(".sh")
+
+    @property
+    def is_python(self) -> bool:
+        return self.basename.endswith(".py")
+
+
+@dataclass(frozen=True)
+class InventoryRow:
+    """One row parsed from the survey table.
+
+    ``rownum`` may carry a letter suffix (``"23"``, ``"23a"``).
+    """
+
+    rownum: str
+    basename: str
+    verdict: str
+    notes: str
+
+
+# ─── Discovery ──────────────────────────────────────────────────────────
+
+
+def discover_guards(scripts_dir: Path, *, self_basename: str) -> list[Guard]:
+    """Return every executable hygiene guard under ``scripts_dir``.
+
+    Mirrors the discovery rules in
+    ``scripts/check-fix-block-coverage-complete.sh``:
+
+      * ``check-*.sh`` files must be executable to count.
+      * ``check-*.py`` and ``check_*.py`` files always count (CI invokes
+        them via ``python3``).
+      * The umbrella wrapper itself is excluded.
+      * Companion ``.py`` files are dropped when a ``.sh`` sibling exists
+        with the same hyphen-stem (the ``.sh`` row covers both).
+    """
+
+    discovered: list[Guard] = []
+    for path in sorted(scripts_dir.iterdir()):
+        if not path.is_file():
+            continue
+        name = path.name
+        if name == self_basename:
+            continue
+        if name.startswith("check-") and name.endswith(".sh"):
+            # .sh must be executable.
+            if path.stat().st_mode & 0o111 == 0:
+                continue
+        elif name.startswith("check-") and name.endswith(".py"):
+            pass
+        elif name.startswith("check_") and name.endswith(".py"):
+            pass
+        else:
+            continue
+        discovered.append(Guard(path=path, basename=name))
+
+    # Drop check-foo.py when check-foo.sh is present (companion-pair
+    # dedup). Underscore-named .py files (check_foo.py) have no .sh
+    # sibling — they stand on their own.
+    basenames = {g.basename for g in discovered}
+    keepers: list[Guard] = []
+    for g in discovered:
+        if g.is_python and g.basename.startswith("check-"):
+            sh_companion = g.basename[: -len(".py")] + ".sh"
+            if sh_companion in basenames:
+                continue
+        keepers.append(g)
+    return keepers
+
+
+# ─── Classification ─────────────────────────────────────────────────────
+
+
+def _strip_comments(content: str, *, language: str) -> str:
+    """Remove comment lines from ``content`` so detectors don't false-match.
+
+    For shell, drop lines whose first non-whitespace character is ``#``
+    (preserving shebangs is unnecessary — they never carry markers).
+    For Python, drop both ``#`` line comments and triple-quoted module
+    docstrings at file scope. We leave inline ``#`` comments inside
+    strings alone (we detect markers in stripped lines, so a trailing
+    ``# Fix:`` comment will not register as a Fix block).
+    """
+
+    lines = content.split("\n")
+    out: list[str] = []
+    if language == "shell":
+        for line in lines:
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            out.append(line)
+        return "\n".join(out)
+
+    # Python: strip module-scope docstrings (triple-quoted at file
+    # start, possibly preceded by ``from __future__`` imports or a
+    # shebang).  We use a simple state machine that walks character by
+    # character — heavyweight but bug-tolerant for our use case.
+    stripped_lines: list[str] = []
+    in_docstring = False
+    docstring_quote = ""
+    for line in lines:
+        if in_docstring:
+            if docstring_quote in line:
+                # Closing line — drop everything up to and including
+                # the closing quote.
+                idx = line.index(docstring_quote)
+                rest = line[idx + len(docstring_quote) :]
+                stripped_lines.append(rest)
+                in_docstring = False
+            continue
+
+        # Detect opening triple-quoted docstring on a line that's
+        # otherwise blank/leading-only.
+        match = re.match(r"^\s*([rRbBuU]?)(\"\"\"|''')", line)
+        if match:
+            quote = match.group(2)
+            after = line[match.end() :]
+            if quote in after:
+                # Single-line docstring — strip the whole line.
+                continue
+            in_docstring = True
+            docstring_quote = quote
+            continue
+
+        # Drop pure-comment lines.
+        if re.match(r"^\s*#", line):
+            continue
+        stripped_lines.append(line)
+
+    return "\n".join(stripped_lines)
+
+
+def _has_decision_flow_exit_codes(content: str) -> bool:
+    """True when the script emits decision-shaped verdict tokens in its output.
+
+    The decision-flow vocabulary used by ``/task`` and the dispatcher is
+    a small fixed set of verdict tokens emitted on stdout/stderr:
+
+      * ``TRUSTED:`` / ``UNTRUSTED:`` (issue-author check)
+      * ``DONE:`` / ``RESUME:`` / ``UNKNOWN:`` (task-recovery check)
+      * ``duplicate:`` / ``ok:`` (duplicate-PR check)
+      * ``shipped:`` / ``not-shipped:`` (shipped-PR check)
+
+    Decision-flow guards are characterised by emitting one of these
+    tokens as the leading content of an ``echo`` / ``print`` line —
+    callers parse the prefix out of stdout to take action. Hygiene
+    guards (the vast majority) emit ``OK:`` / ``FAIL:`` / file:line
+    violation lists instead.
+
+    Detection: walk the content, find quoted strings emitted via echo/
+    print, and look for a string that *starts with* one of the decision
+    tokens. ``OK:`` and ``FAIL:`` are explicitly NOT in the token set —
+    they're the hygiene-pass/fail vocabulary.
+    """
+
+    decision_tokens = (
+        "TRUSTED:",
+        "UNTRUSTED:",
+        "DONE:",
+        "RESUME:",
+        "UNKNOWN:",
+        "duplicate:",
+        "ok:",
+        "shipped:",
+        "not-shipped:",
+    )
+
+    # Find emit lines (echo / print) and inspect their first quoted
+    # argument. We also accept python f-strings.
+    emit_re = re.compile(
+        r"\b(?:echo|print|stderr\.write|sys\.stdout\.write|sys\.stderr\.write|cat\s*<<)"
+    )
+    for line in content.split("\n"):
+        if not emit_re.search(line):
+            continue
+        strings = re.findall(r"\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'", line)
+        for double, single in strings:
+            inside = double or single
+            for token in decision_tokens:
+                if inside.startswith(token):
+                    return True
+    return False
+
+
+def _strip_quoted_strings(line: str) -> str:
+    """Remove ``"..."`` and ``'...'`` substrings from ``line``.
+
+    Used by the operational-probe detector to ensure ``aws ecs ...``
+    patterns embedded in pattern-variable string literals or echo
+    arguments don't trigger a false positive. We don't try to handle
+    every shell-quoting edge case (escape sequences, here-strings) —
+    the goal is to remove the common "string content that mentions an
+    AWS verb" shape.
+    """
+
+    return re.sub(
+        r"\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'",
+        "",
+        line,
+    )
+
+
+def _is_operational_probe(*, content: str, language: str) -> bool:
+    """True when the script targets live infrastructure rather than source code."""
+
+    if language == "shell":
+        for line in content.split("\n"):
+            stripped = _strip_quoted_strings(line)
+            for pat in _OPERATIONAL_SHELL_PATTERNS:
+                if re.search(pat, stripped, flags=re.MULTILINE):
+                    return True
+        return False
+
+    # Python.
+    has_live_import = any(marker in content for marker in _OPERATIONAL_PY_IMPORTS)
+    if has_live_import:
+        # Confirm the import is used substantively — guard files
+        # occasionally import boto3 only for type hints. We require at
+        # least one psycopg/boto3 verb call site.
+        if re.search(
+            r"\.connect\(|\.cursor\(|\.client\(|\.fetchall\(|\.execute\(", content
+        ):
+            return True
+    for pat in _OPERATIONAL_PY_TABLE_PATTERNS:
+        if re.search(pat, content):
+            return True
+    return False
+
+
+def _has_fix_block(content: str) -> bool:
+    """True when an emitted string contains a Fix-block marker.
+
+    Walks every non-comment line, finds quoted strings, and matches
+    each marker per its declared semantics:
+
+      * ``Fix for `` is a prefix-only marker (the "Fix for `<guard>`:"
+        shape from ``check_fix_block_coverage_complete.py``).
+      * Every other marker matches anywhere within the emitted string —
+        the labelled block can appear mid-line in a multi-echo prose
+        sequence (canonical example:
+        ``check-bash-set-u-empty-array.sh``).
+    """
+
+    for line in content.split("\n"):
+        strings = re.findall(r"\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'", line)
+        for double, single in strings:
+            inside = double or single
+            stripped = inside.lstrip()
+            for marker in _FIX_BLOCK_MARKERS:
+                if marker.endswith(" "):
+                    # Prefix-only marker.
+                    if stripped.startswith(marker):
+                        return True
+                else:
+                    if marker in inside:
+                        return True
+    return False
+
+
+def _has_actionable_text(content: str) -> bool:
+    """True when an emitted string contains an actionable-text marker."""
+
+    for line in content.split("\n"):
+        strings = re.findall(r"\"((?:\\.|[^\"\\])*)\"|'((?:\\.|[^'\\])*)'", line)
+        for double, single in strings:
+            inside = double or single
+            for marker in _ACTIONABLE_MARKERS:
+                if marker.lower() in inside.lower():
+                    return True
+    return False
+
+
+def _is_wrapper(content: str) -> bool:
+    """True when the script's primary action is ``exec python3 <helper>.py``.
+
+    The wrapper test is conservative — we require that an ``exec
+    python3`` line appears at top level (not inside a function), and
+    that no Fix-block markers are emitted by the script itself. The
+    caller checks Fix-block emission *first*; if we reach this branch
+    the script doesn't emit a Fix block of its own.
+
+    Recognises two shapes:
+
+      * Literal path: ``exec python3 "$SCRIPT_DIR/check-foo.py" "$@"``.
+      * Variable-indirect: ``HELPER_PY="$SCRIPT_DIR/_check_foo.py"`` /
+        later ``exec python3 "$HELPER_PY" "$@"``. We resolve the
+        variable name from the exec line and confirm it was assigned a
+        ``.py``-suffixed value earlier in the file.
+    """
+
+    if _WRAPPER_EXEC_PATTERN_LITERAL.search(content):
+        return True
+
+    var_match = _WRAPPER_EXEC_PATTERN_VARIABLE.search(content)
+    if var_match is None:
+        return False
+    var_name = var_match.group("var")
+    # Confirm a prior assignment to this variable contains ``.py``.
+    for assign in _PY_VAR_ASSIGN_RE.finditer(content):
+        if assign.group("var") == var_name:
+            return True
+    return False
+
+
+def _extract_header(content: str, *, language: str) -> str:
+    """Return the leading comment block (shell) or module docstring (Python)."""
+
+    if language == "shell":
+        out: list[str] = []
+        for line in content.split("\n"):
+            if line.startswith("#!"):
+                continue
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                out.append(stripped[1:].lstrip())
+                continue
+            if stripped == "":
+                # Blank line — end-of-header heuristic: stop on first
+                # non-comment, non-blank line.
+                if out:
+                    out.append("")
+                continue
+            break
+        return "\n".join(out)
+
+    # Python: extract the first triple-quoted docstring at file scope.
+    match = re.search(
+        r'^(?:#![^\n]*\n)?(?:from __future__[^\n]*\n)?\s*("""|\'\'\')(.*?)\1',
+        content,
+        flags=re.DOTALL,
+    )
+    if match:
+        return match.group(2)
+    # Fall back to the leading ``#``-comment block.
+    out: list[str] = []
+    for line in content.split("\n"):
+        if line.startswith("#!"):
+            continue
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            out.append(stripped[1:].lstrip())
+            continue
+        if stripped == "":
+            if out:
+                out.append("")
+            continue
+        break
+    return "\n".join(out)
+
+
+def classify(guard: Guard, *, _seen: set[str] | None = None) -> str:
+    """Return the verdict string for ``guard``.
+
+    ``_seen`` is an internal cycle-prevention set used during wrapper-
+    helper recursion. Callers should not pass it.
+    """
+
+    if _seen is None:
+        _seen = set()
+    if guard.basename in _seen:
+        # Cycle — fall back to plain wrapper verdict.
+        return VERDICT_WRAPPER
+    _seen.add(guard.basename)
+
+    content = guard.path.read_text(encoding="utf-8", errors="replace")
+    language = "shell" if guard.is_shell else "python"
+    body = _strip_comments(content, language=language)
+
+    # 1. Decision flow — script emits a decision-shaped verdict token
+    #    (TRUSTED:, DONE:, RESUME:, duplicate:, shipped:, etc.).
+    if _has_decision_flow_exit_codes(body):
+        return VERDICT_DECISION_FLOW
+
+    # 2. Self-diagnosing (Fix block) — labelled marker in emitted text.
+    #    Fix block beats operational probe because a probe that also
+    #    emits a Recovery / Fix recipe gives the operator the literal
+    #    next step; the doc treats those as Fix-block-shaped (e.g.
+    #    check-ingestion-worker-task-def-fingerprint.sh's Recovery:
+    #    block).
+    if _has_fix_block(body):
+        return VERDICT_FIX_BLOCK
+
+    # 3. Operational health probe — live-infra calls.
+    if _is_operational_probe(content=body, language=language):
+        return VERDICT_OPERATIONAL
+
+    # 4. Wrapper — exec python3 <helper>.py without own Fix block.
+    #    The wrapper's verdict is always "wrapper (delegates to helper)"
+    #    — the Notes column explains what the helper does. Inheriting
+    #    the helper's verdict here would be tempting (the operator sees
+    #    the helper's output on CI failure), but the doc convention is
+    #    to flag wrappers explicitly so reviewers can immediately see
+    #    where the actual Fix-block lives. Wrappers that emit their own
+    #    Fix block are caught by step 2 above and never reach this branch.
+    if guard.is_shell and _is_wrapper(body):
+        return VERDICT_WRAPPER
+
+    # 5. Self-diagnosing (actionable text) — inline guidance.
+    if _has_actionable_text(body):
+        return VERDICT_ACTIONABLE
+
+    # 6. Fall back: when this is an underscore-named .py with a
+    #    hyphen-named .sh sibling, defer to the sibling's verdict.
+    #    Standalone helper rows in the inventory (#78a
+    #    `check_no_basicconfig_with_extra.py`, etc.) emit only file:line
+    #    text — the wrapper provides the Fix block. The doc credits the
+    #    helper with the wrapper's verdict because that's what the
+    #    operator sees on a CI failure.
+    if guard.is_python and "_" in guard.basename:
+        hyphen_name = guard.basename.replace("_", "-")
+        if hyphen_name.endswith(".py"):
+            sh_sibling = guard.path.parent / (hyphen_name[: -len(".py")] + ".sh")
+            if sh_sibling.is_file() and sh_sibling.name not in _seen:
+                sh_guard = Guard(path=sh_sibling, basename=sh_sibling.name)
+                return classify(sh_guard, _seen=_seen)
+
+    # 7. NEEDS UPGRADE — no signals.
+    return VERDICT_NEEDS_UPGRADE
+
+
+# ─── Inventory parsing ──────────────────────────────────────────────────
+
+# Row format inside the survey table:
+#   | 23a | `scripts/check-foo.sh` | self-diagnosing (Fix block) | <notes> |
+_ROW_RE = re.compile(
+    r"^\|\s*(?P<rn>[0-9]+[a-z]?)\s*\|\s*`scripts/(?P<name>check[-_a-zA-Z0-9_]+\.(?:sh|py))`"
+    r"\s*\|\s*(?P<verdict>[^|]+?)\s*\|\s*(?P<notes>.*?)\s*\|"
+)
+
+
+def parse_inventory(doc_path: Path) -> list[InventoryRow]:
+    """Parse the survey table out of the inventory doc."""
+
+    rows: list[InventoryRow] = []
+    for line in doc_path.read_text(encoding="utf-8").splitlines():
+        m = _ROW_RE.match(line)
+        if m is None:
+            continue
+        rows.append(
+            InventoryRow(
+                rownum=m.group("rn"),
+                basename=m.group("name"),
+                verdict=m.group("verdict").strip(),
+                notes=m.group("notes").strip(),
+            )
+        )
+    return rows
+
+
+# ─── Regenerate / check / print modes ───────────────────────────────────
+
+
+def _short_note(verdict: str, basename: str) -> str:
+    """A minimal one-line note for the regenerated table."""
+
+    if verdict == VERDICT_WRAPPER:
+        # Suggest the helper name from the convention.
+        if basename.endswith(".sh"):
+            stem = basename[: -len(".sh")]
+            # Both hyphen-named (`check-foo.py`) and underscore-named
+            # (`check_foo.py`) helpers exist. Default to hyphen-named —
+            # operators can hand-edit if needed.
+            return f"Wrapper for `{stem}.py` (auto-classified)."
+        return "Wrapper (auto-classified)."
+    if verdict == VERDICT_DECISION_FLOW:
+        return "Returns a verdict for callers (auto-classified)."
+    if verdict == VERDICT_OPERATIONAL:
+        return "Probes live infrastructure (auto-classified)."
+    if verdict == VERDICT_FIX_BLOCK:
+        return "Emits a labelled `Fix:` block (auto-classified)."
+    if verdict == VERDICT_ACTIONABLE:
+        return "Emits actionable text (auto-classified)."
+    return "No actionable Fix text detected — consider upgrade (auto-classified)."
+
+
+def regenerate_table(guards: list[Guard]) -> str:
+    """Return the regenerated survey table (header + rows + summary)."""
+
+    classified = [(g, classify(g)) for g in sorted(guards, key=lambda g: g.basename)]
+
+    lines: list[str] = []
+    lines.append("| # | Guard | Verdict | Notes |")
+    lines.append("|---|-------|---------|-------|")
+    for idx, (g, verdict) in enumerate(classified, start=1):
+        note = _short_note(verdict, g.basename)
+        lines.append(f"| {idx} | `scripts/{g.basename}` | {verdict} | {note} |")
+
+    # Summary section.
+    counts: dict[str, int] = {v: 0 for v in ALL_VERDICTS}
+    for _g, v in classified:
+        counts[v] = counts.get(v, 0) + 1
+    lines.append("")
+    lines.append(f"- Total guards: {len(classified)}")
+    for v in ALL_VERDICTS:
+        lines.append(f"- {v}: {counts.get(v, 0)}")
+    return "\n".join(lines) + "\n"
+
+
+def check_classification(
+    guards: list[Guard], inventory: list[InventoryRow]
+) -> tuple[int, list[str]]:
+    """Compare classifier output against the inventory.
+
+    Returns ``(exit_code, messages)``. Exit code 0 = no drift, 1 = drift,
+    2 = error.
+    """
+
+    by_basename = {row.basename: row for row in inventory}
+    messages: list[str] = []
+    drift = 0
+
+    for g in sorted(guards, key=lambda x: x.basename):
+        if g.basename not in by_basename:
+            messages.append(
+                f"  - missing row: scripts/{g.basename} is not in the inventory"
+            )
+            drift += 1
+            continue
+        actual = classify(g)
+        expected = by_basename[g.basename].verdict
+        if actual != expected:
+            messages.append(
+                f"  - verdict drift: scripts/{g.basename}: doc says "
+                f"{expected!r}, classifier says {actual!r}"
+            )
+            drift += 1
+
+    if drift:
+        return 1, messages
+    return 0, messages
+
+
+# ─── CLI ────────────────────────────────────────────────────────────────
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Survey + classify scripts/check-* hygiene guards."
+    )
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "CI mode. Verify the inventory's verdict for every guard "
+            "matches the classifier output. Exit 0 on match, 1 on drift."
+        ),
+    )
+    mode_group.add_argument(
+        "--regenerate",
+        action="store_true",
+        help=(
+            "Print a fully regenerated survey table to stdout. Manual "
+            "Notes are intentionally lost."
+        ),
+    )
+    mode_group.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="Print '<basename>\\t<verdict>' for every guard, one per line.",
+    )
+    parser.add_argument(
+        "--scripts-dir",
+        type=Path,
+        default=None,
+        help="Override the scripts/ directory (default: <repo>/scripts).",
+    )
+    parser.add_argument(
+        "--doc",
+        type=Path,
+        default=None,
+        help=(
+            "Override the inventory doc path "
+            "(default: <repo>/docs/dx/check-script-fix-block-coverage.md)."
+        ),
+    )
+    return parser
+
+
+def _resolve_paths(args: argparse.Namespace) -> tuple[Path, Path]:
+    """Resolve scripts_dir + doc paths with CLI override support."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+    scripts_dir = args.scripts_dir or (repo_root / "scripts")
+    doc = args.doc or (repo_root / "docs/dx/check-script-fix-block-coverage.md")
+    return scripts_dir, doc
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    scripts_dir, doc = _resolve_paths(args)
+    self_basename = Path(__file__).name
+
+    if not scripts_dir.is_dir():
+        print(f"ERROR: scripts/ dir not found: {scripts_dir}", file=sys.stderr)
+        return 2
+
+    guards = discover_guards(scripts_dir, self_basename=self_basename)
+    if not guards:
+        print(
+            f"ERROR: no scripts/check-*.{{sh,py}} files found under {scripts_dir}",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.print_only:
+        for g in sorted(guards, key=lambda x: x.basename):
+            print(f"{g.basename}\t{classify(g)}")
+        return 0
+
+    if args.regenerate:
+        sys.stdout.write(regenerate_table(guards))
+        return 0
+
+    # --check mode.
+    if not doc.is_file():
+        print(f"ERROR: inventory doc not found: {doc}", file=sys.stderr)
+        return 2
+
+    inventory = parse_inventory(doc)
+    if not inventory:
+        print(f"ERROR: no inventory rows parsed from {doc}", file=sys.stderr)
+        return 2
+
+    exit_code, messages = check_classification(guards, inventory)
+    if exit_code == 0:
+        print(
+            f"OK: classifier verdicts match every row in {doc.relative_to(Path.cwd()) if doc.is_relative_to(Path.cwd()) else doc}",
+            file=sys.stderr,
+        )
+        return 0
+
+    print(
+        "FAIL: classifier verdict(s) drift from inventory:",
+        file=sys.stderr,
+    )
+    for msg in messages:
+        print(msg, file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Fix: update docs/dx/check-script-fix-block-coverage.md so each row's",
+        file=sys.stderr,
+    )
+    print(
+        "Verdict column matches the classifier output, OR adjust the guard so",
+        file=sys.stderr,
+    )
+    print(
+        "it emits the markers expected for its intended verdict. To see the",
+        file=sys.stderr,
+    )
+    print("classifier's output for every guard, run:", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("  python3 scripts/check-fix-block-coverage.py --print", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Verdict markers:", file=sys.stderr)
+    print(
+        "  - self-diagnosing (Fix block): emit `Fix:` / `Fix options:` / "
+        "`Remediation:` / `Required shape:` / `Recovery:` (line-anchored)",
+        file=sys.stderr,
+    )
+    print(
+        "  - self-diagnosing (actionable text): emit `Fix by` / `Replace with` "
+        "/ `Use:` / `Add ` / `rename`",
+        file=sys.stderr,
+    )
+    print(
+        '  - wrapper (delegates to helper): `exec python3 <helper>.py "$@"` '
+        "with no own Fix block",
+        file=sys.stderr,
+    )
+    print(
+        "  - operational health probe: `aws ecs/ssm/secretsmanager`, `curl http`, "
+        "`docker run/build`, or psycopg/boto3 imports",
+        file=sys.stderr,
+    )
+    print(
+        "  - decision flow (no violation list): header `Exit codes:` block with "
+        "decision-shaped labels (DONE/RESUME/UNKNOWN, duplicate/not, etc.)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-ci-guards.sh
+++ b/scripts/run-ci-guards.sh
@@ -134,6 +134,11 @@ SKIP_LIST=(
     "check-scraper-zero-record-runner.py"
     "check-scraper-zero-record-streak.py"
     "check-short-unsubstantive-rulings.py"
+    # check-fix-block-coverage.py needs one of --check / --regenerate /
+    # --print as a required mutually-exclusive argument; blind invocation
+    # exits 2 with "one of the arguments --check --regenerate --print is
+    # required". The CI step runs it explicitly as `--check`.
+    "check-fix-block-coverage.py"
 )
 
 # is_in_skip_list <basename> -> 0 if skipped, 1 otherwise

--- a/scripts/tests/test_check_fix_block_coverage.sh
+++ b/scripts/tests/test_check_fix_block_coverage.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# test_check_fix_block_coverage.sh — Tests for scripts/check-fix-block-coverage.py
+#
+# Synthesizes a fixture tree of representative hygiene-guard shapes and
+# asserts the classifier produces the expected verdict for each.  Also
+# exercises the --check, --regenerate, and --print modes against the
+# fixture so the CLI surface is regression-protected.
+#
+# Usage:
+#   scripts/tests/test_check_fix_block_coverage.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-fix-block-coverage.py"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# All fixture guards live under $TMPDIR_TEST/scripts/.
+FIXTURE_SCRIPTS="$TMPDIR_TEST/scripts"
+FIXTURE_DOC="$TMPDIR_TEST/docs/dx/check-script-fix-block-coverage.md"
+mkdir -p "$FIXTURE_SCRIPTS"
+mkdir -p "$(dirname "$FIXTURE_DOC")"
+
+write_executable() {
+    # $1: filename under $FIXTURE_SCRIPTS
+    # stdin: file contents
+    local path="$FIXTURE_SCRIPTS/$1"
+    cat > "$path"
+    chmod +x "$path"
+}
+
+write_python_helper() {
+    # $1: filename under $FIXTURE_SCRIPTS
+    # stdin: file contents
+    local path="$FIXTURE_SCRIPTS/$1"
+    cat > "$path"
+}
+
+reset_fixture() {
+    rm -rf "$FIXTURE_SCRIPTS"
+    mkdir -p "$FIXTURE_SCRIPTS"
+}
+
+assert_verdict() {
+    # $1: guard basename
+    # $2: expected verdict
+    local basename="$1"
+    local expected="$2"
+    TESTS=$((TESTS + 1))
+    local actual
+    actual=$(python3 "$CHECK_SCRIPT" --print --scripts-dir "$FIXTURE_SCRIPTS" \
+                | awk -F'\t' -v n="$basename" '$1 == n {print $2}')
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: $basename → $expected"
+    else
+        echo "FAIL: $basename → expected '$expected', got '$actual'" >&2
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Fixture A: Fix-block-shaped guard ────────────────────────────────────
+
+reset_fixture
+write_executable "check-foo-fix.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-fix.sh — synthetic Fix-block fixture.
+#
+# Exit codes:
+#   0 — No violations.
+#   1 — Violations.
+
+set -euo pipefail
+
+if [[ -e "/nonexistent" ]]; then
+    echo "ERROR: nonexistent file detected." >&2
+    echo "" >&2
+    echo "  Fix:" >&2
+    echo "    Remove the offending file." >&2
+    exit 1
+fi
+exit 0
+EOF
+assert_verdict "check-foo-fix.sh" "self-diagnosing (Fix block)"
+
+# ─── Fixture B: Actionable text (no labelled Fix: block) ─────────────────
+
+reset_fixture
+write_executable "check-foo-actionable.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-actionable.sh — synthetic actionable-text fixture.
+#
+# Exit codes:
+#   0 — No violations.
+#   1 — Violations.
+
+set -euo pipefail
+
+if [[ -e "/nonexistent" ]]; then
+    echo "ERROR: nonexistent file detected." >&2
+    echo "Replace with a valid path or remove the reference." >&2
+    exit 1
+fi
+exit 0
+EOF
+assert_verdict "check-foo-actionable.sh" "self-diagnosing (actionable text)"
+
+# ─── Fixture C: Wrapper (delegates to helper) ─────────────────────────────
+
+reset_fixture
+write_executable "check-foo-wrap.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-wrap.sh — synthetic wrapper fixture.
+#
+# Exit codes:
+#   0 — No violations.
+#   1 — Violations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-foo-wrap.py" "$@"
+EOF
+write_python_helper "check-foo-wrap.py" <<'EOF'
+#!/usr/bin/env python3
+"""check-foo-wrap.py — synthetic helper for check-foo-wrap.sh."""
+import sys
+print("Fix: rewrite the offending statement.", file=sys.stderr)
+sys.exit(0)
+EOF
+# Companion-pair dedup means only the .sh appears in the discovered guard
+# list — assert against the .sh's verdict, which should be "wrapper".
+assert_verdict "check-foo-wrap.sh" "wrapper (delegates to helper)"
+
+# ─── Fixture D: Operational health probe (aws-flavor) ────────────────────
+
+reset_fixture
+write_executable "check-foo-ops.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-ops.sh — synthetic operational fixture.
+#
+# Exit codes:
+#   0 — Healthy.
+#   1 — Unhealthy.
+
+set -euo pipefail
+
+aws ecs describe-services \
+    --cluster judgemind-dev \
+    --services judgemind-foo-dev > /dev/null
+EOF
+assert_verdict "check-foo-ops.sh" "operational health probe"
+
+# ─── Fixture E: Decision flow (verdict-token emit) ───────────────────────
+
+reset_fixture
+write_executable "check-foo-decide.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-decide.sh — synthetic decision-flow fixture.
+#
+# Exit codes:
+#   0 — Trusted decision.
+#   1 — Untrusted decision.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "good" ]]; then
+    echo "TRUSTED: input matched."
+    exit 0
+fi
+echo "UNTRUSTED: input rejected." >&2
+exit 1
+EOF
+assert_verdict "check-foo-decide.sh" "decision flow (no violation list)"
+
+# ─── Fixture F: NEEDS UPGRADE (only file:line, no Fix marker) ────────────
+
+reset_fixture
+write_executable "check-foo-needs.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-needs.sh — synthetic NEEDS-UPGRADE fixture.
+#
+# Exit codes:
+#   0 — Clean.
+#   1 — Violations.
+
+set -euo pipefail
+
+if [[ -e "/nonexistent" ]]; then
+    echo "scripts/foo.sh:42: bad pattern detected" >&2
+    exit 1
+fi
+exit 0
+EOF
+assert_verdict "check-foo-needs.sh" "NEEDS UPGRADE"
+
+# ─── Fixture G: Wrapper that emits its own Fix block (Fix block wins) ────
+
+reset_fixture
+write_executable "check-foo-wrap-fix.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-wrap-fix.sh — synthetic wrapper-with-own-Fix-block fixture.
+#
+# Exit codes:
+#   0 — Clean.
+#   1 — Violations.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/check-foo-wrap-fix.py"
+if ! python3 "$HELPER" "$@"; then
+    echo "" >&2
+    echo "  Fix: edit the offending file and re-run." >&2
+    exit 1
+fi
+EOF
+write_python_helper "check-foo-wrap-fix.py" <<'EOF'
+#!/usr/bin/env python3
+"""Helper that just prints file:line violations."""
+import sys
+print("scripts/foo.py:1: bad", file=sys.stderr)
+sys.exit(1)
+EOF
+# Wrapper's own Fix: marker beats wrapper detection per priority order.
+assert_verdict "check-foo-wrap-fix.sh" "self-diagnosing (Fix block)"
+
+# ─── Fixture H: Underscore-named .py with hyphen-named .sh sibling ───────
+
+reset_fixture
+write_executable "check-foo-pair.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-pair.sh — synthetic .sh wrapper for the underscore-named
+# .py helper. Emits its own Fix: block in the failure-fallback path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! python3 "$SCRIPT_DIR/check_foo_pair.py" "$@"; then
+    echo "" >&2
+    echo "  Fix: address the violations above." >&2
+    exit 1
+fi
+EOF
+write_python_helper "check_foo_pair.py" <<'EOF'
+#!/usr/bin/env python3
+"""check_foo_pair.py — helper that emits only file:line."""
+import sys
+print("scripts/foo.py:42: bad", file=sys.stderr)
+sys.exit(1)
+EOF
+# .sh has its own Fix block, so its verdict is Fix block.
+assert_verdict "check-foo-pair.sh" "self-diagnosing (Fix block)"
+# .py is underscore-named with hyphen-named .sh sibling; it inherits
+# the .sh's verdict.
+assert_verdict "check_foo_pair.py" "self-diagnosing (Fix block)"
+
+# ─── CLI mode: --check passes when doc matches classifier ────────────────
+
+reset_fixture
+write_executable "check-foo-cli.sh" <<'EOF'
+#!/usr/bin/env bash
+# check-foo-cli.sh — synthetic CLI-test fixture.
+
+set -euo pipefail
+
+echo "Fix: do the thing." >&2
+exit 0
+EOF
+cat > "$FIXTURE_DOC" <<'EOF'
+# Hygiene-Guard Fix-Block Coverage
+
+| # | Guard | Verdict | Notes |
+|---|-------|---------|-------|
+| 1 | `scripts/check-foo-cli.sh` | self-diagnosing (Fix block) | synthetic fixture for CLI tests |
+
+## Summary
+
+- Total guards: 1
+EOF
+TESTS=$((TESTS + 1))
+if python3 "$CHECK_SCRIPT" --check \
+        --scripts-dir "$FIXTURE_SCRIPTS" \
+        --doc "$FIXTURE_DOC" > /dev/null 2>&1; then
+    echo "PASS: --check exits 0 when verdict matches"
+else
+    echo "FAIL: --check should exit 0 when verdict matches" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── CLI mode: --check fails when doc disagrees ──────────────────────────
+
+cat > "$FIXTURE_DOC" <<'EOF'
+# Hygiene-Guard Fix-Block Coverage
+
+| # | Guard | Verdict | Notes |
+|---|-------|---------|-------|
+| 1 | `scripts/check-foo-cli.sh` | wrapper (delegates to helper) | wrong verdict on purpose |
+
+## Summary
+
+- Total guards: 1
+EOF
+TESTS=$((TESTS + 1))
+if python3 "$CHECK_SCRIPT" --check \
+        --scripts-dir "$FIXTURE_SCRIPTS" \
+        --doc "$FIXTURE_DOC" > /dev/null 2>&1; then
+    echo "FAIL: --check should exit 1 when verdict disagrees" >&2
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: --check exits non-zero on verdict drift"
+fi
+
+# ─── CLI mode: --regenerate prints the table ─────────────────────────────
+
+TESTS=$((TESTS + 1))
+regenerated=$(python3 "$CHECK_SCRIPT" --regenerate \
+        --scripts-dir "$FIXTURE_SCRIPTS" 2>/dev/null)
+if grep -q '| 1 | `scripts/check-foo-cli.sh` | self-diagnosing (Fix block) |' \
+        <<< "$regenerated"; then
+    echo "PASS: --regenerate prints the canonical row"
+else
+    echo "FAIL: --regenerate output missing expected row" >&2
+    echo "Got:" >&2
+    echo "$regenerated" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── CLI mode: --print emits one tab-separated line per guard ────────────
+
+TESTS=$((TESTS + 1))
+printed=$(python3 "$CHECK_SCRIPT" --print \
+        --scripts-dir "$FIXTURE_SCRIPTS" 2>/dev/null)
+if [[ "$printed" == *"check-foo-cli.sh"$'\t'"self-diagnosing (Fix block)"* ]]; then
+    echo "PASS: --print emits the expected line"
+else
+    echo "FAIL: --print output missing expected line" >&2
+    echo "Got: $printed" >&2
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Tests run: $TESTS"
+echo "Failures:  $FAILURES"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Ship `scripts/check-fix-block-coverage.py` — a programmatic classifier that surveys every `scripts/check-*.{sh,py}` hygiene guard against the verdict vocabulary in `docs/dx/check-script-fix-block-coverage.md` and fails CI when the doc drifts. Adds `--check` (CI), `--regenerate`, and `--print` modes.

Companion CI job `dx-fix-block-coverage-check` enforces "every row's Verdict column matches the classifier output" — the orthogonal invariant to `fix-block-coverage-complete-check`'s presence guard (#4367 / #23a).

Reconciles 7 verdict drifts the new classifier surfaced in the existing inventory.

Closes #4349

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `dx-fix-block-coverage-check` job passes
- [x] `fix-block-coverage-complete-check` job still passes (no regression)
- [x] `ci-guards-skip-list-coverage-check` still passes (new entry in SKIP_LIST)

### Post-deploy verification
- [x] N/A — no deployed component (CI tooling and docs only)
