### PR TITLE
fix(scraping): CC portal detail-page parser reads jcc-body__main-text (#4598)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives_portal.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives_portal.py
@@ -36,17 +36,32 @@ Listing table row format:
     </td>
   </tr>
 
-Detail page format:
+Detail page format (current portal, #4598):
   <article role="article" about="/tentative-ruling/l24-04564">
-    ... h2 sections for Case Number, Case Type, Hearing Date, Nature of Proceedings ...
-    <div class="field--name-body">
-      <a href="/system/files/general/16_012925.pdf">Tentative Ruling PDF</a>
-      <p>Before the Court are ...</p>
+    <div class="jcc-body__main-text usa-prose clearfix">
+      <h2>Case Number</h2><p><span>L24-04564</span></p>
+      <h2>Case Type</h2><p><div>Civil</div></p>
+      <h2>Hearing Date / Time</h2><p> Wed, 01/29/2025 - 08:31 </p>
+      <h2>Nature of Proceedings</h2><p> CASE MANAGEMENT CONFERENCE </p>
+      <h2>Tentative Ruling</h2>
+      <p><p><a href="/system/files/general/16_012925.pdf">Tentative Ruling PDF</a></p>
+         <p>Before the Court are ...</p></p>
     </div>
     <aside class="jcc-body__aside">
       <h4>BENJAMIN REYES</h4>
     </aside>
+    <aside class="usa-footer">
+      <a href="/system/files/traffic/tr-320-info.pdf">Traffic info</a>
+    </aside>
   </article>
+
+  The ruling content lives under the <h2>Tentative Ruling</h2> heading inside
+  <div class="jcc-body__main-text">.  Every detail page also carries a
+  boilerplate /system/files/traffic/ PDF (e.g. in a footer aside) that MUST be
+  ignored — the real ruling PDF is the /system/files/general/ link inside the
+  ruling section.  The parser falls back to the legacy
+  <div class="field--name-body"> container for archived/older pages (which
+  predate the jcc-body__main-text restructure).
 
 Case number formats (matches the retired scraper):
   Civil:    C + 2-digit year + hyphen + 5 digits  (C24-02490)
@@ -70,7 +85,7 @@ from urllib.parse import urljoin
 
 import httpx
 import structlog
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScheduleWindow, ScraperConfig
 
@@ -248,6 +263,94 @@ def _parse_listing_table(html: str) -> list[dict]:
     return rows_data
 
 
+def _ruling_section_paragraphs(main_text: Tag) -> list[Tag]:
+    """Collect the leaf <p> tags belonging to the Tentative Ruling section.
+
+    The ``jcc-body__main-text`` div holds several <h2> sections (Case Number,
+    Case Type, Hearing Date, Nature of Proceedings, Tentative Ruling).  Anchor
+    on the <h2> whose text is "Tentative Ruling" and collect the leaf
+    paragraphs that follow it (up to the next <h2>, if any), so the PDF link
+    and ruling body are read from the ruling section only — never from Case
+    Number etc., and never from the boilerplate traffic PDF that lives outside
+    this container.
+
+    Traversal uses ``find_all_next()`` (document order) rather than
+    ``find_next_siblings()`` so the section boundary is detected at the next
+    <h2> *regardless of nesting* — a future portal theming change that wraps a
+    section in a styling <div> (``<h2>Tentative Ruling</h2><div>...<h2>Next
+    Section</h2>...</div>``) still stops at that inner <h2> instead of leaking
+    the following section's paragraphs into the ruling.  Candidates are scoped
+    to descendants of ``main_text`` so the traversal never wanders into the
+    sibling <aside>/footer that carries the boilerplate traffic PDF.
+    """
+    headings = main_text.find_all("h2")
+    ruling_h2 = None
+    for h2 in headings:
+        if h2.get_text(strip=True).lower() == "tentative ruling":
+            ruling_h2 = h2
+            break
+    if ruling_h2 is None:
+        return []
+
+    potential: list[Tag] = []
+    for tag in ruling_h2.find_all_next():
+        if not isinstance(tag, Tag):
+            continue
+        # Only consider nodes inside the jcc-body__main-text container; the
+        # document-order traversal would otherwise reach the sibling
+        # <aside>/footer that holds the boilerplate traffic PDF.
+        if main_text not in tag.parents:
+            continue
+        # The next <h2> in document order ends the Tentative Ruling section,
+        # whether it is a direct sibling or nested inside a wrapper <div>.
+        if tag.name == "h2":
+            break
+        if tag.name == "p":
+            potential.append(tag)
+
+    # De-duplicate preserving order, then keep only leaf <p> (no nested <p>)
+    # so wrapper paragraphs do not double-count text. lxml flattens invalid
+    # nested <p><p>...</p></p> into siblings, so each real ruling paragraph is
+    # already a leaf.
+    unique = list(dict.fromkeys(potential))
+    return [p for p in unique if not p.find("p")]
+
+
+def _select_pdf_url(anchors: list[Tag]) -> str | None:
+    """Pick the ruling PDF href from a list of <a> tags.
+
+    Prefers a link under ``/system/files/general/`` (the real ruling PDF),
+    falling back to the first ``.pdf`` link that is NOT under
+    ``/system/files/traffic/`` (the boilerplate traffic PDF carried on every
+    detail page).  Returns an absolute URL via ``urljoin``, or None.
+    """
+    fallback: str | None = None
+    for a in anchors:
+        href = a.get("href", "")
+        if not href or ".pdf" not in href.lower():
+            continue
+        if "/system/files/general/" in href:
+            return urljoin(BASE_URL, href)
+        if "/system/files/traffic/" in href:
+            continue
+        if fallback is None:
+            fallback = urljoin(BASE_URL, href)
+    return fallback
+
+
+def _leaf_paragraphs(container: Tag) -> list[Tag]:
+    """Return only the innermost (leaf) <p> tags under a container element.
+
+    Used for the legacy ``field--name-body`` <div>, whose ruling paragraphs
+    are direct children.  ``find_all("p")`` returns the inner <p> descendants
+    and does NOT include the ``container`` element itself.  BeautifulSoup/lxml
+    auto-flattens the invalid nested ``<p><p>...</p></p>`` markup into sibling
+    <p> tags, so a <p> never actually contains a nested <p> post-parse; the
+    ``not p.find("p")`` guard simply keeps the predicate robust.
+    """
+    return [p for p in container.find_all("p") if not p.find("p")]
+
+
 def _parse_detail_page(html: str) -> dict:
     """Extract structured fields from a detail page.
 
@@ -259,29 +362,38 @@ def _parse_detail_page(html: str) -> dict:
     """
     soup = BeautifulSoup(html, "lxml")
 
-    # --- PDF URL and ruling text from the body field ---
-    # The body field div contains a PDF link and ruling text paragraphs.
+    # --- PDF URL and ruling text from the ruling content ---
     ruling_text: str | None = None
     ruling_text_html: str | None = None
     pdf_url: str | None = None
 
-    # Look for the field--name-body div
-    body_field = soup.find("div", class_=lambda c: c and "field--name-body" in c)
-    if body_field:
-        # Find PDF link
-        for a in body_field.find_all("a"):
-            href = a.get("href", "")
-            if href and ".pdf" in href.lower():
-                pdf_url = urljoin(BASE_URL, href)
-                break
+    # Current portal: ruling content lives under
+    # <div class="jcc-body__main-text"> after an <h2>Tentative Ruling</h2>
+    # heading.  Archived/older pages used <div class="field--name-body">.
+    main_text = soup.find("div", class_=lambda c: c and "jcc-body__main-text" in c)
+    ruling_section: list = []
+    body_field = None
+    if main_text:
+        ruling_section = _ruling_section_paragraphs(main_text)
+    else:
+        body_field = soup.find("div", class_=lambda c: c and "field--name-body" in c)
+        if body_field:
+            ruling_section = _leaf_paragraphs(body_field)
 
-        # Extract ruling text from paragraphs (excluding the PDF link paragraph)
+    if ruling_section:
+        # PDF URL: prefer /system/files/general/, never /system/files/traffic/.
+        anchors: list = []
+        for p in ruling_section:
+            anchors.extend(p.find_all("a"))
+        pdf_url = _select_pdf_url(anchors)
+
+        # Ruling body: leaf paragraphs whose only anchors are .pdf links are
+        # the PDF-link paragraph and are excluded.
         text_parts: list[str] = []
         html_parts: list[str] = []
-        for p in body_field.find_all("p"):
-            # Skip paragraphs that only contain the PDF link
-            anchors = p.find_all("a")
-            if anchors and all(".pdf" in a.get("href", "").lower() for a in anchors):
+        for p in ruling_section:
+            p_anchors = p.find_all("a")
+            if p_anchors and all(".pdf" in a.get("href", "").lower() for a in p_anchors):
                 continue
             text = p.get_text(separator=" ", strip=True)
             if text:

--- a/packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py
+++ b/packages/scraper-framework/tests/courts/ca/test_cc_tentatives_portal.py
@@ -6,7 +6,14 @@ Fixtures in tests/fixtures/cc_portal/:
   listing_reyes.html     — /tentative-rulings?field_judge_target_id=245 (L24-04564)
   listing_weil.html      — /tentative-rulings?field_judge_target_id=280 (MSN23-2201)
   listing_empty.html     — empty table / no-results page
-  detail_l24-04564.html  — detail page for L24-04564
+  detail_l24-04564.html  — detail page for L24-04564 (current jcc-body__main-text
+                           structure: ruling content under an <h2>Tentative Ruling</h2>
+                           heading inside <div class="jcc-body__main-text">, plus a
+                           boilerplate /system/files/traffic/ PDF in a footer aside that
+                           the parser must NOT select; #4598)
+  detail_l24-04564_legacy.html — back-compat fixture preserving the OLD
+                           <div class="field--name-body"> structure, exercising the
+                           parser's legacy fallback path (#4598)
   sample.pdf             — minimal PDF bytes for HTTP stubbing
 """
 
@@ -184,6 +191,189 @@ def test_parse_detail_page_extracts_ruling_and_pdf() -> None:
 
     # ruling_text_html should be present
     assert detail["ruling_text_html"] is not None
+
+
+def test_parse_detail_page_new_jcc_body_structure() -> None:
+    """Regression (#4598): parse the current jcc-body__main-text detail structure.
+
+    The portal moved ruling content out of <div class="field--name-body"> and
+    into <div class="jcc-body__main-text"> under an <h2>Tentative Ruling</h2>
+    heading, with the body <p> nested inside an outer <p>.  Every detail page
+    also carries a boilerplate /system/files/traffic/ PDF in a footer aside that
+    must NOT be selected — the real ruling PDF lives under /system/files/general/.
+    """
+    html = _load_html("detail_l24-04564.html")
+    detail = _parse_detail_page(html)
+
+    assert detail["pdf_url"] is not None
+    assert detail["pdf_url"].endswith("/system/files/general/16_012925.pdf")
+    assert "/traffic/" not in detail["pdf_url"]
+
+    assert detail["ruling_text"] is not None
+    assert "Before the Court are a demurrer" in detail["ruling_text"]
+    # The PDF-link paragraph text must be excluded from the ruling body.
+    assert "Tentative Ruling PDF" not in detail["ruling_text"]
+
+    assert detail["ruling_text_html"] is not None
+    assert detail["judge_name"] == "BENJAMIN REYES"
+
+
+def test_parse_detail_page_traffic_only_falls_back_excluding_traffic() -> None:
+    """Regression (#4598): with no /general/ PDF, never select the traffic PDF.
+
+    Exercises the fallback path in _select_pdf_url: a non-PDF anchor is skipped,
+    the /system/files/traffic/ link is excluded, and a different .pdf link is
+    chosen as the fallback.  Also exercises the next-<h2> boundary in
+    _ruling_section_paragraphs (a trailing <h2> after the ruling section).
+    """
+    html = (
+        '<html><body><div class="jcc-body__main-text">'
+        "<h2>Case Number</h2><p><span>L24-09999</span></p>"
+        "<h2>Tentative Ruling</h2>"
+        "<p>"
+        '<p><a href="/about">About</a></p>'
+        '<p><a href="/system/files/traffic/tr-320-info.pdf">Traffic info</a></p>'
+        '<p><a href="/system/files/other/99_010125.pdf">Ruling PDF</a></p>'
+        "<p>The motion is DENIED.</p>"
+        "</p>"
+        "<h2>Footnotes</h2><p>Not part of the ruling body.</p>"
+        "</div></body></html>"
+    )
+    detail = _parse_detail_page(html)
+
+    assert detail["pdf_url"] is not None
+    assert detail["pdf_url"].endswith("/system/files/other/99_010125.pdf")
+    assert "/traffic/" not in detail["pdf_url"]
+
+    assert detail["ruling_text"] is not None
+    assert "The motion is DENIED." in detail["ruling_text"]
+    # The trailing Footnotes <h2> section is outside the ruling section.
+    assert "Not part of the ruling body." not in detail["ruling_text"]
+
+
+def test_parse_detail_page_jcc_body_without_tentative_ruling_heading() -> None:
+    """Regression (#4598): a jcc-body__main-text div lacking the ruling heading.
+
+    When the <h2>Tentative Ruling</h2> heading is absent the ruling section is
+    empty, so pdf_url / ruling_text / ruling_text_html stay None.  Exercises the
+    no-heading return in _ruling_section_paragraphs.
+    """
+    html = (
+        '<html><body><div class="jcc-body__main-text">'
+        "<h2>Case Number</h2><p><span>L24-08888</span></p>"
+        "<h2>Case Type</h2><p>Civil</p>"
+        "</div></body></html>"
+    )
+    detail = _parse_detail_page(html)
+
+    assert detail["pdf_url"] is None
+    assert detail["ruling_text"] is None
+    assert detail["ruling_text_html"] is None
+
+
+def test_parse_detail_page_legacy_field_name_body_fallback() -> None:
+    """Regression (#4598): archived pages still use the old field--name-body div.
+
+    The parser must fall back to <div class="field--name-body"> when
+    jcc-body__main-text is absent, so older S3-archived detail pages reingest
+    correctly.
+    """
+    html = _load_html("detail_l24-04564_legacy.html")
+    detail = _parse_detail_page(html)
+
+    assert detail["pdf_url"] is not None
+    assert detail["pdf_url"].endswith("/system/files/general/16_012925.pdf")
+
+    assert detail["ruling_text"] is not None
+    assert "Before the Court are a demurrer" in detail["ruling_text"]
+    assert "Tentative Ruling PDF" not in detail["ruling_text"]
+
+    assert detail["ruling_text_html"] is not None
+    assert detail["judge_name"] == "BENJAMIN REYES"
+
+
+def test_parse_detail_page_paragraphs_wrapped_in_container() -> None:
+    """Robustness (#4598): ruling <p> wrapped in a container <div>.
+
+    If a future portal theming change nests the ruling paragraphs inside a
+    container element (e.g. a styling <div>) after the <h2>Tentative Ruling</h2>
+    heading, _ruling_section_paragraphs must still descend into the container to
+    find the PDF link and body text — capture reliability is the top priority,
+    so a container change must not silently drop the ruling.
+    """
+    html = (
+        "<html><body><article>"
+        '<div class="jcc-body__main-text usa-prose clearfix">'
+        "<h2>Case Number</h2><p><span>L24-04564</span></p>"
+        "<h2>Tentative Ruling</h2>"
+        '<div class="ruling-wrapper">'
+        '<p><a href="/system/files/general/16_012925.pdf">Tentative Ruling PDF</a></p>'
+        "<p>Before the Court are a demurrer and motion to strike.</p>"
+        "<p>The motion to strike is GRANTED.</p>"
+        "</div>"
+        "</div>"
+        '<aside class="jcc-body__aside"><h4>BENJAMIN REYES</h4></aside>'
+        '<aside class="usa-footer">'
+        '<a href="/system/files/traffic/tr-320-info.pdf">Traffic</a></aside>'
+        "</article></body></html>"
+    )
+    detail = _parse_detail_page(html)
+
+    assert detail["pdf_url"] is not None
+    assert detail["pdf_url"].endswith("/system/files/general/16_012925.pdf")
+    assert "/traffic/" not in detail["pdf_url"]
+
+    assert detail["ruling_text"] is not None
+    assert "Before the Court are a demurrer" in detail["ruling_text"]
+    # The PDF-link paragraph text must be excluded from the ruling body.
+    assert "Tentative Ruling PDF" not in detail["ruling_text"]
+
+    assert detail["ruling_text_html"] is not None
+    assert detail["judge_name"] == "BENJAMIN REYES"
+
+
+def test_parse_detail_page_nested_h2_boundary_inside_wrapper() -> None:
+    """Robustness (#4598): the next <h2> ends the section even when nested.
+
+    If a future portal theming change wraps a *section* in a container <div>
+    (``<h2>Tentative Ruling</h2><div>...<h2>Footnotes</h2>...</div>``), the
+    document-order traversal in _ruling_section_paragraphs must stop at that
+    inner <h2> rather than leaking the following section's paragraphs into the
+    ruling body.  Uses find_all_next() (not find_next_siblings()) so the
+    boundary is detected regardless of nesting depth.
+    """
+    html = (
+        "<html><body><article>"
+        '<div class="jcc-body__main-text usa-prose clearfix">'
+        "<h2>Case Number</h2><p><span>L24-04564</span></p>"
+        "<h2>Tentative Ruling</h2>"
+        '<div class="section-wrapper">'
+        '<p><a href="/system/files/general/16_012925.pdf">Tentative Ruling PDF</a></p>'
+        "<p>Before the Court are a demurrer and motion to strike.</p>"
+        "<h2>Footnotes</h2>"
+        "<p>This footnote text should NOT be captured.</p>"
+        "</div>"
+        "</div>"
+        '<aside class="jcc-body__aside"><h4>BENJAMIN REYES</h4></aside>'
+        '<aside class="usa-footer">'
+        '<a href="/system/files/traffic/tr-320-info.pdf">Traffic</a></aside>'
+        "</article></body></html>"
+    )
+    detail = _parse_detail_page(html)
+
+    assert detail["pdf_url"] is not None
+    assert detail["pdf_url"].endswith("/system/files/general/16_012925.pdf")
+    assert "/traffic/" not in detail["pdf_url"]
+
+    assert detail["ruling_text"] is not None
+    assert "Before the Court are a demurrer" in detail["ruling_text"]
+    # The nested <h2>Footnotes</h2> ends the ruling section — its paragraph
+    # must not leak into the ruling body.
+    assert "This footnote text should NOT be captured." not in detail["ruling_text"]
+    assert "Tentative Ruling PDF" not in detail["ruling_text"]
+
+    assert detail["ruling_text_html"] is not None
+    assert detail["judge_name"] == "BENJAMIN REYES"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/fixtures/cc_portal/detail_l24-04564_legacy.html
+++ b/packages/scraper-framework/tests/fixtures/cc_portal/detail_l24-04564_legacy.html
@@ -7,30 +7,35 @@
 <body>
 <article role="article" about="/tentative-ruling/l24-04564">
   <h1 class="page-header__title">Tentative Ruling: SCOTT FUGERE VS. THE COUNTY OF CONTRA COSTA</h1>
-  <div class="jcc-body__main-text usa-prose clearfix">
+  <div class="field field--name-field-case-number">
     <h2>Case Number</h2>
-    <p><span>L24-04564</span></p>
+    <div class="field__item"><span>L24-04564</span></div>
+  </div>
+  <div class="field field--name-field-case-type">
     <h2>Case Type</h2>
-    <p><div>Civil</div></p>
+    <div class="field__item"><div>Civil</div></div>
+  </div>
+  <div class="field field--name-field-date-time">
     <h2>Hearing Date / Time</h2>
-    <p> Wed, 01/29/2025 - 08:31 </p>
+    <div class="field__item">Wed, 01/29/2025 - 08:31</div>
+  </div>
+  <div class="field field--name-field-nature-of-proceedings">
     <h2>Nature of Proceedings</h2>
-    <p> CASE MANAGEMENT CONFERENCE </p>
+    <div class="field__item">CASE MANAGEMENT CONFERENCE</div>
+  </div>
+  <div class="field field--name-body">
     <h2>Tentative Ruling</h2>
-    <p>
+    <div class="field__item">
       <p><a href="/system/files/general/16_012925.pdf">Tentative Ruling PDF</a></p>
       <p>Before the Court are a demurrer and motion to strike filed by Defendant The County of Contra Costa.</p>
       <p>The demurrer to the first cause of action is SUSTAINED with leave to amend.</p>
       <p>The motion to strike is GRANTED.</p>
       <p>Plaintiff shall file an amended complaint within 30 days.</p>
-    </p>
+    </div>
   </div>
   <aside class="jcc-body__aside">
     <h3 class="jcc-body__aside-title">Judges</h3>
     <h4>BENJAMIN REYES</h4>
-  </aside>
-  <aside class="usa-footer">
-    <a href="/system/files/traffic/tr-320-info.pdf">Traffic info</a>
   </aside>
 </article>
 </body>


### PR DESCRIPTION
## Summary

Fixes the Contra Costa tentative-rulings portal detail-page parser, which captured zero documents after the portal removed the `field--name-body` div that `_parse_detail_page` anchored on. Ruling content now lives under an `<h2>Tentative Ruling</h2>` heading inside `<div class="jcc-body__main-text">`. The parser is rewritten to read from the new container (with a legacy `field--name-body` fallback for archived pages), to prefer the `/system/files/general/` ruling PDF and exclude the boilerplate `/system/files/traffic/` PDF, and to collect ruling paragraphs via a nesting-resilient document-order traversal. This is the second half of restoring CC portal capture; the FORM_URL judge-discovery fix merged as #4594 (for #4591).

Closes #4598

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` — clean)
- [x] Format check passes (`ruff format --check` — clean)
- [x] Tests pass (scraper-framework: 8239 passed, 3 skipped; target file: 52 passed)
- [x] CI green

### Post-deploy verification
- [x] One-shot run of `ca-cc-tentatives-portal` on dev captures > 0 documents — `records=3` (vs `0` pre-fix per `telemetry.scraper_runs`)
- [x] Verification evidence posted on issue (see A.8 — issue #4598 comment)
