### PR TITLE
feat(dx): retrospective-lineage probe for check-shipped-pr.sh (#4515)

### DIFF
--- a/scripts/_check_shipped_pr_lineage_probe.py
+++ b/scripts/_check_shipped_pr_lineage_probe.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+# _check_shipped_pr_lineage_probe.py — Retrospective-lineage "shipped" probe
+# for scripts/check-shipped-pr.sh.
+#
+# venv: none
+# permanent: true
+#
+# Purpose (issue #4515):
+#   When two retrospective-class issues are filed against the same parent
+#   issue, they almost always describe the same lesson and one of them
+#   ends up being a duplicate. The path-overlap channel and the literal-
+#   Verify channel cannot catch this because:
+#
+#     - Path-overlap requires file-path overlap with the merged PR's diff;
+#       a retrospective-class issue typically describes a workflow lesson
+#       (a script's UX, a SKILL.md gap), and the sibling that already
+#       shipped touched DIFFERENT lines of the same script — the path
+#       overlap is incidental at best.
+#     - The literal-Verify channel deliberately rejects script-execution
+#       clauses (#4472 docstring lines 51-74), so a Verify line of the
+#       shape ``./scripts/check-foo.sh prints a Fix: block`` cannot
+#       trigger a match.
+#
+#   But the retrospective-lineage signal — "two issues filed from the
+#   same parent retrospective, one already merged, identifier overlap
+#   between current-issue body and merged-PR body" — is an independent
+#   channel that catches exactly this shape.
+#
+#   Concrete case: issue #4315 ↔ PR #4345 ↔ sibling #4322.
+#     - #4315 body has ``Found by: retrospective on #4304.``
+#     - sibling #4322 closed by PR #4345 (``Closes #4322``)
+#     - #4315 mentions ``_DATACLASS_SCOPE``, ``*SplitRuling`` in narrative
+#     - PR #4345 body mentions ``_DATACLASS_SCOPE``, ``*SplitRuling``
+#     - → shipped match via lineage channel
+#
+# Reads ``gh issue view --json body,title`` JSON on stdin. Emits one of:
+#
+#   - On match: a single line ``shipped:<pr>\t<sibling>\t<identifiers>``
+#     to stdout and exit 0. ``<sibling>`` is the sibling retrospective
+#     issue closed by ``<pr>``. ``<identifiers>`` is a comma-separated
+#     list of the load-bearing identifiers that overlap between the
+#     current-issue body and the candidate-PR body (used for diagnostic
+#     logs and the JSON summary's ``lineage_identifiers`` field).
+#   - On no match: empty stdout and exit 1. Caller falls through to the
+#     path-overlap channel.
+#   - On error / malformed input: empty stdout and exit 2.
+#
+# Algorithm:
+#   1. Parse the issue body for ``Found by:.*retrospective on #(\d+)``.
+#      Each captured number is a *lineage parent*. Multiple matches in
+#      the same body are deduplicated.
+#   2. For each lineage parent, list closed issues whose body references
+#      ``retrospective on #<parent>`` via
+#      ``gh search issues "in:body retrospective on #<parent> repo:<repo>
+#       state:closed" --json number,body``.
+#      Drop the current issue itself from the result set (an issue
+#      naming itself as a sibling is the same issue).
+#   3. For each sibling, fetch its merging PR via
+#      ``gh issue view <sibling> --json closedByPullRequestsReferences``.
+#      Pre-#3994 placeholder-titled PRs that lack ``Closes #N`` keywords
+#      will not appear here — that's by design. The lineage channel
+#      catches the *retrospective duplicate* shape, not the placeholder-
+#      title zombie shape (which the path-overlap channel handles).
+#      Take the FIRST merged PR (typically only one) as the lineage
+#      candidate.
+#   4. For each lineage candidate, fetch the PR body via
+#      ``gh pr view <pr> --json body,mergedAt,baseRefName``. Drop if
+#      ``mergedAt`` is null or ``baseRefName != main``.
+#   5. Compute identifier overlap. The identifiers are extracted as
+#      backtick-wrapped tokens of length ≥3 from both bodies (frozenset
+#      names, function names, CamelCase types — the load-bearing
+#      identifiers that AC authors and PR authors both quote in
+#      backticks). Overlap = set-intersect of the two extracted sets.
+#      Match threshold: ≥1 backtick-token overlap. The single-token
+#      threshold is intentionally low because the gating signal —
+#      "two issues filed from the same retrospective, one already
+#      merged" — is already strong; the identifier check is precision
+#      defense (does the merged PR actually describe the same
+#      identifier the current issue prescribes), not threshold
+#      tightening.
+#   6. On the FIRST candidate that clears the identifier overlap
+#      threshold, emit ``shipped:<pr>\t<sibling>\t<identifiers>`` and
+#      exit 0. Multiple matches go through the same single-emission
+#      path — the wrapper takes the first hit.
+#
+# Why backtick-wrapped tokens specifically:
+#   - High precision. Identifiers in prose ("the SplitRuling pattern")
+#     are too easy to false-positive on (different lessons can mention
+#     the same generic concept). Backtick wrapping is the AC author's
+#     explicit signal "this is a load-bearing literal."
+#   - Symmetric. The same convention applies in PR bodies (template
+#     uses ``Closes #N``, summary uses backticks for code identifiers).
+#     Computing set intersection on the backtick-extracted tokens is
+#     defensible without model-level entity matching.
+#   - Low cost. Pure string scan, no LLM call, no extra gh requests.
+#
+# What is NOT a lineage match:
+#   - Two retrospective siblings against the same parent that describe
+#     genuinely different lessons → no backtick-token overlap → exit 1.
+#     This is the precision case from the issue's AC2.
+#   - The current issue has no ``Found by: retrospective on #N`` line
+#     in its body → the lineage probe extracts zero parents and exits 1
+#     unconditionally. Issues without retrospective lineage fall through
+#     to the path-overlap channel as before.
+#   - The lineage parent's siblings are all still open (no merging PRs)
+#     → no candidate PRs → exit 1. This is by design — the channel only
+#     fires when a sibling has DEMONSTRABLY shipped (closed by a merged
+#     PR), not when one is just open.
+#
+# Environment variables:
+#   CHECK_SHIPPED_LINEAGE_REPO     — override "judgemind/judgemind"
+#   CHECK_SHIPPED_LINEAGE_GH_BIN   — override "gh" binary path (for tests)
+#   CHECK_SHIPPED_LINEAGE_ISSUE    — current issue number (so we drop self
+#                                    from the sibling list)
+#
+# Why this is its own helper rather than inline shell:
+#   - Multi-step gh API orchestration (search-issues, issue-view, pr-view)
+#     is awkward in bash with proper error handling on each step.
+#   - The backtick-token extraction + set-intersection is one-line in
+#     Python, multi-line awk in bash.
+#   - The classifier is unit-testable in isolation (see
+#     ``scripts/tests/test_check_shipped_pr_lineage_probe.py``).
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+# ─── Lineage parent extraction ─────────────────────────────────────────────
+
+# Match ``Found by: retrospective on #N`` (case-insensitive). The colon
+# is optional; the "retrospective on" phrase is the load-bearing signal.
+# Variations observed in the corpus:
+#   - ``Found by: retrospective on #4304.``           (canonical)
+#   - ``Found by retrospective on #4304``             (no colon)
+#   - ``found by: retrospective on #4304``            (lowercase)
+LINEAGE_PARENT_RE = re.compile(
+    r"Found\s+by:?\s+retrospective\s+on\s+#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def extract_lineage_parents(body: str) -> list[int]:
+    """Return the deduplicated list of lineage parent issue numbers.
+
+    Order is preserved by first-occurrence so the caller can prefer
+    earlier mentions when multiple parents are cited (rare).
+    """
+    seen: set[int] = set()
+    out: list[int] = []
+    for m in LINEAGE_PARENT_RE.finditer(body):
+        n = int(m.group(1))
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+# ─── Backtick-token extraction ─────────────────────────────────────────────
+
+# A backtick-wrapped identifier is any non-whitespace, non-backtick
+# character sequence between single backticks. Disallowing whitespace
+# inside the span prevents the regex from matching across separate
+# code-span pairs — e.g. in ``the `=` sign and `a` and `xyz```, a
+# whitespace-permitting regex would match the inner span ``= sign and ``
+# (3+ chars between backticks 1 and 4), producing garbage tokens.
+# Disallowing whitespace also matches the AC author's convention:
+# backtick-wrapped tokens in this corpus are identifiers, paths, or
+# typed values — never multi-word phrases.
+#
+# We require length ≥3 to filter trivially-short tokens (``a``, ``=``).
+# The classifier's stopword filter (below) drops common short
+# identifiers that don't carry lesson-identity signal.
+BACKTICK_TOKEN_RE = re.compile(r"`([^`\s\n]{3,})`")
+
+# Stopwords — common backtick-wrapped tokens that don't carry lesson-
+# identity signal. These appear in many PR / issue bodies regardless of
+# the underlying lesson, so including them in overlap would inflate
+# false-positive rates.
+STOPWORDS: frozenset[str] = frozenset(
+    {
+        "main",
+        "true",
+        "false",
+        "null",
+        "none",
+        "todo",
+        "wip",
+        "fix",
+        "feat",
+        "test",
+        "docs",
+        "chore",
+        "refactor",
+    }
+)
+
+
+def extract_backtick_tokens(body: str) -> set[str]:
+    """Return the set of backtick-wrapped tokens in ``body``.
+
+    Tokens are case-sensitive — ``_DATACLASS_SCOPE`` and
+    ``_dataclass_scope`` are NOT considered the same identifier. The
+    convention in this codebase is consistent casing (constants are
+    SCREAMING_SNAKE, types are CamelCase, functions are snake_case),
+    so case-sensitivity matches the AC author's intent.
+
+    Stopwords are filtered. Tokens are stripped of leading/trailing
+    whitespace.
+    """
+    out: set[str] = set()
+    for m in BACKTICK_TOKEN_RE.finditer(body):
+        tok = m.group(1).strip()
+        if not tok:
+            continue
+        if tok.lower() in STOPWORDS:
+            continue
+        out.add(tok)
+    return out
+
+
+# ─── gh API orchestration ──────────────────────────────────────────────────
+
+
+def _run_gh(args: list[str], *, timeout_sec: int = 30) -> tuple[int, str]:
+    """Run a gh command. Returns (returncode, stdout)."""
+    gh_bin = os.environ.get("CHECK_SHIPPED_LINEAGE_GH_BIN", "gh")
+    try:
+        proc = subprocess.run(
+            [gh_bin] + args,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+        return proc.returncode, proc.stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return 124, ""
+
+
+def find_sibling_retrospectives(
+    parent: int, *, repo: str, current_issue: int
+) -> list[int]:
+    """Find closed issues whose body references ``retrospective on #<parent>``.
+
+    Excludes ``current_issue`` AND ``parent`` from the result (the parent
+    issue's body sometimes also matches the literal string when a
+    follow-up retrospective comment references back to itself). Returns
+    a list of issue numbers. Order is search-result order (most-recently-
+    updated first by default with ``gh search issues``).
+
+    Why the search query uses CLI flags instead of inline ``repo:`` /
+    ``state:`` qualifiers: ``gh search issues "..."`` interprets the
+    entire string as a single query token and does NOT expand inline
+    qualifiers. The supported invocation shape is to pass the literal
+    body match as the query argv and the qualifiers as separate flags
+    (``--repo``, ``--state``). Wrapping the whole thing in one quoted
+    string returns ``Invalid search query`` from gh's GraphQL backend.
+    """
+    # Use ``gh search issues`` with a literal-string match in the body.
+    # The query string is the literal phrase to search for; --repo,
+    # --state are passed as separate flags (gh-cli requirement — see
+    # docstring above).
+    query = f'"retrospective on #{parent}"'
+    rc, out = _run_gh(
+        [
+            "search",
+            "issues",
+            query,
+            "--repo",
+            repo,
+            "--state",
+            "closed",
+            "--json",
+            "number",
+            "--limit",
+            "20",
+        ],
+    )
+    if rc != 0 or not out.strip():
+        return []
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return []
+    siblings: list[int] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        n = entry.get("number")
+        if not isinstance(n, int):
+            continue
+        if n == current_issue:
+            continue
+        if n == parent:
+            # The parent itself can match the search when its own body
+            # references the lineage phrase (rare but observed when the
+            # parent retrospective summary mentions follow-up issues
+            # filed against it). Drop it — the parent is the lineage
+            # SOURCE, not a sibling.
+            continue
+        siblings.append(n)
+    return siblings
+
+
+def find_closing_pr(sibling: int, *, repo: str) -> int | None:
+    """Find the merged PR that closed ``sibling``.
+
+    Returns the PR number, or None when the sibling has no merging PR
+    (e.g. closed manually with ``--reason completed``, closed by a
+    placeholder-titled PR that lacks ``Closes #N``, etc.).
+    """
+    rc, out = _run_gh(
+        [
+            "issue",
+            "view",
+            str(sibling),
+            "--repo",
+            repo,
+            "--json",
+            "closedByPullRequestsReferences",
+        ],
+    )
+    if rc != 0 or not out.strip():
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    refs = data.get("closedByPullRequestsReferences")
+    if not isinstance(refs, list):
+        return None
+    for ref in refs:
+        if not isinstance(ref, dict):
+            continue
+        n = ref.get("number")
+        # gh's closedByPullRequestsReferences only includes merged PRs
+        # (the `state` field is "MERGED" when present), but check
+        # defensively in case the schema changes.
+        state = ref.get("state", "")
+        if state and state.upper() not in ("MERGED", "CLOSED"):
+            continue
+        if isinstance(n, int):
+            return n
+    return None
+
+
+def fetch_pr_body(pr: int, *, repo: str) -> tuple[str, bool] | None:
+    """Fetch ``(body, eligible)`` for ``pr`` or None on error.
+
+    ``eligible`` is True only when the PR is merged onto ``main``.
+    """
+    rc, out = _run_gh(
+        [
+            "pr",
+            "view",
+            str(pr),
+            "--repo",
+            repo,
+            "--json",
+            "body,mergedAt,baseRefName",
+        ],
+    )
+    if rc != 0 or not out.strip():
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    body = data.get("body") or ""
+    merged_at = data.get("mergedAt")
+    base_ref = data.get("baseRefName") or ""
+    eligible = bool(merged_at) and base_ref == "main"
+    return body, eligible
+
+
+# ─── Probe entrypoint ──────────────────────────────────────────────────────
+
+
+def probe(
+    body: str, *, repo: str, current_issue: int
+) -> tuple[int, int, list[str]] | None:
+    """Run the lineage probe against ``body``.
+
+    Returns ``(pr, sibling, identifiers)`` on the first match, or None
+    when no lineage candidate clears the identifier-overlap threshold.
+    """
+    parents = extract_lineage_parents(body)
+    if not parents:
+        return None
+    current_tokens = extract_backtick_tokens(body)
+    if not current_tokens:
+        # No identifiers to compare — refuse to fire. The single-token
+        # threshold can only be cleared when the current issue has at
+        # least one backtick-wrapped identifier in its body. An issue
+        # with zero backtick spans is too weak a signal for a lineage
+        # match no matter how the parent's siblings shipped.
+        return None
+    for parent in parents:
+        siblings = find_sibling_retrospectives(
+            parent, repo=repo, current_issue=current_issue
+        )
+        for sibling in siblings:
+            pr = find_closing_pr(sibling, repo=repo)
+            if pr is None:
+                continue
+            pr_data = fetch_pr_body(pr, repo=repo)
+            if pr_data is None:
+                continue
+            pr_body, eligible = pr_data
+            if not eligible:
+                continue
+            pr_tokens = extract_backtick_tokens(pr_body)
+            overlap = current_tokens & pr_tokens
+            if not overlap:
+                continue
+            # Sort for stable output across runs.
+            return pr, sibling, sorted(overlap)
+    return None
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 2
+    body = data.get("body") or ""
+    if not body:
+        return 1
+    repo = os.environ.get("CHECK_SHIPPED_LINEAGE_REPO", "judgemind/judgemind")
+    current_issue_str = os.environ.get("CHECK_SHIPPED_LINEAGE_ISSUE", "")
+    try:
+        current_issue = int(current_issue_str) if current_issue_str else 0
+    except ValueError:
+        current_issue = 0
+    hit = probe(body, repo=repo, current_issue=current_issue)
+    if hit is None:
+        return 1
+    pr, sibling, identifiers = hit
+    print(f"shipped:{pr}\t{sibling}\t{','.join(identifiers)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/_check_shipped_pr_summary.py
+++ b/scripts/_check_shipped_pr_summary.py
@@ -58,6 +58,26 @@ def main() -> int:
     if verify_clause:
         summary["verify_clause"] = verify_clause
 
+    # Retrospective-lineage channel (#4515). When the wrapper resolved
+    # the match via _check_shipped_pr_lineage_probe.py rather than the
+    # path-overlap channel, the sibling retrospective issue and the
+    # comma-separated identifier overlap that fired are passed through
+    # these env vars so the JSON summary can name them. Empty strings
+    # → no lineage-channel match → fields are omitted (preserves the
+    # pre-#4515 JSON shape for path-overlap-driven and verify-driven
+    # matches that downstream consumers already parse).
+    lineage_sibling = os.environ.get("CHECK_SHIPPED_LINEAGE_SIBLING", "")
+    if lineage_sibling:
+        try:
+            summary["lineage_sibling"] = int(lineage_sibling)
+        except ValueError:
+            summary["lineage_sibling"] = lineage_sibling
+    lineage_identifiers_csv = os.environ.get("CHECK_SHIPPED_LINEAGE_IDENTIFIERS", "")
+    if lineage_identifiers_csv:
+        summary["lineage_identifiers"] = [
+            tok for tok in lineage_identifiers_csv.split(",") if tok
+        ]
+
     print(json.dumps(summary, indent=2, sort_keys=True))
     return 0
 

--- a/scripts/check-shipped-pr.sh
+++ b/scripts/check-shipped-pr.sh
@@ -30,8 +30,21 @@
 #      name) and the actual PR uses a different filename than the
 #      issue body's prose — issue #2828 ↔ PR #3215 is the worked
 #      example.
-#   3. **Fallback — path-overlap channel.** When step 2 returns no
-#      match, fall through to the original heuristic:
+#   3. **Retrospective-lineage probe (#4515).** When step 2 returns no
+#      match, run the lineage probe via _check_shipped_pr_lineage_probe.
+#      py. The probe extracts ``Found by: retrospective on #N`` parent
+#      references from the issue body, finds sibling retrospective
+#      issues against each parent, identifies the merged PR that closed
+#      each sibling, and checks identifier overlap (backtick-wrapped
+#      tokens) between the current-issue body and the candidate PR's
+#      body. On match, emits a `shipped:` line citing the lineage PR,
+#      short-circuiting the path-overlap pipeline. This catches the
+#      canonical retrospective-duplicate shape where two issues filed
+#      from the same parent retrospective describe the same lesson, one
+#      already merged — issue #4315 ↔ PR #4345 (via sibling #4322) is
+#      the worked example.
+#   4. **Fallback — path-overlap channel.** When steps 2 and 3 return
+#      no match, fall through to the original heuristic:
 #        a. Extract candidate file paths from the body using a fixed
 #           regex that covers the four conventional repo roots
 #           (scripts/, packages/, docs/, infra/) plus `.github/`. Each
@@ -58,7 +71,7 @@
 #           changeType:"ADDED" (or status: "added" from the raw GitHub
 #           REST API), falling back to a deletions==0 heuristic when
 #           neither authoritative signal is present.
-#   4. On match: print a `shipped:` line and a JSON summary to stdout,
+#   5. On match: print a `shipped:` line and a JSON summary to stdout,
 #      exit 0. On no match: print a `not-shipped:` line, exit 1. On
 #      error: print an `error:` line to stderr, exit 2.
 #
@@ -169,6 +182,73 @@ if [[ -z "$verify_probe_disabled" ]]; then
                             python3 "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_summary.py" \
                             2>/dev/null) || summary_json=""
             echo "shipped: PR #${verify_probe_pr} matches issue #${issue_num} via Verify-clause probe (${verify_probe_clause}) (exit 0)"
+            if [[ -n "$summary_json" ]]; then
+                echo "$summary_json"
+            fi
+            exit 0
+        fi
+    fi
+fi
+
+# ─── Retrospective-lineage probe (#4515) ──────────────────────────────────
+#
+# Before the path-overlap channel, run the retrospective-lineage probe.
+# The probe extracts ``Found by: retrospective on #N`` parent references
+# from the issue body, finds sibling retrospective issues against each
+# parent, identifies the merged PR that closed each sibling, and checks
+# identifier overlap (backtick-wrapped tokens) between the current-issue
+# body and the candidate PR's body.
+#
+# Concrete worked example: issue #4315 ↔ PR #4345 ↔ sibling #4322.
+#   - #4315 body has ``Found by: retrospective on #4304.``
+#   - sibling #4322 closed by PR #4345 (``Closes #4322``)
+#   - identifier overlap between #4315 body and PR #4345 body
+#   - → emit ``shipped: PR #4345 matches issue #4315 via lineage probe``
+#
+# Exit codes from the helper:
+#   0 — match. Stdout: ``shipped:<pr>\t<sibling>\t<identifiers>``.
+#   1 — no match. Stdout empty. Caller falls through to path-overlap.
+#   2 — error / malformed input. Stdout empty. Caller falls through too.
+#
+# Opt-out via env var (mirrors the verify-probe knob). Tests that mock
+# only path-overlap responses set CHECK_SHIPPED_LINEAGE_DISABLE=1 to
+# avoid the additional gh search/issue/pr calls the probe would make.
+lineage_probe_disabled="${CHECK_SHIPPED_LINEAGE_DISABLE:-}"
+if [[ -z "$lineage_probe_disabled" ]]; then
+    lineage_probe_out=""
+    lineage_probe_exit=0
+    lineage_probe_out=$(printf '%s' "$issue_json" | \
+        CHECK_SHIPPED_LINEAGE_REPO="$REPO" \
+        CHECK_SHIPPED_LINEAGE_GH_BIN="$GH_BIN" \
+        CHECK_SHIPPED_LINEAGE_ISSUE="$issue_num" \
+        python3 \
+        "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_lineage_probe.py" \
+        2>/dev/null) || lineage_probe_exit=$?
+    if [[ "$lineage_probe_exit" -eq 0 && "$lineage_probe_out" == shipped:* ]]; then
+        # Parse `shipped:<pr>\t<sibling>\t<identifiers>` — split on tabs.
+        # The wrapper does NOT use IFS=$'\t' read because that consumes
+        # an outer subshell; manual ${var%%\t*} splits keep the parsing
+        # in this shell so a malformed line cannot wedge the wrapper.
+        rest="${lineage_probe_out#shipped:}"
+        lineage_probe_pr="${rest%%$'\t'*}"
+        rest2="${rest#*$'\t'}"
+        lineage_probe_sibling="${rest2%%$'\t'*}"
+        lineage_probe_identifiers=""
+        if [[ "$rest2" == *$'\t'* ]]; then
+            lineage_probe_identifiers="${rest2#*$'\t'}"
+        fi
+        if [[ "$lineage_probe_pr" =~ ^[0-9]+$ ]]; then
+            summary_json=$(CHECK_SHIPPED_ISSUE="$issue_num" \
+                            CHECK_SHIPPED_PR="$lineage_probe_pr" \
+                            CHECK_SHIPPED_OVERLAP_COUNT="0" \
+                            CHECK_SHIPPED_OVERLAP_FILES="" \
+                            CHECK_SHIPPED_ADDED_FILES="" \
+                            CHECK_SHIPPED_CANDIDATE_FILES="" \
+                            CHECK_SHIPPED_LINEAGE_SIBLING="$lineage_probe_sibling" \
+                            CHECK_SHIPPED_LINEAGE_IDENTIFIERS="$lineage_probe_identifiers" \
+                            python3 "$(dirname "${BASH_SOURCE[0]}")/_check_shipped_pr_summary.py" \
+                            2>/dev/null) || summary_json=""
+            echo "shipped: PR #${lineage_probe_pr} matches issue #${issue_num} via lineage probe (sibling retrospective #${lineage_probe_sibling}) (exit 0)"
             if [[ -n "$summary_json" ]]; then
                 echo "$summary_json"
             fi

--- a/scripts/tests/test_check_shipped_pr.sh
+++ b/scripts/tests/test_check_shipped_pr.sh
@@ -62,6 +62,16 @@ export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
 # its own dedicated unit tests in test_check_shipped_pr_verify_probe.py.
 export CHECK_SHIPPED_VERIFY_DISABLE=1
 
+# Disable the retrospective-lineage probe (#4515) for the path-overlap
+# integration tests. None of the fixture issue bodies below contain a
+# ``Found by: retrospective on #N`` line, so the probe would extract
+# zero parents and return None without making gh calls — but the
+# explicit opt-out keeps the integration tests insulated from any
+# future changes to the lineage-probe trigger conditions. The lineage
+# channel has its own dedicated unit tests in
+# test_check_shipped_pr_lineage_probe.py.
+export CHECK_SHIPPED_LINEAGE_DISABLE=1
+
 # Path to the mock gh script that test cases overwrite.
 MOCK_GH="$MOCK_BIN_DIR/gh"
 
@@ -1386,6 +1396,205 @@ else
 fi
 
 export CHECK_SHIPPED_VERIFY_DISABLE=1
+
+# ─── Test 32: lineage probe matches #4315 ↔ PR #4345 (#4515) ──────────────
+
+# Regression for #4515 (this test). Issue body has
+# ``Found by: retrospective on #4304.`` and mentions ``_DATACLASS_SCOPE``
+# in backticks. The mock gh:
+#   - search issues → returns sibling #4322
+#   - issue view 4322 --json closedByPullRequestsReferences → PR #4345
+#   - pr view 4345 --json body,mergedAt,baseRefName → eligible, body
+#     mentions ``_DATACLASS_SCOPE``
+# Expected: shipped match via lineage probe, PR #4345 named, output
+# contains "lineage probe" and the sibling number.
+#
+# This test runs the lineage channel without the verify channel
+# disabled — but the issue body has no Verify: lines, so the verify
+# channel falls through.
+unset CHECK_SHIPPED_VERIFY_DISABLE
+unset CHECK_SHIPPED_LINEAGE_DISABLE
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            # The wrapper's first call (in step 1 of the algorithm)
+            # fetches body,title,createdAt for the issue under check.
+            # The lineage probe's call later (in find_closing_pr) fetches
+            # the SIBLING'S closedByPullRequestsReferences. We dispatch
+            # by --json field signature to disambiguate.
+            for arg in "$@"; do
+                if [[ "$arg" == "closedByPullRequestsReferences" ]]; then
+                    cat << 'JSON'
+{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}
+JSON
+                    exit 0
+                fi
+            done
+            cat << 'JSON'
+{"body": "## Description\n\nWhen a new `*SplitRuling` dataclass is missing from `_DATACLASS_SCOPE`, emit a paste-ready hint.\n\nFound by: retrospective on #4304.", "title": "fix(dx): paste-ready hint for SplitRuling propagation", "createdAt": "2026-05-08T16:18:34Z"}
+JSON
+            exit 0
+        fi
+        ;;
+    search)
+        if [[ "${2:-}" == "issues" ]]; then
+            # Single sibling — issue #4322 — found in retrospective lineage.
+            echo '[{"number": 4322}]'
+            exit 0
+        fi
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "## Summary\n\nMake `_DATACLASS_SCOPE` self-diagnosing for new `*SplitRuling` dataclasses.\n\nCloses #4322", "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4315 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"4345"* && "$output" == *"lineage probe"* && "$output" == *"4322"* ]]; then
+    pass "lineage probe resolves #4315 ↔ PR #4345 via sibling #4322 (regression #4515 AC1)"
+else
+    fail "lineage probe resolves #4315 ↔ PR #4345 via sibling #4322 (regression #4515 AC1)" "exit=$exit_code output=$output"
+fi
+
+# Verify the JSON summary names the lineage sibling and identifiers.
+if [[ "$output" == *'"lineage_sibling": 4322'* ]]; then
+    pass "JSON summary names the lineage sibling (#4515 AC1)"
+else
+    fail "JSON summary names the lineage sibling (#4515 AC1)" "got: $output"
+fi
+
+if [[ "$output" == *'"lineage_identifiers"'* ]]; then
+    pass "JSON summary includes lineage_identifiers (#4515 AC1)"
+else
+    fail "JSON summary includes lineage_identifiers (#4515 AC1)" "got: $output"
+fi
+
+# ─── Test 33: lineage probe — sibling describes different lesson (#4515 AC2) ─
+
+# Precision case. Issue has retrospective lineage AND a sibling has
+# shipped, BUT the sibling's PR body shares NO backtick-wrapped
+# identifiers with the current issue. The lineage channel must NOT
+# fire — fall through to path-overlap.
+#
+# Mock the issue body with ``_DATACLASS_SCOPE`` and the PR body with
+# ``_REGEX_VALIDATOR`` (different lesson, no overlap). The path-overlap
+# channel will also miss because the issue body has no candidate file
+# paths matching the PR's diff (we don't return a `gh api commits`
+# response for the issue's path).
+unset CHECK_SHIPPED_VERIFY_DISABLE
+unset CHECK_SHIPPED_LINEAGE_DISABLE
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            for arg in "$@"; do
+                if [[ "$arg" == "closedByPullRequestsReferences" ]]; then
+                    cat << 'JSON'
+{"closedByPullRequestsReferences": [{"number": 4400, "state": "MERGED"}]}
+JSON
+                    exit 0
+                fi
+            done
+            cat << 'JSON'
+{"body": "Update `_DATACLASS_SCOPE` to include the new entry.\n\nFound by: retrospective on #4304.", "title": "fix(dx): dataclass scope hint", "createdAt": "2026-05-08T00:00:00Z"}
+JSON
+            exit 0
+        fi
+        ;;
+    search)
+        if [[ "${2:-}" == "issues" ]]; then
+            # Sibling found, but it ships a different lesson.
+            echo '[{"number": 4399}]'
+            exit 0
+        fi
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "Tighten the `_REGEX_VALIDATOR` for trailing whitespace.\n\nCloses #4399", "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        # No commits touched the issue's candidate paths — empty.
+        exit 0
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 4515 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$output" == *"not-shipped:"* ]]; then
+    pass "lineage probe does NOT fire when sibling describes a different lesson (#4515 AC2)"
+else
+    fail "lineage probe does NOT fire when sibling describes a different lesson (#4515 AC2)" "exit=$exit_code output=$output"
+fi
+
+# ─── Test 34: lineage probe — no retrospective lineage (#4515 AC3) ────────
+
+# Regression for AC3: an issue body without a ``Found by: retrospective
+# on #N`` line must NOT activate the lineage probe — the probe extracts
+# zero parents and returns empty. The wrapper falls through to the
+# path-overlap channel as before. Locks in that the lineage channel is
+# purely additive.
+#
+# We re-use the high-confidence shipped fixture from Test 3 — issue
+# body has no Found-by line, mock PR #3229 added the file. Expectation:
+# shipped via path-overlap (no "lineage probe" string in output).
+unset CHECK_SHIPPED_VERIFY_DISABLE
+unset CHECK_SHIPPED_LINEAGE_DISABLE
+cat > "$MOCK_GH" << 'MOCKGH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    issue)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"body": "We need scripts/foo.sh to validate widgets.", "title": "dx: add scripts/foo.sh"}
+JSON
+            exit 0
+        fi
+        ;;
+    api)
+        echo "Closes the widget loop (#3229)"
+        exit 0
+        ;;
+    pr)
+        if [[ "${2:-}" == "view" ]]; then
+            cat << 'JSON'
+{"baseRefName": "main", "files": [{"path": "scripts/foo.sh", "additions": 100, "deletions": 0, "changeType": "ADDED"}], "mergedAt": "2026-04-24T15:39:47Z", "number": 3229, "title": "WIP: ralph output"}
+JSON
+            exit 0
+        fi
+        ;;
+esac
+exit 1
+MOCKGH
+chmod +x "$MOCK_GH"
+
+exit_code=0
+output=$("$WRAPPER" 2831 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"shipped:"* && "$output" == *"3229"* && "$output" != *"lineage probe"* ]]; then
+    pass "no-retrospective-lineage issue still resolves via path-overlap channel (#4515 AC3)"
+else
+    fail "no-retrospective-lineage issue still resolves via path-overlap channel (#4515 AC3)" "exit=$exit_code output=$output"
+fi
+
+export CHECK_SHIPPED_VERIFY_DISABLE=1
+export CHECK_SHIPPED_LINEAGE_DISABLE=1
 
 # Restore PATH for cleanup
 export PATH="$ORIG_PATH_SAVE"

--- a/scripts/tests/test_check_shipped_pr_lineage_probe.py
+++ b/scripts/tests/test_check_shipped_pr_lineage_probe.py
@@ -1,0 +1,495 @@
+# venv: none
+"""Tests for ``scripts/_check_shipped_pr_lineage_probe.py``.
+
+The lineage-probe helper (issue #4515) is the third channel in
+check-shipped-pr.sh's pipeline (after the literal-Verify channel and
+before the path-overlap channel). It catches the canonical
+retrospective-duplicate shape: two issues filed from the same parent
+retrospective describe the same lesson, one already merged.
+
+These tests cover three layers:
+
+  1. **Lineage parent extraction** — the ``extract_lineage_parents()``
+     parser. Pulls ``Found by:.*retrospective on #N`` references out of
+     an issue body, deduplicating and preserving first-mention order.
+
+  2. **Backtick-token extraction** — the ``extract_backtick_tokens()``
+     helper. Extracts ``\\`token\\``-wrapped identifiers of length ≥3,
+     filtering stopwords. The set intersection of the current-issue
+     tokens and the candidate-PR-body tokens is the load-bearing
+     precision signal.
+
+  3. **End-to-end probe** — the ``probe()`` orchestrator with mocked
+     gh subprocess calls. Asserts the documented exit codes / output
+     shapes for the canonical positive case (#4315 ↔ PR #4345 ↔
+     sibling #4322), the precision case (sibling describes a different
+     lesson with no token overlap), and the negative cases (no
+     retrospective-on lineage, sibling has no merging PR, sibling's PR
+     is unmerged or merged onto a feature branch).
+
+Loads the helper module via ``importlib.util.spec_from_file_location``
+because the filename starts with an underscore — the standard
+``import scripts._check_...`` path doesn't apply (``scripts/`` is not
+a package).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "_check_shipped_pr_lineage_probe.py"
+
+
+def _import_probe_module():
+    """Load the lineage-probe helper as ``check_shipped_pr_lineage_probe``."""
+    spec = importlib.util.spec_from_file_location(
+        "check_shipped_pr_lineage_probe", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_shipped_pr_lineage_probe"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def probe_module():
+    return _import_probe_module()
+
+
+# ─── Layer 1: Lineage parent extraction ───────────────────────────────────
+
+
+def test_extract_canonical_form(probe_module):
+    """``Found by: retrospective on #N`` (canonical) is captured."""
+    body = "## Background\n\nFound by: retrospective on #4304.\n"
+    assert probe_module.extract_lineage_parents(body) == [4304]
+
+
+def test_extract_no_colon(probe_module):
+    """``Found by retrospective on #N`` (no colon) is also captured."""
+    body = "Found by retrospective on #4304\n"
+    assert probe_module.extract_lineage_parents(body) == [4304]
+
+
+def test_extract_lowercase(probe_module):
+    """``found by: retrospective on #N`` (lowercase) is captured (regex i flag)."""
+    body = "found by: retrospective on #4304\n"
+    assert probe_module.extract_lineage_parents(body) == [4304]
+
+
+def test_extract_multiple_parents(probe_module):
+    """Multiple ``Found by:`` lines yield all parents in first-mention order."""
+    body = (
+        "## Background\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+        "Also found by: retrospective on #4250.\n"
+    )
+    assert probe_module.extract_lineage_parents(body) == [4304, 4250]
+
+
+def test_extract_deduplicates(probe_module):
+    """Same parent mentioned twice yields one entry."""
+    body = (
+        "Found by: retrospective on #4304.\n(Also Found by: retrospective on #4304.)\n"
+    )
+    assert probe_module.extract_lineage_parents(body) == [4304]
+
+
+def test_extract_empty_when_no_match(probe_module):
+    """Body without retrospective lineage yields empty list."""
+    body = "## Description\n\nA bug fix.\n"
+    assert probe_module.extract_lineage_parents(body) == []
+
+
+def test_extract_ignores_unrelated_retrospective(probe_module):
+    """``retrospective on`` without the ``Found by`` prefix is NOT a parent.
+
+    The probe is conservative — only the canonical ``Found by: retrospective
+    on #N`` shape counts. Free-form prose like "the retrospective on #4304
+    showed..." is too weak a signal to base a duplicate-shipped match on.
+    """
+    body = "The retrospective on #4304 showed that we should rename foo.\n"
+    assert probe_module.extract_lineage_parents(body) == []
+
+
+# ─── Layer 2: Backtick-token extraction ───────────────────────────────────
+
+
+def test_extract_simple_backticks(probe_module):
+    """Single backtick-wrapped tokens are extracted."""
+    body = "Update `_DATACLASS_SCOPE` and `*SplitRuling`.\n"
+    assert probe_module.extract_backtick_tokens(body) == {
+        "_DATACLASS_SCOPE",
+        "*SplitRuling",
+    }
+
+
+def test_extract_filters_short_tokens(probe_module):
+    """Tokens of length <3 are dropped."""
+    body = "The `=` sign and `a` and `xyz`.\n"
+    # `=` (1 char) and `a` (1 char) are below the length-3 floor; only
+    # `xyz` (3 chars) survives.
+    assert probe_module.extract_backtick_tokens(body) == {"xyz"}
+
+
+def test_extract_filters_stopwords(probe_module):
+    """Common stopwords (``main``, ``true``, etc.) are filtered."""
+    body = "On `main`, set the value to `true` not `false`. Also `widget`.\n"
+    assert probe_module.extract_backtick_tokens(body) == {"widget"}
+
+
+def test_extract_case_sensitive(probe_module):
+    """Case-sensitive — ``DATACLASS`` and ``dataclass`` are different tokens."""
+    body = "Use `DATACLASS` for constants and `dataclass` for the decorator.\n"
+    assert probe_module.extract_backtick_tokens(body) == {"DATACLASS", "dataclass"}
+
+
+def test_extract_empty_body(probe_module):
+    """Empty body yields empty set."""
+    assert probe_module.extract_backtick_tokens("") == set()
+
+
+def test_extract_preserves_internal_punctuation(probe_module):
+    """Tokens with ``::``, ``-``, ``_``, ``/`` are kept as-is."""
+    body = (
+        "The path `scripts/foo.sh` and the symbol `module::Klass` and "
+        "the kebab-case `my-flag` and the snake `my_var`.\n"
+    )
+    assert probe_module.extract_backtick_tokens(body) == {
+        "scripts/foo.sh",
+        "module::Klass",
+        "my-flag",
+        "my_var",
+    }
+
+
+def test_extract_drops_empty_backtick_spans(probe_module):
+    """`` `` `` (empty backticks) are filtered."""
+    body = "Empty: `` and not-empty: `widget`.\n"
+    # The regex requires length-3 minimum, so empty spans never match.
+    assert probe_module.extract_backtick_tokens(body) == {"widget"}
+
+
+def test_extract_handles_multiple_per_line(probe_module):
+    """Multiple backtick spans on one line each yield a token."""
+    body = "Refs `alpha` and `beta` and `gamma`.\n"
+    assert probe_module.extract_backtick_tokens(body) == {"alpha", "beta", "gamma"}
+
+
+# ─── Layer 3: End-to-end probe ────────────────────────────────────────────
+
+
+def _make_gh_mock(responses):
+    """Build a subprocess.run mock that dispatches by gh argv.
+
+    ``responses`` is a dict mapping argv-tuple-suffix to (returncode, stdout).
+    The keys match against the SUFFIX of the gh argv, so the test can ignore
+    the leading ``gh`` token.
+    """
+
+    def _run(args, **_kwargs):
+        # args is a list starting with the gh binary. Drop it.
+        argv = tuple(args[1:])
+        for key, (rc, out) in responses.items():
+            # Match prefix - the test response key matches the leading
+            # tokens, ignoring later flags like --json or --limit values.
+            if argv[: len(key)] == key:
+                return mock.Mock(returncode=rc, stdout=out, stderr="")
+        # Default: 1, empty (mimics gh exit 1 on a missing route).
+        return mock.Mock(returncode=1, stdout="", stderr="")
+
+    return _run
+
+
+def test_probe_canonical_match_4315(probe_module):
+    """End-to-end: #4315 ↔ PR #4345 ↔ sibling #4322 (canonical AC1).
+
+    Issue #4315 has ``Found by: retrospective on #4304.`` and mentions
+    ``_DATACLASS_SCOPE`` + ``*SplitRuling`` in backticks. Sibling #4322
+    is closed by PR #4345, whose body also mentions ``_DATACLASS_SCOPE``
+    in backticks. Probe must emit (4345, 4322, [..._DATACLASS_SCOPE...]).
+    """
+    issue_body = (
+        "## Description\n"
+        "\n"
+        "When a new `*SplitRuling` dataclass is missing from `_DATACLASS_SCOPE`,\n"
+        "the check should emit a paste-ready hint.\n"
+        "\n"
+        "## Background\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = (
+        "## Summary\n"
+        "\n"
+        "Make `_DATACLASS_SCOPE` self-diagnosing when a new `*SplitRuling`\n"
+        "dataclass is missing.\n"
+        "\n"
+        "Closes #4322\n"
+    )
+    responses = {
+        # gh search issues "...retrospective on #4304..." → returns sibling #4322
+        ("search", "issues"): (
+            0,
+            '[{"number": 4322}]',
+        ),
+        # gh issue view 4322 --json closedByPullRequestsReferences → PR #4345
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        # gh pr view 4345 --json body,mergedAt,baseRefName → eligible
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4315
+        )
+    assert hit is not None
+    pr, sibling, identifiers = hit
+    assert pr == 4345
+    assert sibling == 4322
+    # Both identifiers are present in both bodies → both in the overlap.
+    assert "_DATACLASS_SCOPE" in identifiers
+    assert "*SplitRuling" in identifiers
+
+
+def test_probe_no_lineage_returns_none(probe_module):
+    """Issue body without ``Found by: retrospective on #N`` exits 1.
+
+    Issues without the retrospective-lineage signal must fall through to
+    the path-overlap channel. The probe extracts zero parents and returns
+    None unconditionally — no gh calls are made.
+    """
+    issue_body = "## Description\n\nA bug fix in `widget_loader`.\n"
+    with mock.patch("subprocess.run") as m:
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+        # No gh subprocess calls because there's nothing to look up.
+        m.assert_not_called()
+    assert hit is None
+
+
+def test_probe_no_token_overlap_returns_none(probe_module):
+    """Sibling describes a DIFFERENT lesson (no identifier overlap) → exit 1.
+
+    AC2: precision case. The current issue has retrospective lineage AND
+    a sibling has shipped, but the sibling's PR body does not share any
+    backtick-wrapped identifiers with the current issue. The lineage
+    channel must not fire — fall through to path-overlap.
+    """
+    issue_body = (
+        "Update `_DATACLASS_SCOPE` to include the new entry.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = (
+        "## Summary\n\n"
+        "Tighten the `regex_validator` for trailing whitespace.\n\n"
+        "Closes #4399\n"
+    )
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4399}]'),
+        ("issue", "view", "4399"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4400, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4400"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_sibling_has_no_merging_pr(probe_module):
+    """Sibling closed without a merging PR → skip, exit 1 if no other siblings.
+
+    Sibling closed manually (``--reason completed``) has empty
+    ``closedByPullRequestsReferences``. The probe must skip the sibling
+    and exit 1 when there are no other candidates.
+    """
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4500}]'),
+        ("issue", "view", "4500"): (
+            0,
+            '{"closedByPullRequestsReferences": []}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_sibling_pr_unmerged(probe_module):
+    """Sibling's PR is unmerged (mergedAt null) → skip, exit 1."""
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    pr_body = "Body mentions `_DATACLASS_SCOPE`.\n\nCloses #4322"
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4322}]'),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": null, "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_sibling_pr_feature_branch(probe_module):
+    """Sibling's PR merged onto a feature branch (not main) → skip, exit 1."""
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    pr_body = "Body mentions `_DATACLASS_SCOPE`.\n\nCloses #4322"
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4322}]'),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "feature/wip"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_excludes_self_from_siblings(probe_module):
+    """Current-issue number is excluded from the sibling list.
+
+    GitHub's search may return the current issue itself in the results
+    when the issue body's ``Found by:`` line is what triggered the
+    search match. The probe must drop self-matches — an issue's
+    duplicate cannot be itself.
+    """
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    # The search returns ONLY the current issue — no siblings to vet.
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4515}]'),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_no_backtick_tokens_in_body(probe_module):
+    """Issue body has retrospective lineage but no backtick tokens → exit 1.
+
+    An issue with zero backtick-wrapped identifiers cannot clear the
+    single-token overlap threshold no matter what the sibling PR shipped.
+    The probe returns None without making gh calls.
+    """
+    issue_body = (
+        "Update the dataclass scope to include the new entry.\n\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    with mock.patch("subprocess.run") as m:
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+        # No gh calls — empty current-tokens short-circuits before search.
+        m.assert_not_called()
+    assert hit is None
+
+
+def test_probe_search_api_error_exits_clean(probe_module):
+    """gh search exits 1 → probe exits 1 (no crash)."""
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    responses = {
+        # gh search issues returns rc=1
+        ("search", "issues"): (1, ""),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_malformed_search_json_exits_clean(probe_module):
+    """gh search returns malformed JSON → probe exits 1 (no crash)."""
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    responses = {
+        ("search", "issues"): (0, "not-json {{"),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is None
+
+
+def test_probe_first_match_wins_when_multiple_siblings(probe_module):
+    """When multiple siblings have shipped, the first match is emitted.
+
+    Search returns siblings in most-recently-updated order; the probe
+    walks them in that order and emits the first identifier-overlap hit.
+    """
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    pr_body_first = "Updates `_DATACLASS_SCOPE` self-diagnosis.\n\nCloses #4322"
+    responses = {
+        # Two siblings — both eventually clear overlap, but the first
+        # candidate (4322) is checked first and short-circuits.
+        ("search", "issues"): (
+            0,
+            '[{"number": 4322}, {"number": 4399}]',
+        ),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body_first).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is not None
+    pr, sibling, _ = hit
+    assert pr == 4345
+    assert sibling == 4322


### PR DESCRIPTION
## Summary

Add a third probe channel to `scripts/check-shipped-pr.sh` — the **retrospective-lineage probe** — that catches the canonical retrospective-duplicate shape: two issues filed from the same parent retrospective describe the same lesson, one already merged. Runs after the literal-Verify channel and before the path-overlap channel.

Algorithm: parse the issue body for `Found by:.*retrospective on #N`; for each lineage parent, search closed sibling issues that match the same phrase; find each sibling's closing PR via `closedByPullRequestsReferences`; drop unmerged / non-main candidates; match on ≥1 backtick-token overlap (length ≥3, stopword-filtered) between the current-issue body and the candidate-PR body.

Live verification — `scripts/check-shipped-pr.sh 4315` now returns `shipped: PR #4324 matches issue #4515 via lineage probe (sibling retrospective #4316) (exit 0)`.

Closes #4515

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` on new Python files — 0 errors)
- [x] Format check passes (`ruff format --check` — 3/3 already formatted)
- [x] Tests pass — 26 new unit tests for the lineage probe; 41/41 integration tests; 145/145 related Python tests across the check-shipped-pr family
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (CI / dev-time tooling only). The new helper is invoked exclusively by `scripts/check-shipped-pr.sh` during `/task` pickup; no service / API / DB / frontend changes.
