### PR TITLE
feat(scraping): flag portal total-coverage failure distinctly in cc-dual-run-diff (#4600)

### DIFF
--- a/.github/workflows/cc-dual-run-diff.yml
+++ b/.github/workflows/cc-dual-run-diff.yml
@@ -123,12 +123,23 @@ jobs:
           missing = [r for r in diff if r.get("flag") == "missing_portal"]
           check_date = os.environ.get("CHECK_DATE", "unknown")
 
-          lines = [
+          # Total-coverage failure: portal captured nothing at all. Lead with
+          # the dominant signal above the per-department table. Tolerate the
+          # keys being absent (older JSON) — default to no headline. See #4600.
+          portal_total_zero = bool(data.get("portal_total_zero", False))
+          headline = data.get("total_coverage_headline", "") or ""
+
+          lines = []
+          if portal_total_zero and headline:
+              lines.append(f"> **TOTAL-COVERAGE FAILURE:** {headline}")
+              lines.append("")
+
+          lines.extend([
               f"**Date checked:** {check_date}",
               "",
               "| Department | Retired count | Portal count | Cases only in retired |",
               "| --- | --- | --- | --- |",
-          ]
+          ])
           for r in missing:
               lines.append(
                   "| {dept} | {ca} | {cb} | {only_a} |".format(
@@ -142,10 +153,13 @@ jobs:
 
           # Telegram one-liner
           depts = [r["department"] for r in missing]
-          open("/tmp/alert_telegram.txt", "w").write(
+          tg = (
               f"Depts missing from portal on {check_date}: {', '.join(depts)}"
               if depts else "Unknown alert"
           )
+          if portal_total_zero and headline:
+              tg = f"TOTAL-COVERAGE FAILURE — {tg}"
+          open("/tmp/alert_telegram.txt", "w").write(tg)
           PY
 
           echo "Alert summary:"

--- a/packages/scraper-framework/src/framework/dual_run_diff.py
+++ b/packages/scraper-framework/src/framework/dual_run_diff.py
@@ -78,6 +78,33 @@ class DiffRow:
     flag: FlagType = "equal"
 
 
+@dataclass
+class TotalCoverageSignal:
+    """Dominant "captured nothing at all" signal across a single date's diff.
+
+    Distinguishes a **total-coverage failure** (portal captured zero documents
+    while the retired scraper captured some) from the per-department gaps that
+    ``compute_per_department_diff`` surfaces. The total-zero case is usually a
+    fetch / judge-discovery breakage rather than a per-department format gap —
+    see issue #4600.
+
+    Attributes:
+        portal_total_zero: ``True`` **only when** the portal total is 0 **and**
+            the retired total is > 0 (i.e. the portal captured nothing while
+            the retired scraper captured something).
+        retired_total: Sum of ``count_a`` across all diff rows.
+        portal_total: Sum of ``count_b`` across all diff rows.
+        headline: When ``portal_total_zero`` is ``True``, a message naming the
+            "total-coverage failure" and pointing at the fetch / discovery
+            layer. Empty string ``""`` when the signal does not fire.
+    """
+
+    portal_total_zero: bool
+    retired_total: int
+    portal_total: int
+    headline: str = ""
+
+
 # ---------------------------------------------------------------------------
 # Scraper ID constants
 # ---------------------------------------------------------------------------
@@ -170,6 +197,44 @@ def compute_per_department_diff(
 
 
 # ---------------------------------------------------------------------------
+# Total-coverage signal
+# ---------------------------------------------------------------------------
+
+
+def compute_total_coverage_signal(diff_rows: list[DiffRow]) -> TotalCoverageSignal:
+    """Compute the dominant total-coverage signal from a date's diff rows.
+
+    Args:
+        diff_rows: Output from :func:`compute_per_department_diff`.
+
+    Returns:
+        A :class:`TotalCoverageSignal`. ``portal_total_zero`` is ``True`` only
+        when the portal captured nothing (``portal_total == 0``) while the
+        retired scraper captured something (``retired_total > 0``) — the
+        "captured nothing at all" case, which points at a fetch / judge-discovery
+        failure rather than a per-department gap.
+    """
+    retired_total = sum(r.count_a for r in diff_rows)
+    portal_total = sum(r.count_b for r in diff_rows)
+    portal_total_zero = portal_total == 0 and retired_total > 0
+
+    headline = ""
+    if portal_total_zero:
+        headline = (
+            f"Portal captured 0 of {retired_total} rulings the retired scraper "
+            "captured — likely a total-coverage failure (judge discovery / fetch), "
+            "not a per-department gap."
+        )
+
+    return TotalCoverageSignal(
+        portal_total_zero=portal_total_zero,
+        retired_total=retired_total,
+        portal_total=portal_total,
+        headline=headline,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Human-readable summary
 # ---------------------------------------------------------------------------
 
@@ -191,11 +256,22 @@ def format_summary(diff_rows: list[DiffRow]) -> str:
     mismatch = [r for r in diff_rows if r.flag == "mismatch"]
     equal = [r for r in diff_rows if r.flag == "equal"]
 
-    lines: list[str] = [
-        f"CC dual-run diff: {len(diff_rows)} department(s) compared.",
-        f"  equal={len(equal)}, mismatch={len(mismatch)}, "
-        f"missing_portal={len(missing)}, new_portal_coverage={len(new_cov)}",
-    ]
+    lines: list[str] = []
+
+    # When the portal captured nothing at all, lead with the dominant
+    # total-coverage-failure headline ABOVE the per-department rendering.
+    signal = compute_total_coverage_signal(diff_rows)
+    if signal.portal_total_zero:
+        lines.append(f"TOTAL-COVERAGE FAILURE: {signal.headline}")
+        lines.append("")
+
+    lines.extend(
+        [
+            f"CC dual-run diff: {len(diff_rows)} department(s) compared.",
+            f"  equal={len(equal)}, mismatch={len(mismatch)}, "
+            f"missing_portal={len(missing)}, new_portal_coverage={len(new_cov)}",
+        ]
+    )
 
     if missing:
         lines.append("")

--- a/packages/scraper-framework/tests/test_cc_dual_run_diff_script.py
+++ b/packages/scraper-framework/tests/test_cc_dual_run_diff_script.py
@@ -274,3 +274,94 @@ class TestWritesDataQualityMetricsRow:
         assert any("cc_dual_run_diff" in s for s in param_strs), (
             f"Expected 'cc_dual_run_diff' in insert params, got: {params}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 5. Total-coverage signal — AC#1
+# ---------------------------------------------------------------------------
+
+
+class TestTotalCoverageSignal:
+    def test_json_payload_carries_total_coverage_keys(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """When portal captured nothing, the JSON payload includes the
+        total-coverage signal keys with portal_total_zero=true and a headline.
+        """
+        # Retired scraper has dept 16; portal has nothing → total-coverage failure
+        rows = [
+            _row_retired("16", "C24-01001"),
+        ]
+        conn = _make_conn(rows)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            exit_code = main(["--date", TARGET_DATE_STR])
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+
+        assert payload["portal_total_zero"] is True
+        assert payload["retired_total"] == 1
+        assert payload["portal_total"] == 0
+        assert "total-coverage failure" in payload["total_coverage_headline"]
+        # Exit-code semantics unchanged: missing_portal → exit 1
+        assert exit_code == 1
+
+    def test_json_payload_total_coverage_keys_false_on_partial(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Partial coverage — portal_total_zero is false, headline empty."""
+        rows = [
+            _row_retired("16", "C24-01001"),
+            _row_retired("30", "N25-0001"),
+            _row_portal(_PORTAL_S3_KEY_DEPT30, "N25-0001"),
+        ]
+        conn = _make_conn(rows)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            main(["--date", TARGET_DATE_STR])
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+
+        assert payload["portal_total_zero"] is False
+        assert payload["retired_total"] == 2
+        assert payload["portal_total"] == 1
+        assert payload["total_coverage_headline"] == ""
+
+    def test_metrics_metadata_carries_total_coverage_keys(self) -> None:
+        """The metrics-row metadata JSON carries the total-coverage signal keys."""
+        rows = [
+            _row_retired("16", "C24-01001"),
+        ]
+        cur = _make_cursor(rows)
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            main(["--date", TARGET_DATE_STR])
+
+        insert_calls = [
+            c
+            for c in cur.execute.call_args_list
+            if "data_quality_metrics" in str(c).lower() and "INSERT" in str(c).upper()
+        ]
+        assert len(insert_calls) >= 1
+        params = insert_calls[0].args[1]
+        # metadata is the last param — JSON string
+        metadata = json.loads(params[-1])
+        assert metadata["portal_total_zero"] is True
+        assert metadata["retired_total"] == 1
+        assert metadata["portal_total"] == 0
+        assert "total-coverage failure" in metadata["total_coverage_headline"]

--- a/packages/scraper-framework/tests/test_dual_run_diff.py
+++ b/packages/scraper-framework/tests/test_dual_run_diff.py
@@ -15,7 +15,9 @@ from datetime import date
 from framework.dual_run_diff import (
     Capture,
     DiffRow,
+    TotalCoverageSignal,
     compute_per_department_diff,
+    compute_total_coverage_signal,
     format_summary,
 )
 
@@ -386,3 +388,123 @@ class TestNoneDepartmentFiltering:
         assert rows[0].department == "16"
         assert rows[0].flag == "missing_portal"
         assert rows[0].count_b == 0
+
+
+# ---------------------------------------------------------------------------
+# AC#1 — total-coverage signal (portal captured nothing at all)
+# ---------------------------------------------------------------------------
+
+
+def _missing_row(dept: str, count_a: int) -> DiffRow:
+    return DiffRow(
+        department=dept,
+        count_a=count_a,
+        count_b=0,
+        cases_only_a=[f"C24-{dept}{i:03d}" for i in range(count_a)],
+        cases_only_b=[],
+        flag="missing_portal",
+    )
+
+
+class TestComputeTotalCoverageSignal:
+    def test_portal_zero_single_department(self) -> None:
+        """Portal captured nothing while retired has one department —
+        portal_total_zero fires and headline names total-coverage failure.
+        """
+        rows = compute_per_department_diff([_retired("16", "C24-01001")], [], DATE_A)
+        signal = compute_total_coverage_signal(rows)
+
+        assert isinstance(signal, TotalCoverageSignal)
+        assert signal.portal_total_zero is True
+        assert signal.retired_total == 1
+        assert signal.portal_total == 0
+        assert "total-coverage failure" in signal.headline
+
+    def test_portal_zero_multiple_departments(self) -> None:
+        """Portal captured nothing while retired spans several departments."""
+        captures_a = [
+            _retired("09", "C24-00001"),
+            _retired("16", "C24-00002"),
+            _retired("16", "C24-00003"),
+            _retired("30", "N25-0001"),
+        ]
+        rows = compute_per_department_diff(captures_a, [], DATE_A)
+        signal = compute_total_coverage_signal(rows)
+
+        assert signal.portal_total_zero is True
+        assert signal.retired_total == 4
+        assert signal.portal_total == 0
+        assert "total-coverage failure" in signal.headline
+
+    def test_partial_coverage_does_not_fire(self) -> None:
+        """Portal has some departments — signal does NOT fire."""
+        captures_a = [_retired("16", "C24-01001"), _retired("30", "N25-0001")]
+        captures_b = [_portal("30", "N25-0001")]
+        rows = compute_per_department_diff(captures_a, captures_b, DATE_A)
+        signal = compute_total_coverage_signal(rows)
+
+        assert signal.portal_total_zero is False
+        assert signal.retired_total == 2
+        assert signal.portal_total == 1
+        assert signal.headline == ""
+
+    def test_empty_diff_does_not_fire(self) -> None:
+        """Empty diff (no captures either side) — signal does NOT fire."""
+        signal = compute_total_coverage_signal([])
+        assert signal.portal_total_zero is False
+        assert signal.retired_total == 0
+        assert signal.portal_total == 0
+        assert signal.headline == ""
+
+    def test_portal_only_does_not_fire(self) -> None:
+        """Retired captured nothing but portal has data — does NOT fire
+        (the signal targets portal-side total-coverage failure only)."""
+        rows = compute_per_department_diff([], [_portal("16", "C24-01001")], DATE_A)
+        signal = compute_total_coverage_signal(rows)
+        assert signal.portal_total_zero is False
+        assert signal.retired_total == 0
+        assert signal.portal_total == 1
+        assert signal.headline == ""
+
+
+# ---------------------------------------------------------------------------
+# AC#2 / AC#3 — format_summary headline prepend
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSummaryTotalCoverageHeadline:
+    def test_headline_and_per_department_rows_both_render(self) -> None:
+        """When total-zero fires, the headline block prepends ABOVE the
+        existing per-department MISSING FROM PORTAL table (both render)."""
+        rows = compute_per_department_diff(
+            [_retired("09", "C24-00001"), _retired("16", "C24-00002")], [], DATE_A
+        )
+        summary = format_summary(rows)
+
+        assert "TOTAL-COVERAGE FAILURE" in summary
+        assert "total-coverage failure" in summary
+        # Per-department table still produced (AC#2)
+        assert "MISSING FROM PORTAL" in summary
+        assert "dept 09" in summary
+        assert "dept 16" in summary
+        # Headline is ABOVE the per-department table
+        assert summary.index("TOTAL-COVERAGE FAILURE") < summary.index("MISSING FROM PORTAL")
+
+    def test_headline_absent_on_partial_coverage(self) -> None:
+        """When portal has partial coverage, no headline block renders, and
+        the per-department table is unchanged from today."""
+        rows = compute_per_department_diff(
+            [_retired("16", "C24-01001"), _retired("30", "N25-0001")],
+            [_portal("30", "N25-0001")],
+            DATE_A,
+        )
+        summary = format_summary(rows)
+        assert "TOTAL-COVERAGE FAILURE" not in summary
+        assert "total-coverage failure" not in summary
+        assert "MISSING FROM PORTAL" in summary
+
+    def test_empty_diff_keeps_existing_short_message(self) -> None:
+        """format_summary([]) keeps its existing short message — no headline."""
+        summary = format_summary([])
+        assert "TOTAL-COVERAGE FAILURE" not in summary
+        assert "0 departments compared" in summary

--- a/scripts/cc-dual-run-diff.py
+++ b/scripts/cc-dual-run-diff.py
@@ -78,6 +78,7 @@ from courts.ca.cc_tentatives_portal import _cc_dept_from_filename  # noqa: E402
 from framework.dual_run_diff import (  # noqa: E402
     Capture,
     compute_per_department_diff,
+    compute_total_coverage_signal,
     format_summary,
 )
 
@@ -214,12 +215,20 @@ def _write_metrics_row(
     diff_payload: list[dict[str, Any]],
     missing_portal_count: int,
     now: datetime,
+    portal_total_zero: bool,
+    retired_total: int,
+    portal_total: int,
+    total_coverage_headline: str,
 ) -> None:
     """Insert one row into ``telemetry.data_quality_metrics``."""
     metadata_obj: dict[str, Any] = {
         "date": target_date.isoformat(),
         "diff": diff_payload,
         "missing_portal_count": missing_portal_count,
+        "portal_total_zero": portal_total_zero,
+        "retired_total": retired_total,
+        "portal_total": portal_total,
+        "total_coverage_headline": total_coverage_headline,
     }
     metadata_json = json.dumps(metadata_obj)
 
@@ -311,6 +320,10 @@ def main(argv: list[str] | None = None) -> int:
 
         missing_portal_count = sum(1 for r in diff_rows if r.flag == "missing_portal")
 
+        # Distinguish a total-coverage failure (portal captured nothing) from
+        # per-department gaps — see issue #4600.
+        signal = compute_total_coverage_signal(diff_rows)
+
         # Serialize diff rows for JSON output and metrics storage
         diff_payload: list[dict[str, Any]] = [
             {
@@ -324,7 +337,17 @@ def main(argv: list[str] | None = None) -> int:
             for r in diff_rows
         ]
 
-        _write_metrics_row(conn, target_date, diff_payload, missing_portal_count, now)
+        _write_metrics_row(
+            conn,
+            target_date,
+            diff_payload,
+            missing_portal_count,
+            now,
+            portal_total_zero=signal.portal_total_zero,
+            retired_total=signal.retired_total,
+            portal_total=signal.portal_total,
+            total_coverage_headline=signal.headline,
+        )
 
     healthy = missing_portal_count == 0
 
@@ -336,6 +359,10 @@ def main(argv: list[str] | None = None) -> int:
             "diff": diff_payload,
             "healthy": healthy,
             "missing_portal_count": missing_portal_count,
+            "portal_total": signal.portal_total,
+            "portal_total_zero": signal.portal_total_zero,
+            "retired_total": signal.retired_total,
+            "total_coverage_headline": signal.headline,
             "total_departments": len(diff_rows),
         }
         print(json.dumps(payload, indent=2, sort_keys=True))


### PR DESCRIPTION
## Summary

Adds a top-level "total-coverage failure" signal to the cc-dual-run-diff alert so it distinguishes "the portal captured nothing at all" (portal total == 0 while retired total > 0) from ordinary per-department gaps. From the #4591 incident: the portal was capturing zero docs all-time, but the alert framed it as a varying "department N missing" symptom, misdirecting the diagnosis toward unparseable-format / department-reassignment hypotheses.

New pure `compute_total_coverage_signal(diff_rows)` + `TotalCoverageSignal` dataclass in `framework/dual_run_diff.py`. `format_summary` prepends a `TOTAL-COVERAGE FAILURE: <headline>` block above the (still-rendered) per-department table when the signal fires. The script's JSON payload and telemetry metrics metadata carry `portal_total_zero`, `retired_total`, `portal_total`, `total_coverage_headline`. The workflow's Extract-alert-summary step prepends a `> **TOTAL-COVERAGE FAILURE:** ...` blockquote to the auto-filed issue body + Telegram one-liner (defensive on absent keys). Exit-code semantics and the daily cron are unchanged.

Closes #4600

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed-on-demand component. The cc-dual-run-diff workflow is a scheduled daily GitHub Action that runs the script on ECS; the new path is exercised by unit tests and reproduced end-to-end against the merged code (portal=[] scenario → headline + per-dept table). See verification evidence on #4600.
- [x] Verification evidence posted on issue (see A.8)
