### PR TITLE
fix(dispatcher): add Telegram alert + time-bounded auto-recovery to diagnoser circuit breaker (#4586)

### DIFF
--- a/packages/api/migrations/65_dispatcher-diagnoser-breaker-recovery.sql
+++ b/packages/api/migrations/65_dispatcher-diagnoser-breaker-recovery.sql
@@ -1,0 +1,45 @@
+-- Up Migration
+--
+-- Dispatcher — diagnoser circuit-breaker time-bounded auto-recovery.
+--
+-- Issue #4586. The diagnoser circuit breaker
+-- (`scripts/dispatcher/daemon.py::_check_diagnoser_circuit_breaker`) flips
+-- `diagnoser_enabled` to `false` when the 24h fallback rate exceeds the
+-- threshold. Pre-#4586 the recovery semantics were one-way: once disabled,
+-- no diagnoses run → no measurement → the breaker can never re-evaluate the
+-- fallback rate, so the flag stayed `false` until an operator manually
+-- flipped it. The practical effect (observed in #4586) was the dispatcher
+-- silently degraded for an unknown number of days while 213 ralph_not_ship
+-- failures piled up with zero diagnoses.
+--
+-- Design notes
+-- ------------
+-- - `diagnoser_breaker_recovery_window_seconds` is the auto-recovery knob.
+--   `86400` (24h) — one full fallback-measurement window — so a retrip
+--   evaluates a fresh 24h of diagnoses rather than the stale window that
+--   tripped it. The daemon's `_check_diagnoser_breaker_auto_recover` reads
+--   this once per supervisor tick; when `now() - diagnoser_breaker_tripped_at`
+--   exceeds it, the daemon re-enables the diagnoser and clears the trip
+--   timestamp. If the fallback rate is still bad the breaker simply retrips
+--   on the next window — trading "silent degradation forever" for "limited
+--   blast radius per trip."
+-- - `diagnoser_breaker_tripped_at` is NOT seeded here — the daemon UPSERTs it
+--   on trip (a JSON-encoded ISO-8601 UTC string) and clears it (to JSON
+--   `null`) on auto-recovery. Seeding it would imply a trip that never
+--   happened.
+-- - Stored as a JSONB number so operators can tune live (e.g. `'43200'` for
+--   a 12h window). `ON CONFLICT DO NOTHING` keeps the migration idempotent.
+-- - `updated_by='init'` matches the convention in migrations 21/26:
+--   migration-seeded rows are distinguishable from operator edits.
+
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('diagnoser_breaker_recovery_window_seconds', '86400', 'init')
+ON CONFLICT (key) DO NOTHING;
+
+
+-- Down Migration
+DELETE FROM dispatcher.config
+WHERE key IN (
+    'diagnoser_breaker_recovery_window_seconds',
+    'diagnoser_breaker_tripped_at'
+);

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2284,6 +2284,29 @@ CIRCUIT_BREAKER_WINDOW_SECONDS = 24 * 60 * 60
 #: is missing or malformed. Matches the migration-26 seed ``0.30``.
 DEFAULT_CIRCUIT_BREAKER_THRESHOLD = 0.30
 
+#: Config key persisting the wall-clock instant the diagnoser circuit
+#: breaker last flipped ``diagnoser_enabled`` to ``false``. Written as a
+#: JSON-encoded ISO-8601 UTC string by :meth:`_check_diagnoser_circuit_breaker`
+#: on trip; read + cleared by :meth:`_check_diagnoser_breaker_auto_recover`.
+#: Issue #4586: the diagnoser breaker's recovery semantics were one-way
+#: (no diagnoses → no measurement → breaker can never re-evaluate), so the
+#: flag stayed ``false`` until an operator manually flipped it. Persisting
+#: the trip time lets the daemon time-bound the degradation.
+DIAGNOSER_BREAKER_TRIPPED_AT_KEY = "diagnoser_breaker_tripped_at"
+
+#: Config key for the time-bounded auto-recovery window (seconds). When
+#: ``now() - diagnoser_breaker_tripped_at`` exceeds this, the daemon
+#: re-enables the diagnoser. If the fallback rate is still bad the breaker
+#: simply retrips on the next window — trading "silent degradation forever"
+#: for "limited blast radius per trip" (#4586 Option 1).
+DIAGNOSER_BREAKER_RECOVERY_WINDOW_KEY = "diagnoser_breaker_recovery_window_seconds"
+
+#: Default auto-recovery window when the config row is missing or
+#: malformed. 24 h — one full fallback-measurement window
+#: (:data:`CIRCUIT_BREAKER_WINDOW_SECONDS`), so a retrip evaluates a
+#: fresh 24 h of diagnoses rather than the stale window that tripped it.
+DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS = 24 * 60 * 60
+
 # --------------------------------------------------------------------------
 # Overnight-safety circuit breaker (#2860) — separate from the diagnoser
 # circuit breaker above. This one trips on a streak of bad terminal agent
@@ -20125,6 +20148,13 @@ class DispatcherDaemon:
                 pass
             return False
 
+        # Persist the trip instant so the time-bounded auto-recovery
+        # path (#4586) can re-enable the diagnoser after the window
+        # elapses. Best-effort: a failure here does not undo the flip —
+        # the breaker is still tripped, only auto-recovery is lost (the
+        # operator can still manually re-enable, the pre-#4586 behaviour).
+        self._record_diagnoser_breaker_tripped_at()
+
         self._log.warning(
             "daemon.diagnoser_circuit_breaker_tripped",
             extra={
@@ -20137,7 +20167,338 @@ class DispatcherDaemon:
                 "min_diagnoses": CIRCUIT_BREAKER_MIN_DIAGNOSES,
             },
         )
+
+        # Loud alert on trip (#4586 Option 2). The prior trip was only a
+        # ``self._log.warning(...)`` — easy to miss, which is how the
+        # diagnoser stayed silently degraded for days. Best-effort: a
+        # Telegram failure is logged but the breaker stays tripped.
+        try:
+            self._send_diagnoser_breaker_telegram_alert(
+                fallback_rate=fallback_rate,
+                threshold=threshold,
+                total_diagnoses=total_n,
+                failed_diagnoses=failed_n,
+            )
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_telegram_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_telegram_failed",
+                    "run_id": self._run_id,
+                },
+            )
         return True
+
+    def _record_diagnoser_breaker_tripped_at(self) -> None:
+        """UPSERT ``diagnoser_breaker_tripped_at`` = now() into config.
+
+        Best-effort (#4586). Stores a JSON-encoded ISO-8601 UTC string so
+        :meth:`_check_diagnoser_breaker_auto_recover` can time-bound the
+        degradation. A failure is logged but does not undo the breaker
+        flip — only auto-recovery is forfeited for that trip.
+        """
+        assert self._conn is not None, "connect() must run before breaker write"
+        tripped_at = datetime.now(UTC).isoformat()
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.config (key, value, updated_at, updated_by) "
+                    "VALUES (%s, %s::jsonb, now(), 'diagnoser_circuit_breaker') "
+                    "ON CONFLICT (key) DO UPDATE "
+                    "SET value = EXCLUDED.value, "
+                    "    updated_at = now(), "
+                    "    updated_by = 'diagnoser_circuit_breaker'",
+                    (DIAGNOSER_BREAKER_TRIPPED_AT_KEY, json.dumps(tripped_at)),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_record_tripped_at_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_record_tripped_at_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+
+    def _diagnoser_breaker_recovery_window_seconds(self) -> int:
+        """Read ``diagnoser_breaker_recovery_window_seconds`` from config.
+
+        Falls back to
+        :data:`DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS` (24 h) on
+        missing row, malformed JSON, or non-positive value. A non-positive
+        window would auto-recover on the same tick as the trip — defeating
+        the breaker — so it is coerced to the default (#4586).
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    (DIAGNOSER_BREAKER_RECOVERY_WINDOW_KEY,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+
+        if row is None or row[0] is None:
+            return DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+        try:
+            seconds = int(raw)
+        except (TypeError, ValueError):
+            return DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+        if seconds <= 0:
+            return DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+        return seconds
+
+    def _read_diagnoser_breaker_tripped_at(self) -> datetime | None:
+        """Read ``diagnoser_breaker_tripped_at`` as a UTC-aware datetime.
+
+        Returns ``None`` on missing row, NULL, malformed JSON, or an
+        unparseable timestamp. The value is stored as a JSON-encoded
+        ISO-8601 string by :meth:`_record_diagnoser_breaker_tripped_at`;
+        naive datetimes are coerced to UTC so the elapsed comparison in
+        :meth:`_check_diagnoser_breaker_auto_recover` is well-defined.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    (DIAGNOSER_BREAKER_TRIPPED_AT_KEY,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return None
+
+        if row is None or row[0] is None:
+            return None
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(raw, str):
+            return None
+        try:
+            ts = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        return ts
+
+    def _check_diagnoser_breaker_auto_recover(self) -> bool:
+        """Time-bounded re-enable of the diagnoser breaker (#4586 Option 1).
+
+        Called once per supervisor tick BEFORE
+        :meth:`_check_diagnoser_circuit_breaker`. When the diagnoser is
+        currently disabled AND a ``diagnoser_breaker_tripped_at`` exists
+        AND ``now() - tripped_at`` exceeds the recovery window, flip
+        ``diagnoser_enabled`` back to ``true`` and clear the trip
+        timestamp. This breaks the one-way "no diagnoses → no measurement
+        → breaker can never re-evaluate" deadlock: after recovery the
+        diagnoser runs again, and if the fallback rate is still bad the
+        breaker retrips on the next 24 h window.
+
+        Returns True if the breaker was auto-recovered this tick, False
+        otherwise. The hot path (diagnoser already enabled) is a single
+        config read + early return.
+
+        Operator-reflip interplay: if an operator manually re-enables the
+        diagnoser, the hot path early-returns without ever clearing the
+        stale trip timestamp. That is harmless — the timestamp is only
+        consulted while ``diagnoser_enabled`` is false, and a subsequent
+        retrip overwrites it. We do not clear it on the operator path to
+        keep this method's only write the recovery flip itself.
+        """
+        assert self._conn is not None, "connect() must run before auto-recover"
+
+        # Hot path: diagnoser is enabled — nothing to recover.
+        if self._diagnoser_enabled():
+            return False
+
+        tripped_at = self._read_diagnoser_breaker_tripped_at()
+        if tripped_at is None:
+            # Breaker is off but we have no trip timestamp — either the
+            # operator manually disabled it (no auto-recovery owed) or the
+            # trip-time write failed. Leave the open state to the operator.
+            return False
+
+        window_seconds = self._diagnoser_breaker_recovery_window_seconds()
+        elapsed = datetime.now(UTC) - tripped_at
+        if elapsed < timedelta(seconds=window_seconds):
+            return False
+
+        # Window elapsed — re-enable the diagnoser and clear the trip
+        # timestamp so a future trip starts a fresh window.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.config "
+                    "SET value = 'true', "
+                    "    updated_at = now(), "
+                    "    updated_by = 'diagnoser_circuit_breaker_auto_recover' "
+                    "WHERE key = %s",
+                    ("diagnoser_enabled",),
+                )
+                cur.execute(
+                    "UPDATE dispatcher.config "
+                    "SET value = 'null', "
+                    "    updated_at = now(), "
+                    "    updated_by = 'diagnoser_circuit_breaker_auto_recover' "
+                    "WHERE key = %s",
+                    (DIAGNOSER_BREAKER_TRIPPED_AT_KEY,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_auto_recover_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_auto_recover_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return False
+
+        self._log.warning(
+            "daemon.diagnoser_circuit_breaker_auto_recovered",
+            extra={
+                "event": "diagnoser_circuit_breaker_auto_recovered",
+                "run_id": self._run_id,
+                "tripped_at": tripped_at.isoformat(),
+                "elapsed_seconds": int(elapsed.total_seconds()),
+                "recovery_window_seconds": window_seconds,
+            },
+        )
+        return True
+
+    def _send_diagnoser_breaker_telegram_alert(
+        self,
+        *,
+        fallback_rate: float,
+        threshold: float,
+        total_diagnoses: int,
+        failed_diagnoses: int,
+    ) -> None:
+        """Fire a Telegram alert when the diagnoser breaker trips (#4586).
+
+        Best-effort — a non-zero exit from ``scripts/notify-telegram.sh``
+        is logged as a warning and the breaker stays tripped (the
+        ``diagnoser_enabled=false`` flip is the safety action; the alert
+        is operator-UX). Mirrors
+        :meth:`_send_circuit_breaker_telegram_alert` (the overnight-safety
+        breaker), reusing :func:`_map_notify_telegram_exit_code` for the
+        exit-code → event mapping so #3061's false-success guard applies
+        here too.
+        """
+        repo_root = self._repo_root_for_notify_script()
+        notify_script = repo_root / NOTIFY_TELEGRAM_SCRIPT_RELPATH
+        if not notify_script.exists():
+            self._log.info(
+                "daemon.diagnoser_circuit_breaker_telegram_skipped_no_script",
+                extra={
+                    "event": "diagnoser_circuit_breaker_telegram_skipped_no_script",
+                    "run_id": self._run_id,
+                    "script_path": str(notify_script),
+                },
+            )
+            return
+
+        message = self._render_diagnoser_breaker_telegram_message(
+            fallback_rate=fallback_rate,
+            threshold=threshold,
+            total_diagnoses=total_diagnoses,
+            failed_diagnoses=failed_diagnoses,
+        )
+        tmp_dir = repo_root / "tmp"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        msg_path = tmp_dir / f"diagnoser-breaker-alert-{self._run_id or 'unknown'}.txt"
+        msg_path.write_text(message, encoding="utf-8")
+
+        try:
+            result = subprocess.run(
+                [str(notify_script), "--message-file", str(msg_path)],
+                capture_output=True,
+                text=True,
+                timeout=NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.diagnoser_circuit_breaker_telegram_timeout",
+                extra={
+                    "event": "diagnoser_circuit_breaker_telegram_timeout",
+                    "run_id": self._run_id,
+                    "timeout_s": NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS,
+                },
+            )
+            return
+
+        event_suffix, reason = _map_notify_telegram_exit_code(result.returncode)
+        event_name = f"diagnoser_circuit_breaker_telegram_{event_suffix}"
+        log_extra: dict[str, Any] = {
+            "event": event_name,
+            "run_id": self._run_id,
+            "exit_code": result.returncode,
+        }
+        if reason is not None:
+            log_extra["reason"] = reason
+        if result.returncode != 0:
+            log_extra["stderr_tail"] = (result.stderr or "")[-500:]
+
+        if result.returncode == 0:
+            self._log.info(f"daemon.{event_name}", extra=log_extra)
+        else:
+            self._log.warning(f"daemon.{event_name}", extra=log_extra)
+
+    def _render_diagnoser_breaker_telegram_message(
+        self,
+        *,
+        fallback_rate: float,
+        threshold: float,
+        total_diagnoses: int,
+        failed_diagnoses: int,
+    ) -> str:
+        """Render the diagnoser-breaker Telegram alert body (plain text)."""
+        window_hours = round(self._diagnoser_breaker_recovery_window_seconds() / 3600)
+        return (
+            "Dispatcher DIAGNOSER circuit breaker TRIPPED\n"
+            f"{failed_diagnoses}/{total_diagnoses} diagnoses in the last 24h "
+            f"fell back ({round(fallback_rate * 100)}% > "
+            f"{round(threshold * 100)}% threshold).\n"
+            "diagnoser_enabled has been set to false — tier-2/3 failures "
+            "will NOT be auto-diagnosed until the breaker recovers.\n"
+            f"Auto-recovery will re-enable the diagnoser in ~{window_hours}h "
+            "if you take no action; it will retrip if the fallback rate is "
+            "still high.\n"
+            "To re-enable immediately: UPDATE dispatcher.config SET "
+            "value = 'true' WHERE key = 'diagnoser_enabled';"
+        )
 
     # ── Overnight-safety circuit breaker (#2860) ───────────────────────
 
@@ -25389,6 +25750,22 @@ class DispatcherDaemon:
         # side only writes comments/labels if the recommendation
         # action requires them, and those are unavoidable regardless
         # of budget.)
+        # Issue #4586: time-bounded auto-recovery runs BEFORE the breaker
+        # check so a stale trip (diagnoser disabled past the recovery
+        # window) is re-enabled this tick, then the breaker re-evaluates
+        # the fresh window below and retrips if the fallback rate is still
+        # bad. This breaks the one-way deadlock where a tripped breaker
+        # could never re-measure because no diagnoses were running.
+        try:
+            self._check_diagnoser_breaker_auto_recover()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_auto_recover_check_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_auto_recover_check_failed",
+                    "run_id": self._run_id,
+                },
+            )
         try:
             self._check_diagnoser_circuit_breaker()
         except Exception:

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -46,7 +46,7 @@ import json
 import logging
 import subprocess
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -419,6 +419,297 @@ class TestCircuitBreaker:
             if "UPDATE dispatcher.config" in e[0]
         ]
         assert updates == []
+
+
+# --------------------------------------------------------------------------
+# Diagnoser circuit breaker — Telegram alert + auto-recovery (#4586)
+# --------------------------------------------------------------------------
+
+
+def _make_daemon_with_notify_script(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler, Path]:
+    """Make a daemon whose ``baseline_repo_root`` holds a notify-telegram.sh stub.
+
+    The send method short-circuits if the script path does not exist on
+    disk, so we write a stub (never executed — subprocess.run is mocked
+    in the tests that exercise the send path).
+    """
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.phase3d.notify.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=str(tmp_path),
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    notify = scripts_dir / "notify-telegram.sh"
+    notify.write_text("#!/bin/sh\n")
+    notify.chmod(0o755)
+
+    return d, conn, handler, notify
+
+
+class TestDiagnoserBreakerTelegramAlert:
+    """#4586 Option 2: the breaker fires a Telegram alert when it trips."""
+
+    def test_trip_invokes_notify_telegram(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """The canonical regression test: when the breaker flips, the
+        ``notify-telegram.sh`` helper is invoked with --message-file.
+
+        This is the AC's required assertion (``-k notify``)."""
+        d, conn, handler, notify = _make_daemon_with_notify_script(tmp_path)
+        # 10 total, 4 failed → 0.40 > 0.30 threshold → trip.
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),  # threshold read
+            (4, 10),  # COUNT aggregation: failed_n, total_n
+            ("86400",),  # recovery-window read (for the rendered message)
+        ]
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        tripped = d._check_diagnoser_circuit_breaker()
+
+        assert tripped is True
+        # notify-telegram.sh was invoked exactly once with --message-file.
+        assert len(calls) == 1
+        assert str(notify) in calls[0]
+        assert "--message-file" in calls[0]
+        # Exit-0 maps to the "sent" INFO event (reuses #3061 mapping).
+        assert handler.events("diagnoser_circuit_breaker_telegram_sent")
+
+    def test_no_trip_does_not_invoke_notify(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Healthy fallback rate → no trip → no Telegram alert."""
+        d, conn, _handler, _notify = _make_daemon_with_notify_script(tmp_path)
+        # 10 total, 3 failed → 0.30 == threshold → no trip.
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),
+            (3, 10),
+        ]
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        tripped = d._check_diagnoser_circuit_breaker()
+
+        assert tripped is False
+        assert calls == []
+
+    def test_trip_records_tripped_at_timestamp(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """On trip, the breaker UPSERTs ``diagnoser_breaker_tripped_at``."""
+        d, conn, _handler, _notify = _make_daemon_with_notify_script(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),
+            (4, 10),
+            ("86400",),  # recovery-window read for the message
+        ]
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: MagicMock(returncode=0, stdout="", stderr=""),
+        )
+        d._check_diagnoser_circuit_breaker()
+
+        upserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.config" in e[0]
+            and e[1][0] == daemon.DIAGNOSER_BREAKER_TRIPPED_AT_KEY
+        ]
+        assert len(upserts) == 1
+
+    def test_telegram_failure_does_not_undo_trip(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """A non-zero notify exit is logged as a warning; trip still stands."""
+        d, conn, handler, _notify = _make_daemon_with_notify_script(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),
+            (4, 10),
+            ("86400",),
+        ]
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kw: MagicMock(returncode=2, stdout="", stderr="boom"),
+        )
+        tripped = d._check_diagnoser_circuit_breaker()
+        assert tripped is True
+        # Exit 2 → all_send_failed warning (reuses #3061 mapping), not "sent".
+        assert handler.events("diagnoser_circuit_breaker_telegram_all_send_failed")
+        assert not handler.events("diagnoser_circuit_breaker_telegram_sent")
+
+    def test_missing_script_skips_send(self, tmp_path: Path) -> None:
+        """No notify-telegram.sh on disk → skip event, no crash."""
+        # _make_daemon has no baseline_repo_root + no stub script, so the
+        # send path short-circuits with the skipped event.
+        d, conn, handler = _make_daemon(tmp_path)
+        d._cfg.baseline_repo_root = str(tmp_path)  # type: ignore[attr-defined]
+        d._send_diagnoser_breaker_telegram_alert(
+            fallback_rate=0.4,
+            threshold=0.3,
+            total_diagnoses=10,
+            failed_diagnoses=4,
+        )
+        assert handler.events("diagnoser_circuit_breaker_telegram_skipped_no_script")
+
+
+class TestDiagnoserBreakerAutoRecover:
+    """#4586 Option 1: time-bounded auto-recovery re-enables the diagnoser."""
+
+    def test_hot_path_when_enabled(self, tmp_path: Path) -> None:
+        """Diagnoser already enabled → no-op, no UPDATE."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("true",)]  # _diagnoser_enabled read
+        recovered = d._check_diagnoser_breaker_auto_recover()
+        assert recovered is False
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+        ]
+        assert updates == []
+
+    def test_no_recovery_when_no_tripped_at(self, tmp_path: Path) -> None:
+        """Diagnoser disabled but no trip timestamp → leave to operator."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("false",),  # _diagnoser_enabled → disabled
+            (None,),  # _read_diagnoser_breaker_tripped_at → no row value
+        ]
+        recovered = d._check_diagnoser_breaker_auto_recover()
+        assert recovered is False
+
+    def test_no_recovery_before_window_elapsed(self, tmp_path: Path) -> None:
+        """Window not yet elapsed → stay tripped."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        recent = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        conn.cursor_instance.fetch_queue = [
+            ("false",),  # disabled
+            (json.dumps(recent),),  # tripped 1h ago
+            ("86400",),  # recovery window = 24h
+        ]
+        recovered = d._check_diagnoser_breaker_auto_recover()
+        assert recovered is False
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+        ]
+        assert updates == []
+
+    def test_recovers_after_window_elapsed(self, tmp_path: Path) -> None:
+        """Window elapsed → re-enable diagnoser + clear trip timestamp."""
+        d, conn, handler = _make_daemon(tmp_path)
+        stale = (datetime.now(UTC) - timedelta(hours=25)).isoformat()
+        conn.cursor_instance.fetch_queue = [
+            ("false",),  # disabled
+            (json.dumps(stale),),  # tripped 25h ago
+            ("86400",),  # recovery window = 24h → elapsed
+        ]
+        recovered = d._check_diagnoser_breaker_auto_recover()
+        assert recovered is True
+        # Two UPDATEs: re-enable diagnoser_enabled, clear tripped_at.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+        ]
+        assert len(updates) == 2
+        enable_update = [u for u in updates if u[1] == ("diagnoser_enabled",)]
+        clear_update = [
+            u for u in updates if u[1] == (daemon.DIAGNOSER_BREAKER_TRIPPED_AT_KEY,)
+        ]
+        assert len(enable_update) == 1
+        assert "value = 'true'" in enable_update[0][0]
+        assert len(clear_update) == 1
+        assert handler.events("diagnoser_circuit_breaker_auto_recovered")
+
+    def test_recovery_window_default_on_malformed(self, tmp_path: Path) -> None:
+        """Malformed window config → 24h default."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("not-an-int",)]
+        assert (
+            d._diagnoser_breaker_recovery_window_seconds()
+            == daemon.DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+        )
+
+    def test_recovery_window_default_on_nonpositive(self, tmp_path: Path) -> None:
+        """Non-positive window would auto-recover immediately → coerce to default."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("0",)]
+        assert (
+            d._diagnoser_breaker_recovery_window_seconds()
+            == daemon.DEFAULT_DIAGNOSER_BREAKER_RECOVERY_WINDOW_SECONDS
+        )
+
+    def test_read_tripped_at_returns_none_on_malformed(self, tmp_path: Path) -> None:
+        """Unparseable timestamp → None (no auto-recovery owed)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(json.dumps("not-a-timestamp"),)]
+        assert d._read_diagnoser_breaker_tripped_at() is None
+
+
+class TestMigration65DiagnoserBreakerRecovery:
+    """Migration 65 seeds ``diagnoser_breaker_recovery_window_seconds``."""
+
+    def _migration_path(self) -> Path:
+        repo_root = Path(__file__).resolve().parents[3]
+        return (
+            repo_root
+            / "packages"
+            / "api"
+            / "migrations"
+            / "65_dispatcher-diagnoser-breaker-recovery.sql"
+        )
+
+    def test_migration_file_present(self) -> None:
+        assert self._migration_path().exists()
+
+    def test_migration_seeds_recovery_window(self) -> None:
+        sql = self._migration_path().read_text(encoding="utf-8")
+        assert "diagnoser_breaker_recovery_window_seconds" in sql
+        assert "INSERT INTO dispatcher.config" in sql
+        assert "'86400'" in sql
+        assert "ON CONFLICT" in sql
+
+    def test_migration_has_down_migration(self) -> None:
+        sql = self._migration_path().read_text(encoding="utf-8")
+        assert "Down Migration" in sql
+        assert "DELETE FROM dispatcher.config" in sql
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The diagnoser circuit breaker flipped `diagnoser_enabled=false` one-way: once disabled, no diagnoses ran, so the breaker could never re-measure the 24h fallback rate and re-enable itself — the flag stayed false until an operator manually flipped it. This PR adds both proposed fixes: a loud Telegram alert on trip (Option 2) and a time-bounded auto-recovery (Option 1) that re-enables the diagnoser after a window (default 24h), retripping if the fallback rate is still bad.

Closes #4586

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component exercisable. Both v2 and v3 dispatcher daemons are intentionally scaled to 0 (agent-runner ANTHROPIC_API_KEY account out of credit), so the live diagnoser cannot be exercised. Verification rests on the regression tests: `pytest scripts/dispatcher/tests/test_daemon_phase3d.py -k notify` (AC's required assertion) plus `TestDiagnoserBreakerAutoRecover` and `TestMigration65DiagnoserBreakerRecovery`.
- [x] Verification evidence posted on issue (test output)
