### PR TITLE
fix(infra): widen iam_s3_cleanup ListBucket s3:prefix to ca/ subtree (#2661)

### DIFF
--- a/infra/terraform/modules/iam_s3_cleanup/main.tf
+++ b/infra/terraform/modules/iam_s3_cleanup/main.tf
@@ -50,8 +50,14 @@ resource "aws_iam_role" "s3_cleanup" {
 # Actions included:
 #   - s3:ListBucket — required so the script can paginate
 #     `list_objects_v2` to find delete candidates. The
-#     `s3:prefix` condition restricts list visibility to `ca/*/*/raw/`
-#     subtrees only.
+#     `s3:prefix` condition restricts list visibility to the `ca/`
+#     subtree only — the cleanup script paginates from ``ca/`` and
+#     filters keys client-side via the `ca/{county}/{court}/raw/<hex64>`
+#     regex (#2661), so the prefix patterns must accept ``ca/`` and any
+#     deeper child path under it. Listing outside ``ca/`` (e.g.
+#     ``derived/``, ``processed/``, ``transcripts/``, ``staging/``,
+#     ``spotcheck/``) remains denied. DeleteObject is separately and
+#     more narrowly scoped to ``ca/*/*/raw/*`` below.
 #   - s3:GetObject + s3:HeadObject — required by the cleanup script's
 #     metadata-hash safety check (`head_object_metadata_hash` reads the
 #     object's metadata before deciding to delete).
@@ -85,10 +91,20 @@ resource "aws_iam_policy" "s3_raw_cleanup" {
         Resource = var.document_archive_bucket_arn
         Condition = {
           StringLike = {
+            # The cleanup script paginates list_objects_v2 from the
+            # state-level prefix ("ca/") and filters keys client-side
+            # via a `ca/{county}/{court}/raw/<hex64>` regex. The
+            # `s3:prefix` condition gates which Prefix values the
+            # ListBucket call may pass — so it must accept "ca/" and
+            # any deeper child path under it. The narrower
+            # `ca/*/*/raw/*` patterns alone reject `Prefix='ca/'` (#2661
+            # AccessDenied at apply). DeleteObject below remains
+            # narrowly scoped to `ca/*/*/raw/*` so this widening does
+            # not expand the actual destructive blast radius.
             "s3:prefix" = [
-              "ca/*/*/raw/*",
-              "ca/*/*/raw/",
-              "ca/*/*/raw"
+              "ca",
+              "ca/",
+              "ca/*"
             ]
           }
         }

--- a/infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh
+++ b/infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh
@@ -137,13 +137,46 @@ fi
 #
 # `s3:ListBucket` against the bucket ARN without an `s3:prefix` condition
 # would let the role enumerate every key in the bucket. The condition
-# must restrict prefix to `ca/*/*/raw/*`.
+# must restrict prefix so the role can only list under the `ca/` subtree.
+# This is widened from `ca/*/*/raw/*` to `ca/*` because the cleanup
+# script paginates from `ca/` and filters keys client-side (the
+# narrower form rejected `Prefix='ca/'` at apply time, see #2661).
+# DeleteObject remains narrowly scoped to `ca/*/*/raw/*` so the
+# destructive blast radius is unchanged.
 if grep -q '"s3:ListBucket"' "$main_tf"; then
     if grep -q '"s3:prefix"' "$main_tf"; then
         check "s3:ListBucket is gated by s3:prefix condition" 0
     else
         check "s3:ListBucket is gated by s3:prefix condition" 1
     fi
+
+    # The s3:prefix list must include at least one ca/-anchored pattern
+    # so the policy is gated to the ca/ subtree (no listing of
+    # derived/, processed/, transcripts/, staging/, or spotcheck/).
+    if grep -qE '"(ca|ca/|ca/\*)"' "$main_tf"; then
+        check "s3:prefix list includes a ca/-anchored pattern" 0
+    else
+        check "s3:prefix list includes a ca/-anchored pattern" 1
+    fi
+
+    # The s3:prefix list must NOT include patterns that escape ca/ —
+    # e.g. a bare "*", "" (empty allow-anything), "derived/*",
+    # "processed/*", "transcripts/*", "staging/*", or "spotcheck/*".
+    forbidden_prefix_patterns=(
+        '"\*"'
+        '"derived'
+        '"processed'
+        '"transcripts'
+        '"staging'
+        '"spotcheck'
+    )
+    for pat in "${forbidden_prefix_patterns[@]}"; do
+        if grep -qE "$pat" "$main_tf"; then
+            check "s3:prefix list does not escape ca/ via '${pat}'" 1
+        else
+            check "s3:prefix list does not escape ca/ via '${pat}'" 0
+        fi
+    done
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Widen the `iam_s3_cleanup` module's ListBucket `s3:prefix` condition from `ca/*/*/raw/*` to `["ca", "ca/", "ca/*"]` so the cleanup script's `Prefix='ca/'` paginate succeeds. DeleteObject remains narrowly scoped to `ca/*/*/raw/*` — the destructive blast radius is unchanged.

This unblocks the runtime apply step of #2661: today's first attempt at `cleanup_mislabeled_s3_2661.py --apply` under the new `judgemind-s3-cleanup-dev` role failed with `AccessDenied (s3:ListBucket)` because the script paginates from the state-level prefix and the policy's narrow patterns rejected the actual API call.

The runtime precursor work (create_missing_twins → repoint_mislabeled_documents) was executed across all 9 affected counties on dev today. After this PR merges + dev terraform apply runs, `cleanup_mislabeled_s3_2661.py --apply` becomes a one-command run that completes #2661's AC #3 and AC #4.

Closes #2661

## Test plan

### Automated checks
- [x] Lint passes (terraform fmt)
- [x] Format check passes
- [x] Tests pass (`infra/terraform/modules/iam_s3_cleanup/tests/policy-checks/check.sh` — 20 PASS)
- [x] CI green

### Post-deploy verification
- [ ] `terraform.yml` dev-apply runs successfully and updates the `judgemind-s3-cleanup-raw-prefix-dev` policy
- [ ] `aws iam get-policy-version` shows the new s3:prefix patterns (`ca`, `ca/`, `ca/*`)
- [ ] `scripts/ecs-run-task.sh --role judgemind-s3-cleanup-dev scripts/cleanup_mislabeled_s3_2661.py -- --apply` completes successfully and deletes 3734 mislabeled S3 objects
- [ ] Spot-sample HEAD on a few `derived.documents.s3_key` values still returns 200 post-delete (AC #4)
- [ ] Verification evidence posted on issue #2661 (see A.8)
