### PR TITLE
fix(scraping): exclude ca-sd-calendar from zero-record streak alert (#4531)

### DIFF
--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -289,6 +289,52 @@ class TestCheckZeroRecordStreaks:
 
 
 # ---------------------------------------------------------------------------
+# Module-level EXCLUSIONS regression tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleExclusions:
+    """Lock the contents of the module-level ``EXCLUSIONS`` set.
+
+    Each entry in ``EXCLUSIONS`` permanently silences the silent-outage
+    guard for one scraper. Adding an entry without a tracked root-cause
+    follow-up is the failure mode this test class guards against — the
+    streak alert was originally added precisely so silently-zero scrapers
+    could not ride along undetected. See #4531 / #4539.
+    """
+
+    def test_excludes_dept_judges_rosters(self) -> None:
+        """Court directory / roster scrapers are zero-by-design — see EXCLUSIONS docstring."""
+        for sid in (
+            "ca-oc-dept-judges",
+            "ca-la-dept-judges",
+            "ca-fresno-dept-judges",
+            "ca-kern-dept-judges",
+            "ca-sd-dept-judges",
+            "ca-sb-dept-judges",
+            "ca-ventura-dept-judges",
+            "ca-sf-dept-judges",
+            "ca-riverside-dept-judges",
+        ):
+            assert sid in zrs.EXCLUSIONS, f"{sid} should remain in EXCLUSIONS"
+
+    def test_excludes_governor_appointments(self) -> None:
+        """Quarterly cadence — most runs legitimately return zero."""
+        assert "ca-governor-appointments" in zrs.EXCLUSIONS
+
+    def test_excludes_ca_sd_calendar_pending_4539(self) -> None:
+        """ca-sd-calendar is excluded as the structural day_numbers=[2] fix
+        in #4539 is pending. The entry MUST be removed once #4539 ships
+        (the day_numbers default flips to ``[1, 2, 3, 4, 5]`` and the
+        Friday-clustered motion calendar is captured on every run day).
+        See #4531 for the originating alert.
+        """
+        assert "ca-sd-calendar" in zrs.EXCLUSIONS, (
+            "ca-sd-calendar must remain in EXCLUSIONS until #4539 ships"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Formatting tests
 # ---------------------------------------------------------------------------
 

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -112,6 +112,17 @@ EXCLUSIONS: set[str] = {
     # Governor appointments scraper runs quarterly-ish; most runs legitimately
     # return zero records. Exclude until dedicated health signal is wired.
     "ca-governor-appointments",
+    # San Diego civil calendar scrapes only ``day_numbers=[2]`` per run, and
+    # the source court schedules motion hearings predominantly on Fridays —
+    # Mon/Sat/Sun runs land on calendar pages that legitimately have zero
+    # motion-typed events. Verified against 21 days of
+    # ``telemetry.scraper_runs`` (2026-04-19 → 2026-05-09): Mon=0-1,
+    # Tue=0-1, Wed=0-4, Thu=1-16, Fri=269-277, Sat=0-3, Sun=0. The streak
+    # alert fires structurally on this scraper several times per week. The
+    # root-cause fix (fetch all 5 weekday pages so Friday's high-yield
+    # calendar is always in scope) is tracked in #4539; remove this entry
+    # once that ships. Originating alert: #4531.
+    "ca-sd-calendar",
 }
 
 # Scrapers that run more than once per day ("frequent"). All others are


### PR DESCRIPTION
## Summary

Adds `ca-sd-calendar` to `EXCLUSIONS` in
`scripts/check-scraper-zero-record-streak.py` with a rationale
comment + regression test, resolving the structural false-positive
silent-outage alert. Filed follow-up #4539 to track the root-cause
fix (fetch all 5 weekday calendar pages instead of just
`day_numbers=[2]`); once that ships, `ca-sd-calendar` comes back out
of `EXCLUSIONS`.

Closes #4531

## Investigation evidence

21 days of `telemetry.scraper_runs` for `ca-sd-calendar`
(2026-04-19 → 2026-05-09):

| DOW | Records (typical) |
| --- | --- |
| Mon | 0-1 |
| Tue | 0-1 |
| Wed | 0-4 |
| Thu | 1-16 |
| Fri | **269-277** |
| Sat | 0-3 |
| Sun | 0 |

Live source probe (4 divisions × 5 days, 2026-05-09) confirmed the
calendar is healthy and motion hearings cluster on Friday day=5 (e.g.
Central total=906 / motion=201 for Fri 05/15). The 2-zero streak that
fired #4531 is the natural consequence of `day_numbers=[2]` landing
on a Tuesday's low-motion calendar after a Friday's high-yield run,
not a silent outage.

Full investigation evidence is posted as a process-summary comment on
#4531.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] After this PR merges, the `Scraper Zero-Record Streak Check`
      EventBridge job's next scheduled run sees no breaches and the
      workflow's `Auto-close resolved zero-record issues` step closes
      #4531 automatically. (Verified via manual workflow_dispatch run
      25605014303 post-merge — exited healthy.)
- [x] Verification evidence posted on #4531 (manual streak-check run
      25605014303 confirmed healthy; #4531 auto-closed by `Closes #4531`
      on PR merge at 2026-05-09T15:34:05Z).
