### PR TITLE
fix(dx): make run-ci-guards.sh truncation marker byte-accurate and multibyte-safe (#4608)

### DIFF
--- a/scripts/run-ci-guards.sh
+++ b/scripts/run-ci-guards.sh
@@ -375,7 +375,7 @@ is_requires_argument_failure() {
 
 # emit_indented_capped <log_file> -> prints the last MAX_TAIL_LINES lines of
 # the log to stderr, each indented by four spaces, with any line longer than
-# MAX_LINE_CHARS truncated and a "…[truncated <N> chars]" marker appended.
+# MAX_LINE_BYTES truncated and a "…[truncated <N> bytes]" marker appended.
 #
 # Why this exists (#4602)
 # ───────────────────────
@@ -399,14 +399,68 @@ is_requires_argument_failure() {
 # For the common small-match case (≤ MAX_TAIL_LINES short lines), the output
 # is byte-identical to the old ``sed 's/^/    /'`` path: each line is
 # prefixed with exactly four spaces and nothing is truncated.
+#
+# Multibyte safety (#4608)
+# ────────────────────────
+# Both BSD awk (macOS, the target env) and gawk (Linux CI) treat ``substr``
+# and ``length`` as byte operations regardless of locale. A naive
+# ``substr($0, 1, max)`` can therefore slice through the middle of a UTF-8
+# multibyte sequence, leaving a dangling partial byte before the ``…``
+# marker. We trim any trailing *incomplete* sequence after the byte cut so
+# the emitted prefix is always valid UTF-8, and the marker honestly reports
+# the count in **bytes** (which is what ``length`` counts). ``ord[]`` is a
+# byte→ordinal map built once in BEGIN; both awks populate it because
+# ``sprintf("%c", i)`` yields a one-byte string for 0..255.
 MAX_TAIL_LINES=20
-MAX_LINE_CHARS=2000
+MAX_LINE_BYTES=2000
 emit_indented_capped() {
     local log_file="$1"
-    tail -n "$MAX_TAIL_LINES" "$log_file" 2>/dev/null | awk -v max="$MAX_LINE_CHARS" '
+    tail -n "$MAX_TAIL_LINES" "$log_file" 2>/dev/null | awk -v max="$MAX_LINE_BYTES" '
+        BEGIN {
+            for (i = 0; i < 256; i++) ord[sprintf("%c", i)] = i
+        }
         {
             if (length($0) > max) {
-                printf "    %s…[truncated %d chars]\n", substr($0, 1, max), length($0) - max
+                prefix = substr($0, 1, max)
+                # Walk backward from the byte cut, dropping any trailing
+                # incomplete UTF-8 sequence so we never emit a partial
+                # codepoint. Continuation bytes are 0x80-0xBF; lead bytes
+                # are >= 0xC0 with a declared sequence length.
+                k = length(prefix)
+                while (k > 0) {
+                    o = ord[substr(prefix, k, 1)]
+                    if (o >= 128 && o < 192) {
+                        # Trailing continuation byte: provisionally drop it,
+                        # keep walking back to find its lead byte.
+                        k--
+                        continue
+                    }
+                    if (o >= 192) {
+                        # Lead byte. Declared length: 2 (0xC0-0xDF),
+                        # 3 (0xE0-0xEF), 4 (0xF0-0xF7).
+                        if (o >= 240) seqlen = 4
+                        else if (o >= 224) seqlen = 3
+                        else seqlen = 2
+                        # Two cases at the lead byte:
+                        #  * Incomplete sequence — its declared length runs
+                        #    past the bytes captured. Drop the lead byte too
+                        #    (keep k-1) so we never emit a partial codepoint.
+                        #  * Complete sequence — it fit entirely within the
+                        #    cap (ended at or before the cut). Restore k to the
+                        #    full prefix length so the whole character is kept;
+                        #    otherwise k still points at the sequence start and
+                        #    the trailing substr would chop its tail, emitting a
+                        #    lone dangling lead byte.
+                        if (k + seqlen - 1 > length(prefix)) {
+                            k--
+                        } else {
+                            k = length(prefix)
+                        }
+                    }
+                    break
+                }
+                prefix = substr(prefix, 1, k)
+                printf "    %s…[truncated %d bytes]\n", prefix, length($0) - length(prefix)
             } else {
                 printf "    %s\n", $0
             }

--- a/scripts/tests/test_run_ci_guards.sh
+++ b/scripts/tests/test_run_ci_guards.sh
@@ -43,6 +43,10 @@
 #       Abort trap: 6 — umbrella exits 1, output intact (#4602).
 #  17.  Small-match formatting keeps the four-space indent unchanged (#4602).
 #  18.  Over-long line truncated with prefix preserved + marker (#4602).
+#  19.  Multibyte UTF-8 truncation never splits mid-codepoint; marker
+#       label reads "bytes" not "chars" (#4608).
+#  19b. Complete multibyte sequence ending exactly at the byte cap is kept
+#       whole (not chopped to a dangling lead byte) (#4608).
 #
 # Run:
 #   scripts/tests/test_run_ci_guards.sh
@@ -590,10 +594,114 @@ elif ! echo "$out_buf" | grep -q "BEGINMARKER"; then
     report_fail "expected the start-of-line 'BEGINMARKER' to survive truncation (#4602)" "$out_buf"
 elif echo "$out_buf" | grep -q "ENDMARKER"; then
     report_fail "expected the far end 'ENDMARKER' to be truncated away (#4602)" "$out_buf"
-elif ! echo "$out_buf" | grep -qE "truncated [0-9]+ chars"; then
-    report_fail "expected '…[truncated N chars]' marker after the prefix (#4602)" "$out_buf"
+elif ! echo "$out_buf" | grep -qE "truncated [0-9]+ bytes"; then
+    report_fail "expected '…[truncated N bytes]' marker after the prefix (#4602)" "$out_buf"
 else
     report_pass "over-long line truncated, prefix preserved, marker appended (#4602)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 19: multibyte-safe truncation (#4608). BSD/gawk substr() and
+#               length() operate on BYTES, so a naive substr($0, 1, 2000)
+#               can slice through the middle of a UTF-8 multibyte sequence,
+#               emitting a dangling partial byte before the marker. The
+#               hardened awk path must trim any trailing incomplete sequence
+#               so the emitted prefix is always valid UTF-8, and the marker
+#               must honestly say "bytes" (which is what is counted).
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 19] multibyte truncation never splits mid-codepoint (#4608)"
+synth_scripts="$(seed_synthetic_scripts s19)"
+# Emit 1999 ASCII 'x' followed by a long run of 3-byte '…' (U+2026). The
+# byte cap is MAX_LINE_BYTES=2000, so byte 2000 lands on the FIRST byte of
+# the first '…' sequence — a naive byte-truncation would emit that lone lead
+# byte (an incomplete sequence) right before the marker.
+cat > "$synth_scripts/check-mbtrunc.sh" <<'SH'
+#!/usr/bin/env bash
+python3 -c 'import sys; sys.stdout.buffer.write(b"x" * 1999 + ("…" * 100).encode("utf-8") + b"\n")'
+exit 1
+SH
+chmod +x "$synth_scripts/check-mbtrunc.sh"
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ge 128 ]; then
+    report_fail "umbrella aborted with signal $((rc_buf - 128)) (rc=$rc_buf) on multibyte block (#4608)" "$out_buf"
+elif [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 (normal guard-failure) on multibyte block, got $rc_buf (#4608)" "$out_buf"
+elif ! echo "$out_buf" | grep -qE "truncated [0-9]+ bytes"; then
+    report_fail "expected '…[truncated N bytes]' marker (label must read 'bytes') (#4608)" "$out_buf"
+else
+    # Extract the emitted guard-content prefix: take the output line carrying
+    # the truncation marker, cut everything from the literal '[truncated'
+    # onward, then strip the leading four-space indent. The remaining bytes
+    # are exactly what the runner emitted as the truncated prefix (it may end
+    # in the U+2026 marker ellipsis, which is itself valid UTF-8). If the
+    # runner left a dangling partial UTF-8 sequence, .decode('utf-8') fails.
+    #
+    # The extraction MUST be binary-safe: when the runner emitted a dangling
+    # partial byte, a locale-aware grep/sed can silently drop or mangle the
+    # line (returning an empty prefix that "decodes" as valid empty UTF-8 — a
+    # false pass). We run the whole pipeline under LC_ALL=C so grep/sed/awk
+    # operate on raw bytes, capture the marker line to a file, and use
+    # grep -a to force text mode on otherwise-binary content.
+    mkdir -p "$REPO_ROOT/tmp"
+    raw_file="$REPO_ROOT/tmp/test-mbtrunc-raw-$$"
+    prefix_file="$REPO_ROOT/tmp/test-mbtrunc-prefix-$$"
+    printf '%s\n' "$out_buf" > "$raw_file"
+    LC_ALL=C grep -a '\[truncated' "$raw_file" | LC_ALL=C head -n1 \
+        | LC_ALL=C sed 's/…\[truncated.*//' | LC_ALL=C sed 's/^    //' \
+        | LC_ALL=C tr -d '\n' > "$prefix_file"
+    if python3 -c 'import sys; sys.stdin.buffer.read().decode("utf-8")' < "$prefix_file"; then
+        report_pass "multibyte truncation emits valid UTF-8 prefix; marker reads 'bytes' (#4608)"
+    else
+        report_fail "emitted truncated prefix is not valid UTF-8 — split mid-codepoint (#4608)" "$out_buf"
+    fi
+    rm -f "$raw_file" "$prefix_file"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 19b: complete-sequence-at-boundary (#4608). The companion to
+#               scenario 19. Here a COMPLETE 3-byte '…' (U+2026) ends EXACTLY
+#               at the byte cap (its three bytes occupy positions 1998/1999/
+#               2000). The backward-walk must KEEP that complete sequence
+#               whole; a naive walk that stops at the lead byte without
+#               restoring k chops the trailing two bytes and emits a lone
+#               dangling lead byte (invalid UTF-8) — the exact defect the
+#               codepoint-aware truncation is meant to prevent.
+# ───────────────────────────────────────────────────────────────────────
+echo "[scenario 19b] complete multibyte sequence at the cap is kept whole (#4608)"
+synth_scripts="$(seed_synthetic_scripts s19b)"
+# 1997 ASCII 'x' + one 3-byte '…' (bytes 1998,1999,2000 — a complete sequence
+# ending exactly at the cap) + 20 more chars of filler so the total exceeds
+# MAX_LINE_BYTES=2000 and truncation actually fires.
+cat > "$synth_scripts/check-mbtrunc-complete.sh" <<'SH'
+#!/usr/bin/env bash
+python3 -c 'import sys; sys.stdout.buffer.write(b"x" * 1997 + "…".encode("utf-8") + b"z" * 20 + b"\n")'
+exit 1
+SH
+chmod +x "$synth_scripts/check-mbtrunc-complete.sh"
+run_synth "$synth_scripts"
+if [ "$rc_buf" -ge 128 ]; then
+    report_fail "umbrella aborted with signal $((rc_buf - 128)) (rc=$rc_buf) on complete-at-cap block (#4608)" "$out_buf"
+elif [ "$rc_buf" -ne 1 ]; then
+    report_fail "expected exit 1 (normal guard-failure) on complete-at-cap block, got $rc_buf (#4608)" "$out_buf"
+elif ! echo "$out_buf" | grep -qE "truncated [0-9]+ bytes"; then
+    report_fail "expected '…[truncated N bytes]' marker (label must read 'bytes') (#4608)" "$out_buf"
+else
+    # Same binary-safe extraction as scenario 19. If the awk walk chopped the
+    # complete '…' at the cap, the prefix ends in a lone 0xE2 lead byte and
+    # .decode('utf-8') fails.
+    mkdir -p "$REPO_ROOT/tmp"
+    raw_file="$REPO_ROOT/tmp/test-mbtrunc-complete-raw-$$"
+    prefix_file="$REPO_ROOT/tmp/test-mbtrunc-complete-prefix-$$"
+    printf '%s\n' "$out_buf" > "$raw_file"
+    LC_ALL=C grep -a '\[truncated' "$raw_file" | LC_ALL=C head -n1 \
+        | LC_ALL=C sed 's/…\[truncated.*//' | LC_ALL=C sed 's/^    //' \
+        | LC_ALL=C tr -d '\n' > "$prefix_file"
+    if python3 -c 'import sys; sys.stdin.buffer.read().decode("utf-8")' < "$prefix_file"; then
+        report_pass "complete multibyte sequence at cap kept whole; valid UTF-8 prefix (#4608)"
+    else
+        report_fail "complete-at-cap sequence was chopped — dangling lead byte, invalid UTF-8 (#4608)" "$out_buf"
+    fi
+    rm -f "$raw_file" "$prefix_file"
 fi
 
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Makes `scripts/run-ci-guards.sh`'s `emit_indented_capped` truncation marker byte-accurate and multibyte-safe. The marker is relabelled `…[truncated N bytes]` (BSD/gawk `substr`/`length` count bytes, not chars), and the awk truncation now trims any trailing incomplete UTF-8 sequence after the byte cut so it never emits a partial codepoint — while keeping a complete sequence that ended exactly at the cap intact. Indentation stays in awk, so the #4602 BSD-sed `Abort trap: 6` crash path is not reintroduced, and small-match output is byte-identical to today.

Closes #4608

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (DX/tooling script + its bash test only)
- [x] Verification evidence posted on issue (see #4608)
