### PR TITLE
fix(scraping): ca-sd-calendar fetch all 5 weekday pages by default (#4539)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -494,8 +494,16 @@ class SDCalendarScraper(BaseScraper):
         **kwargs: Any,
     ) -> None:
         super().__init__(config, archiver=archiver, event_bus=event_bus, **kwargs)
-        # Which day numbers (1-5) to fetch.  Default: [2] (tomorrow).
-        self._day_numbers = day_numbers or [2]
+        # Which day numbers (1-5) to fetch.  Default: ``[1, 2, 3, 4, 5]`` —
+        # the full Mon-Fri rolling window. The San Diego calendar publishes
+        # ``f_svcal{1-5}.html`` etc. as a 5-business-day window where motion
+        # hearings cluster heavily on Fridays. Fetching only one day (the
+        # prior ``[2]`` default) meant Mon/Sat/Sun runs returned 0 records
+        # — the structural fix in #4539 captures the full window so the
+        # latest Friday calendar (the high-yield page) is always in scope
+        # regardless of which weekday the run executes. See #4531 for the
+        # originating silent-outage alert.
+        self._day_numbers = day_numbers or [1, 2, 3, 4, 5]
 
     def _build_urls(self) -> list[tuple[str, str]]:
         """Build (url, division_name) pairs for all divisions and day numbers."""

--- a/packages/scraper-framework/tests/courts/test_sd_calendar.py
+++ b/packages/scraper-framework/tests/courts/test_sd_calendar.py
@@ -337,6 +337,65 @@ class TestCleanCaseTitle:
 
 
 # ---------------------------------------------------------------------------
+# SDCalendarScraper._build_urls — default day_numbers and URL enumeration
+# ---------------------------------------------------------------------------
+
+
+class TestBuildUrls:
+    """Tests for ``SDCalendarScraper._build_urls()`` — default day_numbers
+    and the (URL, division) enumeration.
+
+    The default ``day_numbers=[1, 2, 3, 4, 5]`` is the structural fix from
+    #4539: prior to that the default was ``[2]`` (one day per run), which
+    caused ``ca-sd-calendar`` to return 0 records on Mon/Sat/Sun and a
+    handful on Tue/Wed/Thu — only Friday's calendar carried the motion
+    hearings. Fetching all 5 days means the latest Friday calendar (the
+    high-yield page) is always in scope regardless of which weekday the
+    run executes. See #4531 for the originating silent-outage alert.
+    """
+
+    def test_default_day_numbers_covers_full_mon_fri_window(self) -> None:
+        """The ``__init__`` default fetches all 5 weekday calendar pages."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+        assert scraper._day_numbers == [1, 2, 3, 4, 5]
+
+    def test_default_build_urls_emits_20_urls(self) -> None:
+        """4 divisions × 5 days = 20 (URL, division) pairs by default."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+        urls = scraper._build_urls()
+        assert len(urls) == 20
+
+    def test_default_build_urls_covers_all_days_per_division(self) -> None:
+        """Every (Central, North, East, South) division emits days 1-5."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config)
+        urls = scraper._build_urls()
+        # Group URLs by division and assert each has all 5 day numbers.
+        by_division: dict[str, set[int]] = {}
+        for url, division in urls:
+            # The day digit is the last char before ``.html``.
+            day = int(url.rsplit(".", 1)[0][-1])
+            by_division.setdefault(division, set()).add(day)
+        assert by_division == {
+            "Central": {1, 2, 3, 4, 5},
+            "North County": {1, 2, 3, 4, 5},
+            "East County": {1, 2, 3, 4, 5},
+            "South County": {1, 2, 3, 4, 5},
+        }
+
+    def test_explicit_day_numbers_override_default(self) -> None:
+        """Passing ``day_numbers=`` to the constructor overrides the default."""
+        config = _make_config()
+        scraper = SDCalendarScraper(config, day_numbers=[3])
+        assert scraper._day_numbers == [3]
+        urls = scraper._build_urls()
+        assert len(urls) == 4  # 4 divisions × 1 day
+        assert all(url.endswith("3.html") for url, _ in urls)
+
+
+# ---------------------------------------------------------------------------
 # SDCalendarScraper — integration test with respx
 # ---------------------------------------------------------------------------
 

--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -322,15 +322,20 @@ class TestModuleExclusions:
         """Quarterly cadence — most runs legitimately return zero."""
         assert "ca-governor-appointments" in zrs.EXCLUSIONS
 
-    def test_excludes_ca_sd_calendar_pending_4539(self) -> None:
-        """ca-sd-calendar is excluded as the structural day_numbers=[2] fix
-        in #4539 is pending. The entry MUST be removed once #4539 ships
-        (the day_numbers default flips to ``[1, 2, 3, 4, 5]`` and the
-        Friday-clustered motion calendar is captured on every run day).
-        See #4531 for the originating alert.
+    def test_does_not_exclude_ca_sd_calendar_after_4539(self) -> None:
+        """ca-sd-calendar must NOT be in EXCLUSIONS now that #4539 has
+        shipped. The structural fix flipped the ``day_numbers`` default
+        from ``[2]`` to ``[1, 2, 3, 4, 5]`` so the Friday-clustered
+        motion calendar is captured on every run day, restoring the
+        silent-outage guard for this scraper. Re-adding ``ca-sd-calendar``
+        to EXCLUSIONS without a fresh tracked root-cause follow-up is
+        the failure mode this test guards against. See #4531 for the
+        originating alert and #4539 for the structural fix.
         """
-        assert "ca-sd-calendar" in zrs.EXCLUSIONS, (
-            "ca-sd-calendar must remain in EXCLUSIONS until #4539 ships"
+        assert "ca-sd-calendar" not in zrs.EXCLUSIONS, (
+            "ca-sd-calendar must NOT be in EXCLUSIONS after #4539 — the "
+            "structural day_numbers fix shipped and the silent-outage "
+            "guard must remain active for this scraper"
         )
 
 

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -112,17 +112,6 @@ EXCLUSIONS: set[str] = {
     # Governor appointments scraper runs quarterly-ish; most runs legitimately
     # return zero records. Exclude until dedicated health signal is wired.
     "ca-governor-appointments",
-    # San Diego civil calendar scrapes only ``day_numbers=[2]`` per run, and
-    # the source court schedules motion hearings predominantly on Fridays —
-    # Mon/Sat/Sun runs land on calendar pages that legitimately have zero
-    # motion-typed events. Verified against 21 days of
-    # ``telemetry.scraper_runs`` (2026-04-19 → 2026-05-09): Mon=0-1,
-    # Tue=0-1, Wed=0-4, Thu=1-16, Fri=269-277, Sat=0-3, Sun=0. The streak
-    # alert fires structurally on this scraper several times per week. The
-    # root-cause fix (fetch all 5 weekday pages so Friday's high-yield
-    # calendar is always in scope) is tracked in #4539; remove this entry
-    # once that ships. Originating alert: #4531.
-    "ca-sd-calendar",
 }
 
 # Scrapers that run more than once per day ("frequent"). All others are


### PR DESCRIPTION
## Summary

Structural fix for `ca-sd-calendar`'s zero-record-on-non-Friday failure mode. The `__init__` default for `day_numbers` flips from `[2]` to `[1, 2, 3, 4, 5]` so every run captures the full Mon-Fri rolling window — Friday's high-yield calendar is now always in scope regardless of run weekday. Also removes the `ca-sd-calendar` workaround entry from `EXCLUSIONS` in `scripts/check-scraper-zero-record-streak.py` (added in #4531), restoring the silent-outage guard, and inverts the regression test so future re-additions fail loudly.

Closes #4539

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deploy ran SUCCESS — `deploy-scraper.yml` run 25605711823 (Build/ECR + Deploy Ingestion Worker + Deploy Staging + Post-Deploy Health Check, all green) on merge SHA `ce9044b3`.
- [x] Verification evidence posted on issue (see #4539 verification-evidence comment). AC #4 (forward-looking 7-day telemetry across all weekdays) requires multiple post-deploy daily runs and is noted as pending; the structural change is verified at the unit level by 4 new `_build_urls` tests asserting 4 divisions × 5 days = 20 URLs covering the full Mon-Fri window.
