### PR TITLE
feat(dx): scripts/gh-pr-with-retry.sh wrapper for graphql rate-limit fallback (#4527)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -684,12 +684,13 @@ The **Post-deploy verification** section must include at least one concrete veri
 - [ ] N/A — no deployed component (docs/CI/tooling only)
 ```
 
-Create the PR (write — stays on `gh` until MCP writes land):
+Create the PR via the `gh-pr-with-retry.sh` wrapper (#4527). The wrapper invokes `gh pr create` first and falls back to `gh api -X POST /repos/.../pulls` on the explicit `GraphQL: API rate limit already exceeded` stderr marker — same shape as `gh-comment-with-retry.sh` (#4503). Auth, validation, and other 5xx failures pass through unchanged. Pass the worktree branch explicitly to `--head` (the wrapper does not infer it from `git rev-parse`):
 ```
-gh pr create --repo judgemind/judgemind \
+{worktree}/scripts/gh-pr-with-retry.sh create \
     --title "..." \
     --body-file {worktree}/tmp/pr_body.txt \
-    --base main
+    --base main \
+    --head <branch>
 ```
 
 #### A.4 — Verify no merge conflicts
@@ -755,9 +756,9 @@ Fetch the current PR body via MCP:
 mcp__github__get_pull_request owner=judgemind repo=judgemind pull_number=<PR-N>
 ```
 
-Check off the **Automated checks** items that passed in CI. Do NOT check off **Post-deploy verification** items yet — those are checked in A.8 after merge and deploy. Write the updated body to `{worktree}/tmp/pr_body.txt`, then (write — `gh pr edit` has no MCP equivalent, stays on `gh`):
+Check off the **Automated checks** items that passed in CI. Do NOT check off **Post-deploy verification** items yet — those are checked in A.8 after merge and deploy. Write the updated body to `{worktree}/tmp/pr_body.txt`, then update via the `gh-pr-with-retry.sh` wrapper (#4527 — same GraphQL-quota REST fallback as A.3):
 ```
-gh pr edit <PR-N> --repo judgemind/judgemind --body-file {worktree}/tmp/pr_body.txt
+{worktree}/scripts/gh-pr-with-retry.sh edit <PR-N> --body-file {worktree}/tmp/pr_body.txt
 ```
 
 #### A.7 — Merge the PR
@@ -784,9 +785,9 @@ gh pr view <PR-N> --repo judgemind/judgemind \
   --jq '{mergeable, rollup: [.statusCheckRollup[] | {name, conclusion}]}'
 ```
 
-If `mergeable` is `MERGEABLE`, `ci-passed` is `SUCCESS`, and nothing is `FAILURE`, merge (stays on `gh` — MCP's `merge_pull_request` has no `--delete-branch` flag):
+If `mergeable` is `MERGEABLE`, `ci-passed` is `SUCCESS`, and nothing is `FAILURE`, merge via the `gh-pr-with-retry.sh` wrapper (#4527). The wrapper invokes `gh pr merge` first and falls back to `gh api -X PUT /repos/.../pulls/<N>/merge` on the explicit `GraphQL: API rate limit already exceeded` stderr marker, plus a follow-up `DELETE /repos/.../git/refs/heads/<head>` when `--delete-branch` is passed (mirroring the one-shot semantic of native `gh pr merge`). The two #4058 / #4231 fallbacks documented below are unchanged — they handle different failure modes (`base branch policy prohibits the merge` and `5xx / 504 Gateway Timeout`) that the wrapper does NOT auto-recover from:
 ```
-gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
+{worktree}/scripts/gh-pr-with-retry.sh merge <PR-N> --squash --delete-branch
 ```
 
 **Fallback — `gh pr merge` rejects with `base branch policy prohibits the merge` (#4058).**

--- a/scripts/_gh_pr_with_retry_payload.py
+++ b/scripts/_gh_pr_with_retry_payload.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""_gh_pr_with_retry_payload.py — Build REST payloads for gh-pr-with-retry.sh.
+
+Reads inputs from environment variables (set by the calling shell
+wrapper), writes a JSON object to ``$GH_PR_PAYLOAD_FILE`` suitable for
+``gh api -X POST/PATCH /repos/.../pulls[/<N>] --input <file>``.
+
+Why a sibling helper instead of an inline ``python -c``
+-------------------------------------------------------
+Same reasoning as scripts/_gh_comment_with_retry_match.py: keeps multi-
+line JSON-building unit-testable on its own, avoids the operator-laptop
+preflight hook's friction with inline ``python -c`` content (the hook
+fires on the agent's Bash tool calls; sibling .py files are fine), and
+honors the project's "Multi-line Python always goes in a .py file"
+rule for consistency.
+
+Usage (called by gh-pr-with-retry.sh)
+-------------------------------------
+    GH_PR_TITLE="..." \
+        GH_PR_BODY_FILE=/path/to/body.txt \
+        GH_PR_HEAD=branch-name \
+        GH_PR_BASE=main \
+        GH_PR_PAYLOAD_FILE=/path/to/out.json \
+        python3 _gh_pr_with_retry_payload.py create
+
+    GH_PR_TITLE="..." \
+        GH_PR_BODY_FILE=/path/to/body.txt \
+        GH_PR_PAYLOAD_FILE=/path/to/out.json \
+        python3 _gh_pr_with_retry_payload.py edit
+
+Subcommands
+-----------
+    create   Builds {"title", "body", "head", "base"} for
+             POST /repos/<owner>/<repo>/pulls.
+    edit     Builds {"title"?, "body"?} for
+             PATCH /repos/<owner>/<repo>/pulls/<N>. Both fields are
+             optional individually but at least one must be present —
+             the wrapper validates this before invoking the helper.
+
+Env contract
+------------
+    GH_PR_PAYLOAD_FILE (str, required): destination path. The helper
+        writes a JSON object to this path (UTF-8). Existing content is
+        overwritten.
+
+    GH_PR_TITLE (str): the PR title. Required for ``create``; optional
+        for ``edit`` (omit by leaving the env var empty/unset).
+    GH_PR_BODY_FILE (str): path to a UTF-8 file containing the PR body.
+        Required for ``create``; optional for ``edit``.
+    GH_PR_HEAD (str, required for ``create``): the PR's head branch
+        (typically ``worktree-agent-<id>`` or the ralph branch).
+    GH_PR_BASE (str, required for ``create``): the PR's base branch
+        (typically ``main``).
+
+Output
+------
+On success: writes JSON to ``$GH_PR_PAYLOAD_FILE``, exits 0 with no
+stdout output.
+
+On failure: prints an error to stderr and exits 1. The wrapper then
+falls through to the original-failure passthrough path.
+
+Tracking: issue #4527.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def _read_body_file(path: str) -> str:
+    """Read the PR body file as UTF-8 and return it verbatim.
+
+    The GitHub REST API accepts ``body`` as a JSON string field; we
+    don't strip trailing newlines or normalize whitespace — the body
+    file is the source of truth, same as ``gh pr create --body-file``.
+    """
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _write_payload(path: str, payload: dict) -> None:
+    """Write the payload JSON to ``path`` (UTF-8, compact).
+
+    `gh api --input <file>` accepts either compact or pretty JSON;
+    compact keeps the file small and readable in tests.
+    """
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False)
+
+
+def _build_create_payload() -> dict:
+    """Build the POST /pulls payload from env vars.
+
+    All four fields (title, body, head, base) are required by the
+    GitHub REST API. The wrapper validates their presence in shell
+    before invoking the helper, so a missing env var here is a bug —
+    we still validate to fail closed.
+    """
+    title = os.environ.get("GH_PR_TITLE", "")
+    body_file = os.environ.get("GH_PR_BODY_FILE", "")
+    head = os.environ.get("GH_PR_HEAD", "")
+    base = os.environ.get("GH_PR_BASE", "")
+
+    missing = []
+    if not title:
+        missing.append("GH_PR_TITLE")
+    if not body_file:
+        missing.append("GH_PR_BODY_FILE")
+    if not head:
+        missing.append("GH_PR_HEAD")
+    if not base:
+        missing.append("GH_PR_BASE")
+    if missing:
+        print(
+            f"ERROR: missing required env vars for create: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    body = _read_body_file(body_file)
+
+    return {
+        "title": title,
+        "body": body,
+        "head": head,
+        "base": base,
+    }
+
+
+def _build_edit_payload() -> dict:
+    """Build the PATCH /pulls/<N> payload from env vars.
+
+    Both ``title`` and ``body`` are optional individually — the GitHub
+    REST API accepts a partial PATCH that updates only the fields
+    present. The wrapper guarantees at least one is set before invoking
+    the helper; we double-check defensively.
+    """
+    title = os.environ.get("GH_PR_TITLE", "")
+    body_file = os.environ.get("GH_PR_BODY_FILE", "")
+
+    payload: dict = {}
+    if title:
+        payload["title"] = title
+    if body_file:
+        payload["body"] = _read_body_file(body_file)
+
+    if not payload:
+        print(
+            "ERROR: edit requires at least one of GH_PR_TITLE or GH_PR_BODY_FILE",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    return payload
+
+
+def main() -> int:
+    """Dispatch on argv[1] (subcommand) and write the payload."""
+    if len(sys.argv) != 2:
+        print(
+            "usage: _gh_pr_with_retry_payload.py <create|edit>",
+            file=sys.stderr,
+        )
+        return 1
+
+    subcommand = sys.argv[1]
+
+    payload_file = os.environ.get("GH_PR_PAYLOAD_FILE", "")
+    if not payload_file:
+        print(
+            "ERROR: GH_PR_PAYLOAD_FILE must be set",
+            file=sys.stderr,
+        )
+        return 1
+
+    if subcommand == "create":
+        payload = _build_create_payload()
+    elif subcommand == "edit":
+        payload = _build_edit_payload()
+    else:
+        print(f"ERROR: unknown subcommand: {subcommand}", file=sys.stderr)
+        return 1
+
+    _write_payload(payload_file, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/gh-pr-with-retry.sh
+++ b/scripts/gh-pr-with-retry.sh
@@ -1,0 +1,593 @@
+#!/usr/bin/env bash
+# permanent: true
+# gh-pr-with-retry.sh — Run `gh pr create` / `gh pr edit` / `gh pr merge`
+# and fall back to the GitHub REST API on GraphQL rate-limit exhaustion.
+#
+# Why this helper exists
+# ----------------------
+# `gh pr create`, `gh pr edit`, and `gh pr merge` all post via GitHub's
+# GraphQL API, which has a separate 5,000-req/hr quota from the REST core
+# API. Long agent sessions (dispatcher, multi-PR /task runs) routinely
+# exhaust GraphQL via `mcp__github__*` reads + `gh pr view` polls while
+# the REST core quota stays healthy, and then `gh pr create / edit /
+# merge` hard-fails with:
+#
+#   GraphQL: API rate limit already exceeded for user ID <N>.
+#
+# This helper detects that exact stderr marker and falls back to the
+# direct REST endpoints, which draw from the REST core quota:
+#
+#   create  → POST   /repos/<owner>/<repo>/pulls
+#   edit    → PATCH  /repos/<owner>/<repo>/pulls/<N>
+#   merge   → PUT    /repos/<owner>/<repo>/pulls/<N>/merge
+#             (+ DELETE /repos/<owner>/<repo>/git/refs/heads/<branch>
+#              when --delete-branch is set, to match `gh pr merge`'s
+#              one-shot semantic)
+#
+# The shape mirrors `scripts/gh-comment-with-retry.sh` (#4478, #4503,
+# #4484): try the gh subcommand first, on the explicit GraphQL-quota
+# marker fall back to REST, otherwise pass the original failure through.
+# This file does NOT implement the 504-after-success recovery path; PR
+# create/edit/merge each have different idempotency stories than the
+# comment endpoint, and the only failure mode #4527 calls out is
+# GraphQL-quota exhaustion. The 504-on-merge recovery is documented in
+# `.claude/skills/task/SKILL.md` §A.7 ("Fallback — `gh pr merge` returns
+# 5xx / 504 Gateway Timeout (#4231)") and stays operator-driven.
+#
+# Tracking: issue #4527.
+#
+# Usage
+# -----
+#   scripts/gh-pr-with-retry.sh create \
+#       --title "..." --body-file <path> --base main --head <branch> \
+#       [--repo <owner/name>]
+#
+#   scripts/gh-pr-with-retry.sh edit <PR-N> \
+#       [--title "..."] [--body-file <path>] [--repo <owner/name>]
+#
+#   scripts/gh-pr-with-retry.sh merge <PR-N> \
+#       --squash [--delete-branch] [--repo <owner/name>]
+#
+#   scripts/gh-pr-with-retry.sh --help
+#
+# Behavior (all subcommands)
+# --------------------------
+#   1. Calls the corresponding `gh pr <subcommand>` first.
+#   2. On exit 0: prints the gh stdout and exits 0.
+#   3. On non-zero exit AND captured stderr matches
+#      ``GraphQL: API rate limit already exceeded`` (#4503):
+#      - Falls back to `gh api -X <METHOD> /repos/.../pulls/...`.
+#      - On REST success: prints "<subcommand> succeeded (REST fallback): <url-or-info>"
+#        and exits 0.
+#      - On REST failure: prints both stderrs (truncated to 5 KB each)
+#        and exits with the REST exit code.
+#   4. On any other non-zero exit (auth failure, branch-protection
+#      reject, validation error, generic 5xx): prints the captured
+#      stderr and exits with the original code.
+#
+# Decision rules for the REST fallback
+# ------------------------------------
+# - Trigger ONLY on the explicit GraphQL-rate-limit-exceeded marker.
+#   Generic 5xx, auth failures, validation errors, and branch-protection
+#   rejects pass through untouched — those need either operator
+#   intervention or a different recovery path (e.g. the #4231 504-on-
+#   merge recipe in SKILL.md).
+# - The REST endpoints draw from the REST core 5,000-req/hr quota,
+#   which is rarely exhausted even in long sessions.
+#
+# Rate-budget hygiene
+# -------------------
+# Stays well within the 5,000 reqs/hr GitHub API budget — at most one
+# extra REST call per GraphQL-quota-exhaustion (two for `merge
+# --delete-branch`, since the API requires a separate DELETE on the
+# branch ref). No exponential backoff retries: a single confirm-or-fail
+# round trip is enough — if the REST quota is also exhausted, the
+# operator needs to wait for the hourly reset.
+#
+# Integration
+# -----------
+# Replaces direct ``gh pr create / edit / merge`` calls in
+# ``.claude/skills/task/SKILL.md`` Steps A.3 (create), A.6 (edit),
+# and A.7 (merge).
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+print_help() {
+    cat << 'EOF'
+gh-pr-with-retry.sh — `gh pr create` / `gh pr edit` / `gh pr merge`
+with GraphQL-quota REST fallback.
+
+Usage:
+  scripts/gh-pr-with-retry.sh create \
+      --title "..." --body-file <path> --base <branch> --head <branch> \
+      [--repo <owner/name>]
+
+  scripts/gh-pr-with-retry.sh edit <PR-N> \
+      [--title "..."] [--body-file <path>] [--repo <owner/name>]
+
+  scripts/gh-pr-with-retry.sh merge <PR-N> \
+      --squash [--delete-branch] [--repo <owner/name>]
+
+  scripts/gh-pr-with-retry.sh --help | -h
+
+Subcommands:
+  create   Open a new PR. Required: --title, --body-file, --base, --head.
+  edit     Update an existing PR's title and/or body. At least one of
+           --title or --body-file is required.
+  merge    Squash-merge a PR. --squash is required (only mode supported);
+           pass --delete-branch to delete the head ref after merging.
+
+Common flags:
+  --repo <owner/name>   Repository (default: judgemind/judgemind).
+  -h, --help            Show this help and exit.
+
+Exit codes:
+  0  — Operation succeeded (including GraphQL-rate-limit REST fallback).
+  1  — Real failure (auth, validation, branch protection, real 5xx, etc.).
+  2  — Usage error (missing args, body-file not found, bad subcommand).
+
+See header comment for behavior details. Tracking: #4527.
+EOF
+}
+
+if [[ $# -eq 0 ]]; then
+    print_help >&2
+    exit 2
+fi
+
+case "${1:-}" in
+    -h|--help)
+        print_help
+        exit 0
+        ;;
+esac
+
+SUBCOMMAND="$1"
+shift
+
+case "$SUBCOMMAND" in
+    create|edit|merge)
+        ;;
+    *)
+        echo "ERROR: unknown subcommand: $SUBCOMMAND" >&2
+        print_help >&2
+        exit 2
+        ;;
+esac
+
+# Shared state across subcommands.
+PR_NUMBER=""
+TITLE=""
+BODY_FILE=""
+BASE=""
+HEAD=""
+REPO="judgemind/judgemind"
+SQUASH=0
+DELETE_BRANCH=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+        --title)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --title requires a value." >&2
+                exit 2
+            fi
+            TITLE="$2"
+            shift 2
+            ;;
+        --body-file)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --body-file requires a value." >&2
+                exit 2
+            fi
+            BODY_FILE="$2"
+            shift 2
+            ;;
+        --base)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --base requires a value." >&2
+                exit 2
+            fi
+            BASE="$2"
+            shift 2
+            ;;
+        --head)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --head requires a value." >&2
+                exit 2
+            fi
+            HEAD="$2"
+            shift 2
+            ;;
+        --repo)
+            if [[ $# -lt 2 ]]; then
+                echo "ERROR: --repo requires a value." >&2
+                exit 2
+            fi
+            REPO="$2"
+            shift 2
+            ;;
+        --squash)
+            SQUASH=1
+            shift
+            ;;
+        --delete-branch)
+            DELETE_BRANCH=1
+            shift
+            ;;
+        -*)
+            echo "ERROR: unknown flag: $1" >&2
+            print_help >&2
+            exit 2
+            ;;
+        *)
+            if [[ -z "$PR_NUMBER" ]]; then
+                PR_NUMBER="${1#\#}"
+            else
+                echo "ERROR: unexpected positional argument: $1" >&2
+                print_help >&2
+                exit 2
+            fi
+            shift
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Per-subcommand validation
+# ---------------------------------------------------------------------------
+
+validate_body_file() {
+    if [[ ! -f "$BODY_FILE" ]]; then
+        echo "ERROR: --body-file does not exist: $BODY_FILE" >&2
+        exit 2
+    fi
+}
+
+validate_pr_number() {
+    if [[ -z "$PR_NUMBER" ]]; then
+        echo "ERROR: missing <PR-N> argument." >&2
+        print_help >&2
+        exit 2
+    fi
+    if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+        echo "ERROR: <PR-N> must be a positive integer, got '$PR_NUMBER'." >&2
+        exit 2
+    fi
+}
+
+case "$SUBCOMMAND" in
+    create)
+        if [[ -z "$TITLE" ]]; then
+            echo "ERROR: 'create' requires --title." >&2
+            exit 2
+        fi
+        if [[ -z "$BODY_FILE" ]]; then
+            echo "ERROR: 'create' requires --body-file." >&2
+            exit 2
+        fi
+        if [[ -z "$BASE" ]]; then
+            echo "ERROR: 'create' requires --base." >&2
+            exit 2
+        fi
+        if [[ -z "$HEAD" ]]; then
+            echo "ERROR: 'create' requires --head." >&2
+            exit 2
+        fi
+        validate_body_file
+        ;;
+    edit)
+        validate_pr_number
+        if [[ -z "$TITLE" && -z "$BODY_FILE" ]]; then
+            echo "ERROR: 'edit' requires at least one of --title or --body-file." >&2
+            exit 2
+        fi
+        if [[ -n "$BODY_FILE" ]]; then
+            validate_body_file
+        fi
+        ;;
+    merge)
+        validate_pr_number
+        if [[ "$SQUASH" -ne 1 ]]; then
+            echo "ERROR: 'merge' requires --squash (only mode supported)." >&2
+            exit 2
+        fi
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+# Capture-and-tee stderr so we can both inspect (for the GraphQL marker)
+# and replay it on real failures without buffering megabytes in shell vars.
+STDERR_FILE=$(mktemp)
+STDOUT_FILE=$(mktemp)
+REST_STDERR_FILE=$(mktemp)
+REST_STDOUT_FILE=$(mktemp)
+DELETE_STDERR_FILE=$(mktemp)
+DELETE_STDOUT_FILE=$(mktemp)
+# shellcheck disable=SC2064  # cleanup paths are fixed at trap-install time.
+trap "rm -f '$STDERR_FILE' '$STDOUT_FILE' '$REST_STDERR_FILE' '$REST_STDOUT_FILE' '$DELETE_STDERR_FILE' '$DELETE_STDOUT_FILE'" EXIT
+
+is_graphql_rate_limit() {
+    # Trigger ONLY on the explicit marker. Generic 5xx, auth failures,
+    # validation errors, etc. all flow through the passthrough path so
+    # the operator (or the SKILL.md recipes) handle them as today.
+    grep -qE "GraphQL: API rate limit already exceeded" "$STDERR_FILE"
+}
+
+passthrough_failure() {
+    local exit_code="$1"
+    cat "$STDERR_FILE" >&2
+    exit "$exit_code"
+}
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+run_create() {
+    set +e
+    gh pr create --repo "$REPO" \
+        --title "$TITLE" \
+        --body-file "$BODY_FILE" \
+        --base "$BASE" \
+        --head "$HEAD" \
+        > "$STDOUT_FILE" 2> "$STDERR_FILE"
+    local gh_exit=$?
+    set -e
+
+    if [[ "$gh_exit" -eq 0 ]]; then
+        cat "$STDOUT_FILE"
+        exit 0
+    fi
+
+    if ! is_graphql_rate_limit; then
+        passthrough_failure "$gh_exit"
+    fi
+
+    echo "gh-pr-with-retry: GraphQL rate-limit exhausted on 'pr create', falling back to REST API..." >&2
+
+    # Build the JSON payload via a sibling python helper. Same pattern
+    # as scripts/_gh_comment_with_retry_match.py and friends — keeps the
+    # helper unit-testable and avoids shell-quoting hazards on the
+    # multi-line body content.
+    local payload_file
+    payload_file=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f '$STDERR_FILE' '$STDOUT_FILE' '$REST_STDERR_FILE' '$REST_STDOUT_FILE' '$DELETE_STDERR_FILE' '$DELETE_STDOUT_FILE' '$payload_file'" EXIT
+
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if ! GH_PR_TITLE="$TITLE" \
+            GH_PR_BODY_FILE="$BODY_FILE" \
+            GH_PR_HEAD="$HEAD" \
+            GH_PR_BASE="$BASE" \
+            GH_PR_PAYLOAD_FILE="$payload_file" \
+            python3 "$script_dir/_gh_pr_with_retry_payload.py" create; then
+        echo "ERROR: failed to build REST payload for 'pr create'." >&2
+        passthrough_failure "$gh_exit"
+    fi
+
+    set +e
+    gh api -X POST "/repos/$REPO/pulls" \
+        --input "$payload_file" \
+        --jq '.html_url' \
+        > "$REST_STDOUT_FILE" 2> "$REST_STDERR_FILE"
+    local rest_exit=$?
+    set -e
+
+    if [[ "$rest_exit" -eq 0 ]]; then
+        local rest_url
+        rest_url=$(cat "$REST_STDOUT_FILE")
+        echo "create succeeded (REST fallback): $rest_url"
+        exit 0
+    fi
+
+    echo "ERROR: GraphQL rate-limit fallback to REST also failed (gh exit $rest_exit)." >&2
+    echo "  --- gh pr create stderr (first 5 KB) ---" >&2
+    head -c 5120 "$STDERR_FILE" >&2
+    echo "" >&2
+    echo "  --- gh api POST /pulls stderr (first 5 KB) ---" >&2
+    head -c 5120 "$REST_STDERR_FILE" >&2
+    echo "" >&2
+    exit "$rest_exit"
+}
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+run_edit() {
+    # Build the gh pr edit args.
+    local -a gh_args=("pr" "edit" "$PR_NUMBER" "--repo" "$REPO")
+    if [[ -n "$TITLE" ]]; then
+        gh_args+=("--title" "$TITLE")
+    fi
+    if [[ -n "$BODY_FILE" ]]; then
+        gh_args+=("--body-file" "$BODY_FILE")
+    fi
+
+    set +e
+    gh "${gh_args[@]}" \
+        > "$STDOUT_FILE" 2> "$STDERR_FILE"
+    local gh_exit=$?
+    set -e
+
+    if [[ "$gh_exit" -eq 0 ]]; then
+        cat "$STDOUT_FILE"
+        exit 0
+    fi
+
+    if ! is_graphql_rate_limit; then
+        passthrough_failure "$gh_exit"
+    fi
+
+    echo "gh-pr-with-retry: GraphQL rate-limit exhausted on 'pr edit', falling back to REST API..." >&2
+
+    local payload_file
+    payload_file=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f '$STDERR_FILE' '$STDOUT_FILE' '$REST_STDERR_FILE' '$REST_STDOUT_FILE' '$DELETE_STDERR_FILE' '$DELETE_STDOUT_FILE' '$payload_file'" EXIT
+
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if ! GH_PR_TITLE="$TITLE" \
+            GH_PR_BODY_FILE="$BODY_FILE" \
+            GH_PR_PAYLOAD_FILE="$payload_file" \
+            python3 "$script_dir/_gh_pr_with_retry_payload.py" edit; then
+        echo "ERROR: failed to build REST payload for 'pr edit'." >&2
+        passthrough_failure "$gh_exit"
+    fi
+
+    set +e
+    gh api -X PATCH "/repos/$REPO/pulls/$PR_NUMBER" \
+        --input "$payload_file" \
+        --jq '.html_url' \
+        > "$REST_STDOUT_FILE" 2> "$REST_STDERR_FILE"
+    local rest_exit=$?
+    set -e
+
+    if [[ "$rest_exit" -eq 0 ]]; then
+        local rest_url
+        rest_url=$(cat "$REST_STDOUT_FILE")
+        echo "edit succeeded (REST fallback): $rest_url"
+        exit 0
+    fi
+
+    echo "ERROR: GraphQL rate-limit fallback to REST also failed (gh exit $rest_exit)." >&2
+    echo "  --- gh pr edit stderr (first 5 KB) ---" >&2
+    head -c 5120 "$STDERR_FILE" >&2
+    echo "" >&2
+    echo "  --- gh api PATCH /pulls/$PR_NUMBER stderr (first 5 KB) ---" >&2
+    head -c 5120 "$REST_STDERR_FILE" >&2
+    echo "" >&2
+    exit "$rest_exit"
+}
+
+# ---------------------------------------------------------------------------
+# merge
+# ---------------------------------------------------------------------------
+
+run_merge() {
+    # Build the gh pr merge args. SQUASH is the only supported mode.
+    local -a gh_args=("pr" "merge" "$PR_NUMBER" "--repo" "$REPO" "--squash")
+    if [[ "$DELETE_BRANCH" -eq 1 ]]; then
+        gh_args+=("--delete-branch")
+    fi
+
+    set +e
+    gh "${gh_args[@]}" \
+        > "$STDOUT_FILE" 2> "$STDERR_FILE"
+    local gh_exit=$?
+    set -e
+
+    if [[ "$gh_exit" -eq 0 ]]; then
+        cat "$STDOUT_FILE"
+        exit 0
+    fi
+
+    if ! is_graphql_rate_limit; then
+        passthrough_failure "$gh_exit"
+    fi
+
+    echo "gh-pr-with-retry: GraphQL rate-limit exhausted on 'pr merge', falling back to REST API..." >&2
+
+    set +e
+    gh api -X PUT "/repos/$REPO/pulls/$PR_NUMBER/merge" \
+        -f "merge_method=squash" \
+        --jq '{merged: .merged, sha: .sha, message: .message}' \
+        > "$REST_STDOUT_FILE" 2> "$REST_STDERR_FILE"
+    local rest_exit=$?
+    set -e
+
+    if [[ "$rest_exit" -ne 0 ]]; then
+        echo "ERROR: GraphQL rate-limit fallback to REST also failed (gh exit $rest_exit)." >&2
+        echo "  --- gh pr merge stderr (first 5 KB) ---" >&2
+        head -c 5120 "$STDERR_FILE" >&2
+        echo "" >&2
+        echo "  --- gh api PUT /pulls/$PR_NUMBER/merge stderr (first 5 KB) ---" >&2
+        head -c 5120 "$REST_STDERR_FILE" >&2
+        echo "" >&2
+        exit "$rest_exit"
+    fi
+
+    # Merge succeeded. If --delete-branch was set, delete the head ref
+    # explicitly — the REST PUT /merge endpoint does not delete the
+    # branch (unlike `gh pr merge --delete-branch` which is a one-shot).
+    local rest_summary
+    rest_summary=$(cat "$REST_STDOUT_FILE")
+
+    if [[ "$DELETE_BRANCH" -ne 1 ]]; then
+        echo "merge succeeded (REST fallback): $rest_summary"
+        exit 0
+    fi
+
+    # Resolve the head ref via REST (one extra core-quota call). We
+    # cannot rely on `gh pr view --jq .headRefName` here because that
+    # path also goes through GraphQL — which is exactly why we're in
+    # the fallback. Use the REST GET on the PR.
+    local head_ref
+    head_ref=$(gh api "/repos/$REPO/pulls/$PR_NUMBER" --jq '.head.ref' 2>/dev/null) || head_ref=""
+    if [[ -z "$head_ref" ]]; then
+        echo "WARNING: merge succeeded but could not resolve head ref to delete (--delete-branch)." >&2
+        echo "merge succeeded (REST fallback): $rest_summary" >&2
+        echo "  manual cleanup: gh api /repos/$REPO/git/refs/heads/<branch> -X DELETE" >&2
+        # The merge succeeded; the branch deletion is best-effort. Exit
+        # 0 — the operator can clean up the branch manually.
+        echo "merge succeeded (REST fallback): $rest_summary"
+        exit 0
+    fi
+
+    set +e
+    gh api -X DELETE "/repos/$REPO/git/refs/heads/$head_ref" \
+        > "$DELETE_STDOUT_FILE" 2> "$DELETE_STDERR_FILE"
+    local delete_exit=$?
+    set -e
+
+    if [[ "$delete_exit" -eq 0 ]]; then
+        echo "merge succeeded (REST fallback): $rest_summary; branch '$head_ref' deleted"
+        exit 0
+    fi
+
+    # If the branch is already gone (DELETE returns 422 / "Reference does not exist"),
+    # treat as success — same semantics as the SKILL.md A.7 recipe.
+    if grep -qE "Reference does not exist|HTTP 422" "$DELETE_STDERR_FILE"; then
+        echo "merge succeeded (REST fallback): $rest_summary; branch '$head_ref' was already deleted"
+        exit 0
+    fi
+
+    echo "WARNING: merge succeeded but branch DELETE failed (gh exit $delete_exit)." >&2
+    head -c 5120 "$DELETE_STDERR_FILE" >&2
+    echo "" >&2
+    echo "merge succeeded (REST fallback): $rest_summary; branch '$head_ref' NOT deleted"
+    # Merge is the user's primary intent and it succeeded — exit 0 even
+    # though the cleanup didn't. The warning above gives the operator
+    # the manual recovery path.
+    exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+case "$SUBCOMMAND" in
+    create)
+        run_create
+        ;;
+    edit)
+        run_edit
+        ;;
+    merge)
+        run_merge
+        ;;
+esac

--- a/scripts/tests/test_gh_pr_with_retry.sh
+++ b/scripts/tests/test_gh_pr_with_retry.sh
@@ -1,0 +1,973 @@
+#!/usr/bin/env bash
+# test_gh_pr_with_retry.sh — Tests for scripts/gh-pr-with-retry.sh.
+#
+# Covers the GraphQL-rate-limit REST fallback path (#4527) for each
+# subcommand:
+#
+#   E   — Usage / argument validation paths.
+#   C.* — `create`: success + GraphQL-rate-limit + REST-fail + auth-passthrough.
+#   X.* — `edit`:   success + GraphQL-rate-limit + REST-fail + auth-passthrough.
+#   M.* — `merge`:  success + GraphQL-rate-limit + REST-fail + auth-passthrough,
+#                   plus --delete-branch coverage (success + already-deleted).
+#
+# All tests run against a PATH-mocked ``gh`` binary — no network. Uses
+# the same temp-cleanup helper pattern as test_gh_comment_with_retry.sh.
+#
+# Usage:
+#   scripts/tests/test_gh_pr_with_retry.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/gh-pr-with-retry.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+ORIG_PATH_SAVE=""
+restore_path() {
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+register_cleanup_hook restore_path
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Set up a mock gh CLI on PATH ──────────────────────────────────────────
+#
+# The mock supports the call shapes the wrapper exercises:
+#
+#   1. ``gh pr create --repo X --title T --body-file B --base BB --head HH``
+#      Behavior controlled by ``MOCK_PR_CREATE_MODE`` env var:
+#        - "success"            : exit 0, print URL on stdout (default).
+#        - "graphql_rate_limit" : exit 1, print GraphQL marker on stderr.
+#        - "auth"               : exit 4, print "authentication required" on stderr.
+#
+#   2. ``gh pr edit <N> --repo X [--title T] [--body-file B]``
+#      Behavior controlled by ``MOCK_PR_EDIT_MODE`` (same modes as create).
+#
+#   3. ``gh pr merge <N> --repo X --squash [--delete-branch]``
+#      Behavior controlled by ``MOCK_PR_MERGE_MODE`` (same modes as create).
+#
+#   4. ``gh api -X POST /repos/<owner>/<repo>/pulls --input <file> --jq .html_url``
+#      REST fallback for `pr create`. Behavior: ``MOCK_REST_CREATE_MODE``
+#      ("success" prints html_url, "fail" prints err on stderr).
+#      Side effect: when MOCK_PAYLOAD_DUMP is set, copies --input file
+#      content there for later assertion.
+#
+#   5. ``gh api -X PATCH /repos/<owner>/<repo>/pulls/<N> --input <file> --jq .html_url``
+#      REST fallback for `pr edit`. Behavior: ``MOCK_REST_EDIT_MODE``.
+#
+#   6. ``gh api -X PUT /repos/<owner>/<repo>/pulls/<N>/merge -f merge_method=squash --jq ...``
+#      REST fallback for `pr merge`. Behavior: ``MOCK_REST_MERGE_MODE``.
+#
+#   7. ``gh api /repos/<owner>/<repo>/pulls/<N> --jq .head.ref``
+#      Resolves the head ref for --delete-branch in the REST path.
+#      Returns ``MOCK_HEAD_REF`` (default: "feature-branch").
+#
+#   8. ``gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<ref>``
+#      Branch-delete in the REST path. Behavior:
+#      ``MOCK_REST_DELETE_MODE`` ("success" exit 0; "already_gone"
+#      exit 1 with "Reference does not exist" on stderr; "fail"
+#      exit 1 with generic stderr).
+
+MOCK_BIN_DIR=$(mktemp -d)
+register_temp_dir "$MOCK_BIN_DIR"
+ORIG_PATH_SAVE="$PATH"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKEOF'
+#!/usr/bin/env bash
+# Record every invocation for assertions.
+if [[ -n "${MOCK_INVOCATIONS:-}" ]]; then
+    echo "$@" >> "$MOCK_INVOCATIONS"
+fi
+
+# ── gh pr create ───────────────────────────────────────────────────────────
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+    mode="${MOCK_PR_CREATE_MODE:-success}"
+    case "$mode" in
+        success)
+            echo "https://github.com/judgemind/judgemind/pull/777"
+            exit 0
+            ;;
+        graphql_rate_limit)
+            echo "GraphQL: API rate limit already exceeded for user ID 3708633." >&2
+            exit 1
+            ;;
+        auth)
+            echo "error: authentication required" >&2
+            exit 4
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_PR_CREATE_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh pr edit ─────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "pr" && "${2:-}" == "edit" ]]; then
+    mode="${MOCK_PR_EDIT_MODE:-success}"
+    case "$mode" in
+        success)
+            echo "https://github.com/judgemind/judgemind/pull/${3:-0}"
+            exit 0
+            ;;
+        graphql_rate_limit)
+            echo "GraphQL: API rate limit already exceeded for user ID 3708633." >&2
+            exit 1
+            ;;
+        auth)
+            echo "error: authentication required" >&2
+            exit 4
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_PR_EDIT_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh pr merge ────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+    mode="${MOCK_PR_MERGE_MODE:-success}"
+    case "$mode" in
+        success)
+            # gh pr merge --squash --delete-branch normally prints
+            # nothing to stdout on success (or a line like "✓ Squashed
+            # and merged"). For the test we just exit 0.
+            exit 0
+            ;;
+        graphql_rate_limit)
+            echo "GraphQL: API rate limit already exceeded for user ID 3708633." >&2
+            exit 1
+            ;;
+        auth)
+            echo "error: authentication required" >&2
+            exit 4
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_PR_MERGE_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api -X POST /repos/.../pulls (REST fallback for create) ────────────
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "POST" \
+        && "${4:-}" =~ ^/repos/.*/pulls$ ]]; then
+    # Capture --input payload if MOCK_PAYLOAD_DUMP is set.
+    if [[ -n "${MOCK_PAYLOAD_DUMP:-}" ]]; then
+        # Walk args looking for "--input <path>".
+        for ((i=1; i<=$#; i++)); do
+            if [[ "${!i}" == "--input" ]]; then
+                next=$((i+1))
+                src_path="${!next}"
+                if [[ -f "$src_path" ]]; then
+                    cp "$src_path" "$MOCK_PAYLOAD_DUMP"
+                fi
+                break
+            fi
+        done
+    fi
+    mode="${MOCK_REST_CREATE_MODE:-success}"
+    case "$mode" in
+        success)
+            echo "https://github.com/judgemind/judgemind/pull/9001"
+            exit 0
+            ;;
+        fail)
+            echo "error: REST create secondary failure" >&2
+            exit 1
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_REST_CREATE_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api -X PATCH /repos/.../pulls/<N> (REST fallback for edit) ─────────
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "PATCH" \
+        && "${4:-}" =~ ^/repos/.*/pulls/[0-9]+$ ]]; then
+    if [[ -n "${MOCK_PAYLOAD_DUMP:-}" ]]; then
+        for ((i=1; i<=$#; i++)); do
+            if [[ "${!i}" == "--input" ]]; then
+                next=$((i+1))
+                src_path="${!next}"
+                if [[ -f "$src_path" ]]; then
+                    cp "$src_path" "$MOCK_PAYLOAD_DUMP"
+                fi
+                break
+            fi
+        done
+    fi
+    mode="${MOCK_REST_EDIT_MODE:-success}"
+    case "$mode" in
+        success)
+            # Extract PR number from URL for echoing back.
+            pr_n=$(echo "${4}" | sed -E 's|.*/pulls/([0-9]+)$|\1|')
+            echo "https://github.com/judgemind/judgemind/pull/${pr_n}"
+            exit 0
+            ;;
+        fail)
+            echo "error: REST edit secondary failure" >&2
+            exit 1
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_REST_EDIT_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api -X PUT /repos/.../pulls/<N>/merge (REST fallback for merge) ────
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "PUT" \
+        && "${4:-}" =~ ^/repos/.*/pulls/[0-9]+/merge$ ]]; then
+    mode="${MOCK_REST_MERGE_MODE:-success}"
+    case "$mode" in
+        success)
+            echo '{"merged":true,"sha":"abc1234567890","message":"Pull Request successfully merged"}'
+            exit 0
+            ;;
+        fail)
+            echo "error: REST merge secondary failure" >&2
+            exit 1
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_REST_MERGE_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api -X DELETE /repos/.../git/refs/heads/<ref> (branch delete) ──────
+if [[ "${1:-}" == "api" && "${2:-}" == "-X" && "${3:-}" == "DELETE" \
+        && "${4:-}" =~ ^/repos/.*/git/refs/heads/.+$ ]]; then
+    mode="${MOCK_REST_DELETE_MODE:-success}"
+    case "$mode" in
+        success)
+            exit 0
+            ;;
+        already_gone)
+            cat >&2 << 'GONE_EOF'
+HTTP 422: Reference does not exist (https://api.github.com/...)
+{"message":"Reference does not exist","documentation_url":"..."}
+GONE_EOF
+            exit 1
+            ;;
+        fail)
+            echo "error: REST DELETE secondary failure" >&2
+            exit 1
+            ;;
+        *)
+            echo "mock gh: unknown MOCK_REST_DELETE_MODE=$mode" >&2
+            exit 99
+            ;;
+    esac
+fi
+
+# ── gh api /repos/.../pulls/<N> --jq .head.ref (head-ref resolution) ──────
+if [[ "${1:-}" == "api" && "${2:-}" =~ ^/repos/.*/pulls/[0-9]+$ ]]; then
+    echo "${MOCK_HEAD_REF:-feature-branch}"
+    exit 0
+fi
+
+# Unknown command — fail loudly so the test surfaces it.
+echo "mock gh: unhandled command: $*" >&2
+exit 127
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+# ── Test E — Usage / argument validation paths ─────────────────────────────
+
+# E.1 — No args prints help and exits 2.
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.1: 0 args exits 2"
+else
+    fail "E.1: 0 args exits 2" "expected 2, got $exit_code"
+fi
+
+# E.2 — --help exits 0 with usage on stdout.
+exit_code=0
+help_output=$("$WRAPPER" --help 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 ]] && [[ "$help_output" == *"Usage:"* ]] \
+        && [[ "$help_output" == *"create"* ]] \
+        && [[ "$help_output" == *"edit"* ]] \
+        && [[ "$help_output" == *"merge"* ]]; then
+    pass "E.2: --help exits 0 and mentions all three subcommands"
+else
+    fail "E.2: --help exits 0 and mentions all three subcommands" \
+        "exit=$exit_code, output: $help_output"
+fi
+
+# E.3 — Unknown subcommand exits 2.
+exit_code=0
+err_output=$("$WRAPPER" frobnicate 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 2 ]] && [[ "$err_output" == *"unknown subcommand"* ]]; then
+    pass "E.3: unknown subcommand exits 2 with descriptive error"
+else
+    fail "E.3: unknown subcommand exits 2 with descriptive error" \
+        "exit=$exit_code, err: $err_output"
+fi
+
+# E.4 — `create` missing --title exits 2.
+BODY_FILE_E4=$(mktemp)
+register_temp_file "$BODY_FILE_E4"
+echo "test body" > "$BODY_FILE_E4"
+exit_code=0
+"$WRAPPER" create --body-file "$BODY_FILE_E4" --base main --head feature \
+    > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.4: create missing --title exits 2"
+else
+    fail "E.4: create missing --title exits 2" "expected 2, got $exit_code"
+fi
+
+# E.5 — `create` missing --body-file exits 2.
+exit_code=0
+"$WRAPPER" create --title "T" --base main --head feature \
+    > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.5: create missing --body-file exits 2"
+else
+    fail "E.5: create missing --body-file exits 2" "expected 2, got $exit_code"
+fi
+
+# E.6 — `create` body-file does not exist exits 2.
+exit_code=0
+err_output=$("$WRAPPER" create --title "T" --body-file /nonexistent/xyz \
+    --base main --head feature 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 2 ]] && [[ "$err_output" == *"does not exist"* ]]; then
+    pass "E.6: create with missing body-file exits 2 with descriptive error"
+else
+    fail "E.6: create with missing body-file exits 2 with descriptive error" \
+        "exit=$exit_code, err: $err_output"
+fi
+
+# E.7 — `edit` with neither --title nor --body-file exits 2.
+exit_code=0
+"$WRAPPER" edit 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.7: edit with no fields exits 2"
+else
+    fail "E.7: edit with no fields exits 2" "expected 2, got $exit_code"
+fi
+
+# E.8 — `edit` non-numeric PR number exits 2.
+exit_code=0
+"$WRAPPER" edit abc --title "T" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.8: edit non-numeric PR exits 2"
+else
+    fail "E.8: edit non-numeric PR exits 2" "expected 2, got $exit_code"
+fi
+
+# E.9 — `merge` without --squash exits 2.
+exit_code=0
+"$WRAPPER" merge 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "E.9: merge without --squash exits 2"
+else
+    fail "E.9: merge without --squash exits 2" "expected 2, got $exit_code"
+fi
+
+# E.10 — Leading '#' on PR number stripped.
+INVOCATIONS_E10="$MOCK_BIN_DIR/invocations_e10.txt"
+: > "$INVOCATIONS_E10"
+exit_code=0
+MOCK_INVOCATIONS="$INVOCATIONS_E10" \
+    MOCK_PR_MERGE_MODE=success \
+    "$WRAPPER" merge "#100" --squash > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]] && grep -qE "^pr merge 100\b" "$INVOCATIONS_E10"; then
+    pass "E.10: leading '#' on PR number is stripped"
+else
+    fail "E.10: leading '#' on PR number is stripped" \
+        "exit=$exit_code, invocations: $(cat "$INVOCATIONS_E10")"
+fi
+
+# ── Test C — `create` ──────────────────────────────────────────────────────
+
+# C.1 — Success path.
+BODY_FILE_C1=$(mktemp)
+register_temp_file "$BODY_FILE_C1"
+cat > "$BODY_FILE_C1" << 'BODY_EOF'
+## Summary
+Test PR body for C.1.
+
+Closes #4527
+BODY_EOF
+
+INVOCATIONS_C1="$MOCK_BIN_DIR/invocations_c1.txt"
+: > "$INVOCATIONS_C1"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_C1" \
+    MOCK_PR_CREATE_MODE=success \
+    "$WRAPPER" create \
+        --title "feat(dx): test create" \
+        --body-file "$BODY_FILE_C1" \
+        --base main \
+        --head feature \
+        2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "C.1: create success exits 0"
+else
+    fail "C.1: create success exits 0" "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/pull/777"* ]]; then
+    pass "C.1: create success prints PR URL on stdout"
+else
+    fail "C.1: create success prints PR URL on stdout" "got: $stdout_output"
+fi
+
+# Verify NO REST fallback was invoked (the marker MOCK_REST_CREATE_MODE wasn't set).
+rest_calls=$(awk '/^api / {n++} END {print n+0}' "$INVOCATIONS_C1")
+if [[ "$rest_calls" == "0" ]]; then
+    pass "C.1: create success makes no REST API calls"
+else
+    fail "C.1: create success makes no REST API calls" \
+        "found $rest_calls api calls: $(cat "$INVOCATIONS_C1")"
+fi
+
+# C.2 — GraphQL rate-limit + REST success.
+BODY_FILE_C2=$(mktemp)
+register_temp_file "$BODY_FILE_C2"
+echo "Body content for the C.2 test." > "$BODY_FILE_C2"
+
+PAYLOAD_DUMP_C2=$(mktemp)
+register_temp_file "$PAYLOAD_DUMP_C2"
+
+INVOCATIONS_C2="$MOCK_BIN_DIR/invocations_c2.txt"
+: > "$INVOCATIONS_C2"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_C2" \
+    MOCK_PR_CREATE_MODE=graphql_rate_limit \
+    MOCK_REST_CREATE_MODE=success \
+    MOCK_PAYLOAD_DUMP="$PAYLOAD_DUMP_C2" \
+    "$WRAPPER" create \
+        --title "feat(dx): C.2 graphql fallback" \
+        --body-file "$BODY_FILE_C2" \
+        --base main \
+        --head feature-c2 \
+        2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "C.2: create GraphQL rate-limit + REST success exits 0"
+else
+    fail "C.2: create GraphQL rate-limit + REST success exits 0" \
+        "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"REST fallback"* ]]; then
+    pass "C.2: create stdout names 'REST fallback' on the recovery path"
+else
+    fail "C.2: create stdout names 'REST fallback' on the recovery path" \
+        "got: $stdout_output"
+fi
+
+if [[ "$stdout_output" == *"https://github.com/judgemind/judgemind/pull/9001"* ]]; then
+    pass "C.2: create stdout includes the REST-posted PR URL"
+else
+    fail "C.2: create stdout includes the REST-posted PR URL" \
+        "got: $stdout_output"
+fi
+
+# Confirm wrapper invoked `gh api -X POST /repos/.../pulls`.
+if grep -qE "^api -X POST /repos/.*/pulls( |$)" "$INVOCATIONS_C2"; then
+    pass "C.2: wrapper invoked 'gh api -X POST /repos/.../pulls'"
+else
+    fail "C.2: wrapper invoked 'gh api -X POST /repos/.../pulls'" \
+        "invocations: $(cat "$INVOCATIONS_C2")"
+fi
+
+# Confirm payload contains all four fields with correct values.
+if [[ -s "$PAYLOAD_DUMP_C2" ]]; then
+    payload_check=$(python3 - "$PAYLOAD_DUMP_C2" << 'PY_CHECK_C2'
+import json, sys
+data = json.load(open(sys.argv[1]))
+ok = (
+    data.get("title") == "feat(dx): C.2 graphql fallback"
+    and data.get("body") == "Body content for the C.2 test.\n"
+    and data.get("head") == "feature-c2"
+    and data.get("base") == "main"
+)
+print("OK" if ok else f"BAD: {data}")
+PY_CHECK_C2
+)
+    if [[ "$payload_check" == "OK" ]]; then
+        pass "C.2: REST payload has correct title/body/head/base"
+    else
+        fail "C.2: REST payload has correct title/body/head/base" "$payload_check"
+    fi
+else
+    fail "C.2: REST payload was captured" "MOCK_PAYLOAD_DUMP file empty"
+fi
+
+# C.3 — GraphQL rate-limit + REST also fails.
+BODY_FILE_C3=$(mktemp)
+register_temp_file "$BODY_FILE_C3"
+echo "C.3 body" > "$BODY_FILE_C3"
+
+INVOCATIONS_C3="$MOCK_BIN_DIR/invocations_c3.txt"
+: > "$INVOCATIONS_C3"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_C3" \
+    MOCK_PR_CREATE_MODE=graphql_rate_limit \
+    MOCK_REST_CREATE_MODE=fail \
+    "$WRAPPER" create \
+        --title "C.3" \
+        --body-file "$BODY_FILE_C3" \
+        --base main \
+        --head feature-c3 \
+        2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "C.3: create GraphQL rate-limit + REST fail exits non-zero"
+else
+    fail "C.3: create GraphQL rate-limit + REST fail exits non-zero" \
+        "expected non-zero, got $exit_code"
+fi
+
+if [[ "$err_output" == *"REST also failed"* ]]; then
+    pass "C.3: create stderr names 'REST also failed'"
+else
+    fail "C.3: create stderr names 'REST also failed'" "got: $err_output"
+fi
+
+if [[ "$err_output" == *"GraphQL: API rate limit"* ]] \
+        && [[ "$err_output" == *"REST create secondary failure"* ]]; then
+    pass "C.3: create stderr includes both gh and REST stderrs"
+else
+    fail "C.3: create stderr includes both gh and REST stderrs" "got: $err_output"
+fi
+
+# C.4 — Auth failure passes through (REST fallback NOT triggered).
+BODY_FILE_C4=$(mktemp)
+register_temp_file "$BODY_FILE_C4"
+echo "C.4 body" > "$BODY_FILE_C4"
+
+INVOCATIONS_C4="$MOCK_BIN_DIR/invocations_c4.txt"
+: > "$INVOCATIONS_C4"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_C4" \
+    MOCK_PR_CREATE_MODE=auth \
+    "$WRAPPER" create \
+        --title "C.4" \
+        --body-file "$BODY_FILE_C4" \
+        --base main \
+        --head feature-c4 \
+        2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 4 ]]; then
+    pass "C.4: create auth-fail passes through original exit code (4)"
+else
+    fail "C.4: create auth-fail passes through original exit code (4)" \
+        "expected 4, got $exit_code"
+fi
+
+if [[ "$err_output" == *"authentication required"* ]]; then
+    pass "C.4: create auth-fail stderr is passed through"
+else
+    fail "C.4: create auth-fail stderr is passed through" "got: $err_output"
+fi
+
+rest_post_calls=$(awk '/^api -X POST / {n++} END {print n+0}' "$INVOCATIONS_C4")
+if [[ "$rest_post_calls" == "0" ]]; then
+    pass "C.4: create auth-fail makes no REST POST calls"
+else
+    fail "C.4: create auth-fail makes no REST POST calls" \
+        "found $rest_post_calls REST POST calls"
+fi
+
+# ── Test X — `edit` ────────────────────────────────────────────────────────
+
+# X.1 — Success path with --body-file only.
+BODY_FILE_X1=$(mktemp)
+register_temp_file "$BODY_FILE_X1"
+echo "X.1 updated body" > "$BODY_FILE_X1"
+
+INVOCATIONS_X1="$MOCK_BIN_DIR/invocations_x1.txt"
+: > "$INVOCATIONS_X1"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_X1" \
+    MOCK_PR_EDIT_MODE=success \
+    "$WRAPPER" edit 200 --body-file "$BODY_FILE_X1" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "X.1: edit success exits 0"
+else
+    fail "X.1: edit success exits 0" "expected 0, got $exit_code"
+fi
+
+if grep -qE "^pr edit 200\b" "$INVOCATIONS_X1" \
+        && grep -qE -- "--body-file" "$INVOCATIONS_X1"; then
+    pass "X.1: edit invokes 'gh pr edit 200 --body-file ...'"
+else
+    fail "X.1: edit invokes 'gh pr edit 200 --body-file ...'" \
+        "invocations: $(cat "$INVOCATIONS_X1")"
+fi
+
+# X.2 — GraphQL rate-limit + REST success (body-only).
+BODY_FILE_X2=$(mktemp)
+register_temp_file "$BODY_FILE_X2"
+echo "X.2 body for edit fallback" > "$BODY_FILE_X2"
+
+PAYLOAD_DUMP_X2=$(mktemp)
+register_temp_file "$PAYLOAD_DUMP_X2"
+
+INVOCATIONS_X2="$MOCK_BIN_DIR/invocations_x2.txt"
+: > "$INVOCATIONS_X2"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_X2" \
+    MOCK_PR_EDIT_MODE=graphql_rate_limit \
+    MOCK_REST_EDIT_MODE=success \
+    MOCK_PAYLOAD_DUMP="$PAYLOAD_DUMP_X2" \
+    "$WRAPPER" edit 250 --body-file "$BODY_FILE_X2" 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "X.2: edit GraphQL rate-limit + REST success exits 0"
+else
+    fail "X.2: edit GraphQL rate-limit + REST success exits 0" \
+        "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"REST fallback"* ]]; then
+    pass "X.2: edit stdout names 'REST fallback' on the recovery path"
+else
+    fail "X.2: edit stdout names 'REST fallback' on the recovery path" \
+        "got: $stdout_output"
+fi
+
+if grep -qE "^api -X PATCH /repos/.*/pulls/250( |$)" "$INVOCATIONS_X2"; then
+    pass "X.2: edit invokes 'gh api -X PATCH /repos/.../pulls/250'"
+else
+    fail "X.2: edit invokes 'gh api -X PATCH /repos/.../pulls/250'" \
+        "invocations: $(cat "$INVOCATIONS_X2")"
+fi
+
+# Confirm payload has body but NO title (we didn't pass --title).
+if [[ -s "$PAYLOAD_DUMP_X2" ]]; then
+    payload_check=$(python3 - "$PAYLOAD_DUMP_X2" << 'PY_CHECK_X2'
+import json, sys
+data = json.load(open(sys.argv[1]))
+ok = (
+    "body" in data
+    and data["body"] == "X.2 body for edit fallback\n"
+    and "title" not in data
+)
+print("OK" if ok else f"BAD: {data}")
+PY_CHECK_X2
+)
+    if [[ "$payload_check" == "OK" ]]; then
+        pass "X.2: REST PATCH payload has body but not title (partial PATCH)"
+    else
+        fail "X.2: REST PATCH payload has body but not title" "$payload_check"
+    fi
+else
+    fail "X.2: REST PATCH payload was captured" "MOCK_PAYLOAD_DUMP file empty"
+fi
+
+# X.3 — GraphQL rate-limit + REST success (title + body).
+BODY_FILE_X3=$(mktemp)
+register_temp_file "$BODY_FILE_X3"
+echo "X.3 body content" > "$BODY_FILE_X3"
+
+PAYLOAD_DUMP_X3=$(mktemp)
+register_temp_file "$PAYLOAD_DUMP_X3"
+
+exit_code=0
+MOCK_PR_EDIT_MODE=graphql_rate_limit \
+    MOCK_REST_EDIT_MODE=success \
+    MOCK_PAYLOAD_DUMP="$PAYLOAD_DUMP_X3" \
+    "$WRAPPER" edit 251 \
+        --title "feat: new title" \
+        --body-file "$BODY_FILE_X3" \
+        > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]] && [[ -s "$PAYLOAD_DUMP_X3" ]]; then
+    payload_check=$(python3 - "$PAYLOAD_DUMP_X3" << 'PY_CHECK_X3'
+import json, sys
+data = json.load(open(sys.argv[1]))
+ok = (
+    data.get("title") == "feat: new title"
+    and data.get("body") == "X.3 body content\n"
+)
+print("OK" if ok else f"BAD: {data}")
+PY_CHECK_X3
+)
+    if [[ "$payload_check" == "OK" ]]; then
+        pass "X.3: edit REST PATCH payload includes both title and body"
+    else
+        fail "X.3: edit REST PATCH payload includes both title and body" "$payload_check"
+    fi
+else
+    fail "X.3: edit REST PATCH success" "exit=$exit_code"
+fi
+
+# X.4 — Auth failure passes through.
+BODY_FILE_X4=$(mktemp)
+register_temp_file "$BODY_FILE_X4"
+echo "X.4 body" > "$BODY_FILE_X4"
+
+exit_code=0
+err_output=$(
+    MOCK_PR_EDIT_MODE=auth \
+    "$WRAPPER" edit 250 --body-file "$BODY_FILE_X4" 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 4 ]] && [[ "$err_output" == *"authentication required"* ]]; then
+    pass "X.4: edit auth-fail passes through original exit code (4) and stderr"
+else
+    fail "X.4: edit auth-fail passes through original exit code (4) and stderr" \
+        "exit=$exit_code, err: $err_output"
+fi
+
+# ── Test M — `merge` ───────────────────────────────────────────────────────
+
+# M.1 — Success path with --squash --delete-branch.
+INVOCATIONS_M1="$MOCK_BIN_DIR/invocations_m1.txt"
+: > "$INVOCATIONS_M1"
+
+exit_code=0
+MOCK_INVOCATIONS="$INVOCATIONS_M1" \
+    MOCK_PR_MERGE_MODE=success \
+    "$WRAPPER" merge 300 --squash --delete-branch \
+    > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "M.1: merge success exits 0"
+else
+    fail "M.1: merge success exits 0" "expected 0, got $exit_code"
+fi
+
+if grep -qE "^pr merge 300 --repo .* --squash --delete-branch" "$INVOCATIONS_M1"; then
+    pass "M.1: merge invokes 'gh pr merge 300 --squash --delete-branch'"
+else
+    fail "M.1: merge invokes 'gh pr merge 300 --squash --delete-branch'" \
+        "invocations: $(cat "$INVOCATIONS_M1")"
+fi
+
+# Verify NO REST fallback calls happened.
+rest_put_calls=$(awk '/^api -X PUT / {n++} END {print n+0}' "$INVOCATIONS_M1")
+if [[ "$rest_put_calls" == "0" ]]; then
+    pass "M.1: merge success makes no REST PUT calls"
+else
+    fail "M.1: merge success makes no REST PUT calls" \
+        "found $rest_put_calls"
+fi
+
+# M.2 — GraphQL rate-limit + REST success + branch-delete success.
+INVOCATIONS_M2="$MOCK_BIN_DIR/invocations_m2.txt"
+: > "$INVOCATIONS_M2"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_M2" \
+    MOCK_PR_MERGE_MODE=graphql_rate_limit \
+    MOCK_REST_MERGE_MODE=success \
+    MOCK_REST_DELETE_MODE=success \
+    MOCK_HEAD_REF="worktree-agent-foo" \
+    "$WRAPPER" merge 350 --squash --delete-branch 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "M.2: merge GraphQL rate-limit + REST success + DELETE success exits 0"
+else
+    fail "M.2: merge GraphQL rate-limit + REST success + DELETE success exits 0" \
+        "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"REST fallback"* ]] \
+        && [[ "$stdout_output" == *"branch 'worktree-agent-foo' deleted"* ]]; then
+    pass "M.2: merge stdout names 'REST fallback' AND branch deletion"
+else
+    fail "M.2: merge stdout names 'REST fallback' AND branch deletion" \
+        "got: $stdout_output"
+fi
+
+if grep -qE "^api -X PUT /repos/.*/pulls/350/merge( |$)" "$INVOCATIONS_M2"; then
+    pass "M.2: merge invokes 'gh api -X PUT /repos/.../pulls/350/merge'"
+else
+    fail "M.2: merge invokes 'gh api -X PUT /repos/.../pulls/350/merge'" \
+        "invocations: $(cat "$INVOCATIONS_M2")"
+fi
+
+if grep -qE "^api -X DELETE /repos/.*/git/refs/heads/worktree-agent-foo( |$)" "$INVOCATIONS_M2"; then
+    pass "M.2: merge invokes DELETE /git/refs/heads/<head-ref>"
+else
+    fail "M.2: merge invokes DELETE /git/refs/heads/<head-ref>" \
+        "invocations: $(cat "$INVOCATIONS_M2")"
+fi
+
+# M.3 — GraphQL rate-limit + REST success + branch already gone (422).
+INVOCATIONS_M3="$MOCK_BIN_DIR/invocations_m3.txt"
+: > "$INVOCATIONS_M3"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_M3" \
+    MOCK_PR_MERGE_MODE=graphql_rate_limit \
+    MOCK_REST_MERGE_MODE=success \
+    MOCK_REST_DELETE_MODE=already_gone \
+    MOCK_HEAD_REF="dead-branch" \
+    "$WRAPPER" merge 351 --squash --delete-branch 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "M.3: merge with already-deleted branch still exits 0"
+else
+    fail "M.3: merge with already-deleted branch still exits 0" \
+        "expected 0, got $exit_code"
+fi
+
+if [[ "$stdout_output" == *"already deleted"* ]]; then
+    pass "M.3: merge stdout notes 'already deleted' for the branch"
+else
+    fail "M.3: merge stdout notes 'already deleted' for the branch" \
+        "got: $stdout_output"
+fi
+
+# M.4 — GraphQL rate-limit + REST merge fails.
+INVOCATIONS_M4="$MOCK_BIN_DIR/invocations_m4.txt"
+: > "$INVOCATIONS_M4"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_M4" \
+    MOCK_PR_MERGE_MODE=graphql_rate_limit \
+    MOCK_REST_MERGE_MODE=fail \
+    "$WRAPPER" merge 352 --squash --delete-branch 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "M.4: merge GraphQL rate-limit + REST fail exits non-zero"
+else
+    fail "M.4: merge GraphQL rate-limit + REST fail exits non-zero" \
+        "expected non-zero, got $exit_code"
+fi
+
+if [[ "$err_output" == *"REST also failed"* ]]; then
+    pass "M.4: merge stderr names 'REST also failed'"
+else
+    fail "M.4: merge stderr names 'REST also failed'" "got: $err_output"
+fi
+
+# Verify DELETE was NOT called (merge failed).
+delete_calls=$(awk '/^api -X DELETE / {n++} END {print n+0}' "$INVOCATIONS_M4")
+if [[ "$delete_calls" == "0" ]]; then
+    pass "M.4: merge REST-fail does not invoke DELETE"
+else
+    fail "M.4: merge REST-fail does not invoke DELETE" \
+        "found $delete_calls DELETE calls"
+fi
+
+# M.5 — Auth failure passes through (no REST fallback, no DELETE).
+INVOCATIONS_M5="$MOCK_BIN_DIR/invocations_m5.txt"
+: > "$INVOCATIONS_M5"
+
+exit_code=0
+err_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_M5" \
+    MOCK_PR_MERGE_MODE=auth \
+    "$WRAPPER" merge 353 --squash --delete-branch 2>&1 >/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 4 ]] && [[ "$err_output" == *"authentication required"* ]]; then
+    pass "M.5: merge auth-fail passes through original exit code (4) and stderr"
+else
+    fail "M.5: merge auth-fail passes through original exit code (4) and stderr" \
+        "exit=$exit_code, err: $err_output"
+fi
+
+api_calls=$(awk '/^api / {n++} END {print n+0}' "$INVOCATIONS_M5")
+if [[ "$api_calls" == "0" ]]; then
+    pass "M.5: merge auth-fail makes no REST API calls"
+else
+    fail "M.5: merge auth-fail makes no REST API calls" \
+        "found $api_calls api calls"
+fi
+
+# M.6 — GraphQL rate-limit + REST success WITHOUT --delete-branch.
+INVOCATIONS_M6="$MOCK_BIN_DIR/invocations_m6.txt"
+: > "$INVOCATIONS_M6"
+
+exit_code=0
+stdout_output=$(
+    MOCK_INVOCATIONS="$INVOCATIONS_M6" \
+    MOCK_PR_MERGE_MODE=graphql_rate_limit \
+    MOCK_REST_MERGE_MODE=success \
+    "$WRAPPER" merge 354 --squash 2>/dev/null
+) || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]] && [[ "$stdout_output" == *"REST fallback"* ]]; then
+    pass "M.6: merge without --delete-branch (REST fallback) exits 0"
+else
+    fail "M.6: merge without --delete-branch (REST fallback) exits 0" \
+        "exit=$exit_code, stdout: $stdout_output"
+fi
+
+# DELETE should NOT be called when --delete-branch was not passed.
+delete_calls=$(awk '/^api -X DELETE / {n++} END {print n+0}' "$INVOCATIONS_M6")
+if [[ "$delete_calls" == "0" ]]; then
+    pass "M.6: merge without --delete-branch makes no DELETE call"
+else
+    fail "M.6: merge without --delete-branch makes no DELETE call" \
+        "found $delete_calls DELETE calls"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/gh-pr-with-retry.sh` — a wrapper for `gh pr create` / `gh pr edit` / `gh pr merge` that falls back to the GitHub REST API when the GraphQL quota is exhausted (the failure mode that blocked the parent `/task #4383` session).

Wires the wrapper into `.claude/skills/task/SKILL.md` Steps A.3 (create), A.6 (edit), and A.7 (merge).

Closes #4527

## Why

`gh pr create / edit / merge` post via GitHub's GraphQL API, which has a separate 5,000-req/hr quota from the REST core API. Long agent sessions (dispatcher, multi-PR `/task` runs) routinely exhaust GraphQL via `mcp__github__*` reads + `gh pr view` / `gh run watch` polls, and then `gh pr create` (etc.) hard-fail with `GraphQL: API rate limit already exceeded for user ID …` even though the REST core quota is at ~99% remaining.

`scripts/gh-comment-with-retry.sh` (#4503) already solved this for issue/PR comments by falling back to `POST /repos/.../issues/<N>/comments`. This PR extends the same pattern to PR-create / -edit / -merge.

## How

`gh-pr-with-retry.sh <create|edit|merge>` mirrors the comment wrapper:

1. Run the corresponding `gh pr <subcommand>` first.
2. On exit 0 → pass stdout through, exit 0.
3. On non-zero with stderr matching `GraphQL: API rate limit already exceeded`:
   - `create` → `POST /repos/.../pulls` with `{title, body, head, base}`
   - `edit`   → `PATCH /repos/.../pulls/<N>` with `{title?, body?}`
   - `merge`  → `PUT /repos/.../pulls/<N>/merge` with `{merge_method: squash}`,
                followed by `DELETE /repos/.../git/refs/heads/<head>` when
                `--delete-branch` is passed (mirrors the one-shot semantic of
                native `gh pr merge`).
4. On any other non-zero exit → pass stderr through with the original code (auth, validation, branch protection, real 5xx all stay operator-driven).

The REST payload for `create` / `edit` is built by a sibling `_gh_pr_with_retry_payload.py` helper, same pattern as `_gh_comment_with_retry_match.py` — keeps the multi-line JSON build unit-testable.

The two existing fallbacks documented under SKILL.md A.7 (#4058 `base branch policy prohibits the merge` lag, #4231 `5xx / 504 Gateway Timeout` after merge succeeded) are unchanged — they handle different failure modes and the wrapper does NOT auto-recover those.

## Acceptance criteria

- [x] **AC1:** `scripts/gh-pr-with-retry.sh` exists with subcommands `create`, `edit`, `merge`. `--help` exits 0 and lists all three. (Test E.2 asserts this.)
- [x] **AC2:** On GraphQL rate-limit, the wrapper transparently falls back to `gh api` REST and succeeds. (Tests C.2 / X.2 / M.2 simulate the failure via mocked `gh` and assert the REST path runs + payload is correct.)
- [x] **AC3:** `.claude/skills/task/SKILL.md` A.3, A.6, A.7 use the wrapper. `grep gh-pr-with-retry .claude/skills/task/SKILL.md` returns 6 hits (≥3).

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass — new `scripts/tests/test_gh_pr_with_retry.sh` (48/48), picked up automatically by `scripts/run-scripts-tests.sh` (the same runner that exercises sibling shell tests in CI's `scripts-tests` job).
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (DX/tooling only; the wrapper is invoked from the operator laptop and from agent-runner Fargate, both of which pull from `main` directly).
