### PR TITLE
fix(dx): extend check-shipped-pr.sh lineage probe to more idioms (#4519)

### DIFF
--- a/scripts/_check_shipped_pr_lineage_probe.py
+++ b/scripts/_check_shipped_pr_lineage_probe.py
@@ -46,15 +46,18 @@
 #   - On error / malformed input: empty stdout and exit 2.
 #
 # Algorithm:
-#   1. Parse the issue body for ``Found by:.*retrospective on #(\d+)``.
-#      Each captured number is a *lineage parent*. Multiple matches in
-#      the same body are deduplicated.
+#   1. Parse the issue body for any recognized lineage idiom (#4519):
+#      ``Found by: retrospective on #N``, ``Found while shipping #N``,
+#      ``Same lesson as #N``, or ``Adjacent to #N`` (all
+#      case-insensitive). Each captured number is a *lineage parent*.
+#      Multiple matches in the same body are deduplicated and ordered by
+#      first-occurrence position across all idioms.
 #   2. For each lineage parent, list closed issues whose body references
-#      ``retrospective on #<parent>`` via
-#      ``gh search issues "in:body retrospective on #<parent> repo:<repo>
-#       state:closed" --json number,body``.
-#      Drop the current issue itself from the result set (an issue
-#      naming itself as a sibling is the same issue).
+#      the parent via any of the same lineage idioms. The probe issues
+#      one ``gh search issues`` call per phrase and unions the results
+#      client-side (``gh search`` OR semantics on quoted phrases are not
+#      reliable across the GraphQL backend). Drop the current issue
+#      itself and the parent itself from the result set.
 #   3. For each sibling, fetch its merging PR via
 #      ``gh issue view <sibling> --json closedByPullRequestsReferences``.
 #      Pre-#3994 placeholder-titled PRs that lack ``Closes #N`` keywords
@@ -98,10 +101,12 @@
 #   - Two retrospective siblings against the same parent that describe
 #     genuinely different lessons → no backtick-token overlap → exit 1.
 #     This is the precision case from the issue's AC2.
-#   - The current issue has no ``Found by: retrospective on #N`` line
-#     in its body → the lineage probe extracts zero parents and exits 1
-#     unconditionally. Issues without retrospective lineage fall through
-#     to the path-overlap channel as before.
+#   - The current issue has no recognized lineage idiom in its body
+#     (none of ``Found by: retrospective on #N``, ``Found while shipping
+#     #N``, ``Same lesson as #N``, or ``Adjacent to #N``) → the lineage
+#     probe extracts zero parents and exits 1 unconditionally. Issues
+#     without retrospective lineage fall through to the path-overlap
+#     channel as before.
 #   - The lineage parent's siblings are all still open (no merging PRs)
 #     → no candidate PRs → exit 1. This is by design — the channel only
 #     fires when a sibling has DEMONSTRABLY shipped (closed by a merged
@@ -131,28 +136,78 @@ import sys
 
 # ─── Lineage parent extraction ─────────────────────────────────────────────
 
-# Match ``Found by: retrospective on #N`` (case-insensitive). The colon
-# is optional; the "retrospective on" phrase is the load-bearing signal.
-# Variations observed in the corpus:
-#   - ``Found by: retrospective on #4304.``           (canonical)
-#   - ``Found by retrospective on #4304``             (no colon)
-#   - ``found by: retrospective on #4304``            (lowercase)
-LINEAGE_PARENT_RE = re.compile(
-    r"Found\s+by:?\s+retrospective\s+on\s+#(\d+)",
-    re.IGNORECASE,
+# Lineage idioms (#4519). Each regex captures a parent issue number from
+# a body phrase that signals "this issue was filed because of work on #N."
+# All matchers are case-insensitive.
+#
+# Canonical idiom:
+#   - ``Found by: retrospective on #N`` (canonical, established by #4515)
+#   - ``Found by retrospective on #N``  (no colon)
+#   - ``found by: retrospective on #N`` (lowercase)
+#
+# Additional idioms (#4519) — same lineage signal, different phrasings
+# observed in the corpus:
+#   - ``Found while shipping #N``  (e.g. issue #4322 cites #4303 this way)
+#   - ``Same lesson as #N``        (explicit cross-reference)
+#   - ``Adjacent to #N``           (sibling-issue link)
+#
+# All four share the same precision-defense — the gating signal is
+# "this issue cites another issue as its lineage source," and the
+# downstream identifier-overlap check still applies. Adding more
+# matchers expands recall without inflating false-positive rate.
+LINEAGE_PARENT_RES: tuple[re.Pattern[str], ...] = (
+    # Canonical "Found by: retrospective on #N" form.
+    re.compile(
+        r"Found\s+by:?\s+retrospective\s+on\s+#(\d+)",
+        re.IGNORECASE,
+    ),
+    # "Found while shipping #N" — same idiom, different phrasing.
+    re.compile(
+        r"Found\s+while\s+shipping\s+#(\d+)",
+        re.IGNORECASE,
+    ),
+    # "Same lesson as #N" — explicit cross-reference.
+    re.compile(
+        r"Same\s+lesson\s+as\s+#(\d+)",
+        re.IGNORECASE,
+    ),
+    # "Adjacent to #N" — sibling-issue link.
+    re.compile(
+        r"Adjacent\s+to\s+#(\d+)",
+        re.IGNORECASE,
+    ),
 )
+
+# Backwards-compatibility alias — older call sites and tests may import
+# the original singular name. It points at the canonical retrospective-on
+# matcher so existing references keep their current semantics.
+LINEAGE_PARENT_RE = LINEAGE_PARENT_RES[0]
 
 
 def extract_lineage_parents(body: str) -> list[int]:
     """Return the deduplicated list of lineage parent issue numbers.
 
-    Order is preserved by first-occurrence so the caller can prefer
-    earlier mentions when multiple parents are cited (rare).
+    Walks every recognized lineage idiom (canonical
+    ``Found by: retrospective on #N`` plus the #4519 variants:
+    ``Found while shipping #N``, ``Same lesson as #N``, ``Adjacent to #N``)
+    and unions the captured parent numbers.
+
+    Order is preserved by first-occurrence in the body so the caller can
+    prefer earlier mentions when multiple parents are cited (rare). When
+    a body uses two different idioms to cite the same parent, only the
+    first-seen occurrence is kept.
     """
     seen: set[int] = set()
     out: list[int] = []
-    for m in LINEAGE_PARENT_RE.finditer(body):
-        n = int(m.group(1))
+    # Walk every match across all idioms in body order. We can't iterate
+    # them per-pattern and concatenate because that would lose body-order
+    # — we have to scan once and pick up matches from any pattern.
+    matches: list[tuple[int, int]] = []
+    for pattern in LINEAGE_PARENT_RES:
+        for m in pattern.finditer(body):
+            matches.append((m.start(), int(m.group(1))))
+    matches.sort(key=lambda x: x[0])
+    for _, n in matches:
         if n not in seen:
             seen.add(n)
             out.append(n)
@@ -241,16 +296,40 @@ def _run_gh(args: list[str], *, timeout_sec: int = 30) -> tuple[int, str]:
         return 124, ""
 
 
+# Search phrases that signal "this closed issue is a sibling
+# retrospective citing the same parent" (#4519). Each entry is a phrase
+# template — ``{parent}`` is substituted with the parent issue number.
+# The phrases mirror the ``LINEAGE_PARENT_RES`` matchers above so any
+# idiom recognized by the body parser is also discoverable via search.
+#
+# Why a tuple of phrases instead of one OR'd query: ``gh search
+# issues "..."`` interprets the entire string as a single query token
+# and the OR semantics on quoted phrases are not reliable across the
+# GraphQL backend. Multiple search calls + client-side union is the
+# straightforward, testable shape.
+LINEAGE_SEARCH_PHRASES: tuple[str, ...] = (
+    "retrospective on #{parent}",
+    "Found while shipping #{parent}",
+    "Same lesson as #{parent}",
+    "Adjacent to #{parent}",
+)
+
+
 def find_sibling_retrospectives(
     parent: int, *, repo: str, current_issue: int
 ) -> list[int]:
-    """Find closed issues whose body references ``retrospective on #<parent>``.
+    """Find closed issues whose body references ``<parent>`` via lineage idioms.
+
+    Searches for all four lineage idioms (#4519):
+    ``retrospective on #N``, ``Found while shipping #N``,
+    ``Same lesson as #N``, and ``Adjacent to #N``. Unions the results
+    in search-result order (the canonical retrospective-on phrase
+    runs first, matching prior precedence; subsequent phrases append
+    only their non-duplicate hits).
 
     Excludes ``current_issue`` AND ``parent`` from the result (the parent
     issue's body sometimes also matches the literal string when a
-    follow-up retrospective comment references back to itself). Returns
-    a list of issue numbers. Order is search-result order (most-recently-
-    updated first by default with ``gh search issues``).
+    follow-up retrospective comment references back to itself).
 
     Why the search query uses CLI flags instead of inline ``repo:`` /
     ``state:`` qualifiers: ``gh search issues "..."`` interprets the
@@ -260,49 +339,58 @@ def find_sibling_retrospectives(
     (``--repo``, ``--state``). Wrapping the whole thing in one quoted
     string returns ``Invalid search query`` from gh's GraphQL backend.
     """
-    # Use ``gh search issues`` with a literal-string match in the body.
-    # The query string is the literal phrase to search for; --repo,
-    # --state are passed as separate flags (gh-cli requirement — see
-    # docstring above).
-    query = f'"retrospective on #{parent}"'
-    rc, out = _run_gh(
-        [
-            "search",
-            "issues",
-            query,
-            "--repo",
-            repo,
-            "--state",
-            "closed",
-            "--json",
-            "number",
-            "--limit",
-            "20",
-        ],
-    )
-    if rc != 0 or not out.strip():
-        return []
-    try:
-        data = json.loads(out)
-    except json.JSONDecodeError:
-        return []
     siblings: list[int] = []
-    for entry in data:
-        if not isinstance(entry, dict):
+    seen: set[int] = set()
+    for phrase_template in LINEAGE_SEARCH_PHRASES:
+        # Use ``gh search issues`` with a literal-string match in the body.
+        # The query string is the literal phrase to search for; --repo,
+        # --state are passed as separate flags (gh-cli requirement — see
+        # docstring above).
+        phrase = phrase_template.format(parent=parent)
+        query = f'"{phrase}"'
+        rc, out = _run_gh(
+            [
+                "search",
+                "issues",
+                query,
+                "--repo",
+                repo,
+                "--state",
+                "closed",
+                "--json",
+                "number",
+                "--limit",
+                "20",
+            ],
+        )
+        if rc != 0 or not out.strip():
+            # One phrase failing (rate limit, transient API error) does
+            # not abort the whole probe — keep walking the remaining
+            # phrases. The probe is best-effort by design.
             continue
-        n = entry.get("number")
-        if not isinstance(n, int):
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError:
             continue
-        if n == current_issue:
-            continue
-        if n == parent:
-            # The parent itself can match the search when its own body
-            # references the lineage phrase (rare but observed when the
-            # parent retrospective summary mentions follow-up issues
-            # filed against it). Drop it — the parent is the lineage
-            # SOURCE, not a sibling.
-            continue
-        siblings.append(n)
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            n = entry.get("number")
+            if not isinstance(n, int):
+                continue
+            if n == current_issue:
+                continue
+            if n == parent:
+                # The parent itself can match the search when its own
+                # body references the lineage phrase (rare but observed
+                # when the parent retrospective summary mentions
+                # follow-up issues filed against it). Drop it — the
+                # parent is the lineage SOURCE, not a sibling.
+                continue
+            if n in seen:
+                continue
+            seen.add(n)
+            siblings.append(n)
     return siblings
 
 

--- a/scripts/tests/test_check_shipped_pr_lineage_probe.py
+++ b/scripts/tests/test_check_shipped_pr_lineage_probe.py
@@ -120,6 +120,73 @@ def test_extract_ignores_unrelated_retrospective(probe_module):
     assert probe_module.extract_lineage_parents(body) == []
 
 
+# ─── #4519: additional lineage idioms ─────────────────────────────────────
+
+
+def test_extract_found_while_shipping(probe_module):
+    """``Found while shipping #N`` is captured (#4519).
+
+    Issue #4322 uses ``Found while shipping #4303`` instead of the
+    canonical ``Found by: retrospective on #4304`` — same lineage signal,
+    different phrasing.
+    """
+    body = "## Background\n\nFound while shipping #4303.\n"
+    assert probe_module.extract_lineage_parents(body) == [4303]
+
+
+def test_extract_found_while_shipping_lowercase(probe_module):
+    """``found while shipping #N`` (lowercase) is captured (regex i flag)."""
+    body = "found while shipping #4303\n"
+    assert probe_module.extract_lineage_parents(body) == [4303]
+
+
+def test_extract_same_lesson_as(probe_module):
+    """``Same lesson as #N`` is captured (#4519, explicit cross-reference)."""
+    body = "## Note\n\nSame lesson as #4250.\n"
+    assert probe_module.extract_lineage_parents(body) == [4250]
+
+
+def test_extract_same_lesson_as_lowercase(probe_module):
+    """``same lesson as #N`` (lowercase) is captured (regex i flag)."""
+    body = "same lesson as #4250\n"
+    assert probe_module.extract_lineage_parents(body) == [4250]
+
+
+def test_extract_adjacent_to(probe_module):
+    """``Adjacent to #N`` is captured (#4519, sibling-issue link)."""
+    body = "## Note\n\nAdjacent to #4099.\n"
+    assert probe_module.extract_lineage_parents(body) == [4099]
+
+
+def test_extract_adjacent_to_lowercase(probe_module):
+    """``adjacent to #N`` (lowercase) is captured (regex i flag)."""
+    body = "adjacent to #4099\n"
+    assert probe_module.extract_lineage_parents(body) == [4099]
+
+
+def test_extract_multiple_idioms_in_one_body(probe_module):
+    """Body using multiple idioms yields all parents in body order (#4519).
+
+    Order is by first body-position across all idioms — matchers don't
+    cluster output by phrase.
+    """
+    body = (
+        "## Background\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+        "Same lesson as #4250.\n"
+        "Adjacent to #4099.\n"
+        "Found while shipping #4303.\n"
+    )
+    assert probe_module.extract_lineage_parents(body) == [4304, 4250, 4099, 4303]
+
+
+def test_extract_dedupes_across_idioms(probe_module):
+    """Same parent cited via two different idioms yields one entry (#4519)."""
+    body = "Found by: retrospective on #4304.\nAlso: same lesson as #4304.\n"
+    assert probe_module.extract_lineage_parents(body) == [4304]
+
+
 # ─── Layer 2: Backtick-token extraction ───────────────────────────────────
 
 
@@ -457,6 +524,131 @@ def test_probe_malformed_search_json_exits_clean(probe_module):
             issue_body, repo="judgemind/judgemind", current_issue=4515
         )
     assert hit is None
+
+
+def test_probe_finds_sibling_via_found_while_shipping(probe_module):
+    """End-to-end (#4519): sibling whose body uses ``Found while shipping #N``.
+
+    AC3: ``find_sibling_retrospectives`` returns the union of issues
+    matching any of the recognized lineage phrases. A current issue
+    citing ``Found while shipping #4303`` finds a sibling whose body
+    also cites ``Found while shipping #4303``, and the lineage match
+    fires.
+
+    The test simulates the search behavior by routing all four phrase
+    queries (``retrospective on #4303``, ``Found while shipping #4303``,
+    ``Same lesson as #4303``, ``Adjacent to #4303``) to the SAME mock
+    response. In the real world, only the matching phrase would return
+    the sibling — but the probe must work regardless of which idiom
+    surfaces it.
+    """
+    issue_body = (
+        "## Description\n"
+        "\n"
+        "Update the `widget_handler` to drain quickly when the queue is\n"
+        "empty.\n"
+        "\n"
+        "## Background\n"
+        "\n"
+        "Found while shipping #4303.\n"
+    )
+    pr_body = (
+        "## Summary\n"
+        "\n"
+        "Make `widget_handler` self-diagnose empty-queue drain.\n"
+        "\n"
+        "Closes #4321\n"
+    )
+    responses = {
+        # All four phrases route to the same response; any of them
+        # surfacing the sibling is sufficient for the union.
+        ("search", "issues"): (
+            0,
+            '[{"number": 4321}]',
+        ),
+        ("issue", "view", "4321"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4399, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4399"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4519
+        )
+    assert hit is not None
+    pr, sibling, identifiers = hit
+    assert pr == 4399
+    assert sibling == 4321
+    assert "widget_handler" in identifiers
+
+
+def test_find_sibling_unions_all_phrases(probe_module):
+    """``find_sibling_retrospectives`` issues a search for each phrase (#4519).
+
+    Direct test of the union behavior: simulate three phrases that each
+    return a different sibling. Function must return the deduplicated
+    union of all four searches.
+    """
+    # Each phrase returns a different sibling. We use a stateful mock
+    # that returns successive payloads for successive ``search issues``
+    # calls — gh search is the only call exercised here so the order
+    # is deterministic.
+    search_payloads = [
+        '[{"number": 4321}]',  # phrase 1: retrospective on #4303
+        '[{"number": 4322}]',  # phrase 2: Found while shipping #4303
+        '[{"number": 4323}]',  # phrase 3: Same lesson as #4303
+        '[{"number": 4324}]',  # phrase 4: Adjacent to #4303
+    ]
+    state = {"call_count": 0}
+
+    def _stateful(args, **_kwargs):
+        argv = tuple(args[1:])
+        if argv[:2] == ("search", "issues"):
+            idx = state["call_count"]
+            state["call_count"] += 1
+            if idx < len(search_payloads):
+                return mock.Mock(returncode=0, stdout=search_payloads[idx], stderr="")
+        return mock.Mock(returncode=1, stdout="", stderr="")
+
+    with mock.patch("subprocess.run", side_effect=_stateful):
+        siblings = probe_module.find_sibling_retrospectives(
+            4303, repo="judgemind/judgemind", current_issue=4519
+        )
+    # All four searches ran and the union is preserved in order.
+    assert state["call_count"] == 4
+    assert siblings == [4321, 4322, 4323, 4324]
+
+
+def test_find_sibling_dedupes_across_phrases(probe_module):
+    """Sibling returned by multiple phrase searches is included once (#4519).
+
+    If two different phrase searches both return sibling #4321 (because
+    the sibling's body uses two different lineage idioms), the union must
+    de-duplicate.
+    """
+    # Each phrase returns sibling 4321; only the first inclusion counts.
+    state = {"call_count": 0}
+
+    def _stateful(args, **_kwargs):
+        argv = tuple(args[1:])
+        if argv[:2] == ("search", "issues"):
+            state["call_count"] += 1
+            return mock.Mock(returncode=0, stdout='[{"number": 4321}]', stderr="")
+        return mock.Mock(returncode=1, stdout="", stderr="")
+
+    with mock.patch("subprocess.run", side_effect=_stateful):
+        siblings = probe_module.find_sibling_retrospectives(
+            4303, repo="judgemind/judgemind", current_issue=4519
+        )
+    # Four phrase searches ran but the sibling appears once.
+    assert state["call_count"] == 4
+    assert siblings == [4321]
 
 
 def test_probe_first_match_wins_when_multiple_siblings(probe_module):


### PR DESCRIPTION
## Summary

Extends `scripts/_check_shipped_pr_lineage_probe.py` to recognize three additional lineage idioms beyond the canonical `Found by: retrospective on #N` shipped in #4517: `Found while shipping #N`, `Same lesson as #N`, and `Adjacent to #N`. `find_sibling_retrospectives` now unions the results of one `gh search issues` call per phrase template, so any of the four idioms surfaces sibling retrospectives. The identifier-overlap precision gate is unchanged — adding more parent-matching idioms expands recall without inflating false-positive rate.

Closes #4519

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` clean on touched files)
- [x] Format check passes (`ruff format --check` clean)
- [x] Tests pass (`pytest scripts/tests/test_check_shipped_pr_lineage_probe.py` → 37 passed; broader `pytest scripts/tests/` → 1769 passed, 29 skipped)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (script-level helper invoked locally + in `/task` flow)
