### PR TITLE
feat(dx): run-ci-guards.sh SKIP_LIST hint on requires-argument failures (#4534)

### DIFF
--- a/scripts/run-ci-guards.sh
+++ b/scripts/run-ci-guards.sh
@@ -84,6 +84,19 @@
 #   0 — every applicable guard passed (or SKIP_CI_GUARDS=1 was set).
 #   1 — one or more guards failed.
 #   2 — usage / discovery error (e.g. invoked from outside the repo).
+#
+# Requires-argument hint (#4534)
+# ──────────────────────────────
+# When a guard fails with what looks like a "rejected blind invocation
+# because it needs arguments" pattern (exit 2 + stderr containing
+# "requires X argument" / "the following arguments are required" /
+# "one of the arguments ... is required" / `${1:?}`'s "parameter null
+# or not set"), the failure summary appends a copy-pasteable Fix block
+# naming the SKIP_LIST as the remedy. The proactive guard
+# `scripts/check-ci-guards-skip-list-coverage.sh` (#11a) catches most
+# of this class at hygiene-check time; the runtime hint is a backstop
+# for guards that ship before their SKIP_LIST entry lands or use
+# argument-shapes the meta-check does not yet detect.
 
 set -uo pipefail
 
@@ -289,6 +302,11 @@ echo "run-ci-guards: running ${#runnable[@]} guard(s) (${#skipped[@]} skipped)..
 
 failures=0
 failed_names=()
+# Names of failures that look like "requires-argument" — we surface a
+# dedicated SKIP_LIST Fix block in the summary so operators don't have to
+# grep this script to discover the remedy. See is_requires_argument_failure
+# below for the heuristic.
+requires_arg_failures=()
 
 # Empty-runnable guard: under bash 3.2 + set -u, iterating
 # ``"${runnable[@]}"`` when the array is empty trips ``unbound
@@ -298,6 +316,42 @@ if [ "${#runnable[@]}" -eq 0 ]; then
     echo "run-ci-guards: no runnable guard(s); nothing to do." >&2
     exit 0
 fi
+
+# is_requires_argument_failure <log_file> <rc> -> 0 if the failure looks
+# like the guard rejected a blind invocation because it requires an
+# argument the umbrella cannot supply, 1 otherwise.
+#
+# The proactive guard `scripts/check-ci-guards-skip-list-coverage.sh`
+# (#11a) catches most of this class at hygiene-check time by AST-walking
+# argparse / `${1:?}` shapes — but a brand-new guard pushed before its
+# row lands, or an exotic argparse shape the meta-check does not yet
+# detect, can still slip through to umbrella-runtime. When that happens,
+# the operator sees "FAILED: scripts/check-foo.sh (exit 2)" and has to
+# read this script to find SKIP_LIST. The Fix block in the summary saves
+# them that round-trip.
+#
+# Heuristic: rc must be 2 (the conventional argparse-style usage exit
+# code, also `${1:?}`'s exit code), AND the captured stderr must contain
+# one of the known "requires X" or "is required" patterns. We require
+# both signals together so a guard that legitimately exits 2 with an
+# unrelated message (e.g. a real source-code violation) does not mis-fire
+# the SKIP_LIST hint.
+is_requires_argument_failure() {
+    local log_file="$1"
+    local rc="$2"
+    [ "$rc" -eq 2 ] || return 1
+    # Match argparse "the following arguments are required:", custom
+    # "requires an issue number argument" / "requires a <X> argument",
+    # bash "${1:?usage}" parameter-substitution emission, and
+    # mutually-exclusive-group "one of the arguments ... is required".
+    grep -qiE \
+        -e 'requires (an? )?[a-z_-]+ (number )?argument' \
+        -e 'the following arguments are required' \
+        -e 'one of the arguments .* is required' \
+        -e ': parameter (null or )?not set' \
+        -e ': usage:' \
+        "$log_file" 2>/dev/null
+}
 
 for path in "${runnable[@]}"; do
     name="$(basename "$path")"
@@ -324,6 +378,9 @@ for path in "${runnable[@]}"; do
     if [ "$rc" -ne 0 ]; then
         failures=$((failures + 1))
         failed_names+=("$name")
+        if is_requires_argument_failure "$log_file" "$rc"; then
+            requires_arg_failures+=("$name")
+        fi
         echo "" >&2
         echo "  FAILED: $name (exit $rc)" >&2
         echo "  Last 20 lines of output:" >&2
@@ -346,6 +403,36 @@ if [ "$failures" -gt 0 ]; then
         for fname in "${failed_names[@]}"; do
             echo "  - $fname" >&2
         done
+    fi
+    # ────────────────────────────────────────────────────────────────
+    # Requires-argument SKIP_LIST hint (#4534)
+    # ────────────────────────────────────────────────────────────────
+    # When a failure looks like "guard rejected blind invocation
+    # because it needs arguments the umbrella cannot supply", surface
+    # the SKIP_LIST remedy as a copy-pasteable Fix block. Same Fix-block
+    # contract as the rest of the hygiene-guard fleet
+    # (docs/dx/check-script-fix-block-coverage.md / #4346).
+    if [ "${#requires_arg_failures[@]}" -gt 0 ]; then
+        echo "" >&2
+        echo "Fix: the guard(s) below appear to require an argument that the" >&2
+        echo "umbrella cannot supply blind. Add each one to SKIP_LIST in" >&2
+        echo "scripts/run-ci-guards.sh (alphabetical order), and add a row" >&2
+        echo "in docs/dx/check-script-fix-block-coverage.md naming the" >&2
+        echo "verdict (typically \"decision flow (no violation list)\")." >&2
+        echo "" >&2
+        echo "  SKIP_LIST=(" >&2
+        echo "      \"check-issue-author.sh\"" >&2
+        echo "      ..." >&2
+        for fname in "${requires_arg_failures[@]}"; do
+            echo "      \"$fname\"   # <-- insert here, alphabetical order" >&2
+        done
+        echo "  )" >&2
+        echo "" >&2
+        echo "If the guard is genuinely runnable blind from the local tree" >&2
+        echo "and the failure is a real violation, ignore this hint and fix" >&2
+        echo "the underlying issue instead. The hint fires on argparse-style" >&2
+        echo "exit-2 + \"requires/required\" stderr; a true violation that" >&2
+        echo "happens to use exit 2 will be a false positive." >&2
     fi
     echo "" >&2
     echo "Fix the issues above and re-run.  These are the same guards CI" >&2

--- a/scripts/tests/test_run_ci_guards.sh
+++ b/scripts/tests/test_run_ci_guards.sh
@@ -31,6 +31,13 @@
 #  11.  Built-in skip list (check-issue-verify-sql.py) — exits 0, listed
 #       as SKIP (#4372 regression — script requires --issue/--body-file
 #       and exits 2 with usage error when invoked blind).
+#  12.  Requires-argument SKIP_LIST hint — a stub guard that exits 2 with
+#       "requires an issue number argument" stderr triggers the
+#       copy-pasteable SKIP_LIST Fix block in the failure summary (#4534).
+#  13.  Requires-argument hint negative case — exit 2 with unrelated
+#       stderr does NOT trigger the SKIP_LIST hint (#4534).
+#  14.  Requires-argument hint covers argparse "the following arguments
+#       are required" shape (#4534).
 #
 # Run:
 #   scripts/tests/test_run_ci_guards.sh
@@ -367,6 +374,89 @@ if [ "$rc_buf" -ne 0 ]; then
     report_fail "check-issue-verify-sql.py ran despite skip-list (rc=$rc_buf, #4372)" "$out_buf"
 else
     report_pass "check-issue-verify-sql.py not invoked during full run (#4372)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 12: requires-argument SKIP_LIST hint — exit 2 + "requires an
+#               issue number argument" stderr triggers the copy-pasteable
+#               SKIP_LIST Fix block in the failure summary (#4534).
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 12] requires-argument SKIP_LIST hint fires (#4534)"
+synth_scripts="$(seed_synthetic_scripts s12)"
+cat > "$synth_scripts/check-needs-issue-arg.sh" <<'SH'
+#!/usr/bin/env bash
+echo "ERROR: this guard requires an issue number argument" >&2
+exit 2
+SH
+chmod +x "$synth_scripts/check-needs-issue-arg.sh"
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 with failing requires-arg guard, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "Fix: the guard(s) below appear to require an argument"; then
+    report_fail "expected SKIP_LIST Fix block header in summary (#4534)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "SKIP_LIST=("; then
+    report_fail "expected SKIP_LIST array sketch in Fix block (#4534)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "\"check-needs-issue-arg.sh\""; then
+    report_fail "expected the offending guard name to appear inside SKIP_LIST" "$out_buf"
+elif ! echo "$out_buf" | grep -q "alphabetical order"; then
+    report_fail "expected 'alphabetical order' insertion guidance (#4534)" "$out_buf"
+else
+    report_pass "requires-argument SKIP_LIST hint fires with copy-pasteable Fix block (#4534)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 13: requires-argument hint negative case — exit 2 with
+#               unrelated stderr does NOT trigger the SKIP_LIST hint
+#               (#4534).
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 13] requires-argument hint negative case (#4534)"
+synth_scripts="$(seed_synthetic_scripts s13)"
+cat > "$synth_scripts/check-real-violation.sh" <<'SH'
+#!/usr/bin/env bash
+# Simulates a hygiene guard that exits 2 with a real source-code
+# violation that has nothing to do with missing arguments.
+echo "FAIL: forbidden pattern detected at packages/foo/bar.py:42" >&2
+exit 2
+SH
+chmod +x "$synth_scripts/check-real-violation.sh"
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 with failing guard, got $rc_buf" "$out_buf"
+elif echo "$out_buf" | grep -q "Fix: the guard(s) below appear to require an argument"; then
+    report_fail "SKIP_LIST hint mis-fired on unrelated exit-2 violation (#4534)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "FAILED: check-real-violation.sh"; then
+    report_fail "expected the failure to still surface in the summary" "$out_buf"
+else
+    report_pass "requires-argument hint correctly suppressed on unrelated exit-2 violation (#4534)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 14: requires-argument hint covers argparse "the following
+#               arguments are required" shape (#4534).
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 14] requires-argument hint covers argparse shape (#4534)"
+synth_scripts="$(seed_synthetic_scripts s14)"
+cat > "$synth_scripts/check-argparse-required.py" <<'PY'
+import sys
+print(
+    "usage: check-argparse-required.py [-h] --issue ISSUE",
+    file=sys.stderr,
+)
+print(
+    "check-argparse-required.py: error: the following arguments are required: --issue",
+    file=sys.stderr,
+)
+sys.exit(2)
+PY
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 with failing argparse guard, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "Fix: the guard(s) below appear to require an argument"; then
+    report_fail "expected SKIP_LIST hint to fire on argparse 'required' stderr (#4534)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "\"check-argparse-required.py\""; then
+    report_fail "expected the offending .py guard inside SKIP_LIST sketch" "$out_buf"
+else
+    report_pass "requires-argument hint covers argparse 'required' shape (#4534)"
 fi
 
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

When a hygiene guard under `scripts/run-ci-guards.sh` fails with exit 2 AND stderr matches a "requires X argument" pattern, the umbrella's failure summary now appends a copy-pasteable Fix block naming SKIP_LIST as the remedy, with the offending guard pre-filled in alphabetical-order placement. Runtime backstop to `check-ci-guards-skip-list-coverage.sh` (#11a) — that catches argparse / `${1:?}` shapes proactively at hygiene-check time; this catches the residual cases at umbrella-runtime when a brand-new guard ships before its SKIP_LIST entry lands.

The heuristic deliberately requires BOTH exit code 2 AND a stderr regex match (covering custom "requires N argument" / argparse "the following arguments are required" / mutually-exclusive-group "one of the arguments ... is required" / `${VAR:?}` parameter-substitution shapes), so a real source-code violation that legitimately exits 2 does not mis-fire the SKIP_LIST hint. Scenario 13 in the test suite explicitly exercises that suppression.

Closes #4534

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_run_ci_guards.sh` — 16/16 green locally, 3 new scenarios for #4534)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (pre-push hygiene-tooling hint only; runs on operator laptops + CI's run-ci-guards step)
- [ ] Verification evidence comment posted on issue (see A.8)
