### PR TITLE
fix(scripts): remove unused mock_gh variable in test_wait_for_ci.sh (#4082)

### DIFF
--- a/scripts/tests/test_wait_for_ci.sh
+++ b/scripts/tests/test_wait_for_ci.sh
@@ -244,8 +244,7 @@ MOCK
 run_script() {
     local tmpdir="$1"
     shift
-    local mock_gh
-    mock_gh=$(setup_mock_gh "$tmpdir")
+    setup_mock_gh "$tmpdir" >/dev/null
 
     PATH="$tmpdir:$PATH" \
     RESPONSES_DIR="$tmpdir/responses" \


### PR DESCRIPTION
## Summary

Replaces the unused `mock_gh` variable assignment in `run_script()` with a direct `setup_mock_gh "$tmpdir" >/dev/null` call. The variable was vestigial — `setup_mock_gh` is called only for its side effect (writing the mock binary into `$tmpdir/gh`, then `PATH="$tmpdir:..."` makes the script under test pick it up). Silences shellcheck `SC2034`.

Closes #4082

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (test-script edit only)
- [x] Verification evidence posted on issue (see A.8)
