### PR TITLE
refine(spotcheck): widen bad-short-title heuristic to stop flagging valid captions (#4620)

### DIFF
--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -145,6 +145,43 @@ When something looks wrong, trace it before filing. Examples of what "trace it" 
 
 A finding without a traced root cause is half-done — you'll either file a vague issue someone else has to re-investigate, or fix the symptom without preventing the regression.
 
+### Bad-short-title heuristic (Federal case_title contamination, #4620)
+
+When checking the **Case title** row of the table above against Federal `derived.cases`, use the refined bad-short-title heuristic. A Federal `case_title` is suspect when it is short (< 40 chars) **and** lacks any legitimate caption structure. The canonical refined SQL (case-insensitive via `ILIKE`, kept in sync with `scripts/spotcheck/inspect.py::is_bad_short_title`):
+
+```sql
+-- Bad-short-title heuristic (#4620): a Federal case_title is suspect when it is
+-- short (< 40 chars) AND lacks any legitimate caption structure. Case-insensitive
+-- via ILIKE. Mirrors scripts/spotcheck/inspect.py::is_bad_short_title.
+SELECT cs.case_title
+FROM derived.cases cs
+JOIN derived.rulings r ON r.case_id = cs.id
+JOIN derived.courts c ON r.court_id = c.id
+JOIN derived.documents d ON d.id = r.document_id AND d.status = 'active'
+WHERE c.county = 'Federal'
+  AND cs.case_title IS NOT NULL
+  AND length(cs.case_title) < 40
+  AND cs.case_title NOT ILIKE '% v %'
+  AND cs.case_title NOT ILIKE '% v. %'
+  AND cs.case_title NOT ILIKE '% vs %'
+  AND cs.case_title NOT ILIKE '% vs. %'
+  AND cs.case_title NOT ILIKE 'In re %'
+  AND cs.case_title NOT ILIKE 'In re:%'
+  AND cs.case_title NOT ILIKE 'In the Matter of %'
+  AND cs.case_title NOT ILIKE 'Matter of %'
+  AND cs.case_title NOT ILIKE 'Ex parte %'
+  AND cs.case_title NOT ILIKE 'United States %'
+  AND cs.case_title NOT ILIKE 'People %'
+  AND cs.case_title NOT ILIKE 'Peo in Interest of %'
+  AND cs.case_title NOT ILIKE 'In Interest of %'
+  AND cs.case_title NOT ILIKE 'Marriage of %'
+  AND cs.case_title NOT ILIKE 'Detention of %'
+  AND cs.case_title NOT ILIKE 'Parental Resp%'
+  AND cs.case_title NOT ILIKE 'Estate of %';
+```
+
+The SQL `ILIKE '% v %'` allow-list lets role-literal captions like `Plaintiff v. Defendant` through (a known limitation of a pure-SQL allow-list). The Python `inspect.py --bad-short-title-only` filter is **stricter and preferred for sampling** — it additionally rejects role-literal captions (`Plaintiff v. Defendant`, `Defendant`) as extraction contamination. Use the SQL as the quick dev-DB count; use `inspect.py --bad-short-title-only` when you want a clean sample to eyeball.
+
 ---
 
 ## Step 3 — Look beyond the bidirectional sample
@@ -204,6 +241,7 @@ The script is permanent (`# permanent: true`) and exits 0 always — it's a disc
 - `scripts/dev-db-query.sh "<SQL>"` — quick read against dev Postgres (no scripts; SELECT/EXPLAIN only).
 - `scripts/ecs-run-task.sh scripts/<file>.py -- <args>` — anything heavier (data scripts, backfills, multi-statement reads).
 - `scripts/run-py.sh scripts/screenshot.py <path>` — UI spot-check on `dev.judgemind.org`.
+- `scripts/run-py.sh scripts/spotcheck/inspect.py <s3-or-path> --bad-short-title-only` — sample Federal `case_title` contamination (the stricter, preferred tool over the bad-short-title SQL above; also rejects role-literal captions). See the bad-short-title heuristic note in Step 2.
 - `mcp__awslabs_cloudwatch-mcp-server__execute_log_insights_query` — dispatcher logs, scraper logs, ingestion-worker logs.
 - `mcp__awslabs_ecs-mcp-server__ecs_resource_management` — service / task / cluster reads.
 - `mcp__github__search_code` — find code patterns across the repo.

--- a/scripts/spotcheck/inspect.py
+++ b/scripts/spotcheck/inspect.py
@@ -147,6 +147,121 @@ def is_empty_text(row: dict[str, Any]) -> bool:
     return n is None or n == 0
 
 
+# ---------------------------------------------------------------------------
+# Bad-short-title heuristic (#4620)
+# ---------------------------------------------------------------------------
+#
+# A Federal ``case_title`` is suspect when it is short (< 40 chars) AND lacks
+# any legitimate caption structure. The canonical SQL equivalent lives in
+# ``.claude/skills/spotcheck/SKILL.md`` (kept in sync by reference). The Python
+# predicate is stricter than the SQL allow-list: it also rejects role-literal
+# captions (e.g. ``Plaintiff v. Defendant``) that the SQL ``ILIKE '% v %'``
+# allow-list would let through.
+
+SHORT_TITLE_MAX_LEN = 40
+
+# Legitimate caption prefixes (matched case-insensitively at the start of the
+# title). Mirrors the SQL ``NOT ILIKE '<prefix> %'`` allow-list.
+LEGIT_TITLE_PREFIXES: tuple[str, ...] = (
+    "in re ",
+    "in re:",
+    "in the matter of ",
+    "matter of ",
+    "ex parte ",
+    "united states ",
+    "people ",
+    "peo in interest of ",
+    "in interest of ",
+    "marriage of ",
+    "detention of ",
+    "parental resp",
+    "estate of ",
+)
+
+# Versus connectors (surrounded by spaces) that mark a real caption. Ordered
+# longest-first so that, when splitting a title on the first matching connector,
+# the most specific connector wins (e.g. " v. " is tried before " v "). The
+# connectors do not actually overlap as substrings for well-formed titles
+# (the period/no-period variants are mutually exclusive), but the defensive
+# ordering keeps the split robust for any oddly-spaced input.
+VERSUS_CONNECTORS: tuple[str, ...] = (" vs. ", " vs ", " v. ", " v ")
+
+# Role-literal tokens — extraction-contamination placeholders, not real party
+# names. A title composed solely of these (even with a ``v.`` connector) is
+# contamination, not a legitimate caption.
+ROLE_LITERAL_TOKENS: frozenset[str] = frozenset(
+    {
+        "plaintiff",
+        "plaintiffs",
+        "defendant",
+        "defendants",
+        "petitioner",
+        "petitioners",
+        "respondent",
+        "respondents",
+        "appellant",
+        "appellants",
+        "appellee",
+        "appellees",
+        "claimant",
+        "defendant(s)",
+        "plaintiff(s)",
+    }
+)
+
+
+def _is_role_literal_only(title: str) -> bool:
+    """Return True if ``title`` is composed solely of role-literal tokens.
+
+    Splits on any versus connector; a title is role-literal contamination when
+    every non-empty side consists only of role-literal tokens (e.g.
+    ``Plaintiff v. Defendant``, ``Defendants v Plaintiffs``), or when the whole
+    title is a single role-literal token (e.g. ``Defendant``).
+    """
+    lowered = title.lower()
+    sides = [lowered]
+    for connector in VERSUS_CONNECTORS:
+        if connector in lowered:
+            sides = lowered.split(connector)
+            break
+    sides = [s.strip() for s in sides if s.strip()]
+    if not sides:
+        return False
+    return all(side in ROLE_LITERAL_TOKENS for side in sides)
+
+
+def is_bad_short_title(row: dict[str, Any]) -> bool:
+    """Return True if ``row['case_title']`` is a bad short title (#4620).
+
+    A title is BAD when it is non-null, short (< ``SHORT_TITLE_MAX_LEN``), and
+    either lacks any legitimate caption structure OR is role-literal
+    contamination (e.g. ``Plaintiff v. Defendant``). Null/empty titles and
+    titles >= the length threshold are never flagged.
+    """
+    title = row.get("case_title")
+    if not isinstance(title, str):
+        return False
+    title = title.strip()
+    if not title:
+        return False
+    if len(title) >= SHORT_TITLE_MAX_LEN:
+        return False
+
+    # Role-literal placeholders are contamination even when they carry a ``v.``.
+    if _is_role_literal_only(title):
+        return True
+
+    lowered = title.lower()
+    # A real versus caption (non-role-literal) is legitimate.
+    if any(connector in lowered for connector in VERSUS_CONNECTORS):
+        return False
+    if any(lowered.startswith(prefix) for prefix in LEGIT_TITLE_PREFIXES):
+        return False
+
+    # Short, non-null, no legitimate caption, not role-literal: bad.
+    return True
+
+
 def in_departments(row: dict[str, Any], departments: list[str]) -> bool:
     """Return True if ``row['department']`` matches any of ``departments``.
 
@@ -170,6 +285,7 @@ def filter_rows(
     null_judge_only: bool = False,
     null_department_only: bool = False,
     empty_text_only: bool = False,
+    bad_short_title_only: bool = False,
     departments: list[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Apply filters in AND fashion. All filters compose."""
@@ -183,6 +299,8 @@ def filter_rows(
         if null_department_only and not is_null_department(row):
             continue
         if empty_text_only and not is_empty_text(row):
+            continue
+        if bad_short_title_only and not is_bad_short_title(row):
             continue
         if depts and not in_departments(row, depts):
             continue
@@ -299,6 +417,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Keep only rows where ruling_text_length is 0/missing.",
     )
     parser.add_argument(
+        "--bad-short-title-only",
+        action="store_true",
+        help=(
+            "Keep only rows with a bad short case_title (#4620): short, "
+            "non-null, no legitimate caption, or role-literal contamination."
+        ),
+    )
+    parser.add_argument(
         "--department-in",
         nargs="+",
         default=[],
@@ -331,6 +457,7 @@ def main(argv: list[str] | None = None) -> int:
         null_judge_only=args.null_judge_only,
         null_department_only=args.null_department_only,
         empty_text_only=args.empty_text_only,
+        bad_short_title_only=args.bad_short_title_only,
         departments=args.department_in,
     )
 

--- a/scripts/tests/test_inspect.py
+++ b/scripts/tests/test_inspect.py
@@ -238,6 +238,16 @@ class TestFilterRows:
         rows = spotcheck_inspect.iter_rulings(result_fixture)
         assert spotcheck_inspect.filter_rows(rows) == rows
 
+    def test_bad_short_title_only(self) -> None:
+        rows = [
+            {"ruling_id": "good", "case_title": "Smith v. Jones"},
+            {"ruling_id": "legit_matter", "case_title": "In the Matter of Smith"},
+            {"ruling_id": "role", "case_title": "Plaintiff v. Defendant"},
+            {"ruling_id": "bare", "case_title": "Jane Doe"},
+        ]
+        out = spotcheck_inspect.filter_rows(rows, bad_short_title_only=True)
+        assert {r["ruling_id"] for r in out} == {"role", "bare"}
+
 
 # ---------------------------------------------------------------------------
 # Predicate helpers
@@ -273,6 +283,62 @@ class TestPredicates:
             is True
         )
         assert spotcheck_inspect.in_departments({"department": None}, ["C20"]) is False
+
+
+# ---------------------------------------------------------------------------
+# is_bad_short_title — refined Federal case_title heuristic (#4620)
+# ---------------------------------------------------------------------------
+
+
+class TestBadShortTitle:
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "In the Matter of Smith",
+            "In Re Taylor Dant",
+            "In Re: Michael White",
+            "Doe V. Roe",
+            "Doe V Roe",
+            "Smith v. Jones",
+            "Smith vs. Jones",
+            "Peo in Interest of A.B.",
+            "Marriage of Lee",
+            "In Interest of J.D.",
+            "Detention Of Gomez",
+            "Parental Resp of Ng",
+            "People V. Garcia",
+            "Estate of Smith",
+        ],
+    )
+    def test_legit_caption_not_flagged(self, title: str) -> None:
+        assert spotcheck_inspect.is_bad_short_title({"case_title": title}) is False
+
+    def test_long_title_not_flagged_even_without_caption(self) -> None:
+        # >= 40 chars: length gate short-circuits, never a "short" title.
+        long_title = "Abcdefghij Klmnopqrst Uvwxyz Anonymous Name"
+        assert len(long_title) >= 40
+        assert spotcheck_inspect.is_bad_short_title({"case_title": long_title}) is False
+
+    def test_null_empty_whitespace_not_flagged(self) -> None:
+        assert spotcheck_inspect.is_bad_short_title({"case_title": None}) is False
+        assert spotcheck_inspect.is_bad_short_title({}) is False
+        assert spotcheck_inspect.is_bad_short_title({"case_title": ""}) is False
+        assert spotcheck_inspect.is_bad_short_title({"case_title": "   "}) is False
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Plaintiff v. Defendant",
+            "Defendants v Plaintiffs",
+            "Defendant",
+            "Dhc",
+            "Jane Doe",
+            "Don Mccoin",
+            "Abdalla",
+        ],
+    )
+    def test_contamination_flagged(self, title: str) -> None:
+        assert spotcheck_inspect.is_bad_short_title({"case_title": title}) is True
 
 
 # ---------------------------------------------------------------------------
@@ -395,6 +461,7 @@ class TestMainCli:
             "--null-judge-only",
             "--null-department-only",
             "--empty-text-only",
+            "--bad-short-title-only",
             "--department-in",
             "--format",
         ]:
@@ -464,6 +531,31 @@ class TestMainCli:
             assert not any(k.startswith("__") for k in row), (
                 "JSON output must strip __source / __county augment keys"
             )
+
+    def test_bad_short_title_only_json(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """``--bad-short-title-only --format json`` selects only contamination."""
+        result = {
+            "rulings_by_county": {
+                "Federal": [
+                    {"ruling_id": "good", "case_title": "Smith v. Jones"},
+                    {"ruling_id": "legit", "case_title": "In Re Taylor Dant"},
+                    {"ruling_id": "role", "case_title": "Plaintiff v. Defendant"},
+                    {"ruling_id": "bare", "case_title": "Abdalla"},
+                ],
+            },
+        }
+        path = tmp_path / "r.json"
+        path.write_text(json.dumps(result), encoding="utf-8")
+        rc = spotcheck_inspect.main(
+            [str(path), "--bad-short-title-only", "--format", "json"]
+        )
+        assert rc == 0
+        rows = json.loads(capsys.readouterr().out)
+        assert {r["ruling_id"] for r in rows} == {"role", "bare"}
 
     def test_missing_file_returns_exit_2(
         self, tmp_path: Path, capsys: pytest.CaptureFixture


### PR DESCRIPTION
## Summary

Refines the "bad short title" / AC#2 heuristic (from #3978, used by `/spotcheck` Federal sampling) so it stops flagging legitimate full case titles as contamination. The heuristic was never committed code — it only existed as an ad-hoc, case-sensitive SQL block with a too-narrow prefix allow-list. This makes it a first-class, testable artifact: a pure `is_bad_short_title()` predicate + `--bad-short-title-only` filter in `scripts/spotcheck/inspect.py`, and the canonical refined (case-insensitive `ILIKE`) SQL documented in `.claude/skills/spotcheck/SKILL.md`. The Python predicate additionally rejects role-literal placeholder captions (e.g. `Plaintiff v. Defendant`) that a pure-SQL allow-list would let through.

Closes #4620

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` clean on touched files)
- [x] Format check passes (`ruff format --check` clean)
- [x] Tests pass (60 passed: 34 pre-existing + 26 new in `scripts/tests/test_inspect.py`)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (changes are to `scripts/spotcheck/`, `scripts/tests/`, and `.claude/skills/` only). The unit tests demonstrate that the named false-positive caption forms (`In the Matter of`, capital `In Re`/`In Re:`, `... V.`/`... V`, `Peo in Interest of`, `Marriage of`, `In Interest of`, `Detention Of`, `Parental Resp`, `People`) are no longer flagged, while real contamination (role-literal placeholders, genuinely-short captionless names) still is.
- [x] Verification evidence posted on issue (see A.8)
