### PR TITLE
fix(dx): suppress lineage probe matches on extension-class issues (#4523)

### DIFF
--- a/scripts/_check_shipped_pr_classify_issue.py
+++ b/scripts/_check_shipped_pr_classify_issue.py
@@ -88,6 +88,28 @@ def classify(title: str, body: str) -> bool:
     return bool(AUDIT_KEYWORDS_REGEX.search(combined))
 
 
+# Predicate alias (#4523). The lineage probe consumes audit-class as a
+# boolean predicate ("should the lineage match be suppressed?"), and the
+# semantic predicate name reads more naturally at the call site than
+# ``classify(title, body)`` — which sounds like it returns the class
+# label rather than a boolean. Both names point at the same regex; the
+# alias is purely an ergonomics / readability improvement, not a
+# behavior change.
+def is_audit_class(title: str, body: str) -> bool:
+    """Predicate alias of ``classify`` — True iff title+body is audit-class.
+
+    Used by the retrospective-lineage probe (#4523) to gate FP-suppression
+    on extension-class issues. The audit-class verb list (``audit``,
+    ``investigate``, ``refactor``, ``migrate``, ``extend``, ``tighten``,
+    ``harden``, ``additional`` plus noun forms) already covers the
+    "extension-class" intent the lineage gate cares about — an issue
+    titled ``extend the lineage probe`` matches via ``extend``, an issue
+    titled ``additional patterns`` matches via ``additional``. Reusing
+    the existing classifier keeps the verb list in one place.
+    """
+    return classify(title, body)
+
+
 def main() -> int:
     try:
         data = json.load(sys.stdin)

--- a/scripts/_check_shipped_pr_lineage_probe.py
+++ b/scripts/_check_shipped_pr_lineage_probe.py
@@ -111,6 +111,22 @@
 #     → no candidate PRs → exit 1. This is by design — the channel only
 #     fires when a sibling has DEMONSTRABLY shipped (closed by a merged
 #     PR), not when one is just open.
+#   - Extension-class suppression (#4523). When the current issue's
+#     title classifies as audit / extension-class via the existing
+#     audit-class classifier (``audit``, ``investigate``, ``refactor``,
+#     ``migrate``, ``extend``, ``tighten``, ``harden``, ``additional``
+#     plus noun forms — see ``_check_shipped_pr_classify_issue.py``)
+#     AND the lineage candidate PR's number OR the sibling's number
+#     appears among the ``#N`` references in the current issue's body,
+#     the probe suppresses that candidate. Concrete reproducer:
+#     issue #4519 ↔ PR #4517 ↔ sibling #4515. #4519's title
+#     ``extend the lineage probe to recognize more idioms`` matches
+#     ``extend`` (extension-class), and #4519's body cites ``#4515``
+#     and ``#4517`` directly — the candidate is suppressed because
+#     the AC author already knows about the prior PR and is asking
+#     for follow-up work, not declaring the work done. The probe
+#     continues to the next candidate; if none clear the gate, the
+#     probe exits 1.
 #
 # Environment variables:
 #   CHECK_SHIPPED_LINEAGE_REPO     — override "judgemind/judgemind"
@@ -128,11 +144,13 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 # ─── Lineage parent extraction ─────────────────────────────────────────────
 
@@ -212,6 +230,114 @@ def extract_lineage_parents(body: str) -> list[int]:
             seen.add(n)
             out.append(n)
     return out
+
+
+# ─── Cited-issue / cited-PR extraction (#4523 extension-class gate) ───────
+
+# Match every ``#N`` reference in an issue body: the parent retrospective,
+# explicit sibling links, prior-art PR / issue numbers, etc. Word boundary
+# on the right keeps ``#4515`` from also matching ``#45151``-style longer
+# runs by accident; the digit class is greedy by default.
+#
+# This is a SUPERSET of `LINEAGE_PARENT_RES`. The lineage parent regex
+# only fires when the ``#N`` appears inside a recognized lineage idiom
+# (``Found by: retrospective on``, etc.); this regex captures every
+# bare ``#N`` mention regardless of surrounding text. The two are used
+# for different purposes — lineage parents drive the search, cited
+# numbers drive the extension-class suppression gate.
+CITED_ISSUE_RE = re.compile(r"#(\d+)\b")
+
+
+def extract_cited_issue_numbers(body: str) -> set[int]:
+    """Return the set of every ``#N`` reference in ``body``.
+
+    Used by the extension-class suppression gate (#4523). When the
+    current issue's title classifies as audit/extension-class AND the
+    lineage candidate PR — or its sibling — appears in this set, the
+    issue is by intent asking for follow-up work on the same code
+    path and the lineage match is almost always a false positive.
+    """
+    out: set[int] = set()
+    for m in CITED_ISSUE_RE.finditer(body):
+        try:
+            out.add(int(m.group(1)))
+        except ValueError:
+            # Defensive: \d+ guarantees an integer, but keep the
+            # try/except so a future regex tweak that introduces a
+            # broader capture group does not crash the probe.
+            continue
+    return out
+
+
+# ─── Audit-class classifier import (#4523) ────────────────────────────────
+#
+# The lineage probe consults the existing audit-class classifier from
+# `_check_shipped_pr_classify_issue.py` to decide whether the current
+# issue's title is "extension-class" — i.e. the AC author is asking for
+# follow-up work on already-shipped code. The classifier's verb list
+# (``audit``, ``investigate``, ``refactor``, ``migrate``, ``extend``,
+# ``tighten``, ``harden``, ``additional``) already covers the
+# extension-class intent the lineage gate needs; sharing the verb list
+# keeps it in one place.
+#
+# Loading via ``importlib.util.spec_from_file_location`` because the
+# sibling helper's filename starts with an underscore (``_check_...``)
+# and ``scripts/`` is not a Python package — the standard
+# ``import scripts._check_shipped_pr_classify_issue`` path doesn't apply.
+# Same loader pattern as the test file uses to import the probe itself.
+def _load_classifier_module():
+    """Load the audit-class classifier module by file path.
+
+    Returns the loaded module, or None if the helper cannot be located
+    (defensive against ad-hoc invocations / partial checkouts). When
+    None, the extension-class gate becomes a no-op — the probe behaves
+    exactly as it did pre-#4523, which is the intended degradation
+    path: a missing classifier helper falls back to the higher-recall
+    pre-gate behavior (more matches, including some FPs), not to a
+    crash.
+    """
+    here = Path(__file__).resolve().parent
+    classifier_path = here / "_check_shipped_pr_classify_issue.py"
+    if not classifier_path.is_file():
+        return None
+    spec = importlib.util.spec_from_file_location(
+        "check_shipped_pr_classify_issue", classifier_path
+    )
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        return None
+    return module
+
+
+def is_extension_class(title: str, body: str) -> bool:
+    """Return True when ``title`` + ``body`` classify as extension-class.
+
+    The lineage probe's extension-class gate (#4523) suppresses FPs
+    where the current issue's intent is "extend / harden / refactor
+    work that already shipped." This is exactly the audit-class verb
+    set the classifier already implements (see
+    ``_check_shipped_pr_classify_issue.py`` — ``audit``, ``investigate``,
+    ``refactor``, ``migrate``, ``extend``, ``tighten``, ``harden``,
+    ``additional`` plus noun forms). Reuse rather than duplicate.
+
+    When the classifier helper cannot be loaded (ad-hoc invocation,
+    partial checkout), this function returns False — the gate becomes
+    a no-op and pre-#4523 behavior is preserved.
+    """
+    mod = _load_classifier_module()
+    if mod is None:
+        return False
+    fn = getattr(mod, "is_audit_class", None) or getattr(mod, "classify", None)
+    if fn is None:
+        return False
+    try:
+        return bool(fn(title, body))
+    except Exception:
+        return False
 
 
 # ─── Backtick-token extraction ─────────────────────────────────────────────
@@ -469,12 +595,30 @@ def fetch_pr_body(pr: int, *, repo: str) -> tuple[str, bool] | None:
 
 
 def probe(
-    body: str, *, repo: str, current_issue: int
+    body: str, *, repo: str, current_issue: int, title: str = ""
 ) -> tuple[int, int, list[str]] | None:
     """Run the lineage probe against ``body``.
 
     Returns ``(pr, sibling, identifiers)`` on the first match, or None
     when no lineage candidate clears the identifier-overlap threshold.
+
+    Extension-class suppression (#4523):
+        When ``title`` + ``body`` classify as audit / extension-class
+        via ``is_extension_class()``, the gate suppresses any
+        candidate (sibling, PR) pair whose sibling number OR PR
+        number appears among the ``#N`` references in the current
+        issue's body. The current issue is by intent asking for
+        follow-up work on a code path it explicitly cites; a lineage
+        match against a PR the issue itself names is almost always
+        a false positive.
+
+        ``title`` is optional and defaults to ``""`` to preserve
+        backwards-compat with callers that don't have the title
+        handy. Empty title + body without audit-class keywords yields
+        ``is_extension_class() == False`` and the gate is a no-op.
+        Probe walks each (sibling, PR) candidate in search order and
+        emits the FIRST match that clears the identifier-overlap
+        threshold AND is not suppressed by the extension-class gate.
     """
     parents = extract_lineage_parents(body)
     if not parents:
@@ -487,6 +631,12 @@ def probe(
         # with zero backtick spans is too weak a signal for a lineage
         # match no matter how the parent's siblings shipped.
         return None
+
+    # Extension-class suppression gate (#4523). Compute once outside
+    # the inner loop — both inputs (title, body) are loop-invariant.
+    extension_class = is_extension_class(title, body)
+    cited_numbers = extract_cited_issue_numbers(body) if extension_class else set()
+
     for parent in parents:
         siblings = find_sibling_retrospectives(
             parent, repo=repo, current_issue=current_issue
@@ -505,6 +655,21 @@ def probe(
             overlap = current_tokens & pr_tokens
             if not overlap:
                 continue
+            # Extension-class suppression — does this candidate's
+            # PR or sibling appear in the cited-numbers set?
+            #
+            # Concrete reproducer (#4519 ↔ PR #4517 ↔ sibling #4515):
+            #   - issue #4519 title classifies as audit-class via
+            #     ``extend`` — extension_class == True
+            #   - #4519 body cites ``#4515`` (and ``#4517``) in
+            #     prose — both numbers land in cited_numbers
+            #   - lineage probe walks #4304 → finds sibling #4515
+            #     → finds closing PR #4517 → token overlap fires
+            #   - #4515 ∈ cited_numbers OR #4517 ∈ cited_numbers
+            #     → gate suppresses, continue to next sibling
+            #   - no other candidates clear the gate → return None
+            if extension_class and (sibling in cited_numbers or pr in cited_numbers):
+                continue
             # Sort for stable output across runs.
             return pr, sibling, sorted(overlap)
     return None
@@ -518,13 +683,18 @@ def main() -> int:
     body = data.get("body") or ""
     if not body:
         return 1
+    # Title is optional in the JSON envelope (#4523). The shell wrapper
+    # passes ``--json body,title,createdAt`` so the title is present in
+    # production calls; defensive fallback to "" preserves backwards
+    # compat for ad-hoc / partial invocations that pass only ``body``.
+    title = data.get("title") or ""
     repo = os.environ.get("CHECK_SHIPPED_LINEAGE_REPO", "judgemind/judgemind")
     current_issue_str = os.environ.get("CHECK_SHIPPED_LINEAGE_ISSUE", "")
     try:
         current_issue = int(current_issue_str) if current_issue_str else 0
     except ValueError:
         current_issue = 0
-    hit = probe(body, repo=repo, current_issue=current_issue)
+    hit = probe(body, repo=repo, current_issue=current_issue, title=title)
     if hit is None:
         return 1
     pr, sibling, identifiers = hit

--- a/scripts/tests/test_check_shipped_pr_lineage_probe.py
+++ b/scripts/tests/test_check_shipped_pr_lineage_probe.py
@@ -36,6 +36,8 @@ a package).
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
 import sys
 from pathlib import Path
 from unittest import mock
@@ -685,3 +687,391 @@ def test_probe_first_match_wins_when_multiple_siblings(probe_module):
     pr, sibling, _ = hit
     assert pr == 4345
     assert sibling == 4322
+
+
+# ─── #4523: extension-class suppression gate ──────────────────────────────
+
+
+def test_cited_issue_numbers_extracts_all(probe_module):
+    """``extract_cited_issue_numbers`` returns every ``#N`` reference (#4523).
+
+    Used by the extension-class suppression gate to identify candidate
+    PRs / siblings the current issue is asking the agent to extend.
+    """
+    body = (
+        "## Found by\n"
+        "\n"
+        "`/task` retrospective on issue #4519 (extending the lineage probe).\n"
+        "\n"
+        "## Description\n"
+        "\n"
+        "PR #4517 shipped the original. Sibling #4515 cited it. See also\n"
+        "#4304 for the parent retrospective.\n"
+    )
+    assert probe_module.extract_cited_issue_numbers(body) == {4304, 4515, 4517, 4519}
+
+
+def test_cited_issue_numbers_empty_body(probe_module):
+    """``extract_cited_issue_numbers`` returns empty set for empty body (#4523)."""
+    assert probe_module.extract_cited_issue_numbers("") == set()
+
+
+def test_cited_issue_numbers_no_hash_references(probe_module):
+    """Body without ``#N`` returns empty set (#4523)."""
+    body = "Some prose that mentions issue numbers like 4515 but never with a hash.\n"
+    assert probe_module.extract_cited_issue_numbers(body) == set()
+
+
+def test_is_extension_class_via_extend_keyword(probe_module):
+    """``is_extension_class`` returns True for ``extend`` titles (#4523).
+
+    The classifier reuses the audit-class verb list, which already
+    includes ``extend|extension``. An issue titled ``extend the lineage
+    probe`` matches without any classifier change.
+    """
+    title = "fix(dx): extend the lineage probe to recognize more idioms"
+    body = "Some body."
+    assert probe_module.is_extension_class(title, body) is True
+
+
+def test_is_extension_class_via_additional_keyword(probe_module):
+    """``is_extension_class`` returns True for ``additional`` (#4523)."""
+    title = "dx: additional patterns for foo"
+    body = ""
+    assert probe_module.is_extension_class(title, body) is True
+
+
+def test_is_extension_class_returns_false_for_non_audit(probe_module):
+    """``is_extension_class`` returns False for canonical non-audit titles (#4523)."""
+    title = "feat(api): expose new graphql resolver for caseDetail"
+    body = "Add the resolver and the corresponding schema entry."
+    assert probe_module.is_extension_class(title, body) is False
+
+
+def test_extension_class_suppresses_lineage(probe_module):
+    """Extension-class title + cited sibling → lineage match suppressed (#4523).
+
+    AC1: When the current issue's title classifies as extension-class
+    via ``is_audit_class()`` AND the lineage candidate's sibling number
+    (or candidate PR number) appears in the issue body's ``#N`` set,
+    ``probe()`` returns None instead of emitting ``shipped:``.
+
+    Setup:
+      - Title contains ``extend`` (extension-class)
+      - Body cites #4515 (the sibling) directly in prose
+      - Lineage walks #4304 → finds sibling #4515 → finds closing PR
+        #4517 → token overlap exists
+      - Gate fires because #4515 ∈ cited_numbers → continue
+      - No other candidates → return None
+    """
+    title = "fix(dx): extend the lineage probe to recognize extension-class issues"
+    issue_body = (
+        "## Description\n"
+        "\n"
+        "Extend `find_sibling_retrospectives` to handle the extension-class\n"
+        "case. Sibling #4515 already shipped the base implementation.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = (
+        "## Summary\n\nAdd `find_sibling_retrospectives` and friends.\n\nCloses #4515\n"
+    )
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4515}]'),
+        ("issue", "view", "4515"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4517, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4517"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body,
+            repo="judgemind/judgemind",
+            current_issue=4519,
+            title=title,
+        )
+    # Suppression gate fires — no match emitted.
+    assert hit is None
+
+
+def test_reproduce_4519_false_positive(probe_module):
+    """Reproduces the exact #4519 ↔ PR #4517 ↔ sibling #4515 FP (#4523).
+
+    The reproducer recreates the situation that motivated #4523:
+
+      - #4519's title is ``extend the lineage probe to recognize more
+        idioms`` (extension-class via ``extend`` and ``additional``-shape
+        intent).
+      - #4519's body has ``Found by: retrospective on #4304`` and
+        cites both #4515 (the sibling) and #4517 (the candidate PR)
+        in prose.
+      - PR #4517 closed sibling #4515 and added
+        ``find_sibling_retrospectives``.
+      - Token overlap between #4519's body and PR #4517's body fires
+        on ``find_sibling_retrospectives``.
+
+    Pre-#4523, the probe emitted ``shipped: PR #4517 matches issue
+    #4519`` — a false positive that would have pivoted /task to a
+    bogus verify-and-close path. With the gate in place, the probe
+    returns None and the agent proceeds to do the work the issue
+    actually asked for.
+    """
+    title = "fix(dx): extend the lineage probe to recognize more idioms"
+    issue_body = (
+        "## Description\n"
+        "\n"
+        "`scripts/check-shipped-pr.sh` returned a false positive for issue\n"
+        "#4519: the lineage probe matched PR #4517 against #4519 because\n"
+        "of `find_sibling_retrospectives` overlap. Sibling #4515 is closed\n"
+        "by PR #4517. The probe walks #4515 → PR #4517 → emits `shipped`.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_4517_body = (
+        "## Summary\n"
+        "\n"
+        "Add the retrospective-lineage probe channel for\n"
+        "`check-shipped-pr.sh`. Introduces `find_sibling_retrospectives`\n"
+        "and `extract_lineage_parents`.\n"
+        "\n"
+        "Closes #4515\n"
+    )
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4515}]'),
+        ("issue", "view", "4515"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4517, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4517"): (
+            0,
+            '{"body": '
+            + repr(pr_4517_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-07T12:00:00Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body,
+            repo="judgemind/judgemind",
+            current_issue=4519,
+            title=title,
+        )
+    assert hit is None, (
+        "Pre-#4523, this would emit shipped:4517 — extension-class gate "
+        "must suppress the FP."
+    )
+
+
+def test_extension_class_suppresses_when_pr_cited(probe_module):
+    """Suppression also fires when the candidate PR # is cited directly (#4523).
+
+    Variant of the AC1 case: the issue body cites the candidate PR (not
+    the sibling) by number. The gate suppresses based on either signal —
+    sibling-cited OR PR-cited — because either signal indicates the AC
+    author already knows about the prior work.
+    """
+    title = "refactor(dx): refactor the lineage probe"
+    issue_body = (
+        "Refactor `find_sibling_retrospectives` for clarity.\n"
+        "PR #4517 introduced the function originally.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = "Add `find_sibling_retrospectives` and friends.\n\nCloses #4322"
+    responses = {
+        # Sibling 4322 is NOT cited in body, but its closing PR (4517) IS.
+        ("search", "issues"): (0, '[{"number": 4322}]'),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4517, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4517"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body,
+            repo="judgemind/judgemind",
+            current_issue=4520,
+            title=title,
+        )
+    # PR #4517 is cited in body → suppression fires.
+    assert hit is None
+
+
+def test_extension_class_does_not_suppress_when_neither_cited(probe_module):
+    """Extension-class title alone is not enough — must also cite (#4523).
+
+    Precision case: an extension-class title with an unrelated lineage
+    candidate (sibling not cited, PR not cited in body) should still
+    emit the match. The gate is conjunctive: extension-class AND
+    cited. A bare extension-class title without explicit prior-art
+    references doesn't indicate the author already knows about the
+    prior PR.
+    """
+    title = "refactor(scraper): refactor the URL parser"
+    issue_body = (
+        "Refactor the URL parser to extract `_DATACLASS_SCOPE` cleanly.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = "Updates `_DATACLASS_SCOPE` self-diagnosis.\n\nCloses #4322"
+    responses = {
+        # Neither sibling 4322 nor closing PR 4345 appears in issue body.
+        ("search", "issues"): (0, '[{"number": 4322}]'),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body,
+            repo="judgemind/judgemind",
+            current_issue=4515,
+            title=title,
+        )
+    # Extension-class is True, but neither sibling 4322 nor PR 4345 is
+    # cited in the issue body → gate does NOT fire → match emits.
+    assert hit is not None
+    pr, sibling, _ = hit
+    assert pr == 4345
+    assert sibling == 4322
+
+
+def test_non_extension_class_match_unaffected(probe_module):
+    """Non-extension-class issues match exactly as before (#4523 regression).
+
+    Confirms the gate is a no-op on the canonical non-audit case. An
+    ordinary feature-add issue with retrospective lineage that overlaps
+    the candidate PR's body still matches — the gate only fires for
+    extension-class titles.
+    """
+    title = "feat(scraper): add new URL parser"
+    issue_body = (
+        "Add a new URL parser. Sibling #4322 covered the read path.\n"
+        "Update `_DATACLASS_SCOPE`.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = "Updates `_DATACLASS_SCOPE` self-diagnosis.\n\nCloses #4322"
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4322}]'),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body,
+            repo="judgemind/judgemind",
+            current_issue=4515,
+            title=title,
+        )
+    # Non-extension-class title → gate is a no-op → match emits.
+    assert hit is not None
+    pr, sibling, _ = hit
+    assert pr == 4345
+    assert sibling == 4322
+
+
+def test_probe_title_default_empty_preserves_compat(probe_module):
+    """Calling probe() without ``title=`` keeps pre-#4523 behavior.
+
+    Backwards compat: pre-#4523 callers (and the existing test suite)
+    invoke ``probe(body, repo=..., current_issue=...)`` without the
+    title kwarg. With the default ``title=""``, ``is_extension_class``
+    returns False (no audit keywords in empty title + canonical body)
+    and the gate is a no-op.
+    """
+    issue_body = "Update `_DATACLASS_SCOPE`.\n\nFound by: retrospective on #4304.\n"
+    pr_body = "Updates `_DATACLASS_SCOPE` self-diagnosis.\n\nCloses #4322"
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4322}]'),
+        ("issue", "view", "4322"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4345, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4345"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-08T18:58:05Z", "baseRefName": "main"}',
+        ),
+    }
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        hit = probe_module.probe(
+            issue_body, repo="judgemind/judgemind", current_issue=4515
+        )
+    assert hit is not None
+    pr, sibling, _ = hit
+    assert pr == 4345
+    assert sibling == 4322
+
+
+def test_main_reads_title_from_stdin_envelope(probe_module, capsys, monkeypatch):
+    """``main()`` reads ``title`` from JSON stdin and applies the gate (#4523).
+
+    End-to-end probe of the ``main()`` entrypoint: the shell wrapper
+    pipes ``gh issue view --json body,title,createdAt`` JSON to the
+    probe; ``main()`` must parse the title and pass it to ``probe()``
+    so the extension-class gate can fire on real invocations.
+
+    Constructs the same #4519-shaped reproducer but exercises the
+    stdin / argv / env path rather than calling ``probe()`` directly.
+    """
+    title = "fix(dx): extend the lineage probe to recognize more idioms"
+    issue_body = (
+        "## Description\n"
+        "\n"
+        "PR #4517 introduced `find_sibling_retrospectives`. Sibling #4515.\n"
+        "\n"
+        "Found by: retrospective on #4304.\n"
+    )
+    pr_body = "Add `find_sibling_retrospectives` and friends.\n\nCloses #4515"
+    envelope = {"title": title, "body": issue_body, "createdAt": "2026-05-09T13:00:00Z"}
+    responses = {
+        ("search", "issues"): (0, '[{"number": 4515}]'),
+        ("issue", "view", "4515"): (
+            0,
+            '{"closedByPullRequestsReferences": [{"number": 4517, "state": "MERGED"}]}',
+        ),
+        ("pr", "view", "4517"): (
+            0,
+            '{"body": '
+            + repr(pr_body).replace("'", '"')
+            + ', "mergedAt": "2026-05-07T12:00:00Z", "baseRefName": "main"}',
+        ),
+    }
+    monkeypatch.setenv("CHECK_SHIPPED_LINEAGE_REPO", "judgemind/judgemind")
+    monkeypatch.setenv("CHECK_SHIPPED_LINEAGE_ISSUE", "4519")
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(envelope)))
+    with mock.patch("subprocess.run", side_effect=_make_gh_mock(responses)):
+        rc = probe_module.main()
+    captured = capsys.readouterr()
+    # Suppression fires → main() returns 1, no `shipped:` line emitted.
+    assert rc == 1
+    assert "shipped:" not in captured.out


### PR DESCRIPTION
## Summary

Adds an extension-class suppression gate to `scripts/_check_shipped_pr_lineage_probe.py`. When the current issue's title classifies as audit/extension-class via the existing audit-class classifier AND the lineage candidate's PR number OR sibling number appears among the `#N` references in the issue's body, the probe suppresses that candidate. Drops the canonical FP class where an extension-class issue cites the prior PR/sibling explicitly and the lineage probe walks back to that same PR via token overlap (concrete reproducer: issue #4519 ↔ PR #4517 ↔ sibling #4515).

Closes #4523

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (50 lineage probe tests including 13 new, 169 in check-shipped-pr family, 41 shell wrapper tests)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (scripts/dx tooling only; runs locally and in /task subagents)
- [ ] Verification evidence posted on issue (see A.8)
