### PR TITLE
feat(infra): migrate OpenSearch clients to SigV4-signed requests (#4040)

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -12,6 +12,7 @@
         "@apollo/server": "^4.10",
         "@aws-sdk/client-s3": "^3.1039.0",
         "@aws-sdk/client-ses": "^3.1039.0",
+        "@aws-sdk/credential-provider-node": "^3.972.0",
         "@aws-sdk/s3-request-presigner": "^3.1039.0",
         "@opensearch-project/opensearch": "^3.5.1",
         "bcrypt": "^6.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,7 @@
     "@apollo/server": "^4.10",
     "@aws-sdk/client-s3": "^3.1039.0",
     "@aws-sdk/client-ses": "^3.1039.0",
+    "@aws-sdk/credential-provider-node": "^3.972.0",
     "@aws-sdk/s3-request-presigner": "^3.1039.0",
     "@opensearch-project/opensearch": "^3.5.1",
     "bcrypt": "^6.0.0",

--- a/packages/api/src/search/client.ts
+++ b/packages/api/src/search/client.ts
@@ -1,27 +1,62 @@
 import { Client } from '@opensearch-project/opensearch';
+import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws-v3';
+import { defaultProvider } from '@aws-sdk/credential-provider-node';
 
-const OPENSEARCH_URL = process.env.OPENSEARCH_URL ?? 'http://localhost:9200';
-const OPENSEARCH_USERNAME = process.env.OPENSEARCH_USERNAME ?? '';
-const OPENSEARCH_PASSWORD = process.env.OPENSEARCH_PASSWORD ?? '';
+const DEFAULT_REGION = 'us-west-2';
 
-const clientOptions: ConstructorParameters<typeof Client>[0] = {
-  node: OPENSEARCH_URL,
-  ssl: { rejectUnauthorized: false },
-};
+type ClientOptions = ConstructorParameters<typeof Client>[0];
 
-// HTTP Basic auth via OpenSearch FGAC's internal user database. The
-// domain's resource-based access policy MUST permit Principal = "*" for
-// basic-auth requests to be evaluated by FGAC at all — see #3771 for the
-// full root-cause analysis of what happens when the policy is narrowed.
-// A future migration to SigV4-signed requests would let the access policy
-// re-tighten to enumerated role ARNs (#3704); track that follow-up issue
-// (filed alongside #3771) before changing the policy in
-// `infra/terraform/modules/search/main.tf`.
-if (OPENSEARCH_USERNAME && OPENSEARCH_PASSWORD) {
-  clientOptions.auth = {
-    username: OPENSEARCH_USERNAME,
-    password: OPENSEARCH_PASSWORD,
+// SigV4-signed requests are the preferred, deployed auth path: the client
+// signs requests with the ambient AWS credential chain so the OpenSearch
+// domain's resource-based access policy can re-tighten to enumerated role ARNs
+// instead of Principal = "*" (#4040). HTTP Basic auth via OpenSearch FGAC's
+// internal user database remains as the local-dev fallback for the
+// Docker-Compose OpenSearch, which does not speak SigV4 (see #3771 for the
+// access-policy root-cause history).
+export function buildOpensearchClientOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): ClientOptions {
+  const node = env.OPENSEARCH_URL ?? 'http://localhost:9200';
+  const username = env.OPENSEARCH_USERNAME ?? '';
+  const password = env.OPENSEARCH_PASSWORD ?? '';
+  const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? DEFAULT_REGION;
+
+  const baseOptions: ClientOptions = {
+    node,
+    ssl: { rejectUnauthorized: false },
+  };
+
+  if (username && password) {
+    // local-dev fallback: HTTP Basic auth against the Docker-Compose
+    // OpenSearch (which does not speak SigV4). Gated behind explicit env vars.
+    return {
+      ...baseOptions,
+      auth: { username, password },
+    };
+  }
+
+  // No no-auth fallback here (unlike the Python make_opensearch_client helper)
+  // is intentional (#4040). The API service only ever runs in two
+  // configurations: (1) deployed on ECS, where the task role always supplies
+  // AWS credentials, so SigV4 resolves at the first request; (2) local dev,
+  // where OPENSEARCH_USERNAME/OPENSEARCH_PASSWORD are set per
+  // docs/agent/local-dev.md, so the basic-auth branch above is taken.
+  // AwsSigv4Signer's getCredentials is lazy (resolved per-request, not at
+  // construction), so building the signer never throws at module load — there
+  // is no import-time regression even when credentials are absent. The Python
+  // helper's no-auth path exists for a different consumer: rebuild_db.py /
+  // reingest_from_s3.py can run locally with OPENSEARCH_URL set but no creds at
+  // all. That scenario does not apply to the always-credentialed API service.
+  const signer = AwsSigv4Signer({
+    region,
+    service: 'es',
+    getCredentials: () => defaultProvider()(),
+  });
+
+  return {
+    ...signer,
+    ...baseOptions,
   };
 }
 
-export const opensearchClient = new Client(clientOptions);
+export const opensearchClient = new Client(buildOpensearchClientOptions());

--- a/packages/api/tests/search-client-auth.unit.test.ts
+++ b/packages/api/tests/search-client-auth.unit.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the SigV4 signer + credential provider so no real AWS/network calls
+// happen and we can assert which auth branch was taken. The signer returns a
+// recognizable marker object spread into the client options. See #4040.
+// vi.mock factories are hoisted above module-level consts, so the spy is
+// declared via vi.hoisted to be available inside the factory.
+const { awsSigv4Signer } = vi.hoisted(() => ({
+  awsSigv4Signer: vi.fn(() => ({ Connection: 'conn', Transport: 'transport' })),
+}));
+
+vi.mock('@opensearch-project/opensearch/aws-v3', () => ({
+  AwsSigv4Signer: (opts: unknown) => awsSigv4Signer(opts),
+}));
+
+vi.mock('@aws-sdk/credential-provider-node', () => ({
+  defaultProvider: () => () => Promise.resolve({}),
+}));
+
+// Prevent the module-load-time `new Client(...)` from doing anything real.
+vi.mock('@opensearch-project/opensearch', () => ({
+  Client: class {
+    constructor() {}
+  },
+}));
+
+import { buildOpensearchClientOptions } from '../src/search/client';
+
+describe('buildOpensearchClientOptions', () => {
+  beforeEach(() => {
+    awsSigv4Signer.mockClear();
+  });
+
+  it('uses basic auth when both username and password are set', () => {
+    const opts = buildOpensearchClientOptions({
+      OPENSEARCH_URL: 'http://localhost:9200',
+      OPENSEARCH_USERNAME: 'admin',
+      OPENSEARCH_PASSWORD: 'secret',
+    } as NodeJS.ProcessEnv);
+
+    expect(opts.auth).toEqual({ username: 'admin', password: 'secret' });
+    expect(opts.node).toBe('http://localhost:9200');
+    // No SigV4 signer in the basic-auth path.
+    expect(awsSigv4Signer).not.toHaveBeenCalled();
+    expect('Connection' in opts).toBe(false);
+  });
+
+  it('uses SigV4 signer when no basic-auth env is present', () => {
+    const opts = buildOpensearchClientOptions({
+      OPENSEARCH_URL: 'https://search.example.com',
+    } as NodeJS.ProcessEnv);
+
+    expect(awsSigv4Signer).toHaveBeenCalledTimes(1);
+    expect(opts.auth).toBeUndefined();
+    // Signer marker fields were spread into the options.
+    expect((opts as Record<string, unknown>).Connection).toBe('conn');
+    expect((opts as Record<string, unknown>).Transport).toBe('transport');
+    expect(opts.node).toBe('https://search.example.com');
+  });
+
+  it('uses SigV4 when only one of username/password is set', () => {
+    const opts = buildOpensearchClientOptions({
+      OPENSEARCH_URL: 'https://search.example.com',
+      OPENSEARCH_USERNAME: 'admin',
+    } as NodeJS.ProcessEnv);
+
+    expect(awsSigv4Signer).toHaveBeenCalledTimes(1);
+    expect(opts.auth).toBeUndefined();
+  });
+
+  it('defaults the region to us-west-2', () => {
+    buildOpensearchClientOptions({
+      OPENSEARCH_URL: 'https://search.example.com',
+    } as NodeJS.ProcessEnv);
+
+    expect(awsSigv4Signer).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'us-west-2', service: 'es' }),
+    );
+  });
+
+  it('honors AWS_REGION over the default', () => {
+    buildOpensearchClientOptions({
+      OPENSEARCH_URL: 'https://search.example.com',
+      AWS_REGION: 'us-east-2',
+    } as NodeJS.ProcessEnv);
+
+    expect(awsSigv4Signer).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'us-east-2' }),
+    );
+  });
+
+  it('falls back to AWS_DEFAULT_REGION when AWS_REGION is unset', () => {
+    buildOpensearchClientOptions({
+      OPENSEARCH_URL: 'https://search.example.com',
+      AWS_DEFAULT_REGION: 'eu-central-1',
+    } as NodeJS.ProcessEnv);
+
+    expect(awsSigv4Signer).toHaveBeenCalledWith(
+      expect.objectContaining({ region: 'eu-central-1' }),
+    );
+  });
+
+  it('defaults the node URL to localhost when OPENSEARCH_URL is unset', () => {
+    const opts = buildOpensearchClientOptions({} as NodeJS.ProcessEnv);
+    expect(opts.node).toBe('http://localhost:9200');
+  });
+});

--- a/packages/scraper-framework/src/framework/opensearch_client.py
+++ b/packages/scraper-framework/src/framework/opensearch_client.py
@@ -1,0 +1,98 @@
+"""Shared OpenSearch client factory with SigV4-signed requests.
+
+SigV4 is the preferred (deployed) auth path: the client signs requests with
+the ambient AWS credentials (the ECS task role in deployed environments) so
+the OpenSearch domain's resource-based access policy can re-tighten to
+enumerated role ARNs instead of ``Principal: AWS = "*"`` (#4040).
+
+Auth selection (in priority order):
+    1. Local-dev basic-auth fallback — ``OPENSEARCH_USERNAME`` +
+       ``OPENSEARCH_PASSWORD`` both set and non-empty.  Keeps
+       ``scripts/rebuild_db.sh`` working against the Docker-Compose OpenSearch,
+       which does not speak SigV4.
+    2. SigV4 — built from the boto3/botocore default credential chain.
+    3. No-auth — local-dev with no creds and no basic-auth env set; preserves
+       today's behavior for the unset-local path.
+
+Usage:
+    from framework.opensearch_client import make_opensearch_client
+    client = make_opensearch_client(opensearch_url)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import boto3
+from opensearchpy import AWSV4SignerAuth, OpenSearch, RequestsHttpConnection
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REGION = "us-west-2"
+_SERVICE_NAME = "es"
+
+
+def _resolve_region(region: str | None, session: boto3.Session) -> str:
+    """Resolve the AWS region: arg > env > botocore session > default."""
+    if region:
+        return region
+    env_region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    if env_region:
+        return env_region
+    if session.region_name:
+        return session.region_name
+    return _DEFAULT_REGION
+
+
+def make_opensearch_client(
+    hosts: str | list[str],
+    *,
+    timeout: int = 30,
+    max_retries: int = 3,
+    retry_on_timeout: bool = True,
+    region: str | None = None,
+) -> OpenSearch:
+    """Build an OpenSearch client, preferring SigV4-signed requests.
+
+    ``hosts`` accepts a single URL string or a list; it is normalized to a
+    list internally.  The ``timeout``/``max_retries``/``retry_on_timeout``
+    knobs default to the values that make rebuilds self-healing under load
+    (opensearchpy otherwise defaults to a 10s read_timeout and no retries,
+    producing sporadic ``ConnectionTimeout`` failures — see #2481).
+    """
+    host_list = [hosts] if isinstance(hosts, str) else list(hosts)
+
+    base_kwargs: dict[str, Any] = {
+        "hosts": host_list,
+        "timeout": timeout,
+        "max_retries": max_retries,
+        "retry_on_timeout": retry_on_timeout,
+    }
+
+    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
+    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
+    if os_user and os_pass:
+        # local-dev fallback: HTTP Basic auth against the Docker-Compose
+        # OpenSearch (which does not speak SigV4).  Excluded from the #4040
+        # http_auth grep because it is gated behind explicit env vars.
+        base_kwargs["http_auth"] = (os_user, os_pass)
+        return OpenSearch(**base_kwargs)
+
+    session = boto3.Session()
+    credentials = session.get_credentials()
+    if credentials is None:
+        # No basic-auth env and no resolvable AWS credentials (local-dev with
+        # neither configured).  Preserve today's no-auth behavior.
+        logger.warning(
+            "No OpenSearch basic-auth env and no AWS credentials resolvable; "
+            "building no-auth OpenSearch client (local-dev path)."
+        )
+        return OpenSearch(**base_kwargs)
+
+    resolved_region = _resolve_region(region, session)
+    signer = AWSV4SignerAuth(credentials, resolved_region, _SERVICE_NAME)
+    base_kwargs["http_auth"] = signer
+    base_kwargs["connection_class"] = RequestsHttpConnection
+    return OpenSearch(**base_kwargs)

--- a/packages/scraper-framework/src/ingestion/__main__.py
+++ b/packages/scraper-framework/src/ingestion/__main__.py
@@ -11,8 +11,12 @@ Required environment variables:
 
 Optional:
     MAX_RETRIES            — Per-message retry limit (default: 3)
-    OPENSEARCH_USERNAME    — OpenSearch basic auth username
-    OPENSEARCH_PASSWORD    — OpenSearch basic auth password
+    OPENSEARCH_USERNAME    — OpenSearch basic-auth username (local-dev fallback)
+    OPENSEARCH_PASSWORD    — OpenSearch basic-auth password (local-dev fallback)
+
+OpenSearch auth: SigV4-signed requests (from the ambient AWS credential chain)
+are the preferred, deployed path; ``OPENSEARCH_USERNAME``/``OPENSEARCH_PASSWORD``
+are a local-dev basic-auth fallback.  See framework.opensearch_client and #4040.
 """
 
 from __future__ import annotations
@@ -22,9 +26,9 @@ import sys
 
 import redis
 import structlog
-from opensearchpy import OpenSearch
 
 from framework.logging import configure_structlog
+from framework.opensearch_client import make_opensearch_client
 from framework.s3_cache import make_s3_client
 
 from .worker import InfrastructureError, IngestionWorker
@@ -65,25 +69,10 @@ def main() -> None:
         redis_client = redis.Redis.from_url(redis_url, decode_responses=False)
         redis_client.ping()  # Fail fast on bad URL
 
-        # timeout/max_retries/retry_on_timeout: opensearchpy defaults to a
-        # 10s read_timeout and no retries, which produces sporadic
-        # ``ConnectionTimeout`` failures during rebuilds under load.  Bumping
-        # the timeout to 30s and enabling retries makes transient network
-        # blips self-healing; ``IndexingConsumer`` also swallows terminal
-        # timeouts as a warning so a Postgres write never gates on a flaky
-        # search backend.  See #2481.
-        os_kwargs: dict = {
-            "hosts": [opensearch_url],
-            "timeout": 30,
-            "max_retries": 3,
-            "retry_on_timeout": True,
-        }
-        os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-        os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-        if os_user and os_pass:
-            os_kwargs["http_auth"] = (os_user, os_pass)
-
-        opensearch_client = OpenSearch(**os_kwargs)
+        # SigV4-preferred client with local-dev basic-auth fallback; keeps the
+        # 30s timeout + 3 retries that make rebuilds self-healing under load
+        # (#2481).  See framework.opensearch_client (#4040).
+        opensearch_client = make_opensearch_client(opensearch_url)
         s3_client = make_s3_client()
 
         worker = IngestionWorker(

--- a/packages/scraper-framework/tests/test_ingestion_main.py
+++ b/packages/scraper-framework/tests/test_ingestion_main.py
@@ -35,7 +35,7 @@ def _make_env() -> dict[str, str]:
 
 @patch("ingestion.__main__.IngestionWorker")
 @patch("ingestion.__main__.make_s3_client")
-@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.make_opensearch_client")
 @patch("ingestion.__main__.redis.Redis")
 @patch.dict("os.environ", _make_env(), clear=False)
 def test_main_logs_infrastructure_error_and_exits(
@@ -64,7 +64,7 @@ def test_main_logs_infrastructure_error_and_exits(
 
 @patch("ingestion.__main__.IngestionWorker")
 @patch("ingestion.__main__.make_s3_client")
-@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.make_opensearch_client")
 @patch("ingestion.__main__.redis.Redis")
 @patch.dict("os.environ", _make_env(), clear=False)
 def test_main_logs_unhandled_exception_and_exits(
@@ -91,7 +91,7 @@ def test_main_logs_unhandled_exception_and_exits(
 
 @patch("ingestion.__main__.IngestionWorker")
 @patch("ingestion.__main__.make_s3_client")
-@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.make_opensearch_client")
 @patch("ingestion.__main__.redis.Redis")
 @patch.dict("os.environ", _make_env(), clear=False)
 def test_main_infrastructure_error_includes_cause_in_log(
@@ -127,7 +127,7 @@ def test_main_infrastructure_error_includes_cause_in_log(
 
 @patch("ingestion.__main__.IngestionWorker")
 @patch("ingestion.__main__.make_s3_client")
-@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.make_opensearch_client")
 @patch("ingestion.__main__.redis.Redis")
 @patch.dict("os.environ", _make_env(), clear=False)
 def test_main_normal_run_does_not_exit(
@@ -154,7 +154,7 @@ def test_main_normal_run_does_not_exit(
 
 @patch("ingestion.__main__.IngestionWorker")
 @patch("ingestion.__main__.make_s3_client")
-@patch("ingestion.__main__.OpenSearch")
+@patch("ingestion.__main__.make_opensearch_client")
 @patch("ingestion.__main__.redis.Redis")
 @patch.dict("os.environ", _make_env(), clear=False)
 def test_main_redis_connection_failure_exits(

--- a/packages/scraper-framework/tests/test_opensearch_client.py
+++ b/packages/scraper-framework/tests/test_opensearch_client.py
@@ -1,0 +1,254 @@
+"""Tests for the shared OpenSearch client helper (SigV4 + local-dev fallbacks).
+
+All boto3/opensearchpy construction is mocked — no real network or AWS calls.
+Covers the three auth branches (local-dev basic-auth, SigV4, no-auth), hosts
+string-vs-list normalization, and region resolution precedence.  See #4040.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from framework import opensearch_client
+from framework.opensearch_client import make_opensearch_client
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every test from a clean OpenSearch/AWS env."""
+    for var in (
+        "OPENSEARCH_USERNAME",
+        "OPENSEARCH_PASSWORD",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _patch_opensearch() -> Any:
+    """Patch the OpenSearch class so we can inspect construction kwargs."""
+    return patch.object(opensearch_client, "OpenSearch")
+
+
+def _session_with_creds(creds: object | None) -> MagicMock:
+    """Build a mock boto3.Session whose get_credentials returns ``creds``."""
+    session = MagicMock()
+    session.get_credentials.return_value = creds
+    session.region_name = None
+    return session
+
+
+class TestBasicAuthFallback:
+    """Local-dev basic-auth fallback takes priority over SigV4."""
+
+    def test_uses_http_auth_when_both_env_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSEARCH_USERNAME", "admin")
+        monkeypatch.setenv("OPENSEARCH_PASSWORD", "secret")
+
+        with _patch_opensearch() as mock_os:
+            make_opensearch_client("http://localhost:9200")
+
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs["http_auth"] == ("admin", "secret")
+        # Basic-auth path must NOT install the SigV4 connection class.
+        assert "connection_class" not in kwargs
+
+    def test_basic_auth_skipped_when_only_username_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OPENSEARCH_USERNAME", "admin")
+        # No password -> not basic auth; should fall through to SigV4.
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch() as mock_os,
+        ):
+            mock_session_cls.return_value = _session_with_creds(MagicMock())
+            make_opensearch_client("http://localhost:9200")
+
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs.get("http_auth") != ("admin", "")
+        assert "connection_class" in kwargs
+
+    def test_basic_auth_keeps_timeout_knobs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("OPENSEARCH_USERNAME", "admin")
+        monkeypatch.setenv("OPENSEARCH_PASSWORD", "secret")
+
+        with _patch_opensearch() as mock_os:
+            make_opensearch_client("http://localhost:9200")
+
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs["timeout"] == 30
+        assert kwargs["max_retries"] == 3
+        assert kwargs["retry_on_timeout"] is True
+
+
+class TestSigV4Path:
+    """SigV4 is selected when no basic-auth env is set and creds resolve."""
+
+    def test_uses_sigv4_signer_when_creds_present(self) -> None:
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch() as mock_os,
+        ):
+            mock_session_cls.return_value = _session_with_creds(MagicMock())
+            make_opensearch_client("https://search.example.com")
+
+        kwargs = mock_os.call_args.kwargs
+        assert isinstance(kwargs["http_auth"], opensearch_client.AWSV4SignerAuth)
+        assert kwargs["connection_class"] is opensearch_client.RequestsHttpConnection
+
+    def test_sigv4_keeps_timeout_knobs(self) -> None:
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch() as mock_os,
+        ):
+            mock_session_cls.return_value = _session_with_creds(MagicMock())
+            make_opensearch_client(
+                "https://search.example.com",
+                timeout=45,
+                max_retries=5,
+                retry_on_timeout=False,
+            )
+
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs["timeout"] == 45
+        assert kwargs["max_retries"] == 5
+        assert kwargs["retry_on_timeout"] is False
+
+
+class TestNoAuthFallback:
+    """No basic-auth env and no resolvable creds -> plain no-auth client."""
+
+    def test_no_auth_when_no_creds(self) -> None:
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch() as mock_os,
+        ):
+            mock_session_cls.return_value = _session_with_creds(None)
+            make_opensearch_client("http://localhost:9200")
+
+        kwargs = mock_os.call_args.kwargs
+        assert "http_auth" not in kwargs
+        assert "connection_class" not in kwargs
+
+    def test_no_auth_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch(),
+        ):
+            mock_session_cls.return_value = _session_with_creds(None)
+            with caplog.at_level("WARNING"):
+                make_opensearch_client("http://localhost:9200")
+
+        assert any(
+            "no-auth" in rec.message.lower() or "no aws credentials" in rec.message.lower()
+            for rec in caplog.records
+        )
+
+
+class TestHostsNormalization:
+    """hosts accepts a string or a list; always normalized to a list."""
+
+    def test_string_host_normalized_to_list(self) -> None:
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch() as mock_os,
+        ):
+            mock_session_cls.return_value = _session_with_creds(None)
+            make_opensearch_client("http://localhost:9200")
+
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs["hosts"] == ["http://localhost:9200"]
+
+    def test_list_host_preserved(self) -> None:
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            _patch_opensearch() as mock_os,
+        ):
+            mock_session_cls.return_value = _session_with_creds(None)
+            make_opensearch_client(["http://a:9200", "http://b:9200"])
+
+        kwargs = mock_os.call_args.kwargs
+        assert kwargs["hosts"] == ["http://a:9200", "http://b:9200"]
+
+
+class TestRegionResolution:
+    """Region precedence: arg > env > botocore session > default us-west-2."""
+
+    def test_explicit_arg_wins(self) -> None:
+        captured: dict[str, str] = {}
+
+        def _fake_signer(credentials: object, region: str, service: str) -> MagicMock:
+            captured["region"] = region
+            return MagicMock()
+
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            patch.object(opensearch_client, "AWSV4SignerAuth", side_effect=_fake_signer),
+            _patch_opensearch(),
+        ):
+            session = _session_with_creds(MagicMock())
+            session.region_name = "eu-central-1"
+            mock_session_cls.return_value = session
+            make_opensearch_client("https://x", region="ap-south-1")
+
+        assert captured["region"] == "ap-south-1"
+
+    def test_env_used_when_no_arg(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWS_REGION", "us-east-2")
+        captured: dict[str, str] = {}
+
+        def _fake_signer(credentials: object, region: str, service: str) -> MagicMock:
+            captured["region"] = region
+            return MagicMock()
+
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            patch.object(opensearch_client, "AWSV4SignerAuth", side_effect=_fake_signer),
+            _patch_opensearch(),
+        ):
+            mock_session_cls.return_value = _session_with_creds(MagicMock())
+            make_opensearch_client("https://x")
+
+        assert captured["region"] == "us-east-2"
+
+    def test_session_region_used_when_no_arg_or_env(self) -> None:
+        captured: dict[str, str] = {}
+
+        def _fake_signer(credentials: object, region: str, service: str) -> MagicMock:
+            captured["region"] = region
+            return MagicMock()
+
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            patch.object(opensearch_client, "AWSV4SignerAuth", side_effect=_fake_signer),
+            _patch_opensearch(),
+        ):
+            session = _session_with_creds(MagicMock())
+            session.region_name = "eu-central-1"
+            mock_session_cls.return_value = session
+            make_opensearch_client("https://x")
+
+        assert captured["region"] == "eu-central-1"
+
+    def test_default_region_when_nothing_set(self) -> None:
+        captured: dict[str, str] = {}
+
+        def _fake_signer(credentials: object, region: str, service: str) -> MagicMock:
+            captured["region"] = region
+            captured["service"] = service
+            return MagicMock()
+
+        with (
+            patch.object(opensearch_client.boto3, "Session") as mock_session_cls,
+            patch.object(opensearch_client, "AWSV4SignerAuth", side_effect=_fake_signer),
+            _patch_opensearch(),
+        ):
+            mock_session_cls.return_value = _session_with_creds(MagicMock())
+            make_opensearch_client("https://x")
+
+        assert captured["region"] == "us-west-2"
+        assert captured["service"] == "es"

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -947,7 +947,7 @@ class TestDeleteOpensearchDocsForCounty:
         mock_client.indices.exists.return_value = True
         mock_client.delete_by_query.return_value = {"deleted": 42}
 
-        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+        with patch("rebuild_db.make_opensearch_client", return_value=mock_client):
             result = rebuild_db.delete_opensearch_docs_for_county("http://os", "Contra Costa")
 
         assert result == 42
@@ -963,56 +963,27 @@ class TestDeleteOpensearchDocsForCounty:
         mock_client = MagicMock()
         mock_client.indices.exists.return_value = False
 
-        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+        with patch("rebuild_db.make_opensearch_client", return_value=mock_client):
             result = rebuild_db.delete_opensearch_docs_for_county("http://os", "Contra Costa")
 
         assert result == 0
         mock_client.delete_by_query.assert_not_called()
 
-    def test_uses_basic_auth_when_credentials_set(self) -> None:
-        """OPENSEARCH_USERNAME/PASSWORD env vars feed http_auth tuple."""
+    def test_delegates_client_construction_to_helper(self) -> None:
+        """Client construction (auth selection) is delegated to make_opensearch_client.
+
+        Auth-branch behavior (SigV4 / basic-auth / no-auth) is unit-tested in
+        test_opensearch_client.py; here we just confirm the helper is used with
+        the OpenSearch URL.  See #4040.
+        """
         mock_client = MagicMock()
         mock_client.indices.exists.return_value = True
         mock_client.delete_by_query.return_value = {"deleted": 0}
 
-        with (
-            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
-            patch.dict(
-                os.environ,
-                {
-                    "OPENSEARCH_USERNAME": "admin",
-                    "OPENSEARCH_PASSWORD": "s3cret",
-                },
-                clear=False,
-            ),
-        ):
+        with patch("rebuild_db.make_opensearch_client", return_value=mock_client) as mock_helper:
             rebuild_db.delete_opensearch_docs_for_county("http://os", "Ventura")
 
-        kwargs = mock_ctor.call_args.kwargs
-        assert kwargs["hosts"] == ["http://os"]
-        assert kwargs["timeout"] == 30
-        assert kwargs["max_retries"] == 3
-        assert kwargs["retry_on_timeout"] is True
-        assert kwargs["http_auth"] == ("admin", "s3cret")
-
-    def test_no_auth_when_credentials_unset(self) -> None:
-        """Missing env vars → http_auth not passed to the client ctor."""
-        mock_client = MagicMock()
-        mock_client.indices.exists.return_value = True
-        mock_client.delete_by_query.return_value = {"deleted": 0}
-
-        env = {k: v for k, v in os.environ.items()}
-        env.pop("OPENSEARCH_USERNAME", None)
-        env.pop("OPENSEARCH_PASSWORD", None)
-
-        with (
-            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
-            patch.dict(os.environ, env, clear=True),
-        ):
-            rebuild_db.delete_opensearch_docs_for_county("http://os", "Ventura")
-
-        kwargs = mock_ctor.call_args.kwargs
-        assert "http_auth" not in kwargs
+        mock_helper.assert_called_once_with("http://os")
 
 
 class TestMainPerCountyResetDispatch:
@@ -2894,7 +2865,7 @@ class TestDeleteOpensearchDocsForCourt:
         mock_client.indices.exists.return_value = True
         mock_client.delete_by_query.return_value = {"deleted": 17}
 
-        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+        with patch("rebuild_db.make_opensearch_client", return_value=mock_client):
             result = rebuild_db.delete_opensearch_docs_for_court(
                 "http://os", "ca", "Orange", "Superior Court"
             )
@@ -2922,7 +2893,7 @@ class TestDeleteOpensearchDocsForCourt:
         mock_client = MagicMock()
         mock_client.indices.exists.return_value = False
 
-        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+        with patch("rebuild_db.make_opensearch_client", return_value=mock_client):
             result = rebuild_db.delete_opensearch_docs_for_court(
                 "http://os", "ca", "Orange", "Superior Court"
             )
@@ -2930,54 +2901,23 @@ class TestDeleteOpensearchDocsForCourt:
         assert result == 0
         mock_client.delete_by_query.assert_not_called()
 
-    def test_uses_basic_auth_when_credentials_set(self) -> None:
-        """OPENSEARCH_USERNAME/PASSWORD env vars feed http_auth tuple."""
+    def test_delegates_client_construction_to_helper(self) -> None:
+        """Client construction (auth selection) is delegated to make_opensearch_client.
+
+        Auth-branch behavior (SigV4 / basic-auth / no-auth) is unit-tested in
+        test_opensearch_client.py; here we just confirm the helper is used with
+        the OpenSearch URL.  See #4040.
+        """
         mock_client = MagicMock()
         mock_client.indices.exists.return_value = True
         mock_client.delete_by_query.return_value = {"deleted": 0}
 
-        with (
-            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
-            patch.dict(
-                os.environ,
-                {
-                    "OPENSEARCH_USERNAME": "admin",
-                    "OPENSEARCH_PASSWORD": "s3cret",
-                },
-                clear=False,
-            ),
-        ):
+        with patch("rebuild_db.make_opensearch_client", return_value=mock_client) as mock_helper:
             rebuild_db.delete_opensearch_docs_for_court(
                 "http://os", "ca", "Orange", "Superior Court"
             )
 
-        kwargs = mock_ctor.call_args.kwargs
-        assert kwargs["hosts"] == ["http://os"]
-        assert kwargs["timeout"] == 30
-        assert kwargs["max_retries"] == 3
-        assert kwargs["retry_on_timeout"] is True
-        assert kwargs["http_auth"] == ("admin", "s3cret")
-
-    def test_no_auth_when_credentials_unset(self) -> None:
-        """Missing env vars → http_auth not passed to the client ctor."""
-        mock_client = MagicMock()
-        mock_client.indices.exists.return_value = True
-        mock_client.delete_by_query.return_value = {"deleted": 0}
-
-        env = {k: v for k, v in os.environ.items()}
-        env.pop("OPENSEARCH_USERNAME", None)
-        env.pop("OPENSEARCH_PASSWORD", None)
-
-        with (
-            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
-            patch.dict(os.environ, env, clear=True),
-        ):
-            rebuild_db.delete_opensearch_docs_for_court(
-                "http://os", "ca", "Orange", "Superior Court"
-            )
-
-        kwargs = mock_ctor.call_args.kwargs
-        assert "http_auth" not in kwargs
+        mock_helper.assert_called_once_with("http://os")
 
 
 class TestResetDerivedTablesForCourt:

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -101,6 +101,7 @@ from typing import Any
 import psycopg
 import structlog
 
+from framework.opensearch_client import make_opensearch_client
 from framework.s3_cache import make_s3_client
 
 structlog.configure(
@@ -427,24 +428,10 @@ def _process_one_document(
 
         rc = redis_lib.Redis.from_url(redis_url, decode_responses=False)
         if os_url:
-            from opensearchpy import OpenSearch
-
-            # 30s timeout + 3 retries: opensearchpy defaults to 10s and no
-            # retries, which produces sporadic ``ConnectionTimeout`` entries
-            # during rebuild under load (#2481).  ``IndexingConsumer`` also
-            # swallows terminal timeouts as a warning so a missed index
-            # never fails document processing.
-            os_kwargs: dict = {
-                "hosts": [os_url],
-                "timeout": 30,
-                "max_retries": 3,
-                "retry_on_timeout": True,
-            }
-            os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-            os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-            if os_user and os_pass:
-                os_kwargs["http_auth"] = (os_user, os_pass)
-            os_client = OpenSearch(**os_kwargs)
+            # SigV4-preferred client with local-dev basic-auth fallback; keeps
+            # the 30s timeout + 3 retries that make rebuild self-healing under
+            # load (#2481).  See framework.opensearch_client (#4040).
+            os_client = make_opensearch_client(os_url)
         else:
             os_client = MagicMock()
         s3 = _make_s3()
@@ -1499,21 +1486,9 @@ def reset_derived_tables_for_court(
 
 def reset_opensearch_index(os_url: str) -> None:
     """Delete the OpenSearch tentative_rulings index so it's rebuilt from scratch."""
-    from opensearchpy import OpenSearch
-
-    # 30s timeout + 3 retries — same rationale as the per-worker client
-    # constructed in ``_process_one_document``.  See #2481.
-    os_kwargs: dict = {
-        "hosts": [os_url],
-        "timeout": 30,
-        "max_retries": 3,
-        "retry_on_timeout": True,
-    }
-    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-    if os_user and os_pass:
-        os_kwargs["http_auth"] = (os_user, os_pass)
-    client = OpenSearch(**os_kwargs)
+    # SigV4-preferred client with local-dev basic-auth fallback; same timeout
+    # rationale as ``_process_one_document`` (#2481).  See #4040.
+    client = make_opensearch_client(os_url)
 
     index_name = "tentative_rulings_v1"
     if client.indices.exists(index=index_name):
@@ -1535,19 +1510,8 @@ def delete_opensearch_docs_for_county(os_url: str, county: str) -> int:
 
     Returns the number of OS docs deleted (0 if index missing).
     """
-    from opensearchpy import OpenSearch
-
-    os_kwargs: dict = {
-        "hosts": [os_url],
-        "timeout": 30,
-        "max_retries": 3,
-        "retry_on_timeout": True,
-    }
-    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-    if os_user and os_pass:
-        os_kwargs["http_auth"] = (os_user, os_pass)
-    client = OpenSearch(**os_kwargs)
+    # SigV4-preferred client with local-dev basic-auth fallback (#2481, #4040).
+    client = make_opensearch_client(os_url)
 
     index_name = "tentative_rulings_v1"
     if not client.indices.exists(index=index_name):
@@ -1594,19 +1558,8 @@ def delete_opensearch_docs_for_court(
 
     Returns the number of OS docs deleted (0 if index missing).
     """
-    from opensearchpy import OpenSearch
-
-    os_kwargs: dict = {
-        "hosts": [os_url],
-        "timeout": 30,
-        "max_retries": 3,
-        "retry_on_timeout": True,
-    }
-    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-    if os_user and os_pass:
-        os_kwargs["http_auth"] = (os_user, os_pass)
-    client = OpenSearch(**os_kwargs)
+    # SigV4-preferred client with local-dev basic-auth fallback (#2481, #4040).
+    client = make_opensearch_client(os_url)
 
     index_name = "tentative_rulings_v1"
     if not client.indices.exists(index=index_name):

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -4130,24 +4130,12 @@ def _process_prefix_document(
 
         rc = redis_lib.Redis.from_url(redis_url, decode_responses=False)
         if os_url:
-            from opensearchpy import OpenSearch
+            from framework.opensearch_client import make_opensearch_client
 
-            # 30s timeout + 3 retries: opensearchpy defaults to 10s and no
-            # retries, which produces sporadic ``ConnectionTimeout`` entries
-            # under load (#2481).  ``IndexingConsumer`` also swallows
-            # terminal timeouts as a warning so a missed index never fails
-            # document processing.
-            os_kwargs: dict = {
-                "hosts": [os_url],
-                "timeout": 30,
-                "max_retries": 3,
-                "retry_on_timeout": True,
-            }
-            os_user = os.environ.get("OPENSEARCH_USERNAME", "")
-            os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
-            if os_user and os_pass:
-                os_kwargs["http_auth"] = (os_user, os_pass)
-            os_client = OpenSearch(**os_kwargs)
+            # SigV4-preferred client with local-dev basic-auth fallback; keeps
+            # the 30s timeout + 3 retries that make reingest self-healing under
+            # load (#2481).  See framework.opensearch_client (#4040).
+            os_client = make_opensearch_client(os_url)
         else:
             os_client = MagicMock()
         s3_for_worker = _make_s3()


### PR DESCRIPTION
## Summary

Migrates all OpenSearch client construction sites from HTTP Basic auth to SigV4-signed requests so the domain access policy can later re-tighten to enumerated role ARNs (the correct re-do of #3704) without replaying the #3771 anonymous-403 outage. This PR ships **only the backward-compatible code foundation**; the Terraform policy tightening, FGAC role mapping, prod rollout, and 24h verification are operationally-coupled and operator-gated, tracked in a follow-up issue.

SigV4 is used when AWS credentials are present (ECS task roles); a gated local-dev basic-auth fallback keeps Docker-Compose OpenSearch working. With the access policy still `Principal=*`, both auth methods succeed, so this deploys safely on its own.

Closes #4040

## What changed

- New shared factory `packages/scraper-framework/src/framework/opensearch_client.py` (`make_opensearch_client`): SigV4 (via `AWSV4SignerAuth` + `RequestsHttpConnection`, service `es`) > gated local-dev basic-auth fallback > no-auth fallback, mirroring `make_s3_client`. #2481 timeout/retry knobs preserved.
- Six Python sites delegate to the helper: ingestion `__main__.py`, `rebuild_db.py` (x4), `reingest_from_s3.py`.
- API `client.ts` uses `AwsSigv4Signer` (`@opensearch-project/opensearch/aws-v3`) + `@aws-sdk/credential-provider-node`'s `defaultProvider()`; auth assembly extracted into a pure, unit-tested `buildOpensearchClientOptions(env)`.
- Adds `@aws-sdk/credential-provider-node` as a direct dep for the SigV4 plugin credential chain.

### Dependency justification

`@aws-sdk/credential-provider-node` is required as a direct import for the OpenSearch AWS SigV4 plugin's credential chain. Pinned at `^3.972.0` (not `^3.1039.0` like sibling `@aws-sdk/*` deps): the AWS SDK v3 packages are independently versioned and `credential-provider-node` has no `3.1039.x` release (latest is `3.972.58`; `^3.1039.0` 404s). `@aws-sdk/types@3.973.8` dedupes tree-wide, so there is no resolution conflict.

### Deferred to follow-up (operator-gated)

The access-policy tightening auto-applies to dev on merge and would replay #3771 unless the SigV4 code is deployed AND FGAC role mappings exist first — an ordering that must be operator-controlled. Production is human-only. A follow-up issue tracks: FGAC role mapping (dev), Terraform `access_policies` tightening + `principal_arns` validation re-add, prod rollout, and the 24h no-403 watch.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker rolls out cleanly on dev (Deploy Scraper green + post-deploy health check) with no SigV4/auth errors in `/ecs/judgemind-ingestion-worker-dev`
- [x] API `searchRulings` returns 200 with non-zero hits on dev after deploy (`totalHits: 25451`)
- [x] Verification evidence posted on issue (see A.8)
