### PR TITLE
docs(dx): document check-* naming overload + add rename hint to Fix blocks (#4558)

### DIFF
--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -219,6 +219,24 @@ The bypass emits a noisy stderr WARNING so it's hard to miss. Use only when one 
 
 See #4332 for the motivating retro (PR #4325 hit a CI-only `sql-column-check` failure that would have surfaced locally with this umbrella).
 
+#### Naming convention: don't name ECS-oneshot data-check scripts `scripts/check-*.{sh,py}`
+
+The `scripts/check-*.{sh,py}` glob is the umbrella's auto-discovery namespace for **code-quality CI guards** — guards that run blind on the local tree, take no arguments, and fail loudly when the tree contains a forbidden pattern. ECS-oneshot data-check scripts (those with `# venv: scraper-framework` + `# permanent: true` headers, invoked by `scripts/ecs-run-task.sh` from a scheduled GitHub Actions workflow with required `--date YYYY-MM-DD`-style arguments) collide with this glob whenever they are named `check-*`. Three cascading pre-push failures result:
+
+1. `scripts/check-ci-guards-skip-list-coverage.sh` (#11a) flags the script for missing-from-`SKIP_LIST` coverage, because its `--date` argument is `required=True` (or its `${1:?}` first positional is strict-required). The remediation is then to add a `SKIP_LIST` entry or a `# ci-guards: skip` marker.
+2. `scripts/check-fix-block-coverage-complete.sh` (#23a) flags the script for missing-from-inventory coverage, because every executable `scripts/check-*.{sh,py}` in the tree must carry a row in `docs/dx/check-script-fix-block-coverage.md`.
+3. `scripts/run-ci-guards.sh` itself blindly invokes the script with no args during pre-push, exits 2 because the required argument is absent, and surfaces that exit 2 as a guard failure.
+
+**Use a descriptive verb-less name instead.** ECS-oneshot data-check scripts are not CI guards and should not appear in the `check-*` namespace at all. The canonical fix is to rename without the `check-` prefix:
+
+- `scripts/cc-dual-run-diff.py` (not `scripts/check-cc-dual-run-diff.py`) — the rename that came out of #2610 / #4558.
+- `scripts/audit_correctly_labeled_s3_orphans.py` — uses the verb `audit_` which signals the intent more accurately than `check_` and dodges the glob entirely.
+- `scripts/scraper_zero_record_streak.py` would be the canonical rename for `scripts/check-scraper-zero-record-streak.py` (and its two siblings) the next time they are touched. The current `check-` names are grandfathered into `SKIP_LIST` for historical reasons; new ECS-oneshot data-check scripts should not perpetuate the pattern.
+
+**The `SKIP_LIST` route is the fallback, not the recommended path.** When you absolutely must name an ECS-oneshot data-check script `check-*` (e.g. you are extending an existing series of `check-foo-*` data scripts and renaming would break runtime / dashboards / incident-response muscle memory), add a `SKIP_LIST` entry plus an inventory row plus a `# ci-guards: skip` marker, all in the same PR. But: when the rename is cheap, prefer the rename — every avoided `SKIP_LIST` entry is one less landmine for the next agent who touches `run-ci-guards.sh`.
+
+Tracking: #4558 (this rule), #2610 (the rename that surfaced the naming overload).
+
 ### Test assertion hygiene (enforced in CI)
 
 Blind exception swallows inside test files hide bugs: if the call under test raises, the test silently passes on a never-executed code path (see #2443). CI enforces this via `scripts/check-test-except-pass.sh`, which forbids the following patterns inside any file under a `tests/` directory:

--- a/scripts/check-ci-guards-skip-list-coverage.py
+++ b/scripts/check-ci-guards-skip-list-coverage.py
@@ -625,9 +625,27 @@ def _format_fix_block(violations: list[tuple[Path, str]]) -> str:
     lines.append("  Use Option B for ad-hoc guards that depend on uncommon context")
     lines.append("  (Docker, npm-install, packages/web/ deps, etc.).")
     lines.append("")
+    lines.append("  Option C — rename without the `check-` prefix. For ECS-oneshot")
+    lines.append("  data-check scripts (those with `# venv:` + `# permanent: true`")
+    lines.append("  headers that are invoked by scripts/ecs-run-task.sh with a")
+    lines.append("  required argument like --date YYYY-MM-DD, NOT code-quality CI")
+    lines.append("  guards). The canonical rename drops the `check-` prefix")
+    lines.append("  entirely:")
+    lines.append("")
+    for path, _kind in violations:
+        stripped = path.name
+        if stripped.startswith("check-"):
+            stripped = stripped[len("check-") :]
+        lines.append(f"      {path.name}  →  {stripped}")
+    lines.append("")
+    lines.append("  See docs/agent/code-standards.md §\"Naming convention: don't")
+    lines.append('  name ECS-oneshot data-check scripts scripts/check-*.{sh,py}"')
+    lines.append("  for the full rationale (#4558).")
+    lines.append("")
     lines.append("Reference: scripts/run-ci-guards.sh §SKIP_LIST entries (lines 37-66)")
-    lines.append("for the decision rubric. Tracking: #4384 (env-var extension), #4379")
-    lines.append("(parent meta-check), #4332 (motivating retro).")
+    lines.append("for the decision rubric. Tracking: #4558 (Option C / naming")
+    lines.append("convention), #4384 (env-var extension), #4379 (parent meta-check),")
+    lines.append("#4332 (motivating retro).")
     return "\n".join(lines)
 
 

--- a/scripts/check-fix-block-coverage-complete.sh
+++ b/scripts/check-fix-block-coverage-complete.sh
@@ -191,6 +191,16 @@ if [ -n "$missing" ]; then
         echo "To minimise renumbering churn, use letter-suffix row numbers (e.g. \`50a\`)" >&2
         echo "for the alphabetical insertion point — see the existing \`31a\` row for" >&2
         echo "\`check-issue-verify-sql.py\`." >&2
+        echo "" >&2
+        echo "Alternative — rename without the \`check-\` prefix. If the missing guard" >&2
+        echo "is an ECS-oneshot data-check script (\`# venv:\` + \`# permanent: true\`" >&2
+        echo "headers, invoked by scripts/ecs-run-task.sh with a required argument" >&2
+        echo "like --date YYYY-MM-DD), it doesn't belong in the check-* namespace at" >&2
+        echo "all. Rename without the \`check-\` prefix (e.g. \`check-foo-data.py\` →" >&2
+        echo "\`foo_data.py\` or \`audit_foo_data.py\`); inventory coverage and the" >&2
+        echo "umbrella runner stop applying. See docs/agent/code-standards.md" >&2
+        echo "§\"Naming convention: don't name ECS-oneshot data-check scripts" >&2
+        echo "scripts/check-*.{sh,py}\" for the full rationale (#4558)." >&2
     fi
     echo "" >&2
     echo "Note: the \`# ci-guards: skip\` opt-out marker only suppresses umbrella" >&2

--- a/scripts/check_fix_block_coverage_complete.py
+++ b/scripts/check_fix_block_coverage_complete.py
@@ -242,6 +242,19 @@ def format_fix_block(
 
     template_line = f"| {template_rownum} | `scripts/{new_basename}` | <verdict> | <one-line note> |"
 
+    # Compute the rename-without-`check-`-prefix suggestion for the
+    # alternative remediation hint (#4558). The hint applies when the
+    # missing guard is actually an ECS-oneshot data-check script (`# venv:`
+    # + `# permanent: true` headers, invoked via scripts/ecs-run-task.sh
+    # with a required argument like --date YYYY-MM-DD) rather than a true
+    # code-quality CI guard. Rename drops the `check-`/`check_` prefix.
+    if new_basename.startswith("check-"):
+        renamed = new_basename[len("check-") :]
+    elif new_basename.startswith("check_"):
+        renamed = new_basename[len("check_") :]
+    else:
+        renamed = new_basename
+
     return (
         f"Fix for `scripts/{new_basename}`:\n"
         f"  {location_line}\n"
@@ -250,6 +263,13 @@ def format_fix_block(
         f"  Update the Summary section's count: Total guards: {new_total}\n"
         f"  Verdict options: self-diagnosing (Fix block), self-diagnosing (actionable text),\n"
         f"  wrapper (delegates to helper), operational health probe, decision flow, NEEDS UPGRADE.\n"
+        f"  Alternative — rename without the `check-` prefix. If `{new_basename}` is\n"
+        f"  an ECS-oneshot data-check script (`# venv:` + `# permanent: true` headers,\n"
+        f"  invoked by scripts/ecs-run-task.sh with a required argument like\n"
+        f"  --date YYYY-MM-DD) rather than a code-quality CI guard, rename to e.g.\n"
+        f"  `scripts/{renamed}` so it falls outside the umbrella's auto-discovery\n"
+        f"  namespace. See docs/agent/code-standards.md §\"Naming convention: don't\n"
+        f'  name ECS-oneshot data-check scripts scripts/check-*.{{sh,py}}" (#4558).\n'
     )
 
 

--- a/scripts/run-ci-guards.sh
+++ b/scripts/run-ci-guards.sh
@@ -423,18 +423,44 @@ if [ "$failures" -gt 0 ]; then
     if [ "${#requires_arg_failures[@]}" -gt 0 ]; then
         echo "" >&2
         echo "Fix: the guard(s) below appear to require an argument that the" >&2
-        echo "umbrella cannot supply blind. Add each one to SKIP_LIST in" >&2
-        echo "scripts/run-ci-guards.sh (alphabetical order), and add a row" >&2
-        echo "in docs/dx/check-script-fix-block-coverage.md naming the" >&2
-        echo "verdict (typically \"decision flow (no violation list)\")." >&2
+        echo "umbrella cannot supply blind. Pick the option that matches" >&2
+        echo "what the guard does:" >&2
         echo "" >&2
-        echo "  SKIP_LIST=(" >&2
-        echo "      \"check-issue-author.sh\"" >&2
-        echo "      ..." >&2
+        echo "  Option A — Add to SKIP_LIST. For genuine code-quality CI" >&2
+        echo "  guards (lives in scripts/ permanently, runs blind in CI with" >&2
+        echo "  the right args). Add each one to SKIP_LIST in" >&2
+        echo "  scripts/run-ci-guards.sh (alphabetical order), and add a row" >&2
+        echo "  in docs/dx/check-script-fix-block-coverage.md naming the" >&2
+        echo "  verdict (typically \"decision flow (no violation list)\")." >&2
+        echo "" >&2
+        echo "    SKIP_LIST=(" >&2
+        echo "        \"check-issue-author.sh\"" >&2
+        echo "        ..." >&2
         for fname in "${requires_arg_failures[@]}"; do
-            echo "      \"$fname\"   # <-- insert here, alphabetical order" >&2
+            echo "        \"$fname\"   # <-- insert here, alphabetical order" >&2
         done
-        echo "  )" >&2
+        echo "    )" >&2
+        echo "" >&2
+        echo "  Option B — Add the per-file opt-out marker. Add this line as" >&2
+        echo "  a top-level comment in the first 20 lines of each guard:" >&2
+        echo "" >&2
+        echo "      # ci-guards: skip" >&2
+        echo "" >&2
+        echo "  Option C — rename without the \`check-\` prefix. For" >&2
+        echo "  ECS-oneshot data-check scripts (those with \`# venv:\` +" >&2
+        echo "  \`# permanent: true\` headers that are invoked by" >&2
+        echo "  scripts/ecs-run-task.sh with a required argument like" >&2
+        echo "  --date YYYY-MM-DD, NOT code-quality CI guards). The" >&2
+        echo "  canonical rename drops the \`check-\` prefix entirely:" >&2
+        echo "" >&2
+        for fname in "${requires_arg_failures[@]}"; do
+            stripped="${fname#check-}"
+            echo "      $fname  →  $stripped" >&2
+        done
+        echo "" >&2
+        echo "  See docs/agent/code-standards.md §\"Naming convention: don't" >&2
+        echo "  name ECS-oneshot data-check scripts scripts/check-*.{sh,py}\"" >&2
+        echo "  for the full rationale (#4558)." >&2
         echo "" >&2
         echo "If the guard is genuinely runnable blind from the local tree" >&2
         echo "and the failure is a real violation, ignore this hint and fix" >&2

--- a/scripts/tests/test_check_ci_guards_skip_list_coverage.py
+++ b/scripts/tests/test_check_ci_guards_skip_list_coverage.py
@@ -867,6 +867,40 @@ class TestCli:
         # The marker hint must include the literal opt-out comment.
         assert "# ci-guards: skip" in result.stderr
 
+    def test_cli_fix_block_includes_rename_option_c(self, tmp_path: Path) -> None:
+        """Fix block surfaces Option C — rename without `check-` prefix (#4558).
+
+        ECS-oneshot data-check scripts that need required arguments collide
+        with the umbrella's `scripts/check-*.{sh,py}` auto-discovery
+        namespace. The canonical fix is to rename without the `check-`
+        prefix; the Fix block must list this as one of the remediation
+        options so the operator doesn't reach for SKIP_LIST as the only
+        option.
+        """
+
+        scripts_dir = self._build_failing_tree(tmp_path)
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT_PATH),
+                "--scripts-dir",
+                str(scripts_dir),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        # Option C header.
+        assert "Option C" in result.stderr
+        # The literal phrase the AC's verify line searches for.
+        assert "rename without the `check-` prefix" in result.stderr
+        # The post-rename suggestion — drops the `check-` prefix entirely.
+        assert "check-missing.py  →  missing.py" in result.stderr
+        # Doc cross-reference + tracking issue.
+        assert "code-standards.md" in result.stderr
+        assert "#4558" in result.stderr
+
     def test_cli_exit_two_on_missing_umbrella(self, tmp_path: Path) -> None:
         scripts_dir = tmp_path / "scripts"
         scripts_dir.mkdir()

--- a/scripts/tests/test_check_fix_block_coverage_complete.py
+++ b/scripts/tests/test_check_fix_block_coverage_complete.py
@@ -283,6 +283,42 @@ def test_format_fix_block_sums_n_missing_in_total(
     assert "Total guards: 14" in block
 
 
+def test_format_fix_block_includes_rename_alternative(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """Fix block names the rename-without-`check-` prefix alternative (#4558).
+
+    The naming-convention overload — ECS-oneshot data-check scripts named
+    `scripts/check-*` getting flagged by the umbrella's auto-discovery —
+    must surface as one of the listed remediation options. The alternative
+    points at ``docs/agent/code-standards.md`` for the full rationale.
+    """
+
+    result = compute_insertion("check-foo-data.py", sample_rows)
+    block = format_fix_block("check-foo-data.py", result, total_guards=12, n_missing=1)
+
+    # The literal phrase the AC's verify line searches for.
+    assert "rename without the `check-` prefix" in block
+    # The post-rename suggestion — drops the `check-` prefix entirely.
+    assert "`scripts/foo-data.py`" in block
+    # Doc cross-reference + tracking issue.
+    assert "code-standards.md" in block
+    assert "#4558" in block
+
+
+def test_format_fix_block_rename_alternative_handles_underscore_prefix(
+    sample_rows: list[InventoryRow],
+) -> None:
+    """Rename alternative drops the `check_` prefix for underscore-named guards (#4558)."""
+
+    result = compute_insertion("check_foo_data.py", sample_rows)
+    block = format_fix_block("check_foo_data.py", result, total_guards=12, n_missing=1)
+
+    assert "rename without the `check-` prefix" in block
+    # `check_foo_data.py` → `foo_data.py` (underscore prefix stripped).
+    assert "`scripts/foo_data.py`" in block
+
+
 # ─── Live inventory smoke test ────────────────────────────────────────────
 
 

--- a/scripts/tests/test_check_fix_block_coverage_complete.sh
+++ b/scripts/tests/test_check_fix_block_coverage_complete.sh
@@ -282,6 +282,82 @@ else
     FAILURES=$((FAILURES + 1))
 fi
 
+# ─── Test 6: ECS-oneshot rename hint surfaces as an alternative (#4558) ──
+# Issue #4558 acceptance criterion: a fresh `scripts/check-foo-data.py`
+# ECS oneshot must trigger an error message that includes the literal
+# "rename without `check-` prefix" phrase as one of the listed fix
+# options. The per-guard Fix-block formatter is the canonical surface for
+# this hint; this test exercises the full wrapper → helper invocation
+# path so a regression that drops the hint surfaces locally before CI.
+
+reset_tmpdir
+mkdir -p "$TMPDIR_TEST/scripts"
+write_synth_inventory "$TMPDIR_TEST/inventory.md"
+for name in \
+    check-ci-job-skipped.sh \
+    check-ci-guards-skip-list-coverage.sh \
+    check-ci-passed-coverage.sh \
+    check-duplicate-pr.sh \
+    check-fix-block-coverage-complete.sh \
+    check-git-gh-retries.sh \
+    check-no-api-github-fetch.sh \
+    check-no-duplicate-stubs.sh \
+    check-workflow-paths-filter-coverage.sh; do
+    write_synth_guard "$TMPDIR_TEST/scripts" "$name"
+done
+for name in \
+    check_no_basicconfig_with_extra.py \
+    check_no_redos_pattern.py \
+    check_tf_empty_resource.py; do
+    cat > "$TMPDIR_TEST/scripts/$name" <<'EOF'
+#!/usr/bin/env python3
+EOF
+done
+
+# The ECS-oneshot fixture: a Python check-* script that the umbrella
+# would pick up via `scripts/check-*.py` glob.
+cat > "$TMPDIR_TEST/scripts/check-foo-data.py" <<'EOF'
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+import argparse
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--date", required=True)
+    p.parse_args()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+EOF
+
+TESTS=$((TESTS + 1))
+last_stderr=$(mktemp)
+set +e
+SCRIPTS_DIR_OVERRIDE="$TMPDIR_TEST/scripts" \
+    DOC_OVERRIDE="$TMPDIR_TEST/inventory.md" \
+    "$WRAPPER" 2> "$last_stderr"
+rc=$?
+set -e
+
+if [[ $rc -eq 1 ]] \
+    && grep -q "rename without the .check-. prefix" "$last_stderr" \
+    && grep -q '`scripts/foo-data.py`' "$last_stderr" \
+    && grep -q "code-standards.md" "$last_stderr" \
+    && grep -q "#4558" "$last_stderr"; then
+    echo "PASS: Test 6 — ECS-oneshot rename hint surfaces as alternative remediation (#4558)"
+else
+    echo "FAIL: Test 6 — Fix block missing rename-without-check-prefix hint (#4558)"
+    echo "  rc: $rc"
+    echo "  stderr:"
+    cat "$last_stderr" | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+rm -f "$last_stderr"
+
 # ─── Summary ──────────────────────────────────────────────────────────────
 echo ""
 echo "Results: $((TESTS - FAILURES))/$TESTS passed"

--- a/scripts/tests/test_run_ci_guards.sh
+++ b/scripts/tests/test_run_ci_guards.sh
@@ -460,6 +460,42 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# Scenario 15: requires-argument hint includes Option C — rename without
+#               `check-` prefix (#4558). The naming-convention overload
+#               between code-quality CI guards and ECS-oneshot data-check
+#               scripts named `check-*` must surface as one of the listed
+#               remediation options in the umbrella's failure summary.
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 15] requires-argument hint includes Option C rename (#4558)"
+synth_scripts="$(seed_synthetic_scripts s15)"
+cat > "$synth_scripts/check-foo-data.py" <<'PY'
+import sys
+print(
+    "usage: check-foo-data.py [-h] --date DATE",
+    file=sys.stderr,
+)
+print(
+    "check-foo-data.py: error: the following arguments are required: --date",
+    file=sys.stderr,
+)
+sys.exit(2)
+PY
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 with failing argparse guard, got $rc_buf" "$out_buf"
+elif ! echo "$out_buf" | grep -q "Option C"; then
+    report_fail "expected Option C header in Fix block (#4558)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "rename without the.*check-.*prefix"; then
+    report_fail "expected 'rename without check- prefix' phrase in Fix block (#4558)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "check-foo-data.py  →  foo-data.py"; then
+    report_fail "expected post-rename suggestion 'check-foo-data.py → foo-data.py' (#4558)" "$out_buf"
+elif ! echo "$out_buf" | grep -q "code-standards.md"; then
+    report_fail "expected code-standards.md cross-reference (#4558)" "$out_buf"
+else
+    report_pass "requires-argument hint includes Option C rename remediation (#4558)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Documents the `scripts/check-*.{sh,py}` naming overload between code-quality CI guards and ECS-oneshot data-check scripts in `docs/agent/code-standards.md`, and updates the three Fix-block emitters that surface when the collision triggers a pre-push failure to list "rename without the `check-` prefix" as a remediation option (alongside the existing SKIP_LIST and `# ci-guards: skip` opt-out marker options).

Closes #4558

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI tooling only)
- [ ] Verification evidence posted on issue (skip-reason explanation)
