### PR TITLE
feat(ingestion): honor --s3-key-list in reingest --prefix mode (#3855)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -12185,6 +12185,287 @@ class TestRunReingestFromPrefix:
     @patch("reingest_from_s3._seed_courts")
     @patch("reingest_from_s3._discover_courts")
     @patch("reingest_from_s3.psycopg")
+    def test_s3_key_list_intersects_listed_keys(
+        self,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """#3855/#4049: ``s3_key_list`` narrows the prefix scan to the
+        intersection of S3-listed keys and the requested list; requested
+        keys not found under the prefix are dropped."""
+        mock_list.return_value = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+        ]
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        # Request two real keys + one that does not exist under the prefix.
+        requested = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+            "ca/orange/superior_court/raw/missing.pdf",
+        ]
+        stats = reingest.run_reingest_from_prefix(
+            "postgresql://test",
+            prefix="ca/orange/superior_court/raw/",
+            s3_key_list=requested,
+            dry_run=True,
+        )
+        # Only the 2 keys present under the prefix survive the intersection.
+        assert stats["total_keys"] == 2
+        # _discover_courts must receive the narrowed set, not the full prefix.
+        discovered_keys = mock_discover.call_args[0][0]
+        assert set(discovered_keys) == {
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+        }
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    def test_s3_key_list_none_processes_full_prefix(
+        self,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """``s3_key_list=None`` leaves prefix behavior unchanged: every key
+        under the prefix is processed."""
+        keys = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        stats = reingest.run_reingest_from_prefix(
+            "postgresql://test",
+            prefix="ca/orange/superior_court/raw/",
+            s3_key_list=None,
+            dry_run=True,
+        )
+        assert stats["total_keys"] == 3
+        discovered_keys = mock_discover.call_args[0][0]
+        assert set(discovered_keys) == set(keys)
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    def test_s3_key_list_empty_processes_full_prefix(
+        self,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """An empty ``s3_key_list`` is treated like ``None`` (full prefix)."""
+        keys = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        stats = reingest.run_reingest_from_prefix(
+            "postgresql://test",
+            prefix="ca/orange/superior_court/raw/",
+            s3_key_list=[],
+            dry_run=True,
+        )
+        assert stats["total_keys"] == 2
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    def test_s3_key_list_dry_run_reports_narrowed_total(
+        self,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """``--dry-run`` with ``--prefix --s3-key-list`` reports the narrowed
+        ``total_keys`` (the intersection count), not the full prefix size."""
+        mock_list.return_value = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+            "ca/orange/superior_court/raw/ddd.pdf",
+        ]
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        stats = reingest.run_reingest_from_prefix(
+            "postgresql://test",
+            prefix="ca/orange/superior_court/raw/",
+            s3_key_list=["ca/orange/superior_court/raw/bbb.pdf"],
+            dry_run=True,
+        )
+        assert stats["total_keys"] == 1
+        assert stats["processed"] == 0
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    def test_s3_key_list_applied_before_limit(
+        self,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """The intersection happens BEFORE ``--limit`` truncation, so limit
+        applies to the narrowed set."""
+        mock_list.return_value = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+            "ca/orange/superior_court/raw/ccc.pdf",
+            "ca/orange/superior_court/raw/ddd.pdf",
+        ]
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        stats = reingest.run_reingest_from_prefix(
+            "postgresql://test",
+            prefix="ca/orange/superior_court/raw/",
+            s3_key_list=[
+                "ca/orange/superior_court/raw/bbb.pdf",
+                "ca/orange/superior_court/raw/ccc.pdf",
+                "ca/orange/superior_court/raw/ddd.pdf",
+            ],
+            limit=2,
+            dry_run=True,
+        )
+        # Intersection narrows to 3, then limit caps to 2.
+        assert stats["total_keys"] == 2
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3.psycopg")
+    def test_s3_key_list_no_matches_returns_zeros(
+        self,
+        mock_psycopg: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """When none of the requested keys are found under the prefix, the
+        narrowed set is empty and the function returns zeros early."""
+        mock_list.return_value = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+        ]
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        stats = reingest.run_reingest_from_prefix(
+            "postgresql://test",
+            prefix="ca/orange/superior_court/raw/",
+            s3_key_list=["ca/orange/superior_court/raw/nope.pdf"],
+            dry_run=True,
+        )
+        assert stats["total_keys"] == 0
+        assert stats["processed"] == 0
+        assert stats["errors"] == 0
+        assert stats["skipped"] == 0
+        # The no-match early return honors the function's documented return
+        # schema (hash_mismatch_warnings + wall_time_seconds) so any
+        # programmatic consumer can read these keys without a KeyError.
+        assert stats["hash_mismatch_warnings"] == 0
+        assert stats["wall_time_seconds"] == 0.0
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
     def test_limit_caps_keys(
         self,
         mock_psycopg: MagicMock,
@@ -13384,6 +13665,67 @@ class TestCLIBustLlmCacheFlag:
             reingest.main()
         mock_run.assert_called_once()
         assert mock_run.call_args.kwargs["bust_llm_cache"] is False
+
+
+class TestCLIPrefixS3KeyListPlumbing:
+    """#3855/#4049: main() forwards --s3-key-list into the --prefix path."""
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    @patch("reingest_from_s3._read_s3_key_list_file")
+    def test_main_passes_s3_key_list_to_prefix(
+        self,
+        mock_read: MagicMock,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """``--prefix`` + ``--s3-key-list`` forwards the parsed key list to
+        ``run_reingest_from_prefix`` (mirrors the standard-mode plumbing test
+        ``test_s3_key_list_filter_passed_through``)."""
+        keys = [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+        ]
+        mock_read.return_value = keys
+        mock_run_prefix.return_value = {
+            "total_keys": 2,
+            "processed": 0,
+            "errors": 0,
+            "skipped": 0,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "ca/orange/superior_court/raw/",
+            "--s3-key-list",
+            "keys.txt",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()
+        mock_run_prefix.assert_called_once()
+        assert mock_run_prefix.call_args.kwargs["s3_key_list"] == keys
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_main_prefix_without_key_list_forwards_none(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """``--prefix`` alone forwards ``s3_key_list=None`` (unchanged behavior)."""
+        mock_run_prefix.return_value = {
+            "total_keys": 0,
+            "processed": 0,
+            "errors": 0,
+            "skipped": 0,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "ca/orange/superior_court/raw/",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()
+        mock_run_prefix.assert_called_once()
+        assert mock_run_prefix.call_args.kwargs["s3_key_list"] is None
 
 
 class TestBustLlmCachePassedThrough:

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -4171,6 +4171,7 @@ def run_reingest_from_prefix(
     bust_llm_cache: bool = False,
     parse_timeout: float = 60.0,
     skip_judge_prepass: bool = False,
+    s3_key_list: list[str] | None = None,
 ) -> dict[str, Any]:
     """Scan S3 by key prefix and ingest documents not in the DB.
 
@@ -4224,6 +4225,23 @@ def run_reingest_from_prefix(
         misbehaves; in normal operation it closes the chronological
         resolver-race class (#4397) and should always run.  Always
         implicitly skipped under ``dry_run=True``.
+    s3_key_list:
+        Optional list of full S3 keys (e.g.
+        ``ca/orange/superior_court/raw/<sha>.pdf``) to restrict the run to.
+        When non-empty, the keys listed under ``prefix`` are intersected
+        with this list: only keys that appear in *both* the S3 listing and
+        ``s3_key_list`` are processed (S3-listing order preserved).
+        Requested keys not found under the prefix are dropped with a warning.
+        The intersection is applied *before* the ``limit`` truncation and
+        *before* court discovery / the judge pre-pass, so every downstream
+        step operates on the narrowed set.  When ``None`` or empty, the full
+        prefix is processed (behavior unchanged).  Combining ``--prefix`` +
+        ``--s3-key-list`` + ``--bust-llm-cache`` is the surgical path for
+        re-extracting a hand-picked set of already-split parent PDFs: DB-row
+        mode skips split-child rows via the ``is_split_child_id`` guard to
+        avoid the #2416 exponential explosion (see #4049), so the prefix path
+        is the only avenue once a parent has been split — and this filter
+        keeps that path from rescanning the entire prefix (see #3855).
 
     Returns
     -------
@@ -4253,6 +4271,40 @@ def run_reingest_from_prefix(
             "errors": 0,
             "skipped": 0,
         }
+
+    # Step 1b: Narrow to the --s3-key-list intersection (#3855/#4049).
+    # Applied before --limit truncation and before court discovery / the
+    # judge pre-pass so every downstream step sees the narrowed set.
+    if s3_key_list:
+        requested = set(s3_key_list)
+        matched = [key for key in keys if key in requested]
+        missing = requested - set(matched)
+        logger.info(
+            "Filtered prefix keys by --s3-key-list",
+            requested=len(requested),
+            matched=len(matched),
+            missing=len(missing),
+        )
+        if missing:
+            logger.warning(
+                "Some --s3-key-list keys were not found under the prefix",
+                missing_count=len(missing),
+                prefix=prefix,
+            )
+        keys = matched
+        if not keys:
+            logger.warning(
+                "No --s3-key-list keys matched under prefix",
+                prefix=prefix,
+            )
+            return {
+                "total_keys": 0,
+                "processed": 0,
+                "errors": 0,
+                "skipped": 0,
+                "hash_mismatch_warnings": 0,
+                "wall_time_seconds": 0.0,
+            }
 
     if limit is not None:
         total_available = len(keys)
@@ -4980,7 +5032,9 @@ def main() -> None:
             "Combine with --bust-llm-cache to re-extract already-split "
             "documents (the only path once parent PDFs have produced "
             "split-child rows; DB-row mode skips them to avoid #2416). "
-            "See #4049."
+            "See #4049.  Combine with --s3-key-list to narrow the scan to a "
+            "hand-picked subset of keys under the prefix instead of the whole "
+            "prefix (#3855)."
         ),
     )
     parser.add_argument(
@@ -5025,7 +5079,11 @@ def main() -> None:
             "PDFs whose cached LLM payload predates #3655) — where county-wide "
             "rescope would over-shoot 10-100x and --date-from/--date-to clamp "
             "to whole days only.  Combine with --bust-llm-cache to force "
-            "fresh LLM extraction on those keys."
+            "fresh LLM extraction on those keys.  Can be combined with "
+            "--prefix: in prefix mode the listed keys are intersected with "
+            "the keys found under the prefix (#3855), the surgical path for "
+            "re-extracting already-split parent PDFs that DB-row mode skips "
+            "(#4049)."
         ),
     )
     parser.add_argument(
@@ -5098,6 +5156,7 @@ def main() -> None:
             bust_llm_cache=args.bust_llm_cache,
             parse_timeout=args.parse_timeout,
             skip_judge_prepass=args.skip_judge_prepass,
+            s3_key_list=s3_key_list_values,
         )
         logger.info(
             "Prefix reingest complete",


### PR DESCRIPTION
## Summary

Makes `reingest_from_s3.py --prefix` mode honor the existing `--s3-key-list` flag by intersecting the S3-listed keys with the key-list file. This is the surgical enabler for #3855: it lets a `--bust-llm-cache` reingest target a hand-picked set of already-split parent PDFs (the only path once a parent has been split, per #4049) without rescanning the entire S3 prefix. The DB-row `run_reingest` path is untouched.

**Investigation finding driving this PR:** the residual 865 null-judge-AND-null-department Orange rulings come from only 78 distinct multi-ruling source PDFs. All 78 were downloaded and probed — every one has judge AND department clearly present on page 1 (0/78 genuinely-unextractable). The nulls are stale-LLM-cache artifacts that the post-#3831 `_join_page_rows` header scan fixes on a `--bust-llm-cache` re-extraction. Re-extracting only those 78 PDFs (vs. all 1774 Orange PDFs) requires this `--prefix` + `--s3-key-list` combination.

Closes #3855

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Run `reingest_from_s3.py --prefix ca/orange/superior_court/raw/ --s3-key-list <78-keys> --bust-llm-cache --multimodal` on dev; confirm it processes exactly the 78 listed PDFs (not the full 1774-PDF prefix)
- [ ] Orange `null_both` rate drops below 5% after the reingest
- [ ] Verification evidence posted on issue #3855 and #3722 (see A.8)
