### PR TITLE
feat(dx): extract _test-helpers.sh with --err-file dump-on-mismatch (#4540)

### DIFF
--- a/docs/investigations/scripts-tests-stderr-discarded-2026-05.md
+++ b/docs/investigations/scripts-tests-stderr-discarded-2026-05.md
@@ -239,3 +239,91 @@ Three reasons:
   worth it."
 
 (Filed as part of this task's retro — issue TBD when this PR opens.)
+
+## Update — 2026-05-08: helper-driven 1-line recipe is now available (#4540)
+
+The recommended follow-up landed as `scripts/tests/_test-helpers.sh`
+in PR for #4540. The helper provides `pass`, `fail`, `assert_eq`,
+`assert_ge`, `assert_contains` with optional `--err-file FILE`
+support — on assertion mismatch, the helper dumps FILE's last 50
+lines bracketed with the `── #4540 stderr dump ──` banner. Pass-path
+calls are silent on `--err-file`, mirroring the dump-on-mismatch
+contract this audit established.
+
+### The new 1-line recipe
+
+```bash
+# Source the shared harness once at the top of the test:
+. "$SCRIPT_DIR/tests/_test-helpers.sh"
+
+# Then at each site, the canonical 6-line block:
+err1="$TMPDIR_TEST/cmd.err"
+out1=$("$WRAPPER" 1 2>"$err1") || exit_code=$?
+assert_eq "exit code matches" "$exit_code" "1"
+if [[ "$exit_code" != "1" ]]; then
+    echo "  ── #4528 stderr dump ──"
+    tail -n 50 "$err1" 2>/dev/null | sed 's/^/    /'
+    echo "  ── end #4528 dump ──"
+fi
+
+# ... collapses to 4 lines (or 3 with the existing rc capture):
+err1="$TMPDIR_TEST/cmd.err"
+out1=$("$WRAPPER" 1 2>"$err1") || exit_code=$?
+assert_eq "exit code matches" "$exit_code" "1" --err-file "$err1"
+```
+
+The conditional dump block disappears entirely; the helper handles
+it.
+
+### Worked example migrations from this audit's harm class
+
+The three patched sites in `scripts/tests/test_profile_shell_test.sh`
+were all migrated to the helper-driven form as part of #4540.
+Compare before-and-after:
+
+**Site 1 — fixture1 (basic fixture):**
+
+```bash
+# Before (#4528 inline form):
+err1="$TMPDIR_TEST/fixture1.err"
+out1=$("$PROFILER" --tsv "$tsv1" --top 5 "$fixture1" 2>"$err1")
+exit1=$?
+assert_eq "basic fixture exits 0" "$exit1" "0"
+if [[ "$exit1" != "0" ]]; then
+    echo "  ── #4528 stderr dump (basic fixture) ──"
+    echo "  profiler stderr (last 50 lines):"
+    tail -n 50 "$err1" 2>/dev/null | sed 's/^/    /'
+    echo "  fixture stdout (last 50 lines):"
+    printf '%s\n' "$out1" | tail -n 50 | sed 's/^/    /'
+    echo "  ── end #4528 dump ──"
+fi
+
+# After (#4540 helper-driven form):
+err1="$TMPDIR_TEST/fixture1.err"
+out1=$("$PROFILER" --tsv "$tsv1" --top 5 "$fixture1" 2>"$err1")
+exit1=$?
+assert_eq "basic fixture exits 0" "$exit1" "0" --err-file "$err1"
+```
+
+**Site 2 — fixture5 (no-section fixture):** Same shape — the
+6-line conditional dump block is replaced by a single `--err-file`
+argument on the `assert_eq` call.
+
+**Site 3 — Test 8 (--top 1 stdout-derived metric):** Same shape, but
+the assertion is on a derived metric (`top_rows`) rather than the rc
+directly. The helper's `--err-file` still surfaces the profiler's
+stderr on mismatch — matching the harm class this audit identified.
+
+### Cost/benefit math now flips for the long tail
+
+The audit's "Sites considered and intentionally NOT patched" section
+(~60+ already-debuggable sites whose `fail` messages already include
+`output`) argued patching each was high-churn for marginal benefit
+under the inline 6-line recipe. With the helper-driven 1-line form,
+each site is one extra arg on the existing `assert_*` call (or one
+`fail "..." "$(tail -n 50 "$err_file")"` for the hand-rolled `fail`
+sites). A follow-up `type/dx` issue can audit those sites for
+opportunistic migration as they're touched for other reasons; a
+wholesale sweep is still not worth it (the `fail` message + stdout
+remain a sufficient signal in most cases), but the upgrade is now
+mechanical.

--- a/scripts/tests/_test-helpers.sh
+++ b/scripts/tests/_test-helpers.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# _test-helpers.sh — Shared assert harness for shell-test fixtures.
+#
+# Source this file (do NOT execute it) from a shell test to use the
+# canonical pass / fail / assert_eq / assert_ge / assert_contains
+# helpers. Each ``assert_*`` call optionally accepts a
+# ``--err-file FILE`` flag — on assertion mismatch, the harness dumps
+# the file's last 50 lines bracketed with the standard
+# ``── #4540 stderr dump ──`` banner.
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+#   . "$SCRIPT_DIR/tests/_test-helpers.sh"
+#
+#   # Initialise per-test counters in the consumer's scope. The helpers
+#   # increment these via the shell's lexical scoping rules (the
+#   # functions reference $TESTS / $FAILURES at runtime).
+#   FAILURES=0
+#   TESTS=0
+#
+#   pass "trivial truth"
+#   fail "trivial untruth" "context: anything you want"
+#
+#   # No err-file:
+#   assert_eq "exit code matches" "$exit_code" "0"
+#   assert_ge "row count meets floor" "$rows" "30"
+#   assert_contains "summary header present" "$out" "Top 5 longest sections"
+#
+#   # With err-file (one-line collapse of the #4528 6-line recipe):
+#   err1="$TMPDIR_TEST/cmd.err"
+#   out1=$("$WRAPPER" 1 2>"$err1") || exit_code=$?
+#   assert_eq "exit code matches" "$exit_code" "1" --err-file "$err1"
+#
+# When the assertion fails AND ``--err-file FILE`` was passed, the
+# harness emits:
+#
+#     ── #4540 stderr dump ──
+#       (last 50 lines of FILE, indented by 4 spaces)
+#     ── end #4540 dump ──
+#
+# The dump fires only on assertion failure — passing assertions are
+# silent on the err-file path, mirroring the "dump-on-mismatch only"
+# contract PR #4526 / #4538 established for the 6-line inline recipe.
+#
+# Why this helper exists
+# ----------------------
+# Issue #4528 patched 3 sites in test_profile_shell_test.sh with the
+# canonical 6-line stderr-capture-and-dump-on-failure pattern. The
+# audit found ~60+ adjacent sites in other shell tests that include
+# stdout in their fail message but NOT stderr. Patching each
+# individually is high-churn / low-benefit with the ad-hoc helpers —
+# each needs a separate ``*.err`` file + a separate conditional dump
+# block. The structural fix is to extend the shared assert harness so
+# every assertion call optionally accepts a stderr-file argument that
+# is dumped automatically on assertion mismatch. With the helper in
+# place, the canonical recipe collapses from 6 lines to 1 line per
+# site. See #4540.
+#
+# Argument-style choice
+# ---------------------
+# ``assert_eq desc actual expected`` — actual before expected.
+#
+# This matches the existing inline assert_eq in
+# test_profile_shell_test.sh (the one #4528 patched) and the worked
+# example in #4540's body. test_scripts_tests_runner.sh defines the
+# inverse (``desc expected actual``) but uses ``==`` so the order is
+# observationally identical for equality; it does not source this
+# helper, so the two coexist without conflict.
+#
+# Compatibility
+# -------------
+# bash 3.2 compatible — no bash 4+ features (no ``mapfile``, no
+# associative arrays, no namerefs). The ``${var:-}`` guard is the
+# canonical bash-3.2-safe idiom for testing maybe-unset variables.
+#
+# Idempotence
+# -----------
+# Sourcing this file twice is safe — the helper functions are simply
+# redefined the second time, which is a no-op.
+
+# ── Internal: dump --err-file on assertion failure ────────────────────────
+# _test_helpers__dump_err <err-file>
+#   Print the last 50 lines of <err-file> bracketed with the standard
+#   #4540 banner. Silent (no banner) when <err-file> is empty or does
+#   not exist — matches the dump-on-mismatch contract that the file
+#   may legitimately be empty/absent (e.g. the wrapped command did not
+#   write to stderr at all). Indents file content by 4 spaces so the
+#   dump nests cleanly under the FAIL line in test output.
+# shellcheck disable=SC2329  # invoked indirectly via the assert_* helpers.
+_test_helpers__dump_err() {
+    local err_file="${1:-}"
+    if [[ -z "$err_file" ]]; then
+        return 0
+    fi
+    if [[ ! -e "$err_file" ]]; then
+        return 0
+    fi
+    echo "  ── #4540 stderr dump ──"
+    echo "  stderr capture (last 50 lines of $err_file):"
+    tail -n 50 "$err_file" 2>/dev/null | sed 's/^/    /'
+    echo "  ── end #4540 dump ──"
+}
+
+# ── Internal: extract --err-file FILE from a varargs tail ─────────────────
+# _test_helpers__parse_err_file <args...>
+#   Echo the value of any ``--err-file FILE`` pair found in the
+#   trailing positional args. Emits empty string if absent. The flag
+#   may appear anywhere in the optional-args portion (we only inspect
+#   the args the assert helpers pass us, not the leading desc/value
+#   args). Nothing fancy — just walk the args looking for the literal
+#   ``--err-file``.
+# shellcheck disable=SC2329  # invoked indirectly via the assert_* helpers.
+_test_helpers__parse_err_file() {
+    while [[ $# -gt 0 ]]; do
+        if [[ "$1" == "--err-file" ]]; then
+            shift
+            echo "${1:-}"
+            return 0
+        fi
+        shift
+    done
+    echo ""
+}
+
+# ── Public: pass <desc> ───────────────────────────────────────────────────
+# Increments $TESTS in the caller's scope and prints "PASS: <desc>".
+# The caller MUST have $TESTS initialised before the first call.
+# shellcheck disable=SC2329  # invoked indirectly via consumer test scripts.
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+# ── Public: fail <desc> [<context>] ───────────────────────────────────────
+# Increments $TESTS and $FAILURES in the caller's scope and prints
+# "FAIL: <desc>" plus an optional indented context line. The caller
+# MUST have $TESTS and $FAILURES initialised before the first call.
+# shellcheck disable=SC2329  # invoked indirectly via consumer test scripts.
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Public: assert_eq <desc> <actual> <expected> [--err-file FILE] ───────
+# Asserts ``actual == expected`` (string equality, ``[[ a = b ]]``).
+# On mismatch, emits FAIL plus expected/actual lines AND, if
+# ``--err-file FILE`` was passed, dumps FILE's last 50 lines.
+# shellcheck disable=SC2329  # invoked indirectly via consumer test scripts.
+assert_eq() {
+    local desc="$1"
+    local actual="$2"
+    local expected="$3"
+    shift 3
+    local err_file
+    err_file=$(_test_helpers__parse_err_file "$@")
+    TESTS=$((TESTS + 1))
+    if [[ "$actual" = "$expected" ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        FAILURES=$((FAILURES + 1))
+        _test_helpers__dump_err "$err_file"
+    fi
+}
+
+# ── Public: assert_ge <desc> <actual> <floor> [--err-file FILE] ──────────
+# Asserts ``actual >= floor`` (integer comparison, ``[[ a -ge b ]]``).
+# On mismatch, emits FAIL plus expected/actual lines AND, if
+# ``--err-file FILE`` was passed, dumps FILE's last 50 lines.
+# shellcheck disable=SC2329  # invoked indirectly via consumer test scripts.
+assert_ge() {
+    local desc="$1"
+    local actual="$2"
+    local floor="$3"
+    shift 3
+    local err_file
+    err_file=$(_test_helpers__parse_err_file "$@")
+    TESTS=$((TESTS + 1))
+    if [[ "$actual" -ge "$floor" ]]; then
+        echo "PASS: $desc (got $actual, floor $floor)"
+    else
+        echo "FAIL: $desc"
+        echo "  expected ≥ $floor"
+        echo "  actual:    $actual"
+        FAILURES=$((FAILURES + 1))
+        _test_helpers__dump_err "$err_file"
+    fi
+}
+
+# ── Public: assert_contains <desc> <haystack> <needle> [--err-file FILE] ─
+# Asserts ``haystack`` contains ``needle`` (literal-string match via
+# ``grep -qF --``). On mismatch, emits FAIL plus expected/haystack
+# lines AND, if ``--err-file FILE`` was passed, dumps FILE's last 50
+# lines.
+# shellcheck disable=SC2329  # invoked indirectly via consumer test scripts.
+assert_contains() {
+    local desc="$1"
+    local haystack="$2"
+    local needle="$3"
+    shift 3
+    local err_file
+    err_file=$(_test_helpers__parse_err_file "$@")
+    TESTS=$((TESTS + 1))
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc"
+        echo "  expected to contain: $needle"
+        echo "  haystack: $haystack"
+        FAILURES=$((FAILURES + 1))
+        _test_helpers__dump_err "$err_file"
+    fi
+}

--- a/scripts/tests/test__test_helpers.sh
+++ b/scripts/tests/test__test_helpers.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# test__test_helpers.sh — Regression test for scripts/tests/_test-helpers.sh.
+#
+# NOTE on the filename — the issue body for #4540 named this file
+# `_test-helpers-test.sh`, but `scripts/run-scripts-tests.sh::is_helper`
+# silently skips any file whose basename starts with `_` (treating
+# them as sourceable helpers, not standalone tests). Naming the test
+# `test__test_helpers.sh` keeps the AC's intent (a runnable test for
+# the new shared helper) and makes the test discoverable by the runner.
+#
+# Exercises the shared assert harness extracted in #4540:
+#
+#   AC1 — Helper sources cleanly and exposes pass / fail / assert_eq /
+#         assert_ge / assert_contains as functions.
+#   AC2 — bash -n exits 0 on the helper file.
+#   AC3 — pass / fail / assert_eq / assert_ge / assert_contains
+#         increment $TESTS / $FAILURES correctly on the pass path
+#         AND on the fail path.
+#   AC4 — assert_eq accepts ``--err-file FILE`` and dumps the file's
+#         last 50 lines on mismatch ONLY (not on pass).
+#   AC5 — assert_ge accepts ``--err-file FILE`` and dumps on mismatch.
+#   AC6 — assert_contains accepts ``--err-file FILE`` and dumps on
+#         mismatch.
+#   AC7 — When --err-file points to a missing file, the dump is
+#         silent (no banner) — this is the "the wrapped command did
+#         not write to stderr" case the contract permits.
+#   AC8 — Bash 3.2 compatibility — scripts/check-bash-compat.sh exits 0
+#         on the helper file.
+#
+# Test strategy
+# -------------
+# Each scenario invokes the helper from inside this fixture and
+# captures stdout/stderr to verify both the assertion side-effects
+# (counter increments) and the printed output (PASS/FAIL banners,
+# dump bracket markers).
+#
+# The fail-path tests deliberately invoke the helper's fail path and
+# capture its output into a string, so the parent fixture's own
+# $TESTS / $FAILURES accounting reflects only the regression-test
+# results, not the inner failure.
+#
+# Usage:
+#   scripts/tests/_test-helpers-test.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$SCRIPT_DIR/tests/_test-helpers.sh"
+
+TESTS=0
+FAILURES=0
+
+# ── Precondition: helper exists ───────────────────────────────────────────
+if [[ ! -f "$HELPER" ]]; then
+    echo "FAIL: $HELPER does not exist" >&2
+    exit 1
+fi
+
+# Cleanup of temp directories via the shared #4343 helper.
+. "$SCRIPT_DIR/tests/_temp_cleanup_helpers.sh"
+
+TMPDIR_TEST=$(mktemp -d)
+register_temp_dir "$TMPDIR_TEST"
+
+# Local pass/fail for THIS regression test — defined inline so the
+# parent fixture's accounting is independent of the helper under test.
+# (The helper's pass/fail are exercised via child shells below.)
+parent_pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+parent_fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── AC1: helper sources cleanly and exposes the five functions ────────────
+out=$(bash -c "set -uo pipefail; . '$HELPER'; \
+declare -F pass > /dev/null && \
+declare -F fail > /dev/null && \
+declare -F assert_eq > /dev/null && \
+declare -F assert_ge > /dev/null && \
+declare -F assert_contains > /dev/null && \
+echo OK" 2>&1) || true
+if [[ "$out" == "OK" ]]; then
+    parent_pass "AC1: helper sources and exposes pass/fail/assert_{eq,ge,contains}"
+else
+    parent_fail "AC1: helper does not expose all five functions" "got: $out"
+fi
+
+# ── AC2: bash -n exits 0 on the helper ────────────────────────────────────
+if bash -n "$HELPER" 2>/dev/null; then
+    parent_pass "AC2: bash -n on helper exits 0"
+else
+    parent_fail "AC2: bash -n on helper does not exit 0" ""
+fi
+
+# ── AC3a: pass increments TESTS by 1 and prints PASS banner ───────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+pass 'foo'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"PASS: foo"* && "$out" == *"TESTS=1 FAILURES=0"* ]]; then
+    parent_pass "AC3a: pass prints PASS banner and increments TESTS"
+else
+    parent_fail "AC3a: pass output unexpected" "got: $out"
+fi
+
+# ── AC3b: fail increments TESTS+FAILURES and prints FAIL banner ──────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+fail 'foo' 'context'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"FAIL: foo"* && "$out" == *"context"* && "$out" == *"TESTS=1 FAILURES=1"* ]]; then
+    parent_pass "AC3b: fail prints FAIL banner+context and increments TESTS+FAILURES"
+else
+    parent_fail "AC3b: fail output unexpected" "got: $out"
+fi
+
+# ── AC3c: assert_eq pass-path ────────────────────────────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_eq 'eq-pass' 'a' 'a'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"PASS: eq-pass"* && "$out" == *"TESTS=1 FAILURES=0"* ]]; then
+    parent_pass "AC3c: assert_eq pass-path increments TESTS only"
+else
+    parent_fail "AC3c: assert_eq pass-path unexpected" "got: $out"
+fi
+
+# ── AC3d: assert_eq fail-path ────────────────────────────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_eq 'eq-fail' 'a' 'b'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"FAIL: eq-fail"* && "$out" == *"expected: b"* && "$out" == *"actual:   a"* && "$out" == *"TESTS=1 FAILURES=1"* ]]; then
+    parent_pass "AC3d: assert_eq fail-path emits FAIL+expected/actual and increments FAILURES"
+else
+    parent_fail "AC3d: assert_eq fail-path unexpected" "got: $out"
+fi
+
+# ── AC3e: assert_ge pass-path ────────────────────────────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_ge 'ge-pass' '5' '3'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"PASS: ge-pass (got 5, floor 3)"* && "$out" == *"TESTS=1 FAILURES=0"* ]]; then
+    parent_pass "AC3e: assert_ge pass-path increments TESTS only"
+else
+    parent_fail "AC3e: assert_ge pass-path unexpected" "got: $out"
+fi
+
+# ── AC3f: assert_ge fail-path ────────────────────────────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_ge 'ge-fail' '2' '5'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"FAIL: ge-fail"* && "$out" == *"expected ≥ 5"* && "$out" == *"actual:    2"* && "$out" == *"TESTS=1 FAILURES=1"* ]]; then
+    parent_pass "AC3f: assert_ge fail-path emits FAIL+floor/actual and increments FAILURES"
+else
+    parent_fail "AC3f: assert_ge fail-path unexpected" "got: $out"
+fi
+
+# ── AC3g: assert_contains pass-path ──────────────────────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_contains 'cn-pass' 'hello world' 'world'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"PASS: cn-pass"* && "$out" == *"TESTS=1 FAILURES=0"* ]]; then
+    parent_pass "AC3g: assert_contains pass-path increments TESTS only"
+else
+    parent_fail "AC3g: assert_contains pass-path unexpected" "got: $out"
+fi
+
+# ── AC3h: assert_contains fail-path ──────────────────────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_contains 'cn-fail' 'hello world' 'goodbye'; echo \"TESTS=\$TESTS FAILURES=\$FAILURES\"" 2>&1) || true
+if [[ "$out" == *"FAIL: cn-fail"* && "$out" == *"expected to contain: goodbye"* && "$out" == *"haystack: hello world"* && "$out" == *"TESTS=1 FAILURES=1"* ]]; then
+    parent_pass "AC3h: assert_contains fail-path emits FAIL+needle/haystack and increments FAILURES"
+else
+    parent_fail "AC3h: assert_contains fail-path unexpected" "got: $out"
+fi
+
+# ── AC4a: assert_eq with --err-file PASS — no dump emitted ───────────────
+err_file="$TMPDIR_TEST/ac4a.err"
+echo "captured-stderr-line" > "$err_file"
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_eq 'eq-ok' 'x' 'x' --err-file '$err_file'" 2>&1) || true
+if [[ "$out" == *"PASS: eq-ok"* && "$out" != *"#4540 stderr dump"* && "$out" != *"captured-stderr-line"* ]]; then
+    parent_pass "AC4a: assert_eq pass-path is silent on --err-file"
+else
+    parent_fail "AC4a: assert_eq pass-path leaked --err-file dump" "got: $out"
+fi
+
+# ── AC4b: assert_eq with --err-file FAIL — dump emitted ──────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_eq 'eq-bad' 'x' 'y' --err-file '$err_file'" 2>&1) || true
+if [[ "$out" == *"FAIL: eq-bad"* \
+    && "$out" == *"── #4540 stderr dump ──"* \
+    && "$out" == *"captured-stderr-line"* \
+    && "$out" == *"── end #4540 dump ──"* ]]; then
+    parent_pass "AC4b: assert_eq fail-path with --err-file emits #4540 dump banner+content"
+else
+    parent_fail "AC4b: assert_eq fail-path dump unexpected" "got: $out"
+fi
+
+# ── AC5a: assert_ge with --err-file PASS — no dump ───────────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_ge 'ge-ok' '7' '5' --err-file '$err_file'" 2>&1) || true
+if [[ "$out" == *"PASS: ge-ok"* && "$out" != *"#4540 stderr dump"* ]]; then
+    parent_pass "AC5a: assert_ge pass-path is silent on --err-file"
+else
+    parent_fail "AC5a: assert_ge pass-path leaked --err-file dump" "got: $out"
+fi
+
+# ── AC5b: assert_ge with --err-file FAIL — dump emitted ──────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_ge 'ge-bad' '2' '5' --err-file '$err_file'" 2>&1) || true
+if [[ "$out" == *"FAIL: ge-bad"* \
+    && "$out" == *"── #4540 stderr dump ──"* \
+    && "$out" == *"captured-stderr-line"* \
+    && "$out" == *"── end #4540 dump ──"* ]]; then
+    parent_pass "AC5b: assert_ge fail-path with --err-file emits #4540 dump banner+content"
+else
+    parent_fail "AC5b: assert_ge fail-path dump unexpected" "got: $out"
+fi
+
+# ── AC6a: assert_contains with --err-file PASS — no dump ─────────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_contains 'cn-ok' 'hello world' 'hello' --err-file '$err_file'" 2>&1) || true
+if [[ "$out" == *"PASS: cn-ok"* && "$out" != *"#4540 stderr dump"* ]]; then
+    parent_pass "AC6a: assert_contains pass-path is silent on --err-file"
+else
+    parent_fail "AC6a: assert_contains pass-path leaked --err-file dump" "got: $out"
+fi
+
+# ── AC6b: assert_contains with --err-file FAIL — dump emitted ────────────
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_contains 'cn-bad' 'hello world' 'goodbye' --err-file '$err_file'" 2>&1) || true
+if [[ "$out" == *"FAIL: cn-bad"* \
+    && "$out" == *"── #4540 stderr dump ──"* \
+    && "$out" == *"captured-stderr-line"* \
+    && "$out" == *"── end #4540 dump ──"* ]]; then
+    parent_pass "AC6b: assert_contains fail-path with --err-file emits #4540 dump banner+content"
+else
+    parent_fail "AC6b: assert_contains fail-path dump unexpected" "got: $out"
+fi
+
+# ── AC7: --err-file pointing at a missing file is silent ──────────────────
+missing_err="$TMPDIR_TEST/does-not-exist.err"
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_eq 'eq-missing-err' 'x' 'y' --err-file '$missing_err'" 2>&1) || true
+if [[ "$out" == *"FAIL: eq-missing-err"* && "$out" != *"#4540 stderr dump"* ]]; then
+    parent_pass "AC7: --err-file pointing at a missing file does not emit a dump banner"
+else
+    parent_fail "AC7: missing --err-file path leaked dump banner" "got: $out"
+fi
+
+# ── AC8: bash 3.2 compatibility ──────────────────────────────────────────
+if "$SCRIPT_DIR/check-bash-compat.sh" "$HELPER" >/dev/null 2>&1; then
+    parent_pass "AC8: helper passes scripts/check-bash-compat.sh"
+else
+    parent_fail "AC8: helper has bash 4+ constructs" ""
+fi
+
+# ── Tail: empty --err-file argument is silent (defensive) ────────────────
+empty_err_arg="$TMPDIR_TEST/empty.err"
+: > "$empty_err_arg"  # zero-byte file
+out=$(bash -c "set -uo pipefail; TESTS=0; FAILURES=0; . '$HELPER'; \
+assert_eq 'eq-empty-err' 'x' 'y' --err-file '$empty_err_arg'" 2>&1) || true
+# A zero-byte file should still emit the banner (file exists, has 0
+# lines to dump — the banner is informative, the empty body is fine).
+# This documents the behavior: existence is the gate, not non-emptiness.
+if [[ "$out" == *"FAIL: eq-empty-err"* && "$out" == *"── #4540 stderr dump ──"* && "$out" == *"── end #4540 dump ──"* ]]; then
+    parent_pass "AC9: --err-file pointing at a zero-byte file still emits the banner (existence is the gate)"
+else
+    parent_fail "AC9: zero-byte --err-file behavior unexpected" "got: $out"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_profile_shell_test.sh
+++ b/scripts/tests/test_profile_shell_test.sh
@@ -37,6 +37,12 @@ cleanup() {
 trap cleanup EXIT
 
 # ─── Helpers ─────────────────────────────────────────────────────────────
+# Source the shared assert harness extracted in #4540. Provides pass /
+# fail / assert_eq / assert_ge / assert_contains plus the optional
+# ``--err-file FILE`` flag that dumps FILE's last 50 lines on
+# assertion mismatch. Replaces three inline assert helper definitions
+# that previously lived here (pre-#4540).
+. "$SCRIPT_DIR/tests/_test-helpers.sh"
 
 # Make a fixture .sh file under the temp dir; chmod +x so the wrapper can
 # run it. Returns the absolute path.
@@ -47,51 +53,6 @@ make_fixture() {
     printf '%s\n' "$content" > "$path"
     chmod +x "$path"
     echo "$path"
-}
-
-assert_eq() {
-    local desc="$1"
-    local actual="$2"
-    local expected="$3"
-    TESTS=$((TESTS + 1))
-    if [[ "$actual" = "$expected" ]]; then
-        echo "PASS: $desc"
-    else
-        echo "FAIL: $desc"
-        echo "  expected: $expected"
-        echo "  actual:   $actual"
-        FAILURES=$((FAILURES + 1))
-    fi
-}
-
-assert_ge() {
-    local desc="$1"
-    local actual="$2"
-    local floor="$3"
-    TESTS=$((TESTS + 1))
-    if [[ "$actual" -ge "$floor" ]]; then
-        echo "PASS: $desc (got $actual, floor $floor)"
-    else
-        echo "FAIL: $desc"
-        echo "  expected ≥ $floor"
-        echo "  actual:    $actual"
-        FAILURES=$((FAILURES + 1))
-    fi
-}
-
-assert_contains() {
-    local desc="$1"
-    local haystack="$2"
-    local needle="$3"
-    TESTS=$((TESTS + 1))
-    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
-        echo "PASS: $desc"
-    else
-        echo "FAIL: $desc"
-        echo "  expected to contain: $needle"
-        echo "  haystack: $haystack"
-        FAILURES=$((FAILURES + 1))
-    fi
 }
 
 # ─── Test 1: Three-section fixture; preserves exit code 0 ────────────────
@@ -121,23 +82,16 @@ sleep 0.50
 exit 0
 ')
 tsv1="$TMPDIR_TEST/fixture1.tsv"
-# #4528: capture stderr (do NOT discard) so a future flake records the
-# profiler's diagnostic output alongside the wrapped fixture's stdout.
-# Without this capture the only signal on rc mismatch is "expected 0,
-# actual N" with no context — exactly the #4383 failure mode this issue
-# is generalising. The dump fires only on the rc assertion failing.
+# #4528 / #4540: capture stderr (do NOT discard) so a future flake
+# records the profiler's diagnostic output alongside the wrapped
+# fixture's stdout. Without this capture the only signal on rc
+# mismatch is "expected 0, actual N" with no context — exactly the
+# #4383 failure mode this issue is generalising. The dump fires only
+# on the rc assertion failing, via the shared helper's --err-file.
 err1="$TMPDIR_TEST/fixture1.err"
 out1=$("$PROFILER" --tsv "$tsv1" --top 5 "$fixture1" 2>"$err1")
 exit1=$?
-assert_eq "basic fixture exits 0" "$exit1" "0"
-if [[ "$exit1" != "0" ]]; then
-    echo "  ── #4528 stderr dump (basic fixture) ──"
-    echo "  profiler stderr (last 50 lines):"
-    tail -n 50 "$err1" 2>/dev/null | sed 's/^/    /'
-    echo "  fixture stdout (last 50 lines):"
-    printf '%s\n' "$out1" | tail -n 50 | sed 's/^/    /'
-    echo "  ── end #4528 dump ──"
-fi
+assert_eq "basic fixture exits 0" "$exit1" "0" --err-file "$err1"
 sections1=$(wc -l < "$tsv1" | tr -d ' ')
 assert_eq "basic fixture records 3 sections" "$sections1" "3"
 assert_contains "basic fixture summary names section 3" "$out1" "Test 3: gamma"
@@ -216,19 +170,12 @@ echo hello
 exit 0
 ')
 tsv5="$TMPDIR_TEST/fixture5.tsv"
-# #4528: capture stderr (see same pattern at fixture1 above).
+# #4528 / #4540: capture stderr (see same pattern at fixture1 above).
+# Dump-on-mismatch handled by the shared helper's --err-file flag.
 err5="$TMPDIR_TEST/fixture5.err"
 out5=$("$PROFILER" --tsv "$tsv5" "$fixture5" 2>"$err5")
 exit5=$?
-assert_eq "no-section fixture exits 0" "$exit5" "0"
-if [[ "$exit5" != "0" ]]; then
-    echo "  ── #4528 stderr dump (no-section fixture) ──"
-    echo "  profiler stderr (last 50 lines):"
-    tail -n 50 "$err5" 2>/dev/null | sed 's/^/    /'
-    echo "  fixture stdout (last 50 lines):"
-    printf '%s\n' "$out5" | tail -n 50 | sed 's/^/    /'
-    echo "  ── end #4528 dump ──"
-fi
+assert_eq "no-section fixture exits 0" "$exit5" "0" --err-file "$err5"
 sections5=$(wc -l < "$tsv5" 2>/dev/null | tr -d ' ' || echo 0)
 assert_eq "no-section fixture records 0 sections" "$sections5" "0"
 assert_contains "no-section fixture reports 0 sections" "$out5" "Sections recorded: 0"
@@ -251,26 +198,18 @@ else
 fi
 
 # ─── Test 8: --top N controls number of rows printed ─────────────────────
-# #4528: capture stderr — Test 8 doesn't capture rc directly, but its
-# `top_rows` derived value is computed from out6's stdout. If the
-# profiler dies silently, top_rows is 0 and the assertion fires with
-# "expected 1, actual 0" and no context. Same flake-hider class as the
-# fixture1/fixture5 sites above.
+# #4528 / #4540: capture stderr — Test 8 doesn't capture rc directly,
+# but its `top_rows` derived value is computed from out6's stdout. If
+# the profiler dies silently, top_rows is 0 and the assertion fires
+# with "expected 1, actual 0" and no context. Same flake-hider class
+# as the fixture1/fixture5 sites above. Dump-on-mismatch handled by
+# the shared helper's --err-file flag.
 err6="$TMPDIR_TEST/top1.err"
 out6=$("$PROFILER" --tsv "$TMPDIR_TEST/top1.tsv" --top 1 "$fixture1" 2>"$err6")
 exit6=$?
 # Count rows after "Top 1 longest sections:" header. Stop at "----- end -----".
 top_rows=$(printf '%s' "$out6" | awk '/^Top 1 longest sections:/{flag=1; next} /^----- end -----/{flag=0} flag' | wc -l | tr -d ' ')
-assert_eq "--top 1 prints 1 row" "$top_rows" "1"
-if [[ "$top_rows" != "1" ]]; then
-    echo "  ── #4528 stderr dump (--top 1) ──"
-    echo "  profiler exit: $exit6"
-    echo "  profiler stderr (last 50 lines):"
-    tail -n 50 "$err6" 2>/dev/null | sed 's/^/    /'
-    echo "  fixture stdout (last 50 lines):"
-    printf '%s\n' "$out6" | tail -n 50 | sed 's/^/    /'
-    echo "  ── end #4528 dump ──"
-fi
+assert_eq "--top 1 prints 1 row" "$top_rows" "1" --err-file "$err6"
 
 # ─── Test 9: Bash 3.2 compatibility check ────────────────────────────────
 TESTS=$((TESTS + 1))


### PR DESCRIPTION
## Summary

Extracts the shared assert harness `pass` / `fail` / `assert_eq` /
`assert_ge` / `assert_contains` into `scripts/tests/_test-helpers.sh`,
with optional `--err-file FILE` support that dumps the file's last
50 lines on assertion mismatch. Migrates `test_profile_shell_test.sh`
(the canonical #4528 consumer) to the helper-driven form, collapsing
3 × 6-line conditional dump blocks into 3 × 1-line `--err-file` args.
Updates the `scripts-tests-stderr-discarded-2026-05.md` audit doc
with the new 1-line recipe and worked migrations.

Closes #4540

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test__test_helpers.sh` 19/19; `scripts/tests/test_profile_shell_test.sh` 32/32)
- [x] CI green (100/100)

### Post-deploy verification
- [x] N/A — no deployed component (test scaffolding + investigation doc only)
