### PR TITLE
fix(ingestion): accept federal pro se 'v. Judge X' captions in is_plausible_case_title (#4536)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1725,6 +1725,58 @@ _TRAILING_CONNECTOR_RE = re.compile(
 # Examples: "Steinman v", "Doe vs", "Aoyagi vs.", "Serrato Vs"
 _BARE_VS_SUFFIX_RE = re.compile(r"(?:^|\s)[Vv][Ss]?\.?\s*$")
 
+# Federal pro se "v. Judge X" defendant pattern (#4536).
+#
+# Federal pro se civil-rights / habeas / appellate cases (42 U.S.C. § 1983,
+# § 2254, etc.) frequently caption the case as ``<plaintiff> v. (Circuit |
+# Magistrate | Hon. )?Judge <Name>`` — i.e. the judge IS the named defendant,
+# not a procedural-context reference.  The #3615 widening of
+# _IMPLAUSIBLE_FRAGMENTS_RE adds a generic ``\bJudge\s+[A-Z][\w'\-]*`` clause
+# that correctly catches body-text contamination ("Judge Smith's Report"),
+# but produces a 100% false-positive rate on this federal pro se subset.
+#
+# The shape we mask out is the entire judge-defendant phrase that begins with
+# ``v.`` and (optionally) extends through ``; <next-judge>`` continuations.
+# Matched spans are replaced with a placeholder before running the
+# _IMPLAUSIBLE_FRAGMENTS_RE check so a legitimate caption isn't rejected for
+# naming a judge as a defendant.  See is_plausible_case_title() for the call
+# site.
+#
+# Acceptance criteria (issue #4536) called out these shapes:
+#   - "X v. Judge Y"
+#   - "X v. Circuit Judge Y"
+#   - "X v. Hon. Judge Y"
+#   - "X v. Magistrate Judge Y"
+#   - "X v. Judge Y, Former Chief Judge Z"   (comma continuation)
+#   - "X v. Judge Y; Judge Z; Judge W"        (semicolon continuation)
+#
+# Honorific-prefix order is constrained: ``(Hon\.\s+)?(Circuit\s+|Magistrate\s+)?``
+# matches ``Hon. Judge X``, ``Hon. Circuit Judge X``, ``Hon. Magistrate Judge X``,
+# and ``Circuit Judge X`` / ``Magistrate Judge X``.  The continuation half adds
+# an optional ``Former (Chief |Senior )?`` rank prefix.
+# Sub-patterns:
+#   _JUDGE_RANK matches the honorific + rank prefix + "Judge <Name>"
+#     where <Name> is 1-3 capitalized words (covers single surnames like
+#     "Sjostrom" through "Mary Beth Smith" / "Dominique Ross"; supports
+#     compound/apostrophe/hyphen via [\w'\-]).  Cap at 3 to avoid overrunning
+#     into trailing prose like "Judge Sjostrom of the Second Judicial Circuit
+#     Court" — at 4+ words the pattern would consume the prose.
+#   The leading "v.\s+" anchors the first instance to the defendant position,
+#     so we don't mask body-text "Judge X" contamination.
+#   The continuation half allows ", " / "; " delimited additional judge
+#     defendants, optionally prefixed with "Former (Chief|Senior) " ranks.
+#   The trailing ",?" tolerates truncated-mid-list captions like Gill where
+#     a 120-char cut leaves a dangling comma.
+_JUDGE_NAME = r"[A-Z][\w'\-]*(?:\s+[A-Z][\w'\-]*){0,2}"
+_JUDGE_RANK = r"(?:Hon\.\s+)?(?:Circuit\s+|Magistrate\s+)?Judge\s+" + _JUDGE_NAME
+_FEDERAL_PRO_SE_VS_JUDGE_RE = re.compile(
+    r"\bv\.\s+"
+    + _JUDGE_RANK
+    + r"(?:[,;]\s+(?:Former\s+(?:Chief|Senior)\s+)?"
+    + _JUDGE_RANK
+    + r")*,?"
+)
+
 
 def strip_trailing_connectors(title: str) -> str:
     """Strip trailing English connector words from a case title.
@@ -1805,8 +1857,20 @@ def is_plausible_case_title(title: str) -> bool:
     if _IN_THE_NOT_MATTER_RE.match(stripped):
         return False
 
+    # Federal pro se "v. Judge X" exception (#4536): when the title names a
+    # judge as the defendant (post-"v." position), mask the judge-defendant
+    # span so the procedural-context "Judge X" clause inside
+    # _IMPLAUSIBLE_FRAGMENTS_RE doesn't reject the legitimate caption.  The
+    # contamination shape (#3615) places "Judge X" AFTER a complete party
+    # name, never directly after "v.", so this mask preserves rejection of
+    # real contamination.
+    stripped_for_check = _FEDERAL_PRO_SE_VS_JUDGE_RE.sub(
+        "v. <judge-defendant>",
+        stripped,
+    )
+
     # Reject titles containing ruling/procedural fragments
-    if _IMPLAUSIBLE_FRAGMENTS_RE.search(stripped):
+    if _IMPLAUSIBLE_FRAGMENTS_RE.search(stripped_for_check):
         return False
 
     # Reject titles containing multiple case numbers — strong indicator

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -3604,6 +3604,85 @@ class TestProceduralVocabularyFragments:
         assert is_plausible_case_title("In re Marriage of Garcia") is True
 
 
+class TestFederalProSeJudgeDefendant:
+    """Issue #4536 — federal pro se civil-rights / habeas / appellate cases
+    legitimately caption the case as ``<plaintiff> v. (Circuit | Magistrate
+    | Hon. )?Judge <Name>`` where the judge IS the named defendant.
+
+    The #3615 widening's ``\\bJudge\\s+[A-Z][\\w'\\-]*`` clause inside
+    _IMPLAUSIBLE_FRAGMENTS_RE produces a false positive on this shape.
+    The fix masks the ``v.`` + judge-defendant span before running the
+    implausibility check so legitimate captions are accepted.
+    """
+
+    # --- The 3 confirmed false positives on dev (issue #4536 table) ---
+
+    def test_federal_pro_se_judge_defendant_is_plausible_walker(self) -> None:
+        """Walker case: 'X v. Circuit Judge Y of the Second Judicial Circuit Court'."""
+        title = "Torrey D. Walker v. Circuit Judge Sjostrom of the Second Judicial Circuit Court"
+        assert is_plausible_case_title(title) is True
+
+    def test_federal_pro_se_judge_defendant_is_plausible_gill(self) -> None:
+        """Gill case: 'X v. Judge Y, Former Chief Judge Z,' (mid-list truncation)."""
+        title = "Yolanda S. Gill v. Judge Dominique Ross, Former Chief Judge Cheryl Ingram,"
+        assert is_plausible_case_title(title) is True
+
+    def test_federal_pro_se_judge_defendant_is_plausible_holtzclaw(self) -> None:
+        """Holtzclaw case: 'X v. Judge Y; Judge Z; <non-judge>; ...' semicolon list."""
+        title = "Weldon Eugene Holtzclaw, Jr. v. Judge Stokes; Judge Stone; Wendy Moses;"
+        assert is_plausible_case_title(title) is True
+
+    # --- Additional shapes called out in the issue acceptance criteria ---
+
+    def test_federal_pro_se_judge_defendant_is_plausible_hon_judge(self) -> None:
+        """'X v. Hon. Judge Y' — Hon. honorific prefix is allowed."""
+        title = "Doe v. Hon. Judge Sotomayor"
+        assert is_plausible_case_title(title) is True
+
+    def test_federal_pro_se_judge_defendant_is_plausible_magistrate_judge(self) -> None:
+        """'X v. Magistrate Judge Y' — Magistrate rank prefix is allowed."""
+        title = "Doe v. Magistrate Judge Smith"
+        assert is_plausible_case_title(title) is True
+
+    def test_federal_pro_se_judge_defendant_is_plausible_compound_name(self) -> None:
+        """Compound surnames ('Smith-Jones', 'O'Brien', 'd'Arcy') still match."""
+        assert is_plausible_case_title("Doe v. Judge Smith-Jones") is True
+        assert is_plausible_case_title("Doe v. Judge O'Brien") is True
+
+    def test_federal_pro_se_judge_defendant_is_plausible_two_part_name(self) -> None:
+        """Two-word judge names are accepted ('Dominique Ross', 'Mary Beth')."""
+        assert is_plausible_case_title("Doe v. Judge Mary Beth") is True
+
+    def test_federal_pro_se_judge_defendant_is_plausible_three_part_name(self) -> None:
+        """Three-word judge names are accepted ('John Quincy Adams')."""
+        assert is_plausible_case_title("Doe v. Judge John Quincy Adams") is True
+
+    # --- Regression: the #3615 contamination shape MUST still be rejected ---
+
+    def test_judge_smith_report_contamination_still_rejected(self) -> None:
+        """The original #3615 shape 'X v. Y Judge Smith's Report' is still
+        rejected — 'Judge Smith' here is body text following a complete
+        defendant name, not the defendant itself.
+        """
+        title = "Balt USA, LLC v. Treadstone Medical Judge Smith's Report"
+        assert is_plausible_case_title(title) is False
+
+    def test_judge_smith_report_contamination_still_rejected_with_pro_se_lookalike(
+        self,
+    ) -> None:
+        """Even if a contamination caption begins 'v. <entity> Judge X', it
+        is still rejected because the judge phrase doesn't *immediately*
+        follow 'v.' — the entity name 'Treadstone' sits between.
+        """
+        title = "Acme v. Widget Judge d'Arcy's report on the motion"
+        assert is_plausible_case_title(title) is False
+
+    def test_judge_named_after_non_v_separator_still_rejected(self) -> None:
+        """'X Judge Smith ruled ...' (no 'v.' anchor) is still rejected."""
+        title = "Smith Industries Judge Smith ruled on the motion"
+        assert is_plausible_case_title(title) is False
+
+
 class TestProceduralVocabularyTerminators:
     """Issue #3615 — widened _TITLE_TERMINATOR_RE causes clean_case_title()
     to find the boundary in contaminated titles and return clean party names."""


### PR DESCRIPTION
## Summary

The #3615 widening of `_IMPLAUSIBLE_FRAGMENTS_RE` added a generic `\bJudge\s+[A-Z][\w'\-]*` clause that correctly catches body-text "Judge Smith's Report" contamination but produces a 100% false-positive rate on legitimate federal pro se civil-rights / habeas / appellate captions of the shape `<plaintiff> v. (Hon. )?(Circuit | Magistrate )?Judge <Name>`. Three confirmed false positives on dev (Walker, Gill, Holtzclaw) had their case_title nulled or lossy-truncated. This PR adds a `_FEDERAL_PRO_SE_VS_JUDGE_RE` pattern that masks the judge-defendant span (and any `[,;]`-delimited continuation defendants) before running the implausibility check, so legitimate captions are accepted while the #3615 contamination rejection is preserved.

Closes #4536

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no immediate deployed verification component. The fix changes a pure-function regex behavior in `is_plausible_case_title()`. The 3 dev rows that surface the bug are stuck due to the upsert COALESCE semantics (#2006) and per-issue scope explicitly defers re-extracting them to a separate p3 follow-up. No new ingestion run on dev is required to validate this PR — the regression tests + #3615 negative-regression tests provide full coverage.
- [x] Verification evidence posted on issue (see A.8)
