### PR TITLE
fix(scraping): breach never-captured scrapers in zero-record-streak guard (#4611)

### DIFF
--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -113,15 +113,28 @@ class TestHasHistoricalNonzero:
 # ---------------------------------------------------------------------------
 
 
-def _mock_conn(rows: list[tuple[str, datetime, int, str]]) -> MagicMock:
+def _mock_conn(
+    rows: list[tuple[str, datetime, int, str]],
+    *,
+    ever_captured: bool = False,
+) -> MagicMock:
     """Build a MagicMock that mimics psycopg's cursor().execute()/fetchall().
 
     ``rows`` should be a flat list of ``(scraper_id, started_at, records_captured, status)``
     tuples in the order the SQL query would return them (grouped by scraper_id,
     started_at DESC within each group).
+
+    ``ever_captured`` controls the ``fetchone()`` answer for the unbounded
+    ``_ever_captured`` probe (``SELECT 1 ... LIMIT 1``). It is only reached for
+    scrapers whose in-window runs are all zero. Default False → the probe says
+    the scraper has never captured (true never-captured path). Set True to
+    simulate a scraper whose last nonzero run predates the lookback window
+    (long streak path). Tests with a nonzero in-window run never reach the
+    probe, so the default is safe for all.
     """
     cur = MagicMock()
     cur.fetchall.return_value = list(rows)
+    cur.fetchone.return_value = (1,) if ever_captured else None
     cur.__enter__ = MagicMock(return_value=cur)
     cur.__exit__ = MagicMock(return_value=False)
 
@@ -287,6 +300,238 @@ class TestCheckZeroRecordStreaks:
         )
         assert not result.breaches
 
+    def test_existing_streak_breach_has_streak_category(self) -> None:
+        """AC#3: an ordinary (started-then-stopped) streak breach is
+        categorized ``streak``, distinct from never-captured breaches."""
+        rows = [
+            ("ca-oc-tentatives", NOW - timedelta(hours=2), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=26), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=50), 18, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+        )
+        assert len(result.breaches) == 1
+        assert result.breaches[0].category == "streak"
+
+
+# ---------------------------------------------------------------------------
+# Never-captured breach tests (#4611)
+# ---------------------------------------------------------------------------
+
+
+class TestNeverCapturedBreach:
+    """A scraper that is registered, scheduled, not excluded, old enough,
+    and has captured 0 records on EVERY run in its history is a silent
+    outage that started at birth — it must breach, not be excused as
+    insufficient_history. See #4611 (Contra Costa #4591 / #4598)."""
+
+    def test_never_captured_old_enough_breaches(self) -> None:
+        """AC#1: never-captured, schedule-active, non-excluded, older than
+        the min-age window → breach with category ``never_captured``."""
+        rows = [
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=25), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=49), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=73), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=97), 0, "success"),
+        ]
+        # ever_captured=False → unbounded probe confirms a TRUE never-captured
+        # scraper (no nonzero run anywhere), so the category stays
+        # never_captured. See #4611.
+        conn = _mock_conn(rows, ever_captured=False)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-cc-judge-discovery"},
+        )
+        assert not result.insufficient_history
+        assert len(result.breaches) == 1
+        b = result.breaches[0]
+        assert b.scraper_id == "ca-cc-judge-discovery"
+        assert b.category == "never_captured"
+        assert "never captured" in b.message
+        assert b.streak == 5
+        assert b.last_nonzero_at is None
+        # Runner-read attributes must all be populated.
+        assert b.first_zero_at is not None
+        assert b.last_zero_at is not None
+        # Run-count floor = max(applicable_threshold=2 daily, min_runs=3) = 3.
+        assert b.threshold == 3
+
+    def test_never_captured_too_young_stays_insufficient(self) -> None:
+        """AC#2: never-captured but younger than the min-age window stays
+        insufficient_history (no new false positive)."""
+        rows = [
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=5), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=9), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-cc-judge-discovery"},
+        )
+        assert not result.breaches
+        assert len(result.insufficient_history) == 1
+        assert result.insufficient_history[0].scraper_id == "ca-cc-judge-discovery"
+
+    def test_never_captured_too_few_runs_stays_insufficient(self) -> None:
+        """AC#2: old enough but too few runs (below the run-count floor)
+        stays insufficient_history."""
+        rows = [
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=97), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            min_runs=3,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-cc-judge-discovery"},
+        )
+        assert not result.breaches
+        assert len(result.insufficient_history) == 1
+
+    def test_never_captured_excluded_is_suppressed(self) -> None:
+        """AC#2: an EXCLUSIONS-listed never-captured scraper is still
+        skipped entirely — no breach, no insufficient_history."""
+        rows = [
+            ("ca-oc-dept-judges", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-oc-dept-judges", NOW - timedelta(hours=25), 0, "success"),
+            ("ca-oc-dept-judges", NOW - timedelta(hours=49), 0, "success"),
+            ("ca-oc-dept-judges", NOW - timedelta(hours=97), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions={"ca-oc-dept-judges"},
+            known_scraper_ids={"ca-oc-dept-judges"},
+        )
+        assert result.excluded_count == 1
+        assert not result.breaches
+        assert not result.insufficient_history
+
+    def test_never_captured_naive_datetimes_handled(self) -> None:
+        """tz-defensiveness: naive started_at values must not blow up the
+        age computation (mirror the _iso normalization)."""
+        sid = "ca-cc-judge-discovery"
+        rows = [
+            (sid, (NOW - timedelta(hours=1)).replace(tzinfo=None), 0, "success"),
+            (sid, (NOW - timedelta(hours=49)).replace(tzinfo=None), 0, "success"),
+            (sid, (NOW - timedelta(hours=97)).replace(tzinfo=None), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-cc-judge-discovery"},
+        )
+        assert len(result.breaches) == 1
+        assert result.breaches[0].category == "never_captured"
+
+
+class TestLongStoppedScraperStreak:
+    """#4611 reviewer fix: a scraper that captured for months then broke,
+    producing zeros for LONGER than the lookback window, has all-zero
+    in-window runs but is NOT never-captured. The unbounded ``_ever_captured``
+    probe must categorize it as a long ``streak`` breach, NOT never_captured —
+    the exact distinction AC#3 exists to surface."""
+
+    def test_long_stopped_scraper_is_streak_not_never_captured(self) -> None:
+        """All in-window runs zero + ever_captured=True (historical nonzero
+        predates the window) → breach with category ``streak`` (NOT
+        never_captured), gated on applicable_threshold."""
+        rows = [
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=25), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=49), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=73), 0, "success"),
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=97), 0, "success"),
+        ]
+        conn = _mock_conn(rows, ever_captured=True)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            lookback_days=14,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-cc-judge-discovery"},
+        )
+        assert not result.insufficient_history
+        assert len(result.breaches) == 1
+        b = result.breaches[0]
+        assert b.scraper_id == "ca-cc-judge-discovery"
+        assert b.category == "streak"
+        # Last nonzero run is outside the window.
+        assert b.last_nonzero_at is None
+        # Gated on the daily streak threshold, NOT the never-captured floor.
+        assert b.threshold == 2
+        assert b.streak == 5
+        # Message must NOT claim never captured since deploy.
+        assert "never captured" not in b.message
+        assert "lookback window" in b.message
+        # Runner-read attributes populated.
+        assert b.first_zero_at is not None
+        assert b.last_zero_at is not None
+
+    def test_long_stopped_too_few_runs_is_insufficient(self) -> None:
+        """ever_captured=True but in-window run count below
+        applicable_threshold → no breach, falls through to
+        insufficient_history (streak gate honored)."""
+        rows = [
+            ("ca-cc-judge-discovery", NOW - timedelta(hours=1), 0, "success"),
+        ]
+        conn = _mock_conn(rows, ever_captured=True)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            lookback_days=14,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-cc-judge-discovery"},
+        )
+        assert not result.breaches
+        assert len(result.insufficient_history) == 1
+        ih = result.insufficient_history[0]
+        assert ih.scraper_id == "ca-cc-judge-discovery"
+        # The scraper DID capture historically (ever_captured=True), just
+        # before the lookback window — so the message must scope its claim to
+        # the window, not falsely assert "no historical nonzero run" (#4611).
+        assert "lookback window" in ih.message
+        assert "in window but no historical nonzero run" not in ih.message
+
 
 # ---------------------------------------------------------------------------
 # Module-level EXCLUSIONS regression tests
@@ -393,6 +638,79 @@ class TestOutputFormatting:
         assert payload["healthy"] is False
         assert len(payload["breaches"]) == 1
         assert payload["breaches"][0]["scraper_id"] == "ca-sf-tentatives-civil"
+
+    def test_format_json_breach_includes_category(self) -> None:
+        """AC#3: JSON output surfaces a ``category`` field distinguishing
+        never_captured from streak breaches."""
+        import json as _json
+
+        result = CheckResult(
+            breaches=[
+                Breach(
+                    scraper_id="ca-streak",
+                    streak=3,
+                    threshold=3,
+                    first_zero_at="2026-04-16T12:00:00+00:00",
+                    last_zero_at="2026-04-18T00:00:00+00:00",
+                    last_nonzero_at="2026-04-15T12:00:00+00:00",
+                    message="streak breach",
+                    category="streak",
+                ),
+                Breach(
+                    scraper_id="ca-never",
+                    streak=5,
+                    threshold=5,
+                    first_zero_at="2026-04-14T12:00:00+00:00",
+                    last_zero_at="2026-04-18T00:00:00+00:00",
+                    last_nonzero_at=None,
+                    message="never captured",
+                    category="never_captured",
+                ),
+            ],
+            insufficient_history=[],
+            checked_count=2,
+            excluded_count=0,
+        )
+        payload = _json.loads(format_json(result))
+        cats = {b["scraper_id"]: b["category"] for b in payload["breaches"]}
+        assert cats["ca-streak"] == "streak"
+        assert cats["ca-never"] == "never_captured"
+
+    def test_format_text_labels_never_captured(self) -> None:
+        """AC#3: format_text labels never-captured breaches distinctly."""
+        result = CheckResult(
+            breaches=[
+                Breach(
+                    scraper_id="ca-never",
+                    streak=5,
+                    threshold=5,
+                    first_zero_at="2026-04-14T12:00:00+00:00",
+                    last_zero_at="2026-04-18T00:00:00+00:00",
+                    last_nonzero_at=None,
+                    message="never captured since deploy",
+                    category="never_captured",
+                ),
+            ],
+            insufficient_history=[],
+            checked_count=1,
+            excluded_count=0,
+        )
+        text = format_text(result)
+        assert "NEVER" in text.upper()
+
+    def test_breach_category_defaults_to_streak(self) -> None:
+        """Positional Breach construction (no category) defaults to ``streak``
+        so the runner and legacy callers keep working."""
+        b = Breach(
+            scraper_id="ca-x",
+            streak=3,
+            threshold=3,
+            first_zero_at="2026-04-16T12:00:00+00:00",
+            last_zero_at="2026-04-18T00:00:00+00:00",
+            last_nonzero_at=None,
+            message="m",
+        )
+        assert b.category == "streak"
 
     def test_format_text_lists_breaches(self) -> None:
         result = CheckResult(

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -22,12 +22,29 @@ Streak-counting rules:
   = 0`` rows. As soon as a row with ``records_captured > 0`` is seen the
   streak is broken.
 * If the scraper has **no** historical run with ``records_captured > 0`` it
-  is reported as ``insufficient_history`` — never a breach. This avoids
-  false positives on brand-new scrapers and on permanently-quiet feeds
-  (court directory rosters that only record when the roster file changes).
+  may be reported either as ``insufficient_history`` (never a breach) or as a
+  ``never_captured`` breach, depending on age and run count (see below). This
+  distinction avoids false positives on brand-new scrapers while still
+  catching the silent-outage-since-deploy case (#4611).
+* A ``never_captured`` breach fires for a registered, scheduled, non-excluded
+  scraper that has captured 0 records on **every** run in its **entire**
+  history, **and** whose oldest in-window run is at least
+  ``--never-captured-min-age-days`` old, **and** which has at least
+  ``max(applicable_threshold, --never-captured-min-runs)`` runs. Younger /
+  barely-run never-captured scrapers stay ``insufficient_history`` to preserve
+  the brand-new false-positive guard.
+* When all in-window runs are zero, the unbounded ``scraper_runs`` history is
+  probed (``_ever_captured``) to tell a true never-captured scraper from a long
+  ``streak`` breach whose last nonzero run predates the lookback window (e.g.
+  15 days of zeros with a 14d lookback). If the scraper ever captured, it is a
+  ``streak`` breach (gated on ``applicable_threshold``), NOT ``never_captured``
+  — this keeps the AC#3 distinction correct.
+* This is distinct from the ordinary ``streak`` breach (started capturing, then
+  stopped); the ``category`` field on each breach names which is which.
 * An explicit ``EXCLUSIONS`` allowlist suppresses specific scraper IDs
   regardless of streak length (e.g. roster / directory scrapers that
-  legitimately emit zero-record runs).
+  legitimately emit zero-record runs). EXCLUSIONS suppress never_captured
+  breaches too.
 
 Usage:
     scripts/with-secret.sh \\
@@ -42,6 +59,10 @@ Options:
     --daily-threshold N Override the daily-scraper threshold (default: 2).
     --scraper ID        Check only the specified scraper ID.
     --lookback-days N   Runs older than this are ignored (default: 14).
+    --never-captured-min-age-days N  Min age before a never-captured scraper
+                        breaches (default: 3).
+    --never-captured-min-runs N      Min run count before a never-captured
+                        scraper breaches (default: 3).
 
 Exit code: 0 if no breaches, 1 if one or more scrapers are in breach.
 
@@ -91,6 +112,14 @@ DEFAULT_DAILY_STREAK_THRESHOLD = 2
 # How far back to pull runs when computing the streak. 14 days is more than
 # enough for any daily or frequent scraper and caps query cost.
 DEFAULT_LOOKBACK_DAYS = 14
+
+# Never-captured breach thresholds. A registered, scheduled, non-excluded
+# scraper that has produced 0 records on EVERY run in its history is a silent
+# outage that started at birth (#4611). It breaches only once it is both old
+# enough (so genuinely-new scrapers are not flagged) AND has accumulated
+# enough runs (so a scraper with a couple of runs is not flagged).
+DEFAULT_NEVER_CAPTURED_MIN_AGE_DAYS = 3
+DEFAULT_NEVER_CAPTURED_MIN_RUNS = 3
 
 # Scrapers that legitimately produce zero-record runs by design.
 # Each entry must include a rationale comment so future maintainers can
@@ -146,6 +175,11 @@ class Breach:
     last_zero_at: str  # ISO-8601
     last_nonzero_at: str | None  # ISO-8601 or None if none seen in window
     message: str
+    # Breach category — defaulted so existing positional constructions and the
+    # ECS runner keep working. ``streak`` = started capturing then stopped;
+    # ``never_captured`` = registered/scheduled but 0 records since deploy
+    # (#4611). ``format_json``'s ``asdict`` surfaces it automatically.
+    category: str = "streak"
 
 
 @dataclass
@@ -283,6 +317,32 @@ def has_historical_nonzero(runs: list[tuple[datetime, int, str]]) -> bool:
     return any(records > 0 for _, records, _ in runs)
 
 
+# Unbounded (no time filter) probe: has this scraper EVER captured? Used to
+# distinguish a true never-captured scraper from a long streak whose last
+# nonzero run predates the lookback window (#4611).
+EVER_CAPTURED_QUERY = (
+    "SELECT 1 FROM scraper_runs WHERE scraper_id = %s AND records_captured > 0 LIMIT 1"
+)
+
+
+def _ever_captured(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    scraper_id: str,
+) -> bool:
+    """True if the scraper has ANY run (unbounded history) with records > 0.
+
+    Unlike ``has_historical_nonzero`` (which only inspects the in-window runs),
+    this queries the full ``scraper_runs`` history. A scraper that captured for
+    months and then broke, producing zeros for longer than ``lookback_days``,
+    has all-zero in-window runs but is NOT never-captured — it is a long
+    ``streak`` breach (#4611). One cheap ``LIMIT 1`` query, only for the small
+    subset of scrapers with zero in-window captures.
+    """
+    with conn.cursor() as cur:
+        cur.execute(EVER_CAPTURED_QUERY, (scraper_id,))
+        return cur.fetchone() is not None
+
+
 # ---------------------------------------------------------------------------
 # Main check
 # ---------------------------------------------------------------------------
@@ -307,6 +367,8 @@ def check_zero_record_streaks(
     threshold: int = DEFAULT_STREAK_THRESHOLD,
     daily_threshold: int = DEFAULT_DAILY_STREAK_THRESHOLD,
     lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    min_age_days: int = DEFAULT_NEVER_CAPTURED_MIN_AGE_DAYS,
+    min_runs: int = DEFAULT_NEVER_CAPTURED_MIN_RUNS,
     scraper_id: str | None = None,
     exclusions: set[str] | None = None,
     frequent_scraper_ids: set[str] | None = None,
@@ -326,6 +388,12 @@ def check_zero_record_streaks(
             is already ~48h of silent outage.
         lookback_days: How far back to consider runs. Runs older than
             this are ignored entirely.
+        min_age_days: Minimum age (oldest run in window vs ``now``) before a
+            never-captured scraper breaches. Younger scrapers stay
+            ``insufficient_history``. See #4611.
+        min_runs: Minimum run count before a never-captured scraper breaches.
+            The applied run-count floor is ``max(applicable_threshold,
+            min_runs)``.
         scraper_id: Optional single scraper ID to check.
         exclusions: Scrapers to skip. Defaults to ``EXCLUSIONS``.
         frequent_scraper_ids: Scraper IDs that run more than once per day.
@@ -389,14 +457,82 @@ def check_zero_record_streaks(
             continue
 
         if not has_historical_nonzero(runs):
+            # All runs in the lookback window are zero. This is EITHER a true
+            # never-captured scraper OR a long streak whose last nonzero run
+            # predates the window (e.g. 15 days of zeros with a 14d lookback).
+            # ``has_historical_nonzero`` only inspects in-window rows, so we
+            # must probe the unbounded history to tell them apart (#4611) —
+            # otherwise a "started then stopped" scraper is mislabeled
+            # never_captured, the exact distinction AC#3 exists to surface.
+            run_count = len(runs)
+            oldest_started_at = runs[-1][0]
+            if oldest_started_at.tzinfo is None:
+                oldest_started_at = oldest_started_at.replace(tzinfo=UTC)
+            age = now - oldest_started_at
+
+            if _ever_captured(conn, sid):
+                # Long streak breach: last nonzero run is older than the
+                # lookback window. Gate on the ordinary streak threshold (NOT
+                # the never-captured run-count floor); too-few in-window runs
+                # fall through to insufficient_history below.
+                if run_count >= applicable_threshold:
+                    breaches.append(
+                        Breach(
+                            scraper_id=sid,
+                            streak=run_count,
+                            threshold=applicable_threshold,
+                            first_zero_at=_iso(first_zero),
+                            last_zero_at=_iso(last_zero),
+                            last_nonzero_at=None,
+                            message=(
+                                f"{sid}: at least {run_count} consecutive "
+                                f"zero-record runs (threshold: "
+                                f"{applicable_threshold}); last nonzero run is "
+                                f"older than the {lookback_days}d lookback "
+                                f"window"
+                            ),
+                            category="streak",
+                        )
+                    )
+                    continue
+            else:
+                # True never-captured. Distinguish a genuinely new / barely-run
+                # scraper (suppress as insufficient_history) from a registered,
+                # scheduled, non-excluded scraper that has silently captured 0
+                # records since deploy (breach). See #4611.
+                run_count_floor = max(applicable_threshold, min_runs)
+                if age >= timedelta(days=min_age_days) and run_count >= run_count_floor:
+                    age_days = age.total_seconds() / 86400
+                    breaches.append(
+                        Breach(
+                            scraper_id=sid,
+                            streak=run_count,
+                            threshold=run_count_floor,
+                            first_zero_at=_iso(first_zero),
+                            last_zero_at=_iso(last_zero),
+                            last_nonzero_at=None,
+                            message=(
+                                f"{sid}: registered/scheduled but never captured "
+                                f"since deploy — {run_count} zero-record runs over "
+                                f"{age_days:.1f} days (run-count floor: "
+                                f"{run_count_floor}, min age: {min_age_days}d)"
+                            ),
+                            category="never_captured",
+                        )
+                    )
+                    continue
+
+            # No breach fired for either sub-path (too young / too few runs for
+            # never-captured; below applicable_threshold for the long streak).
+            # Keep the brand-new false-positive guard intact.
             insufficient.append(
                 InsufficientHistory(
                     scraper_id=sid,
                     zero_run_count=streak,
                     message=(
-                        f"{sid}: {streak} zero-record runs in window but no "
-                        f"historical nonzero run — insufficient history, "
-                        f"not a breach"
+                        f"{sid}: {streak} zero-record runs but no historical "
+                        f"nonzero run in the lookback window — insufficient "
+                        f"history, not a breach"
                     ),
                 )
             )
@@ -485,7 +621,8 @@ def format_text(result: CheckResult) -> str:
         lines.append("")
         lines.append("BREACHES:")
         for b in result.breaches:
-            lines.append(f"  * {b.message}")
+            label = "NEVER CAPTURED" if b.category == "never_captured" else "STREAK"
+            lines.append(f"  * [{label}] {b.message}")
             lines.append(f"      first_zero_at={b.first_zero_at}")
             lines.append(f"      last_zero_at={b.last_zero_at}")
             lines.append(f"      last_nonzero_at={b.last_nonzero_at or '(none)'}")
@@ -550,6 +687,24 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=DEFAULT_LOOKBACK_DAYS,
         help=(f"Runs older than this are ignored (default: {DEFAULT_LOOKBACK_DAYS})."),
     )
+    parser.add_argument(
+        "--never-captured-min-age-days",
+        type=int,
+        default=DEFAULT_NEVER_CAPTURED_MIN_AGE_DAYS,
+        help=(
+            "Minimum age before a never-captured scraper breaches "
+            f"(default: {DEFAULT_NEVER_CAPTURED_MIN_AGE_DAYS})."
+        ),
+    )
+    parser.add_argument(
+        "--never-captured-min-runs",
+        type=int,
+        default=DEFAULT_NEVER_CAPTURED_MIN_RUNS,
+        help=(
+            "Minimum run count before a never-captured scraper breaches "
+            f"(default: {DEFAULT_NEVER_CAPTURED_MIN_RUNS})."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -571,6 +726,8 @@ def main(argv: list[str] | None = None) -> int:
             threshold=args.threshold,
             daily_threshold=args.daily_threshold,
             lookback_days=args.lookback_days,
+            min_age_days=args.never_captured_min_age_days,
+            min_runs=args.never_captured_min_runs,
             scraper_id=args.scraper,
         )
 


### PR DESCRIPTION
## Summary

The zero-record-streak guard bucketed any scraper with no `records_captured > 0` run as `insufficient_history` and never breached, masking registered/scheduled scrapers that captured 0 records since deploy (the blind spot behind the CC portal regressions #4591/#4598). This adds a `never_captured` breach category — a registered, schedule-active, non-excluded scraper that is old enough and has enough runs but has NEVER captured now breaches — while keeping brand-new and `EXCLUSIONS` feeds suppressed. An unbounded `_ever_captured` history probe keeps the category honest across the lookback boundary, so a long-stopped scraper is classified `streak`, not `never_captured`.

Closes #4611

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (tooling/observability script; the daily `scraper-zero-record-alert` workflow runs the check unchanged in cadence, only the guard logic changed). Verification evidence (test output) posted on issue.
