### PR TITLE
fix(dx): migrate 10 stderr-discarded sites in scripts/tests to err-file capture (#4546)

### DIFF
--- a/docs/investigations/scripts-tests-stderr-discarded-2026-05.md
+++ b/docs/investigations/scripts-tests-stderr-discarded-2026-05.md
@@ -327,3 +327,29 @@ opportunistic migration as they're touched for other reasons; a
 wholesale sweep is still not worth it (the `fail` message + stdout
 remain a sufficient signal in most cases), but the upgrade is now
 mechanical.
+
+## Update — 2026-05-09: long-tail migration first chunk shipped (#4546)
+
+The first opportunistic chunk of the long-tail migration shipped as
+part of issue #4546. Migrated 10 sites across two test files using
+the hand-rolled `tail -n 50 "$err"` form (since both files define
+their own `pass`/`fail` and do not source `_test-helpers.sh`):
+
+* `scripts/tests/test_check_issue_plan_blocked.sh` — 7 sites
+  (Tests 3, 4, 5, 6, 7, 8, 9). Each `output=$("$WRAPPER" 1 2>/dev/null)`
+  now captures stderr to `$MOCK_BIN_DIR/test<N>.err` and the `fail`
+  message includes `stderr=$(tail -n 50 "$err" 2>/dev/null)`.
+* `scripts/tests/test_check_duplicate_pr.sh` — 3 sites (Tests 2, 3, 4).
+  Same pattern.
+
+The grep verification (`grep -rn -F '2>"$' scripts/tests/ | wc -l`)
+went from a baseline of 47 to 57 (+10 sites — well above the AC's
+required +5). Migrated tests still pass; baseline 3 unrelated
+failures (graphql-queries, cleanup-worktree-review-log-mirror,
+fleet-status-cooldown) are unchanged.
+
+The remaining ~50+ already-debuggable sites identified in the
+"Sites considered and intentionally NOT patched" section above
+remain unmigrated by design — the cost/benefit math says migrate
+opportunistically as those tests are touched, not in a wholesale
+sweep.

--- a/scripts/tests/test_check_duplicate_pr.sh
+++ b/scripts/tests/test_check_duplicate_pr.sh
@@ -90,17 +90,18 @@ MOCKGH
 chmod +x "$MOCK_BIN_DIR/gh"
 
 exit_code=0
-output=$("$WRAPPER" 99999 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test2.err"
+output=$("$WRAPPER" 99999 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 1 ]]; then
     pass "exits 1 when no duplicate PR exists"
 else
-    fail "exits 1 when no duplicate PR exists" "expected exit 1, got $exit_code"
+    fail "exits 1 when no duplicate PR exists" "expected exit 1, got $exit_code stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 if [[ "$output" == *"ok"* ]]; then
     pass "prints ok line to stdout when no duplicate"
 else
-    fail "prints ok line to stdout when no duplicate" "expected stdout containing 'ok', got '$output'"
+    fail "prints ok line to stdout when no duplicate" "expected stdout containing 'ok', got '$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 3: exit 0 and prints duplicate line when a duplicate exists ────────
@@ -125,27 +126,29 @@ MOCKGH
 chmod +x "$MOCK_BIN_DIR/gh"
 
 exit_code=0
-output=$("$WRAPPER" 42 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test3.err"
+output=$("$WRAPPER" 42 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 0 ]]; then
     pass "exits 0 when a duplicate PR exists"
 else
-    fail "exits 0 when a duplicate PR exists" "expected exit 0, got $exit_code"
+    fail "exits 0 when a duplicate PR exists" "expected exit 0, got $exit_code stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 if [[ "$output" == *"duplicate:"* && "$output" == *"1234"* ]]; then
     pass "prints duplicate line with PR number to stdout"
 else
-    fail "prints duplicate line with PR number to stdout" "expected stdout containing 'duplicate:' and '1234', got '$output'"
+    fail "prints duplicate line with PR number to stdout" "expected stdout containing 'duplicate:' and '1234', got '$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 4: strips a leading '#' from the issue argument ───────────────────
 
 exit_code=0
-output=$("$WRAPPER" "#42" 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test4.err"
+output=$("$WRAPPER" "#42" 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 0 && "$output" == *"duplicate:"* && "$output" == *"1234"* ]]; then
     pass "strips leading '#' from the issue argument"
 else
-    fail "strips leading '#' from the issue argument" "exit=$exit_code output='$output'"
+    fail "strips leading '#' from the issue argument" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 5: exit 2 when gh CLI call fails (API error) ──────────────────────

--- a/scripts/tests/test_check_issue_plan_blocked.sh
+++ b/scripts/tests/test_check_issue_plan_blocked.sh
@@ -104,50 +104,54 @@ MOCKGH
 
 write_mock_gh '{"comments":[]}'
 exit_code=0
-output=$("$WRAPPER" 1 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test3.err"
+output=$("$WRAPPER" 1 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 1 && "$output" == *"clear:"* && "$output" == *"no-comments"* ]]; then
     pass "exits 1 with clear:no-comments when issue has no comments"
 else
-    fail "exits 1 with clear:no-comments when issue has no comments" "exit=$exit_code output='$output'"
+    fail "exits 1 with clear:no-comments when issue has no comments" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 4: exit 1 ("clear:no-marker") when comments lack the sentinel ─────
 
 write_mock_gh '{"comments":[{"author":{"login":"drewthaler"},"createdAt":"2026-05-01T00:00:00Z","body":"some other comment"}]}'
 exit_code=0
-output=$("$WRAPPER" 1 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test4.err"
+output=$("$WRAPPER" 1 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 1 && "$output" == *"clear:"* && "$output" == *"no-marker"* ]]; then
     pass "exits 1 with clear:no-marker when sentinel absent"
 else
-    fail "exits 1 with clear:no-marker when sentinel absent" "exit=$exit_code output='$output'"
+    fail "exits 1 with clear:no-marker when sentinel absent" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 5: exit 0 when latest non-bot comment carries the sentinel ────────
 
 write_mock_gh '{"comments":[{"author":{"login":"drewthaler"},"createdAt":"2026-04-23T00:00:00Z","body":"<!-- dispatcher-plan-blocked -->\nplan returned go=false\n<!-- dispatcher-plan-blocked-recommendation: operator-triage -->"}]}'
 exit_code=0
-output=$("$WRAPPER" 1 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test5.err"
+output=$("$WRAPPER" 1 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 0 && "$output" == *"plan-blocked:"* ]]; then
     pass "exits 0 with plan-blocked: line when sentinel present on latest comment"
 else
-    fail "exits 0 with plan-blocked: line when sentinel present on latest comment" "exit=$exit_code output='$output'"
+    fail "exits 0 with plan-blocked: line when sentinel present on latest comment" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 if [[ "$output" == *"operator-triage"* ]]; then
     pass "extracts recommendation token from footer"
 else
-    fail "extracts recommendation token from footer" "output='$output'"
+    fail "extracts recommendation token from footer" "output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 6: exit 1 ("clear:superseded") when a later human comment follows ─
 
 write_mock_gh '{"comments":[{"author":{"login":"drewthaler"},"createdAt":"2026-04-23T00:00:00Z","body":"<!-- dispatcher-plan-blocked -->\nplan reason"},{"author":{"login":"drewthaler"},"createdAt":"2026-04-24T00:00:00Z","body":"acknowledged, will re-scope"}]}'
 exit_code=0
-output=$("$WRAPPER" 1 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test6.err"
+output=$("$WRAPPER" 1 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 1 && "$output" == *"clear:"* && "$output" == *"superseded"* ]]; then
     pass "exits 1 with clear:superseded when later human comment follows the marker"
 else
-    fail "exits 1 with clear:superseded when later human comment follows the marker" "exit=$exit_code output='$output'"
+    fail "exits 1 with clear:superseded when later human comment follows the marker" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 7: bot comments are filtered out of the latest-comment pick ──────
@@ -156,11 +160,12 @@ fi
 # bot comment is filtered.
 write_mock_gh '{"comments":[{"author":{"login":"drewthaler"},"createdAt":"2026-04-23T00:00:00Z","body":"<!-- dispatcher-plan-blocked -->\nplan reason"},{"author":{"login":"github-actions[bot]"},"createdAt":"2026-04-24T00:00:00Z","body":"automated noise"}]}'
 exit_code=0
-output=$("$WRAPPER" 1 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test7.err"
+output=$("$WRAPPER" 1 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 0 && "$output" == *"plan-blocked:"* ]]; then
     pass "filters github-actions[bot] when picking the latest non-bot comment"
 else
-    fail "filters github-actions[bot] when picking the latest non-bot comment" "exit=$exit_code output='$output'"
+    fail "filters github-actions[bot] when picking the latest non-bot comment" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 8: empty/missing recommendation footer (pre-#4438 comments) ───────
@@ -169,22 +174,24 @@ fi
 # recommendation field is empty / "(unspecified)".
 write_mock_gh '{"comments":[{"author":{"login":"drewthaler"},"createdAt":"2026-04-23T00:00:00Z","body":"<!-- dispatcher-plan-blocked -->\nlegacy comment without footer"}]}'
 exit_code=0
-output=$("$WRAPPER" 1 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test8.err"
+output=$("$WRAPPER" 1 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 0 && "$output" == *"plan-blocked:"* ]]; then
     pass "exits 0 even when comment lacks the recommendation footer (pre-#4438)"
 else
-    fail "exits 0 even when comment lacks the recommendation footer (pre-#4438)" "exit=$exit_code output='$output'"
+    fail "exits 0 even when comment lacks the recommendation footer (pre-#4438)" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 9: strips a leading '#' from the issue argument ───────────────────
 
 write_mock_gh '{"comments":[]}'
 exit_code=0
-output=$("$WRAPPER" "#42" 2>/dev/null) || exit_code=$?
+err="$MOCK_BIN_DIR/test9.err"
+output=$("$WRAPPER" "#42" 2>"$err") || exit_code=$?
 if [[ "$exit_code" -eq 1 && "$output" == *"clear:"* ]]; then
     pass "strips leading '#' from the issue argument"
 else
-    fail "strips leading '#' from the issue argument" "exit=$exit_code output='$output'"
+    fail "strips leading '#' from the issue argument" "exit=$exit_code output='$output' stderr=$(tail -n 50 "$err" 2>/dev/null)"
 fi
 
 # ── Test 10: exit 2 when gh CLI fails (API error) ──────────────────────────


### PR DESCRIPTION
## Summary

Migrates 10 stderr-discarded sites across two `scripts/tests/` files (the first opportunistic chunk of #4528's long-tail audit) from `output=$(... 2>/dev/null)` to err-file capture with `stderr=$(tail -n 50 "$err" 2>/dev/null)` appended to each `fail` message — the hand-rolled form the issue's AC explicitly permits for tests that don't source `_test-helpers.sh`. Picks the `check-issue-plan-blocked.sh` and `check-duplicate-pr.sh` test files because both are tightly scoped, exercise hot agent-fleet preflight wrappers, and together produce 10 migrated sites (well above the AC's +5 floor).

Closes #4546

## Test plan

### Automated checks
- [x] Lint passes (no Python/TS files touched)
- [x] Format check passes (shell only)
- [x] Tests pass — `test_check_issue_plan_blocked.sh` 13/13, `test_check_duplicate_pr.sh` 9/9 locally
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test-suite-only changes; no service ships)
