### PR TITLE
feat(scraping): retire federal-courtlistener-opinions + bump dev ElastiCache to cache.t4g.small (#4571)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -109,7 +109,7 @@ module "cache" {
   environment        = "dev"
   vpc_id             = module.networking.vpc_id
   private_subnet_ids = module.networking.private_subnet_ids
-  node_type          = "cache.t4g.micro"
+  node_type          = "cache.t4g.small"
   num_cache_nodes    = 1
 
   # Dev applies node_type / engine_version / parameter-group changes on the

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -376,8 +376,6 @@ def _build_registry() -> list[tuple[str, type, callable]]:
     from courts.ca.sf_tentatives import default_config as sf_config
     from courts.ca.ventura_tentatives import VenturaTentativeRulingsScraper
     from courts.ca.ventura_tentatives import default_config as ventura_config
-    from courts.federal.courtlistener import CourtListenerScraper
-    from courts.federal.courtlistener import default_config as cl_config
 
     _REGISTRY.extend(
         [
@@ -403,7 +401,6 @@ def _build_registry() -> list[tuple[str, type, callable]]:
             ("ca-sf-tentatives-civil", SFCivilTentativeRulingsScraper, sf_civil_config),
             ("ca-sf-tentatives-family-law", SFTentativeRulingsScraper, sf_config),
             ("ca-ventura-tentatives", VenturaTentativeRulingsScraper, ventura_config),
-            ("federal-courtlistener-opinions", CourtListenerScraper, cl_config),
         ]
     )
     return _REGISTRY

--- a/packages/scraper-framework/tests/test_check_scraper_registry.py
+++ b/packages/scraper-framework/tests/test_check_scraper_registry.py
@@ -159,10 +159,14 @@ class TestFindRegisteredModules:
             "courts.ca.sd_tentatives",
             "courts.ca.sf_tentatives",
             "courts.ca.ventura_tentatives",
-            "courts.federal.courtlistener",
         }
         for mod in expected:
             assert mod in registered, f"Expected {mod} to be registered in runner.py"
+        # CourtListener was retired per #4571 / #4474 — de-registered from the
+        # runner while the module stays in tree. It must NOT appear as a
+        # registered import, and the guard tolerates it via RETIRED_MODULES.
+        assert "courts.federal.courtlistener" not in registered
+        assert "courts.federal.courtlistener" in check_registry.RETIRED_MODULES
 
     def test_with_synthetic_runner(self, tmp_path: Path) -> None:
         """Parses imports from a synthetic runner.py file."""

--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -322,6 +322,16 @@ class TestModuleExclusions:
         """Quarterly cadence — most runs legitimately return zero."""
         assert "ca-governor-appointments" in zrs.EXCLUSIONS
 
+    def test_excludes_federal_courtlistener_opinions_after_4571(self) -> None:
+        """CourtListener federal-opinions retired per #4571 / #4474.
+
+        The scraper was de-registered (its envelopes drove dev ElastiCache
+        OOM and wedged the dispatcher). It is kept in EXCLUSIONS so the
+        silent-outage guard does not alert on the now-retired scraper.
+        See #4571 for the retirement and #4474 for the operator decision.
+        """
+        assert "federal-courtlistener-opinions" in zrs.EXCLUSIONS
+
     def test_does_not_exclude_ca_sd_calendar_after_4539(self) -> None:
         """ca-sd-calendar must NOT be in EXCLUSIONS now that #4539 has
         shipped. The structural fix flipped the ``day_numbers`` default

--- a/scripts/audit_scraper_field_population.py
+++ b/scripts/audit_scraper_field_population.py
@@ -15,9 +15,9 @@ CourtListener ``cluster.court`` field documented as canonical but empty
 in every actual API response). Running this audit daily catches drift
 within ~24 h instead of weeks.
 
-Scope (initial registry):
-  - ``federal-courtlistener-opinions`` -- envelope is JSON
-    {cluster, opinion, docket}; load-bearing field is ``docket.court``.
+Scope (registry):
+  The CourtListener federal-opinions scraper was retired per #4571 / #4474
+  (its envelopes drove dev ElastiCache OOM) and is no longer audited here.
   - ``ca-sf-civil-tentatives`` -- envelope is a flat JSON dict of
     ParsedRuling fields plus ruling_id/department. Load-bearing fields
     are ``case_number`` and ``department``.
@@ -135,27 +135,14 @@ class ScraperFieldSpec:
     rationale: str
 
 
-# Initial registry (issue #4255 acceptance criterion: cover the
-# 3 highest-volume JSON-envelope scrapers).  CourtListener is the
-# motivating case (#4247).  SF civil and CC portal are the other two
-# JSON-envelope scrapers in the codebase today; OC / LA / SD store
-# binary PDFs or bare HTML that don't admit field-path introspection
-# from S3 alone.
+# Registry (issue #4255 acceptance criterion: cover the highest-volume
+# JSON-envelope scrapers).  SF civil and CC portal are the JSON-envelope
+# scrapers in the codebase today; OC / LA / SD store binary PDFs or bare
+# HTML that don't admit field-path introspection from S3 alone.  The
+# CourtListener federal-opinions scraper was the original motivating case
+# (#4247) but was retired per #4571 / #4474 (its envelopes drove dev
+# ElastiCache OOM), so it no longer appears in this registry.
 REGISTRY: tuple[ScraperFieldSpec, ...] = (
-    ScraperFieldSpec(
-        scraper_id="federal-courtlistener-opinions",
-        envelope_format="json",
-        field_paths=("docket.court_id",),
-        rationale=(
-            "docket.court_id is the canonical bare short-id (e.g. "
-            "'dcd', 'scotus', 'texapp1') after #4247 / #4310. "
-            "cluster.court / cluster.court_id are empty in every "
-            "CourtListener API response we capture; docket.court is a "
-            "URL with a ?format=json query string and previously parsed "
-            "to '?format=json' (#4310).  docket.court_id is the bare "
-            "short-id directly and avoids URL parsing entirely."
-        ),
-    ),
     ScraperFieldSpec(
         scraper_id="ca-sf-civil-tentatives",
         envelope_format="json",
@@ -470,21 +457,24 @@ def run_audit(
 def synthetic_drift_result() -> AuditResult:
     """Return a synthetic AuditResult for --dry-run.
 
-    Simulates the bug class behind #4247: courtlistener's docket.court
-    empty in 10/10 samples.  Used for the AC verification step
-    "dry-run against a synthetic empty-field scenario produces a
-    generated issue body in tmp/" and for unit tests.
+    Simulates the bug class behind #4247: a load-bearing field empty in
+    10/10 samples.  CourtListener (the original motivating scraper) was
+    retired per #4571 / #4474, so this synthetic scenario is now keyed on
+    the surviving ``ca-sf-civil-tentatives`` JSON-envelope scraper with
+    ``case_number`` empty.  Used for the AC verification step "dry-run
+    against a synthetic empty-field scenario produces a generated issue
+    body in tmp/" and for unit tests.
     """
-    spec = get_spec("federal-courtlistener-opinions")
-    assert spec is not None, "registry must contain courtlistener"
+    spec = get_spec("ca-sf-civil-tentatives")
+    assert spec is not None, "registry must contain ca-sf-civil-tentatives"
     drifted = FieldResult(
         scraper_id=spec.scraper_id,
-        field_path="docket.court_id",
+        field_path="case_number",
         populated=0,
         sampled=10,
         sample_keys=[
-            f"federal/dc/dc_district/raw/{'a' * 64}.txt",
-            f"federal/dc/dc_district/raw/{'b' * 64}.txt",
+            f"ca/sf/sf_civil/raw/{'a' * 64}.json",
+            f"ca/sf/sf_civil/raw/{'b' * 64}.json",
         ],
     )
     return AuditResult(field_results=[drifted])

--- a/scripts/check-scraper-registry.py
+++ b/scripts/check-scraper-registry.py
@@ -24,6 +24,19 @@ import re
 import sys
 from pathlib import Path
 
+# Scraper modules intentionally kept in the tree but NOT wired into
+# ``_build_registry()``. Each entry must carry a rationale so the guard
+# stays honest — leaving a module unregistered silently produces zero data,
+# which is exactly what this check exists to catch. A module belongs here
+# only when it has been deliberately retired (not merely forgotten).
+RETIRED_MODULES: set[str] = {
+    # CourtListener federal-opinions scraper retired per #4571 / #4474 — its
+    # envelopes drove dev ElastiCache OOM and wedged the dispatcher. The
+    # module + its test stay in tree so the scraper can be re-enabled later,
+    # but it is intentionally de-registered from the runner for now.
+    "courts.federal.courtlistener",
+}
+
 
 def find_repo_root() -> Path:
     """Walk up from the script's location to find the repository root."""
@@ -121,7 +134,11 @@ def main() -> int:
             print(f"  {status}: {mod}")
         print()
 
-    unregistered = [mod for mod in scraper_modules if mod not in registered_modules]
+    unregistered = [
+        mod
+        for mod in scraper_modules
+        if mod not in registered_modules and mod not in RETIRED_MODULES
+    ]
 
     if unregistered:
         print(

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -112,6 +112,11 @@ EXCLUSIONS: set[str] = {
     # Governor appointments scraper runs quarterly-ish; most runs legitimately
     # return zero records. Exclude until dedicated health signal is wired.
     "ca-governor-appointments",
+    # CourtListener federal-opinions scraper retired per #4571 / #4474 — its
+    # envelopes drove dev ElastiCache OOM and wedged the dispatcher. Kept in
+    # EXCLUSIONS so the silent-outage guard does not alert on the now-retired
+    # (de-registered) scraper.
+    "federal-courtlistener-opinions",
 }
 
 # Scrapers that run more than once per day ("frequent"). All others are

--- a/scripts/tests/test_audit_scraper_field_population.py
+++ b/scripts/tests/test_audit_scraper_field_population.py
@@ -1,7 +1,8 @@
 """Tests for audit_scraper_field_population.
 
 Covers:
-- REGISTRY contains the 3 highest-volume JSON-envelope scrapers
+- REGISTRY contains the surviving JSON-envelope scrapers (CourtListener
+  was retired per #4571 / #4474; SF civil + CC portal remain)
 - lookup_field walks dotted paths and tolerates missing/non-dict segments
 - is_populated treats None / "" / [] / {} as not populated and 0 / False as populated
 - audit_one_scraper skips below min-captures, returns drift on 0/N, healthy on >0/N
@@ -76,15 +77,17 @@ fetch_envelope = _script.fetch_envelope
 class TestRegistry:
     """The registry must cover the 3 highest-volume JSON-envelope scrapers."""
 
-    def test_courtlistener_is_registered(self) -> None:
-        spec = get_spec("federal-courtlistener-opinions")
-        assert spec is not None
-        # Per #4310: docket.court_id is the canonical bare short-id.  docket.court
-        # is a URL with a ?format=json query string and was previously the
-        # registered field, but parsing it produced "?format=json" as the court
-        # id (#4310).  docket.court_id is the bare short-id directly and avoids
-        # URL parsing entirely.
-        assert "docket.court_id" in spec.field_paths
+    def test_courtlistener_is_retired(self) -> None:
+        """CourtListener federal-opinions was retired per #4571 / #4474.
+
+        Its envelopes drove dev ElastiCache OOM, so the scraper was
+        de-registered from the runner and dropped from this audit REGISTRY.
+        The two surviving JSON-envelope scrapers must remain registered so
+        the audit still covers them.
+        """
+        assert get_spec("federal-courtlistener-opinions") is None
+        assert get_spec("ca-sf-civil-tentatives") is not None
+        assert get_spec("ca-cc-tentatives-portal") is not None
 
     def test_sf_civil_is_registered(self) -> None:
         spec = get_spec("ca-sf-civil-tentatives")
@@ -98,9 +101,13 @@ class TestRegistry:
         assert "judge_id" in spec.field_paths
         assert "judge_name_dropdown" in spec.field_paths
 
-    def test_at_least_three_scrapers_covered(self) -> None:
-        """AC #4: registry covers at least 3 highest-volume scrapers."""
-        assert len(REGISTRY) >= 3
+    def test_surviving_scrapers_covered(self) -> None:
+        """Registry covers the surviving JSON-envelope scrapers.
+
+        CourtListener was retired per #4571 / #4474, leaving the two CA
+        JSON-envelope scrapers (SF civil + CC portal).
+        """
+        assert len(REGISTRY) >= 2
 
     def test_all_specs_are_json_envelope(self) -> None:
         """Initial registry only inspects JSON envelopes -- PDF/HTML are out of scope."""
@@ -242,10 +249,14 @@ _NOW = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
 
 
 class TestAuditOneScraper:
+    # Re-fixtured from the retired ``federal-courtlistener-opinions`` (#4571 /
+    # #4474) to the surviving ``ca-sf-civil-tentatives`` JSON-envelope scraper.
+    # SF civil has two load-bearing field paths (``case_number`` + ``department``),
+    # so each audited scraper now yields TWO FieldResults instead of CL's one.
     def test_skip_when_below_min_captures(self) -> None:
-        conn = _make_conn({"federal-courtlistener-opinions": 10}, {})
+        conn = _make_conn({"ca-sf-civil-tentatives": 10}, {})
         s3 = _make_s3({})
-        spec = get_spec("federal-courtlistener-opinions")
+        spec = get_spec("ca-sf-civil-tentatives")
         assert spec is not None
 
         results, skip = audit_one_scraper(
@@ -264,9 +275,9 @@ class TestAuditOneScraper:
         assert skip["capture_count"] == 10
 
     def test_skip_when_no_sample_keys(self) -> None:
-        conn = _make_conn({"federal-courtlistener-opinions": 100}, {})
+        conn = _make_conn({"ca-sf-civil-tentatives": 100}, {})
         s3 = _make_s3({})
-        spec = get_spec("federal-courtlistener-opinions")
+        spec = get_spec("ca-sf-civil-tentatives")
         assert spec is not None
 
         results, skip = audit_one_scraper(
@@ -284,25 +295,19 @@ class TestAuditOneScraper:
         assert skip["reason"] == "no_sample_keys"
 
     def test_drift_when_field_empty_in_all_samples(self) -> None:
-        """The motivating bug class (#4247 / #4310): docket.court_id empty
-        in 10/10 samples.  Now keyed on docket.court_id (the bare short-id)
-        rather than docket.court (the URL form) -- see #4310."""
-        keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
-        # Simulates the #4310 scenario: docket present but court_id empty.
-        envelopes = {
-            k: {
-                "cluster": {"id": i, "case_name": "X v. Y"},
-                "opinion": {"id": i, "plain_text": "text"},
-                "docket": {"id": i, "court_id": ""},  # empty -- the bug!
-            }
-            for i, k in enumerate(keys)
-        }
+        """The motivating bug class (#4247): a load-bearing field empty in
+        10/10 samples.  Re-fixtured to the surviving SF civil scraper after
+        CourtListener's retirement (#4571 / #4474): case_number is empty in
+        every sample while department stays populated."""
+        keys = [f"ca/sf/sf_civil/raw/{'a' * 63}{i:x}.json" for i in range(10)]
+        # case_number empty in every sample -- the drift; department populated.
+        envelopes = {k: {"case_number": "", "department": "12"} for k in keys}
         conn = _make_conn(
-            {"federal-courtlistener-opinions": 100},
-            {"federal-courtlistener-opinions": keys},
+            {"ca-sf-civil-tentatives": 100},
+            {"ca-sf-civil-tentatives": keys},
         )
         s3 = _make_s3(envelopes)  # type: ignore[arg-type]
-        spec = get_spec("federal-courtlistener-opinions")
+        spec = get_spec("ca-sf-civil-tentatives")
         assert spec is not None
 
         results, skip = audit_one_scraper(
@@ -316,31 +321,31 @@ class TestAuditOneScraper:
             now=_NOW,
         )
         assert skip is None
-        assert len(results) == 1
-        assert results[0].scraper_id == "federal-courtlistener-opinions"
-        assert results[0].field_path == "docket.court_id"
-        assert results[0].populated == 0
-        assert results[0].sampled == 10
-        assert results[0].drifted is True
+        # SF civil has two load-bearing fields.
+        assert len(results) == 2
+        by_path = {r.field_path: r for r in results}
+        assert by_path["case_number"].scraper_id == "ca-sf-civil-tentatives"
+        assert by_path["case_number"].populated == 0
+        assert by_path["case_number"].sampled == 10
+        assert by_path["case_number"].drifted is True
+        # department stays populated -- not drifted.
+        assert by_path["department"].populated == 10
+        assert by_path["department"].drifted is False
 
     def test_healthy_when_field_populated_in_at_least_one(self) -> None:
         """1/N populated is enough to clear -- the audit's floor is 'at least one'."""
-        keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
-        # Only one sample has docket.court_id populated; the audit clears.
+        keys = [f"ca/sf/sf_civil/raw/{'a' * 63}{i:x}.json" for i in range(10)]
+        # Only one sample has case_number populated; the audit clears.
         envelopes = {}
         for i, k in enumerate(keys):
-            court_id = "ca9" if i == 0 else ""
-            envelopes[k] = {
-                "cluster": {},
-                "opinion": {},
-                "docket": {"court_id": court_id},
-            }
+            case_number = "CGC-24-0001" if i == 0 else ""
+            envelopes[k] = {"case_number": case_number, "department": "12"}
         conn = _make_conn(
-            {"federal-courtlistener-opinions": 100},
-            {"federal-courtlistener-opinions": keys},
+            {"ca-sf-civil-tentatives": 100},
+            {"ca-sf-civil-tentatives": keys},
         )
         s3 = _make_s3(envelopes)  # type: ignore[arg-type]
-        spec = get_spec("federal-courtlistener-opinions")
+        spec = get_spec("ca-sf-civil-tentatives")
         assert spec is not None
 
         results, skip = audit_one_scraper(
@@ -354,25 +359,26 @@ class TestAuditOneScraper:
             now=_NOW,
         )
         assert skip is None
-        assert len(results) == 1
-        assert results[0].populated == 1
-        assert results[0].sampled == 10
-        assert results[0].drifted is False
+        assert len(results) == 2
+        by_path = {r.field_path: r for r in results}
+        assert by_path["case_number"].populated == 1
+        assert by_path["case_number"].sampled == 10
+        assert by_path["case_number"].drifted is False
 
     def test_unparseable_envelope_skipped(self) -> None:
         """Envelopes that aren't valid JSON or aren't dicts don't count toward sampled."""
         keys = ["k1", "k2", "k3"]
         envelopes = {
             "k1": b"not json at all",  # parse fail
-            "k2": {"docket": {"court_id": "ca9"}},  # OK
+            "k2": {"case_number": "CGC-24-0001", "department": "12"},  # OK
             "k3": b"[1, 2, 3]",  # JSON but not a dict
         }
         conn = _make_conn(
-            {"federal-courtlistener-opinions": 100},
-            {"federal-courtlistener-opinions": keys},
+            {"ca-sf-civil-tentatives": 100},
+            {"ca-sf-civil-tentatives": keys},
         )
         s3 = _make_s3(envelopes)  # type: ignore[arg-type]
-        spec = get_spec("federal-courtlistener-opinions")
+        spec = get_spec("ca-sf-civil-tentatives")
         assert spec is not None
 
         results, skip = audit_one_scraper(
@@ -386,11 +392,12 @@ class TestAuditOneScraper:
             now=_NOW,
         )
         assert skip is None
-        assert len(results) == 1
+        assert len(results) == 2
+        by_path = {r.field_path: r for r in results}
         # Only k2 was inspected; populated=1, sampled=1.
-        assert results[0].sampled == 1
-        assert results[0].populated == 1
-        assert results[0].drifted is False
+        assert by_path["case_number"].sampled == 1
+        assert by_path["case_number"].populated == 1
+        assert by_path["case_number"].drifted is False
 
 
 # ---------------------------------------------------------------------------
@@ -400,16 +407,19 @@ class TestAuditOneScraper:
 
 class TestRunAudit:
     def test_scraper_filter_limits_scope(self) -> None:
-        # Only courtlistener has captures; the others below threshold.
-        keys = [f"federal/dc/dc_district/raw/{'a' * 63}{i:x}.txt" for i in range(10)]
-        envelopes = {k: {"docket": {"court": "ca9"}} for k in keys}
+        # Only SF civil has captures; the other is below threshold.  Re-fixtured
+        # from the retired CourtListener scraper (#4571 / #4474) to SF civil,
+        # which has two load-bearing field paths.
+        keys = [f"ca/sf/sf_civil/raw/{'a' * 63}{i:x}.json" for i in range(10)]
+        envelopes = {
+            k: {"case_number": "CGC-24-0001", "department": "12"} for k in keys
+        }
         conn = _make_conn(
             {
-                "federal-courtlistener-opinions": 100,
-                "ca-sf-civil-tentatives": 0,
+                "ca-sf-civil-tentatives": 100,
                 "ca-cc-tentatives-portal": 0,
             },
-            {"federal-courtlistener-opinions": keys},
+            {"ca-sf-civil-tentatives": keys},
         )
         s3 = _make_s3(envelopes)  # type: ignore[arg-type]
 
@@ -420,19 +430,21 @@ class TestRunAudit:
             sample_size=10,
             min_captures=50,
             lookback_days=7,
-            scraper_filter=["federal-courtlistener-opinions"],
+            scraper_filter=["ca-sf-civil-tentatives"],
             now=_NOW,
         )
         # No skipped entries for the others -- they were filtered out.
-        assert len(result.field_results) == 1
-        assert result.field_results[0].scraper_id == "federal-courtlistener-opinions"
+        # SF civil has two load-bearing fields, so two FieldResults.
+        assert len(result.field_results) == 2
+        assert all(
+            r.scraper_id == "ca-sf-civil-tentatives" for r in result.field_results
+        )
         assert result.skipped == []
 
     def test_full_run_records_skipped(self) -> None:
         """Without --scraper, all REGISTRY entries are tried; below-threshold ones are skipped."""
         conn = _make_conn(
             {
-                "federal-courtlistener-opinions": 0,
                 "ca-sf-civil-tentatives": 0,
                 "ca-cc-tentatives-portal": 0,
             },
@@ -460,11 +472,17 @@ class TestRunAudit:
 
 class TestSyntheticDriftResult:
     def test_synthetic_is_unhealthy(self) -> None:
-        """The synthetic scenario simulates the #4247 / #4310 bug class."""
+        """The synthetic scenario simulates the #4247 bug class.
+
+        Re-fixtured to the surviving ``ca-sf-civil-tentatives`` scraper after
+        CourtListener's retirement (#4571 / #4474): case_number empty in
+        every sample.
+        """
         result = synthetic_drift_result()
         assert result.healthy is False
         assert result.drift_count == 1
-        assert result.field_results[0].field_path == "docket.court_id"
+        assert result.field_results[0].scraper_id == "ca-sf-civil-tentatives"
+        assert result.field_results[0].field_path == "case_number"
         assert result.field_results[0].drifted is True
 
 
@@ -477,8 +495,8 @@ class TestBuildIssueBody:
     def test_body_contains_scraper_and_field(self) -> None:
         result = synthetic_drift_result()
         body = build_issue_body(result)
-        assert "federal-courtlistener-opinions" in body
-        assert "docket.court_id" in body
+        assert "ca-sf-civil-tentatives" in body
+        assert "case_number" in body
         # Markdown table delimiter present.
         assert "| Scraper |" in body
 
@@ -509,7 +527,7 @@ class TestMainDryRun:
         assert out.exists()
         text = out.read_text()
         assert "Scraper Field-Mapping Drift Alert" in text
-        assert "docket.court_id" in text
+        assert "case_number" in text
 
     def test_dry_run_returns_1_when_unhealthy(self) -> None:
         rc = _script.main(["--dry-run"])
@@ -523,9 +541,9 @@ class TestMainDryRun:
 
 class TestDbHelpers:
     def test_fetch_capture_count(self) -> None:
-        conn = _make_conn({"federal-courtlistener-opinions": 42}, {})
+        conn = _make_conn({"ca-sf-civil-tentatives": 42}, {})
         n = fetch_capture_count(
-            conn, "federal-courtlistener-opinions", _NOW - timedelta(days=7)
+            conn, "ca-sf-civil-tentatives", _NOW - timedelta(days=7)
         )
         assert n == 42
 
@@ -537,9 +555,9 @@ class TestDbHelpers:
     def test_fetch_sample_keys_truncates_to_sample_size(self) -> None:
         conn = _make_conn(
             {},
-            {"federal-courtlistener-opinions": [f"k{i}" for i in range(20)]},
+            {"ca-sf-civil-tentatives": [f"k{i}" for i in range(20)]},
         )
-        keys = fetch_sample_keys(conn, "federal-courtlistener-opinions", 5)
+        keys = fetch_sample_keys(conn, "ca-sf-civil-tentatives", 5)
         assert keys == [f"k{i}" for i in range(5)]
 
 


### PR DESCRIPTION
## Summary

Retire the `federal-courtlistener-opinions` scraper (the dominant filler driving dev ElastiCache OOM per #4474) and bump dev ElastiCache from `cache.t4g.micro` to `cache.t4g.small` for headroom. The CL scraper module and its test stay in tree for trivial re-enable, per the operator decision in the #4474 thread. This PR is on the critical path to unwedge the dispatcher (every ECS task-runner agent is currently failing on dev Redis at 100% memory).

Changes:
- `runner.py` — remove the registry entry + unused `CourtListenerScraper` / `cl_config` imports from `_build_registry()`.
- `audit_scraper_field_population.py` — remove the REGISTRY entry; re-point `synthetic_drift_result()` to `ca-sf-civil-tentatives`; reword docstring.
- `check-scraper-zero-record-streak.py` — add `federal-courtlistener-opinions` to `EXCLUSIONS` so the silent-outage guard doesn't alert on the retired scraper.
- `check-scraper-registry.py` — add a `RETIRED_MODULES` allowlist so the registry-completeness guard tolerates the deliberately de-registered module that stays in tree (necessary un-specced change).
- Tests re-fixtured away from the retired CL scraper (arity-1) to surviving JSON-envelope scrapers (`ca-sf-civil-tentatives` / `ca-cc-tentatives-portal`, arity-2); retirement locked in by test assertions.
- `infra/terraform/environments/dev/main.tf` — `node_type` `cache.t4g.micro` → `cache.t4g.small` (`apply_immediately` already set per #2581; merge auto-applies via terraform.yml dev-apply).

Closes #4571

## Test plan

### Automated checks
- [x] Lint passes (ruff check, 8 files)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (scraper-framework: 8220 passed / 3 skipped; scripts audit: 49 passed)
- [x] CI green

### Post-deploy verification
- [ ] After merge, dev-apply runs and `aws elasticache describe-cache-clusters --cache-cluster-id judgemind-dev --query 'CacheClusters[0].CacheNodeType'` returns `cache.t4g.small`
- [ ] `grep -c 'federal-courtlistener-opinions'` returns 0 in `runner.py` and `audit_scraper_field_population.py` on merged main
- [ ] Verification evidence posted on issue (see A.8)
