### PR TITLE
feat(ingestion): support s3:// URIs in reingest --s3-key-list (#4606)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -3699,6 +3699,52 @@ class TestReadS3KeyListFile:
         with pytest.raises(FileNotFoundError):
             reingest._read_s3_key_list_file(str(path))
 
+    def test_s3_uri_reads_keys_from_s3(self) -> None:
+        """An ``s3://bucket/key`` URI fetches the keylist body from S3 and
+        applies the same parsing semantics as a local file."""
+        body_mock = MagicMock()
+        body_mock.read.return_value = (
+            b"# extracted from #3855 spotcheck\n"
+            b"ca/orange/superior_court/raw/aaa.pdf\n"
+            b"\n"
+            b"  ca/orange/superior_court/raw/bbb.pdf  \n"
+            b"ca/orange/superior_court/raw/aaa.pdf\n"
+        )
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+        with patch.object(reingest.boto3, "client", return_value=s3) as mock_client:
+            keys = reingest._read_s3_key_list_file(
+                "s3://judgemind-assets-dev/keylists/orange-78.txt"
+            )
+        assert keys == [
+            "ca/orange/superior_court/raw/aaa.pdf",
+            "ca/orange/superior_court/raw/bbb.pdf",
+        ]
+        mock_client.assert_called_once_with("s3")
+        s3.get_object.assert_called_once_with(
+            Bucket="judgemind-assets-dev",
+            Key="keylists/orange-78.txt",
+        )
+
+    def test_s3_uri_empty_object_raises_value_error(self) -> None:
+        """An s3:// object whose body is empty (or all comments/blanks) raises
+        ValueError, matching the local-file fail-loud behavior."""
+        body_mock = MagicMock()
+        body_mock.read.return_value = b"# only comments\n\n   \n"
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+        with patch.object(reingest.boto3, "client", return_value=s3):
+            with pytest.raises(ValueError, match="empty"):
+                reingest._read_s3_key_list_file("s3://bucket/keylists/empty.txt")
+
+    def test_s3_uri_without_key_raises_value_error(self) -> None:
+        """A malformed ``s3://bucket-only`` URI with no key component raises a
+        clear ValueError before any S3 call is made."""
+        with patch.object(reingest.boto3, "client") as mock_client:
+            with pytest.raises(ValueError, match="s3://"):
+                reingest._read_s3_key_list_file("s3://bucket-only")
+        mock_client.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Cursor minimum values

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -154,9 +154,14 @@ Options:
                         the old prompt hash.  See #2424.
     --s3-key-list PATH  Path to a file listing S3 keys (one per line, blank
                         lines and ``#`` comments ignored) to restrict the
-                        reingest to.  Surgical scope for hand-picked SHAs
-                        where county / date / regex filters all over- or
-                        under-match.  See #3659.
+                        reingest to.  May be a container-local path or an
+                        ``s3://bucket/key`` URI — the URI form lets the
+                        surgical path run from ECS, where companion files
+                        cannot be staged into the task (see #4606): upload
+                        the keylist with ``aws s3 cp`` and pass the URI.
+                        Surgical scope for hand-picked SHAs where county /
+                        date / regex filters all over- or under-match.
+                        See #3659.
     --skip-judge-prepass
                         Disable the one-shot judge pre-pass that walks the
                         FETCH cursor (standard mode) or listed S3 keys
@@ -618,22 +623,28 @@ def _build_filters(
     return " ".join(clauses), params
 
 
-def _read_s3_key_list_file(path: str) -> list[str]:
-    """Read a list of S3 keys from a file, one per line.
+def _parse_s3_key_list_text(raw: str, source: str) -> list[str]:
+    """Parse keylist text into a de-duplicated, order-preserving list of keys.
 
     Blank lines and lines starting with ``#`` are skipped, leading/trailing
     whitespace on each entry is stripped, and duplicates are de-duplicated
-    while preserving first-occurrence order.
+    while preserving first-occurrence order. Shared by the local-file and
+    ``s3://`` branches of :func:`_read_s3_key_list_file`.
+
+    Parameters
+    ----------
+    raw:
+        The full keylist text (decoded UTF-8).
+    source:
+        Human-readable origin (local path or s3:// URI) used in the
+        empty-list error message.
 
     Raises
     ------
-    FileNotFoundError
-        If *path* does not exist.
     ValueError
-        If the file produces an empty key list (every line was blank or a
+        If *raw* produces an empty key list (every line was blank or a
         comment) — fail loud rather than silently match every document.
     """
-    raw = Path(path).read_text(encoding="utf-8")
     seen: set[str] = set()
     keys: list[str] = []
     for line in raw.splitlines():
@@ -645,9 +656,47 @@ def _read_s3_key_list_file(path: str) -> list[str]:
         seen.add(stripped)
         keys.append(stripped)
     if not keys:
-        msg = f"--s3-key-list file is empty after stripping blanks/comments: {path}"
+        msg = f"--s3-key-list source is empty after stripping blanks/comments: {source}"
         raise ValueError(msg)
     return keys
+
+
+def _read_s3_key_list_file(path: str) -> list[str]:
+    """Read a list of S3 keys, one per line, from a local file or S3 object.
+
+    *path* may be either a container-local filesystem path or an
+    ``s3://bucket/key`` URI. The latter form lets the surgical reingest path
+    run from ECS, where companion files cannot be staged into the task
+    (see #4606): upload the keylist with ``aws s3 cp`` and pass the URI.
+
+    Blank lines and lines starting with ``#`` are skipped, leading/trailing
+    whitespace on each entry is stripped, and duplicates are de-duplicated
+    while preserving first-occurrence order.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *path* is a local path that does not exist.
+    ValueError
+        If *path* is a malformed ``s3://`` URI with no key component, or if
+        the source produces an empty key list (every line was blank or a
+        comment) — fail loud rather than silently match every document.
+    """
+    if path.startswith("s3://"):
+        without_scheme = path[len("s3://") :]
+        bucket, _, key = without_scheme.partition("/")
+        if not bucket or not key:
+            msg = (
+                "--s3-key-list s3:// URI must include both a bucket and a key "
+                f"(e.g. s3://my-bucket/path/keys.txt): {path}"
+            )
+            raise ValueError(msg)
+        s3_client = boto3.client("s3")
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        raw = response["Body"].read().decode("utf-8")
+        return _parse_s3_key_list_text(raw, path)
+    raw = Path(path).read_text(encoding="utf-8")
+    return _parse_s3_key_list_text(raw, path)
 
 
 def _is_real_case_number(case_number: str | None) -> bool:
@@ -5071,8 +5120,12 @@ def main() -> None:
         default=None,
         dest="s3_key_list",
         help=(
-            "Path to a file listing S3 keys (one per line) to restrict the "
-            "reingest to.  Blank lines and lines starting with '#' are "
+            "File listing S3 keys (one per line) to restrict the reingest to. "
+            "Accepts a container-local path OR an s3://bucket/key URI; the "
+            "s3:// form lets this surgical path run from ECS, where companion "
+            "files cannot be staged into the task — upload the keylist with "
+            "'aws s3 cp keys.txt s3://bucket/keylists/<name>.txt' and pass the "
+            "URI (#4606).  Blank lines and lines starting with '#' are "
             "ignored.  Adds an AND d.s3_key = ANY(...) clause to the document "
             "query.  Useful for surgical backfills against a hand-picked set "
             "of SHAs — e.g. #3659 (re-resolve cross-references on the 13 SC "


### PR DESCRIPTION
## Summary

Adds `s3://` URI support to `_read_s3_key_list_file` in `scripts/reingest_from_s3.py` so the #4603 surgical key-list reingest path is reachable from ECS, where `scripts/ecs-run-task.sh` cannot stage a companion keylist file into the task. When `--s3-key-list` starts with `s3://`, the bucket+key are parsed and the keylist is fetched via boto3 `get_object`; otherwise behavior is unchanged. The line-parsing/dedupe/empty-check logic is extracted into a shared `_parse_s3_key_list_text` helper so the local and `s3://` paths cannot diverge. A malformed `s3://bucket-only` URI raises `ValueError` before any S3 call; empty/all-comment bodies fail loud with the same "empty" semantics as the local path.

Operator workflow becomes: `aws s3 cp keys.txt s3://judgemind-assets-dev/keylists/<name>.txt` then `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --prefix <p> --s3-key-list s3://judgemind-assets-dev/keylists/<name>.txt --bust-llm-cache --multimodal`.

Closes #4606

## Test plan

### Automated checks
- [x] Lint passes (ruff check, both changed files clean)
- [x] Format check passes (ruff format --check, both files already formatted)
- [x] Tests pass (`TestReadS3KeyListFile`: 10 passed — 7 existing unchanged + 3 new; full `test_reingest_from_s3.py`: 438 passed)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX tooling: a `scripts/` one-off reingest helper, not a deployed service). Verified locally: new `s3://` branch unit tests pass with boto3 mocked; argparse help grep for `s3://` succeeds.
- [x] Verification evidence posted on issue (see A.8)
