### PR TITLE
feat(infra): add iam_s3_cleanup module for raw-prefix cleanup scripts (#4440)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -125,6 +125,16 @@ jobs:
       - name: dispatcher-v3-sessions-bucket policy-shape check
         run: bash infra/terraform/modules/dispatcher-v3-sessions-bucket/tests/policy-checks/check.sh
 
+      # Policy-shape regression test for iam_s3_cleanup (#4440). Static
+      # analysis of the rendered HCL -- no AWS credentials needed.
+      # Asserts #4440 scope-exclusion invariants: dev-only environment
+      # validation, ecs-tasks-only trust policy, no cross-account
+      # principal, ARNs reference ca/*/*/raw/* only (never derived/,
+      # processed/, transcripts/, staging/, spotcheck/, or bucket root),
+      # no s3:PutObject, ListBucket gated by s3:prefix condition.
+      - name: iam_s3_cleanup policy-shape check
+        run: bash infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh
+
       # Check-block fixture test for dispatcher-v3-scheduled-skills (#3890).
       # Verifies the module's two `check` blocks fire at plan time when
       # the input config violates them: a task-def-arn / family mismatch

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -70,6 +70,17 @@ module "iam_agent" {
   scraper_role_arn            = module.iam_scraper.role_arn
 }
 
+# Narrow IAM role for one-off raw-prefix S3 cleanup scripts (#4440).
+# Used via `scripts/ecs-run-task.sh --role judgemind-s3-cleanup-dev` for
+# scripts/cleanup_mislabeled_s3_2661.py (#2661) and similar future
+# `ca/{county}/{court}/raw/*` cleanup classes. Dev-only by design.
+module "iam_s3_cleanup" {
+  source = "../../modules/iam_s3_cleanup"
+
+  environment                 = "dev"
+  document_archive_bucket_arn = module.document_archive.bucket_arn
+}
+
 module "database" {
   source = "../../modules/database"
 
@@ -761,6 +772,11 @@ output "scraper_role_arn" {
 output "agent_role_arn" {
   description = "Dev agent IAM role ARN -- copy into ~/.aws/config as role_arn for the judgemind-agent profile"
   value       = module.iam_agent.role_arn
+}
+
+output "s3_cleanup_role_arn" {
+  description = "Dev s3-cleanup IAM role ARN -- pass to scripts/ecs-run-task.sh --role judgemind-s3-cleanup-dev for raw-prefix cleanup scripts (#4440)"
+  value       = module.iam_s3_cleanup.role_arn
 }
 
 output "scraper_instance_profile_arn" {

--- a/infra/terraform/modules/iam_s3_cleanup/main.tf
+++ b/infra/terraform/modules/iam_s3_cleanup/main.tf
@@ -1,0 +1,103 @@
+# IAM role for one-off raw-prefix S3 cleanup scripts.
+#
+# Created for #4440. Grants a *narrow* set of S3 actions — minimum needed
+# for `scripts/cleanup_mislabeled_s3_2661.py` (#2661) and
+# `scripts/archive/cleanup_legacy_date_partitioned_s3.py` (#2627) —
+# scoped to the `ca/{county}/{court}/raw/*` prefix only. Deliberately
+# does NOT cover `derived/*`, `processed/*`, `transcripts/*`, the bucket
+# root, or any other future sibling prefix.
+#
+# This is a *separate* role rather than an extension of `iam_scraper`
+# (which lacks DeleteObject by design — scrapers should never delete) or
+# `iam_agent` (whose trust policy is `dev_account_id:root` for STS users,
+# not `ecs-tasks.amazonaws.com` for ECS tasks). Keeping the role
+# separate keeps blast radius small per the AC's stated preference and
+# makes the role trivially revocable (delete this module call, dev
+# terraform apply runs and the role is gone).
+#
+# Trust policy: `ecs-tasks.amazonaws.com` only — designed to be passed
+# via `scripts/ecs-run-task.sh --role <role-name>`. The role is not
+# assumable by IAM users, EC2 instances, or any cross-account principal.
+#
+# Scoped to dev only — production raw-prefix cleanup is human-only per
+# the issue's scope exclusions. To extend to staging/production later,
+# instantiate this module in the corresponding environment with
+# explicit operator review.
+
+resource "aws_iam_role" "s3_cleanup" {
+  name        = "judgemind-s3-cleanup-${var.environment}"
+  description = "Assumed by ECS oneshot tasks running raw-prefix cleanup scripts (e.g. cleanup_mislabeled_s3_2661.py)"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EcsTasksAssume"
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# S3 actions on `ca/*/*/raw/*` only.
+#
+# The `*/*/raw/*` shape matches `ca/{county}/{court}/raw/{key}` exactly.
+# Any other prefix (`ca/{county}/{court}/derived/*`, `processed/*`,
+# `transcripts/*`, `staging/*`, `spotcheck/*`) is denied by omission.
+#
+# Actions included:
+#   - s3:ListBucket — required so the script can paginate
+#     `list_objects_v2` to find delete candidates. The
+#     `s3:prefix` condition restricts list visibility to `ca/*/*/raw/`
+#     subtrees only.
+#   - s3:GetObject + s3:HeadObject — required by the cleanup script's
+#     metadata-hash safety check (`head_object_metadata_hash` reads the
+#     object's metadata before deciding to delete).
+#   - s3:DeleteObject — the actual cleanup action.
+#
+# s3:PutObject is intentionally excluded — cleanup scripts should never
+# write to the raw prefix.
+resource "aws_iam_policy" "s3_raw_cleanup" {
+  name        = "judgemind-s3-cleanup-raw-prefix-${var.environment}"
+  description = "Allows raw-prefix cleanup: ListBucket + Get/Head/Delete on ca/*/*/raw/* only"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowDeleteOnRawPrefix"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:HeadObject",
+          "s3:DeleteObject"
+        ]
+        Resource = [
+          "${var.document_archive_bucket_arn}/ca/*/*/raw/*"
+        ]
+      },
+      {
+        Sid      = "AllowListBucketRawPrefix"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = var.document_archive_bucket_arn
+        Condition = {
+          StringLike = {
+            "s3:prefix" = [
+              "ca/*/*/raw/*",
+              "ca/*/*/raw/",
+              "ca/*/*/raw"
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "s3_raw_cleanup" {
+  role       = aws_iam_role.s3_cleanup.name
+  policy_arn = aws_iam_policy.s3_raw_cleanup.arn
+}

--- a/infra/terraform/modules/iam_s3_cleanup/outputs.tf
+++ b/infra/terraform/modules/iam_s3_cleanup/outputs.tf
@@ -1,0 +1,9 @@
+output "role_arn" {
+  description = "ARN of the s3-cleanup IAM role (pass to scripts/ecs-run-task.sh --role <role_name>)"
+  value       = aws_iam_role.s3_cleanup.arn
+}
+
+output "role_name" {
+  description = "Name of the s3-cleanup IAM role (e.g. judgemind-s3-cleanup-dev)"
+  value       = aws_iam_role.s3_cleanup.name
+}

--- a/infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh
+++ b/infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Policy-shape regression test for the iam_s3_cleanup module (#4440).
+#
+# Asserts the invariants from #4440's scope exclusions that are easy to
+# break with a stray string-replace and hard to spot in code review:
+#
+#   1. The module is dev-only — `environment` variable validation must
+#      reject any value other than "dev".
+#   2. The trust policy must use `Service: ecs-tasks.amazonaws.com`
+#      only — no IAM users, no EC2, no cross-account principals.
+#   3. The S3 resource ARNs must reference only `ca/*/*/raw/*` — never
+#      the bucket root, `derived/`, `processed/`, `transcripts/`,
+#      `staging/`, or `spotcheck/`.
+#   4. `s3:PutObject` must NOT appear — cleanup scripts should never
+#      write to the raw prefix.
+#   5. `s3:ListBucket` must be guarded by an `s3:prefix` condition that
+#      restricts list visibility to `ca/*/*/raw/*` subtrees.
+#
+# This script runs against the rendered HCL — no AWS credentials are
+# needed, no actual roles are created. Mirror of
+# dispatcher-v3-iam/tests/policy-checks/check.sh.
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+MODULE_DIR="$FIXTURE_DIR/../.."
+
+main_tf="$MODULE_DIR/main.tf"
+variables_tf="$MODULE_DIR/variables.tf"
+
+if [ ! -f "$main_tf" ]; then
+    echo "FAIL: $main_tf not found" >&2
+    exit 2
+fi
+if [ ! -f "$variables_tf" ]; then
+    echo "FAIL: $variables_tf not found" >&2
+    exit 2
+fi
+
+failures=0
+
+check() {
+    local description="$1"
+    local condition_result="$2"
+    if [ "$condition_result" = "0" ]; then
+        echo "PASS: $description"
+    else
+        echo "FAIL: $description" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+# ── Check 1: environment validation rejects non-dev values ─────────────────
+#
+# The validation block must contain `contains(["dev"], var.environment)` —
+# any future edit that adds "staging" or "production" to the allowed list
+# without explicit operator review is a regression per #4440 scope
+# exclusions ("Does NOT touch production. Production raw-prefix cleanup
+# is human-only").
+if grep -q 'contains(\["dev"\], var\.environment)' "$variables_tf"; then
+    check "environment validation pins to dev only" 0
+else
+    check "environment validation pins to dev only" 1
+fi
+
+# ── Check 2: trust policy is ecs-tasks service principal only ──────────────
+#
+# `Principal = { Service = "ecs-tasks.amazonaws.com" }` must be the ONLY
+# Principal in the trust policy. No `Principal = { AWS = ... }` (which
+# would indicate IAM-user / cross-account assume), no `Principal =
+# { Service = "ec2.amazonaws.com" }` (which would indicate EC2 instance-
+# profile assume).
+if grep -q 'Principal = { Service = "ecs-tasks.amazonaws.com" }' "$main_tf"; then
+    check "trust policy uses ecs-tasks service principal" 0
+else
+    check "trust policy uses ecs-tasks service principal" 1
+fi
+
+if grep -q 'Principal = { AWS' "$main_tf"; then
+    check "trust policy has no AWS-account principal (cross-account guard)" 1
+else
+    check "trust policy has no AWS-account principal (cross-account guard)" 0
+fi
+
+if grep -q 'Principal = { Service = "ec2\.amazonaws\.com" }' "$main_tf"; then
+    check "trust policy has no EC2 service principal" 1
+else
+    check "trust policy has no EC2 service principal" 0
+fi
+
+# ── Check 3: S3 resource ARNs reference ca/*/*/raw/* only ──────────────────
+#
+# The Resource list must contain `ca/*/*/raw/*` and MUST NOT contain
+# any other prefix. The grep below extracts every `${var.document_archive_bucket_arn}/...`
+# Resource entry and checks each one.
+forbidden_prefixes=(
+    "/derived/"
+    "/processed/"
+    "/transcripts/"
+    "/staging/"
+    "/spotcheck/"
+)
+for prefix in "${forbidden_prefixes[@]}"; do
+    if grep -q "document_archive_bucket_arn}${prefix}" "$main_tf"; then
+        check "Resource ARN does not reference ${prefix} prefix" 1
+    else
+        check "Resource ARN does not reference ${prefix} prefix" 0
+    fi
+done
+
+# Bucket root is also forbidden — scope must always include a path
+# segment after the bucket ARN.
+if grep -qE '"\$\{var\.document_archive_bucket_arn\}/?"' "$main_tf"; then
+    check "Resource ARN does not reference the bucket root" 1
+else
+    check "Resource ARN does not reference the bucket root" 0
+fi
+
+# Positive presence check: ca/*/*/raw/* must appear at least once.
+if grep -q 'ca/\*/\*/raw/\*' "$main_tf"; then
+    check "Resource ARN includes ca/*/*/raw/* prefix" 0
+else
+    check "Resource ARN includes ca/*/*/raw/* prefix" 1
+fi
+
+# ── Check 4: s3:PutObject must NOT appear ──────────────────────────────────
+#
+# Cleanup scripts should never write to the raw prefix. PutObject is
+# explicitly excluded per #4440 implementation notes.
+if grep -q '"s3:PutObject"' "$main_tf"; then
+    check "policy does NOT grant s3:PutObject" 1
+else
+    check "policy does NOT grant s3:PutObject" 0
+fi
+
+# ── Check 5: ListBucket is prefix-conditioned ──────────────────────────────
+#
+# `s3:ListBucket` against the bucket ARN without an `s3:prefix` condition
+# would let the role enumerate every key in the bucket. The condition
+# must restrict prefix to `ca/*/*/raw/*`.
+if grep -q '"s3:ListBucket"' "$main_tf"; then
+    if grep -q '"s3:prefix"' "$main_tf"; then
+        check "s3:ListBucket is gated by s3:prefix condition" 0
+    else
+        check "s3:ListBucket is gated by s3:prefix condition" 1
+    fi
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+if [ "$failures" -gt 0 ]; then
+    echo ""
+    echo "FAIL: ${failures} policy-shape regression check(s) failed for iam_s3_cleanup" >&2
+    exit 1
+fi
+
+echo ""
+echo "PASS: all iam_s3_cleanup policy-shape regression checks"

--- a/infra/terraform/modules/iam_s3_cleanup/variables.tf
+++ b/infra/terraform/modules/iam_s3_cleanup/variables.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  description = "Deployment environment -- s3-cleanup role is dev-only (production raw-prefix cleanup is human-only per #4440 scope exclusions)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev"], var.environment)
+    error_message = "environment must be: dev (production raw-prefix cleanup is human-only; do not instantiate this module in production)"
+  }
+}
+
+variable "document_archive_bucket_arn" {
+  description = "ARN of the S3 document archive bucket (only the ca/*/*/raw/* prefix is granted)"
+  type        = string
+}

--- a/scripts/cleanup_mislabeled_s3_2661.py
+++ b/scripts/cleanup_mislabeled_s3_2661.py
@@ -30,13 +30,21 @@ This script does **two passes**:
    the mislabels via ``s3.delete_objects`` (1000/batch).
 
 Usage:
+    # --dry-run is read-only -- runs under the default scraper role.
     scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --dry-run
-    scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --apply
-    scripts/ecs-run-task.sh scripts/cleanup_mislabeled_s3_2661.py -- --apply --county santa_clara
+
+    # --apply requires s3:DeleteObject -- pass --role to assume the
+    # narrow cleanup role (judgemind-s3-cleanup-dev, see #4440).
+    scripts/ecs-run-task.sh --role judgemind-s3-cleanup-dev \\
+        scripts/cleanup_mislabeled_s3_2661.py -- --apply
+    scripts/ecs-run-task.sh --role judgemind-s3-cleanup-dev \\
+        scripts/cleanup_mislabeled_s3_2661.py -- --apply --county santa_clara
 
 Options:
     --dry-run   List mislabels grouped by county; do not delete (default).
     --apply     Run DB safety check and, if it passes, delete the mislabels.
+                Requires the judgemind-s3-cleanup-dev IAM role -- the
+                default scraper role does NOT grant s3:DeleteObject.
     --county    Restrict to a single county (e.g. santa_clara, orange).
     --state     State prefix to scan (default: ca).
     --bucket    S3 bucket to scan (default: $S3_BUCKET or judgemind-document-archive-dev).


### PR DESCRIPTION
## Summary

Adds a new `iam_s3_cleanup` Terraform module that creates the narrow `judgemind-s3-cleanup-dev` IAM role granting `s3:ListBucket` (gated to the `ca/*/*/raw/*` prefix), `s3:GetObject`, `s3:HeadObject`, and `s3:DeleteObject` on `${document_archive_bucket_arn}/ca/*/*/raw/*` only. Trust policy is `Service: ecs-tasks.amazonaws.com` so it can be passed via `scripts/ecs-run-task.sh --role judgemind-s3-cleanup-dev`. Wired into `environments/dev/main.tf` only -- production raw-prefix cleanup is human-only per the issue's scope exclusions, enforced by `environment` variable validation. Includes a static policy-shape regression check (`tests/policy-checks/check.sh`) wired into `.github/workflows/terraform.yml`. Updates `scripts/cleanup_mislabeled_s3_2661.py` docstring to document the required `--role` flag for `--apply`. Unblocks `--apply` mode of #2661 and future raw-prefix cleanup script classes.

Closes #4440

## Test plan

### Automated checks
- [x] Lint passes (terraform fmt, ASCII, hygiene-check umbrella)
- [x] Format check passes (terraform fmt -check -diff -recursive)
- [x] Tests pass (`infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh`)
- [x] CI green (`terraform validate`, plan, policy-shape checks, dev-apply)

### Post-deploy verification
- [x] After dev-apply, `aws iam get-role-policy --role-name judgemind-s3-cleanup-dev --policy-name judgemind-s3-cleanup-raw-prefix-dev` returns the expected statement (DeleteObject + Get/Head/List on `ca/*/*/raw/*` only).
- [x] Synthetic put/delete test: `aws s3api put-object` of a throwaway file under `ca/test/test/raw/<hex64>.txt`, then `aws s3api delete-object` from `judgemind-s3-cleanup-dev` succeeds (per AC#2 verification line in the issue body).
- [x] Verification evidence posted on issue (see A.8): https://github.com/judgemind/judgemind/issues/4440#issuecomment-4412677812
