### PR TITLE
feat(ingestion): surface reingest --prefix partial failure (#4619)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -6402,6 +6402,10 @@ class TestProgressLogging:
             "output_tokens",
             "llm_api_calls",
             "estimated_cost_usd",
+            # error_ratio is always added to the run_reingest stats so the
+            # --max-error-ratio exit gate (#4619) can read it; it is
+            # total_failed/(total_processed+total_failed), 0.0 when denom 0.
+            "error_ratio",
             # judge_prepass_complete is appended when the pre-pass runs
             # (default behaviour, #4408).  The pre-pass is skipped only
             # under ``dry_run=True`` or ``skip_judge_prepass=True`` —
@@ -14778,3 +14782,673 @@ class TestFullReparsePassesPdfBytesToSplitter:
             )
         finally:
             reingest._LLM_SPLIT_REGISTRY.pop(scraper_id, None)
+
+
+# ---------------------------------------------------------------------------
+# #4619 — reingest --prefix should surface partial failure.  These tests cover
+# the per-key error tracking + error-class capture, the loud WARNING summary,
+# the --max-error-ratio threshold-gated non-zero exit, and the optional
+# failed-keys S3 manifest.
+# ---------------------------------------------------------------------------
+
+
+class TestEmitPartialFailureWarning:
+    """Unit tests for the _emit_partial_failure_warning helper (#4619)."""
+
+    def test_returns_ratio_and_warns_when_errors(self) -> None:
+        from collections import Counter
+
+        mock_logger = MagicMock()
+        with patch.object(reingest, "logger", mock_logger):
+            ratio = reingest._emit_partial_failure_warning(
+                errors=3,
+                total=10,
+                error_classes=Counter({"BrokenProcessPool": 2, "ValueError": 1}),
+                context="reingest",
+            )
+        assert ratio == pytest.approx(0.3)
+        mock_logger.warning.assert_called_once()
+        kwargs = mock_logger.warning.call_args.kwargs
+        assert kwargs["errors"] == 3
+        assert kwargs["total"] == 10
+        assert kwargs["error_ratio"] == pytest.approx(0.3)
+        assert kwargs["top_error_class"] == "BrokenProcessPool"
+
+    def test_no_warning_when_zero_errors(self) -> None:
+        mock_logger = MagicMock()
+        with patch.object(reingest, "logger", mock_logger):
+            ratio = reingest._emit_partial_failure_warning(
+                errors=0,
+                total=10,
+                error_classes=None,
+                context="reingest",
+            )
+        assert ratio == 0.0
+        mock_logger.warning.assert_not_called()
+
+    def test_zero_total_returns_zero(self) -> None:
+        mock_logger = MagicMock()
+        with patch.object(reingest, "logger", mock_logger):
+            ratio = reingest._emit_partial_failure_warning(
+                errors=0,
+                total=0,
+                error_classes=None,
+            )
+        assert ratio == 0.0
+        mock_logger.warning.assert_not_called()
+
+    def test_top_error_class_none_without_classes(self) -> None:
+        mock_logger = MagicMock()
+        with patch.object(reingest, "logger", mock_logger):
+            ratio = reingest._emit_partial_failure_warning(
+                errors=2,
+                total=4,
+                error_classes=None,
+            )
+        assert ratio == pytest.approx(0.5)
+        assert mock_logger.warning.call_args.kwargs["top_error_class"] is None
+
+
+class TestParseS3Uri:
+    """Unit tests for the _parse_s3_uri helper (#4619)."""
+
+    def test_parses_bucket_and_key(self) -> None:
+        bucket, key = reingest._parse_s3_uri("s3://my-bucket/path/to/keys.txt")
+        assert bucket == "my-bucket"
+        assert key == "path/to/keys.txt"
+
+    def test_rejects_non_s3_uri(self) -> None:
+        with pytest.raises(ValueError):
+            reingest._parse_s3_uri("/local/path.txt")
+
+    def test_rejects_missing_key(self) -> None:
+        with pytest.raises(ValueError):
+            reingest._parse_s3_uri("s3://bucket-only")
+
+
+class TestProcessPrefixDocumentErrorClass:
+    """_process_prefix_document populates error_class (#4619)."""
+
+    def test_error_class_none_on_skip_invalid_key(self) -> None:
+        result = reingest._process_prefix_document(
+            "invalid/key",
+            "test-bucket",
+            "postgresql://test",
+            "redis://localhost:6379",
+            "",
+        )
+        assert result["status"] == "skip"
+        assert result["error_class"] is None
+
+    def test_error_class_set_on_s3_fetch_failure(self) -> None:
+        key = "federal/federal/courtlistener/raw/abc123.html"
+        mock_s3 = MagicMock()
+        mock_s3.get_object.side_effect = KeyError("boom")
+
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        with patch("framework.s3_cache.make_s3_client", return_value=mock_s3):
+            result = reingest._process_prefix_document(
+                key,
+                "test-bucket",
+                "postgresql://test",
+                "redis://localhost:6379",
+                "",
+            )
+        assert result["status"] == "error"
+        assert result["error_class"] == "KeyError"
+
+    def test_error_class_set_on_worker_raises(self) -> None:
+        content = b"<html>ok</html>"
+        key_hash = hashlib.sha256(content).hexdigest()
+        key = f"federal/federal/courtlistener/raw/{key_hash}.html"
+
+        mock_s3 = MagicMock()
+        body = MagicMock()
+        body.read.return_value = content
+        mock_s3.get_object.return_value = {"Body": body}
+
+        mock_worker = MagicMock()
+        mock_worker.process_event.side_effect = ValueError("bad extract")
+
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        with (
+            patch("framework.s3_cache.make_s3_client", return_value=mock_s3),
+            patch("ingestion.worker.IngestionWorker", return_value=mock_worker),
+            patch("redis.Redis.from_url", return_value=MagicMock()),
+        ):
+            result = reingest._process_prefix_document(
+                key,
+                "test-bucket",
+                "postgresql://test",
+                "redis://localhost:6379",
+                "",
+            )
+        assert result["status"] == "error"
+        assert result["error_class"] == "ValueError"
+
+    def test_error_class_none_on_success(self) -> None:
+        content = b"<html>ok</html>"
+        key_hash = hashlib.sha256(content).hexdigest()
+        key = f"federal/federal/courtlistener/raw/{key_hash}.html"
+
+        mock_s3 = MagicMock()
+        body = MagicMock()
+        body.read.return_value = content
+        mock_s3.get_object.return_value = {"Body": body}
+
+        mock_worker = MagicMock()
+        mock_worker.process_event = MagicMock()
+
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        with (
+            patch("framework.s3_cache.make_s3_client", return_value=mock_s3),
+            patch("ingestion.worker.IngestionWorker", return_value=mock_worker),
+            patch("redis.Redis.from_url", return_value=MagicMock()),
+        ):
+            result = reingest._process_prefix_document(
+                key,
+                "test-bucket",
+                "postgresql://test",
+                "redis://localhost:6379",
+                "",
+            )
+        assert result["status"] == "ok"
+        assert result["error_class"] is None
+
+
+class TestPrefixPartialFailureStats:
+    """run_reingest_from_prefix surfaces error_ratio / top class / failed_keys
+    and writes the failed-keys manifest (#4619)."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_partial_failure_surfaces_ratio_and_top_class(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+            "federal/federal/courtlistener/raw/ccc333.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future1 = MagicMock()
+        future1.result.return_value = {
+            "status": "ok",
+            "hash_mismatch": False,
+            "error_class": None,
+        }
+        future2 = MagicMock()
+        future2.result.return_value = {
+            "status": "error",
+            "hash_mismatch": False,
+            "error_class": "BrokenProcessPool",
+        }
+        future3 = MagicMock()
+        future3.result.return_value = {
+            "status": "error",
+            "hash_mismatch": False,
+            "error_class": "BrokenProcessPool",
+        }
+        pool.submit.side_effect = [future1, future2, future3]
+
+        # Map each future back to its key so failed_keys is populated in
+        # submit order (futures patched into as_completed in the same order).
+        futures_map = {future1: keys[0], future2: keys[1], future3: keys[2]}
+
+        mock_logger = MagicMock()
+        # ``skip_judge_prepass=True`` — see test_processes_documents_with_pool
+        # and #4449.
+        with (
+            patch(
+                "reingest_from_s3.as_completed",
+                return_value=[future1, future2, future3],
+            ),
+            patch.object(reingest, "logger", mock_logger),
+        ):
+            # Patch the dict comprehension's submit/key mapping by making
+            # submit return our futures; run_reingest_from_prefix builds the
+            # futures->key dict itself from the keys list, so the ordering is
+            # preserved.
+            _ = futures_map
+            stats = reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+                skip_judge_prepass=True,
+            )
+
+        assert stats["errors"] == 2
+        assert stats["error_ratio"] == pytest.approx(2 / 3)
+        assert stats["top_error_class"] == "BrokenProcessPool"
+        assert set(stats["failed_keys"]) == {keys[1], keys[2]}
+
+        warn_calls = mock_logger.warning.call_args_list
+        partial_warnings = [
+            call for call in warn_calls if call.kwargs.get("top_error_class") == "BrokenProcessPool"
+        ]
+        assert partial_warnings, (
+            f"expected partial-failure warning with top_error_class. Got: {warn_calls!r}"
+        )
+        assert partial_warnings[0].kwargs["error_ratio"] == pytest.approx(2 / 3, abs=1e-3)
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_future_raising_counts_as_error_with_class(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """A future that raises (e.g. BrokenProcessPool) is tallied as an
+        error and its exception class name is captured in error_classes."""
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future1 = MagicMock()
+        future1.result.return_value = {
+            "status": "ok",
+            "hash_mismatch": False,
+            "error_class": None,
+        }
+        future2 = MagicMock()
+        future2.result.side_effect = RuntimeError("pool died")
+        pool.submit.side_effect = [future1, future2]
+
+        with patch(
+            "reingest_from_s3.as_completed",
+            return_value=[future1, future2],
+        ):
+            stats = reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+                skip_judge_prepass=True,
+            )
+
+        assert stats["errors"] == 1
+        assert stats["top_error_class"] == "RuntimeError"
+        assert len(stats["failed_keys"]) == 1
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_writes_failed_manifest_when_failures(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        s3_client = MagicMock()
+        mock_boto3.client.return_value = s3_client
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future1 = MagicMock()
+        future1.result.return_value = {
+            "status": "ok",
+            "hash_mismatch": False,
+            "error_class": None,
+        }
+        future2 = MagicMock()
+        future2.result.return_value = {
+            "status": "error",
+            "hash_mismatch": False,
+            "error_class": "ValueError",
+        }
+        pool.submit.side_effect = [future1, future2]
+
+        with patch(
+            "reingest_from_s3.as_completed",
+            return_value=[future1, future2],
+        ):
+            stats = reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+                skip_judge_prepass=True,
+                write_failed_manifest="s3://manifest-bucket/failed/keys.txt",
+            )
+
+        assert stats["errors"] == 1
+        put_calls = [
+            call
+            for call in s3_client.put_object.call_args_list
+            if call.kwargs.get("Bucket") == "manifest-bucket"
+        ]
+        assert put_calls, (
+            f"expected put_object to manifest-bucket. Got: {s3_client.put_object.call_args_list!r}"
+        )
+        call = put_calls[0]
+        assert call.kwargs["Key"] == "failed/keys.txt"
+        body = call.kwargs["Body"]
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        assert body == "\n".join(stats["failed_keys"]) + "\n"
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_no_manifest_when_no_failures(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = []
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {}
+
+        s3_client = MagicMock()
+        mock_boto3.client.return_value = s3_client
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future1 = MagicMock()
+        future1.result.return_value = {
+            "status": "ok",
+            "hash_mismatch": False,
+            "error_class": None,
+        }
+        future2 = MagicMock()
+        future2.result.return_value = {
+            "status": "ok",
+            "hash_mismatch": False,
+            "error_class": None,
+        }
+        pool.submit.side_effect = [future1, future2]
+
+        with patch(
+            "reingest_from_s3.as_completed",
+            return_value=[future1, future2],
+        ):
+            stats = reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+                skip_judge_prepass=True,
+                write_failed_manifest="s3://manifest-bucket/failed/keys.txt",
+            )
+
+        assert stats["errors"] == 0
+        manifest_calls = [
+            call
+            for call in s3_client.put_object.call_args_list
+            if call.kwargs.get("Bucket") == "manifest-bucket"
+        ]
+        assert not manifest_calls
+
+
+class TestPrefixMaxErrorRatioExit:
+    """main() exit-code gating via --max-error-ratio (#4619)."""
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_no_flag_partial_failure_exits_zero(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """No --max-error-ratio: partial failure must NOT raise SystemExit
+        (backward-compatible exit 0)."""
+        mock_run_prefix.return_value = {
+            "total_keys": 10,
+            "processed": 6,
+            "errors": 4,
+            "skipped": 0,
+            "error_ratio": 0.4,
+        }
+        argv = ["reingest_from_s3", "--prefix", "x/"]
+        with patch("sys.argv", argv):
+            reingest.main()  # must not raise
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_above_threshold_exits_nonzero(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        mock_run_prefix.return_value = {
+            "total_keys": 10,
+            "processed": 5,
+            "errors": 5,
+            "skipped": 0,
+            "error_ratio": 0.5,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "x/",
+            "--max-error-ratio",
+            "0.05",
+        ]
+        with patch("sys.argv", argv):
+            with pytest.raises(SystemExit) as exc:
+                reingest.main()
+        assert exc.value.code == 1
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_below_threshold_no_exit(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        mock_run_prefix.return_value = {
+            "total_keys": 10,
+            "processed": 7,
+            "errors": 3,
+            "skipped": 0,
+            "error_ratio": 0.3,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "x/",
+            "--max-error-ratio",
+            "0.5",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()  # below threshold → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_all_success_with_zero_threshold_no_exit(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """error_ratio 0.0 with --max-error-ratio 0.0 must NOT exit (strictly
+        greater-than semantics)."""
+        mock_run_prefix.return_value = {
+            "total_keys": 10,
+            "processed": 10,
+            "errors": 0,
+            "skipped": 0,
+            "error_ratio": 0.0,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "x/",
+            "--max-error-ratio",
+            "0.0",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()  # all-success → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_write_failed_manifest_threaded_into_prefix(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        mock_run_prefix.return_value = {
+            "total_keys": 0,
+            "processed": 0,
+            "errors": 0,
+            "skipped": 0,
+            "error_ratio": 0.0,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "x/",
+            "--write-failed-manifest",
+            "s3://b/k",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()
+        assert mock_run_prefix.call_args.kwargs["write_failed_manifest"] == "s3://b/k"
+
+
+class TestStandardModeErrorRatioExit:
+    """main() standard (DB-row) mode threshold gating + run_reingest
+    error_ratio surfacing (#4619)."""
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest")
+    def test_standard_above_threshold_exits_nonzero(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = {
+            "total_processed": 5,
+            "total_updated": 5,
+            "total_llm_skipped": 0,
+            "error_ratio": 0.5,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--county",
+            "Fresno",
+            "--max-error-ratio",
+            "0.1",
+        ]
+        with patch("sys.argv", argv):
+            with pytest.raises(SystemExit) as exc:
+                reingest.main()
+        assert exc.value.code == 1
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest")
+    def test_standard_no_flag_partial_failure_exits_zero(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        mock_run.return_value = {
+            "total_processed": 5,
+            "total_updated": 5,
+            "total_llm_skipped": 0,
+            "error_ratio": 0.5,
+        }
+        argv = ["reingest_from_s3", "--county", "Fresno"]
+        with patch("sys.argv", argv):
+            reingest.main()  # must not raise

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -172,6 +172,18 @@ Options:
                         itself misbehaves; in normal operation it closes
                         the chronological resolver-race class.  See #4408
                         (parent #4397) and #4419 (extended to prefix mode).
+    --max-error-ratio R Fail the process (exit non-zero) when the observed
+                        error ratio strictly exceeds R (a fraction 0.0-1.0,
+                        e.g. 0.05 for 5%).  When unset (default), the exit
+                        code is unchanged — all-success and partial-failure
+                        both exit 0 — preserving the ECS-oneshot exit-code
+                        contract for existing callers.  Applies to both
+                        --prefix and standard mode.  See #4619.
+    --write-failed-manifest s3://bucket/key
+                        In --prefix mode, when at least one key fails, write
+                        the failed keys (one per line) to this S3 object so a
+                        retry can be scoped via --s3-key-list.  No-op when
+                        there are no failures or in standard mode.  See #4619.
 """
 
 from __future__ import annotations
@@ -186,6 +198,7 @@ import sys
 import tempfile
 import time
 import uuid
+from collections import Counter
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -4090,6 +4103,63 @@ def _seed_judges_from_keys(
     }
 
 
+def _parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Split an ``s3://bucket/key`` URI into ``(bucket, key)``.
+
+    Raises ``ValueError`` if *uri* is not an ``s3://`` URI or is missing
+    either the bucket or the key component.  Used by the prefix path to
+    resolve ``--write-failed-manifest s3://...`` destinations (#4619).
+    """
+    if not uri.startswith("s3://"):
+        raise ValueError(f"Not an s3:// URI: {uri}")
+    without_scheme = uri[len("s3://") :]
+    bucket, _, key = without_scheme.partition("/")
+    if not bucket or not key:
+        raise ValueError(
+            "s3:// URI must include both a bucket and a key "
+            f"(e.g. s3://my-bucket/path/keys.txt): {uri}"
+        )
+    return bucket, key
+
+
+def _emit_partial_failure_warning(
+    *,
+    errors: int,
+    total: int,
+    error_classes: Counter[str] | None = None,
+    context: str = "reingest",
+) -> float:
+    """Emit a WARNING-level summary when ``errors > 0``; return the error ratio.
+
+    Returns ``errors / total`` (0.0 when ``total == 0``).  No-ops (returns the
+    ratio without logging) when ``errors == 0`` so all-success runs stay quiet.
+    When ``error_classes`` is provided, the most common class is surfaced as
+    ``top_error_class`` so ops can see the dominant failure mode (e.g.
+    ``BrokenProcessPool`` OOM-kills).  See #4619.
+    """
+    error_ratio = errors / total if total else 0.0
+    if errors <= 0:
+        return error_ratio
+    top_error_class: str | None = None
+    if error_classes:
+        most_common = error_classes.most_common(1)
+        if most_common:
+            top_error_class = most_common[0][0]
+    logger.warning(
+        "Partial failure during %s — %d of %d documents failed (%.1f%%)",
+        context,
+        errors,
+        total,
+        100 * error_ratio,
+        errors=errors,
+        total=total,
+        error_ratio=round(error_ratio, 4),
+        top_error_class=top_error_class,
+        context=context,
+    )
+    return error_ratio
+
+
 def _process_prefix_document(
     key: str,
     bucket: str,
@@ -4118,6 +4188,11 @@ def _process_prefix_document(
 
     Returns a dict with:
       - ``status``: ``"ok"``, ``"skip"``, or ``"error"``
+      - ``error_class``: ``None`` for ok/skip results; the exception class
+        name (e.g. ``"BrokenProcessPool"``, ``"ValueError"``) for the two
+        error-return branches (S3 fetch failure and ``worker.process_event``
+        raising).  Surfaced so the prefix path can report the dominant
+        failure class in its partial-failure WARNING (#4619).
       - ``hash_mismatch``: whether the S3 key hash did not match the object
         bytes' SHA-256.  Non-fatal — reingest proceeds using the key hash as
         the canonical ``content_hash`` so the worker's LLM split path can
@@ -4127,7 +4202,7 @@ def _process_prefix_document(
     """
     parsed = _parse_s3_key(key)
     if not parsed:
-        return {"status": "skip", "hash_mismatch": False}
+        return {"status": "skip", "hash_mismatch": False, "error_class": None}
 
     from framework.s3_cache import make_s3_client as _make_s3
 
@@ -4135,12 +4210,16 @@ def _process_prefix_document(
     try:
         response = s3.get_object(Bucket=bucket, Key=key)
         content = response["Body"].read()
-    except Exception:
+    except Exception as exc:
         logger.warning("Failed to fetch S3 object, skipping", s3_key=key, exc_info=True)
-        return {"status": "error", "hash_mismatch": False}
+        return {
+            "status": "error",
+            "hash_mismatch": False,
+            "error_class": type(exc).__name__,
+        }
 
     if not content:
-        return {"status": "skip", "hash_mismatch": False}
+        return {"status": "skip", "hash_mismatch": False, "error_class": None}
 
     # Byte-integrity check.  A mismatch used to short-circuit with
     # ``status="error"``, but that caused the ~4% flat-hash orphan rate on
@@ -4204,10 +4283,14 @@ def _process_prefix_document(
 
     try:
         worker.process_event(event)
-        return {"status": "ok", "hash_mismatch": hash_mismatch}
-    except Exception:
+        return {"status": "ok", "hash_mismatch": hash_mismatch, "error_class": None}
+    except Exception as exc:
         logger.warning("Failed to process document", s3_key=key, exc_info=True)
-        return {"status": "error", "hash_mismatch": hash_mismatch}
+        return {
+            "status": "error",
+            "hash_mismatch": hash_mismatch,
+            "error_class": type(exc).__name__,
+        }
 
 
 def run_reingest_from_prefix(
@@ -4221,6 +4304,7 @@ def run_reingest_from_prefix(
     parse_timeout: float = 60.0,
     skip_judge_prepass: bool = False,
     s3_key_list: list[str] | None = None,
+    write_failed_manifest: str | None = None,
 ) -> dict[str, Any]:
     """Scan S3 by key prefix and ingest documents not in the DB.
 
@@ -4291,13 +4375,20 @@ def run_reingest_from_prefix(
         avoid the #2416 exponential explosion (see #4049), so the prefix path
         is the only avenue once a parent has been split — and this filter
         keeps that path from rescanning the entire prefix (see #3855).
+    write_failed_manifest:
+        Optional ``s3://bucket/key`` destination.  When set and at least one
+        key failed, the failed keys are written (one per line, trailing
+        newline) to that S3 object so a retry can be scoped via
+        ``--s3-key-list``.  No-op when ``None`` or when there are no
+        failures.  See #4619.
 
     Returns
     -------
     dict with keys: ``total_keys``, ``processed``, ``errors``, ``skipped``,
-    ``hash_mismatch_warnings``, ``wall_time_seconds``, and (when the judge
-    pre-pass ran) ``judge_prepass_docs_scanned``,
-    ``judge_prepass_judges_seeded``, ``judge_prepass_judges_skipped_invalid``.
+    ``hash_mismatch_warnings``, ``wall_time_seconds``, ``error_ratio``,
+    ``top_error_class``, ``failed_keys``, and (when the judge pre-pass ran)
+    ``judge_prepass_docs_scanned``, ``judge_prepass_judges_seeded``,
+    ``judge_prepass_judges_skipped_invalid``.
     """
     bucket = os.environ.get(
         "JUDGEMIND_ARCHIVE_BUCKET", "judgemind-document-archive-dev"
@@ -4432,6 +4523,8 @@ def run_reingest_from_prefix(
     errors = 0
     skipped = 0
     hash_mismatch_warnings = 0
+    failed_keys: list[str] = []
+    error_classes: Counter[str] = Counter()
 
     logger.info(
         "Processing documents from S3",
@@ -4472,6 +4565,11 @@ def run_reingest_from_prefix(
                     skipped += 1
                 else:
                     errors += 1
+                    failed_keys.append(key)
+                    if isinstance(result, dict):
+                        error_classes[result.get("error_class") or "unknown"] += 1
+                    else:
+                        error_classes["unknown"] += 1
                 total_done = processed + errors + skipped
                 if processed > 0 and processed % 50 == 0:
                     elapsed = time.monotonic() - t_start
@@ -4494,9 +4592,24 @@ def run_reingest_from_prefix(
                     )
             except Exception as exc:
                 errors += 1
+                failed_keys.append(key)
+                error_classes[type(exc).__name__] += 1
                 logger.error("Failed to process", key=key, error=str(exc))
 
     wall_time = round(time.monotonic() - t_start, 2)
+
+    # Partial-failure surfacing (#4619).  Denominator is the full key set so
+    # the ratio reflects fraction-of-attempted, and the WARNING names the
+    # dominant failure class (e.g. BrokenProcessPool OOM-kills).
+    error_ratio = _emit_partial_failure_warning(
+        errors=errors,
+        total=len(keys),
+        error_classes=error_classes,
+        context="reingest",
+    )
+    top_error_class: str | None = None
+    if error_classes:
+        top_error_class = error_classes.most_common(1)[0][0]
 
     stats: dict[str, Any] = {
         "total_keys": len(keys),
@@ -4505,6 +4618,9 @@ def run_reingest_from_prefix(
         "skipped": skipped,
         "hash_mismatch_warnings": hash_mismatch_warnings,
         "wall_time_seconds": wall_time,
+        "error_ratio": error_ratio,
+        "top_error_class": top_error_class,
+        "failed_keys": failed_keys,
     }
     if prepass_stats is not None:
         stats["judge_prepass_docs_scanned"] = prepass_stats["docs_scanned"]
@@ -4513,10 +4629,24 @@ def run_reingest_from_prefix(
             "judges_skipped_invalid"
         ]
 
+    # Spread the stats into the completion log but report ``failed_keys`` as a
+    # count rather than dumping the full list (which can be hundreds of keys).
+    log_stats = {k: v for k, v in stats.items() if k != "failed_keys"}
     logger.info(
         "Prefix reingest complete",
-        **stats,
+        failed_key_count=len(failed_keys),
+        **log_stats,
     )
+
+    if write_failed_manifest and failed_keys:
+        manifest_bucket, manifest_key = _parse_s3_uri(write_failed_manifest)
+        body = ("\n".join(failed_keys) + "\n").encode("utf-8")
+        s3_client.put_object(Bucket=manifest_bucket, Key=manifest_key, Body=body)
+        logger.info(
+            "Wrote failed-keys manifest",
+            manifest_uri=write_failed_manifest,
+            failed_key_count=len(failed_keys),
+        )
 
     if hash_mismatch_warnings > 0:
         logger.warning(
@@ -4898,6 +5028,17 @@ def run_reingest(
         "llm_api_calls": tracker.api_calls,
         "estimated_cost_usd": round(estimated_cost_usd, 4),
     }
+    # Partial-failure surfacing (#4619).  The DB-row path has no per-key
+    # error-class detail, so pass ``error_classes=None``.  Denominator guards
+    # against divide-by-zero (e.g. a 0-document run).
+    db_total = total_processed + total_failed
+    error_ratio = _emit_partial_failure_warning(
+        errors=total_failed,
+        total=db_total,
+        error_classes=None,
+        context="reingest",
+    )
+    result["error_ratio"] = error_ratio
     if before_metrics is not None:
         result["quality_before"] = before_metrics
     if after_metrics is not None:
@@ -4907,6 +5048,28 @@ def run_reingest(
     if prepass_stats is not None:
         result["judge_prepass"] = prepass_stats
     return result
+
+
+def _enforce_max_error_ratio(max_error_ratio: float | None, error_ratio: float) -> None:
+    """Exit non-zero when ``error_ratio`` strictly exceeds the threshold.
+
+    No-op when ``max_error_ratio`` is ``None`` (the flag was not passed) — this
+    preserves the ECS-oneshot exit-code contract for existing callers, which
+    exit 0 on partial failure.  Only a set threshold that is strictly exceeded
+    triggers ``sys.exit(1)``; all-success and below-threshold both return.
+    See #4619.
+    """
+    if max_error_ratio is None:
+        return
+    if error_ratio > max_error_ratio:
+        logger.warning(
+            "Error ratio %.4f exceeds --max-error-ratio %.4f — failing run",
+            error_ratio,
+            max_error_ratio,
+            error_ratio=round(error_ratio, 4),
+            max_error_ratio=max_error_ratio,
+        )
+        sys.exit(1)
 
 
 def main() -> None:
@@ -5083,7 +5246,10 @@ def main() -> None:
             "split-child rows; DB-row mode skips them to avoid #2416). "
             "See #4049.  Combine with --s3-key-list to narrow the scan to a "
             "hand-picked subset of keys under the prefix instead of the whole "
-            "prefix (#3855)."
+            "prefix (#3855).  Combine with --max-error-ratio to fail the run "
+            "when too large a fraction of keys error, and "
+            "--write-failed-manifest to capture the failed keys for a scoped "
+            "retry (#4619)."
         ),
     )
     parser.add_argument(
@@ -5171,6 +5337,33 @@ def main() -> None:
             "judge rows."
         ),
     )
+    parser.add_argument(
+        "--max-error-ratio",
+        type=float,
+        default=None,
+        help=(
+            "Fail the process (exit non-zero) when the observed error ratio "
+            "strictly exceeds this fraction (0.0-1.0, e.g. 0.05 for 5%%).  "
+            "The error ratio is errors/total_keys in --prefix mode and "
+            "total_failed/(total_processed+total_failed) in standard mode.  "
+            "When unset (default), the exit code is unchanged — all-success "
+            "and partial-failure both exit 0 — preserving the ECS-oneshot "
+            "exit-code contract for existing callers.  Only the presence of "
+            "this flag changes exit behavior.  See #4619."
+        ),
+    )
+    parser.add_argument(
+        "--write-failed-manifest",
+        type=str,
+        default=None,
+        dest="write_failed_manifest",
+        help=(
+            "An s3://bucket/key destination.  In --prefix mode, when at least "
+            "one key fails, the failed keys are written (one per line) to this "
+            "S3 object so a retry can be scoped via --s3-key-list.  No-op when "
+            "there are no failures or in standard (DB-row) mode.  See #4619."
+        ),
+    )
     args = parser.parse_args()
 
     if args.resume and not args.checkpoint_file:
@@ -5210,6 +5403,7 @@ def main() -> None:
             parse_timeout=args.parse_timeout,
             skip_judge_prepass=args.skip_judge_prepass,
             s3_key_list=s3_key_list_values,
+            write_failed_manifest=args.write_failed_manifest,
         )
         logger.info(
             "Prefix reingest complete",
@@ -5219,6 +5413,7 @@ def main() -> None:
             skipped=stats["skipped"],
             judge_prepass_judges_seeded=stats.get("judge_prepass_judges_seeded"),
         )
+        _enforce_max_error_ratio(args.max_error_ratio, stats.get("error_ratio", 0.0))
         return
 
     # Standard mode: query the database for existing document records.
@@ -5266,6 +5461,7 @@ def main() -> None:
         llm_api_calls=stats.get("llm_api_calls", 0),
         estimated_cost_usd=stats.get("estimated_cost_usd", 0),
     )
+    _enforce_max_error_ratio(args.max_error_ratio, stats.get("error_ratio", 0.0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`scripts/reingest_from_s3.py` no longer exits 0 when a large fraction of PDFs fail to re-extract. Both reingest paths now compute an error ratio and emit a loud WARNING (count + ratio + top error class) when any errors occurred. A new opt-in `--max-error-ratio` flag makes the process exit non-zero when the observed ratio strictly exceeds the threshold (default behavior unchanged — existing callers still exit 0, preserving the ECS-oneshot exit-code contract). The prefix path tracks per-key failures + exception classes (so `BrokenProcessPool` OOM-kills are named), and `--write-failed-manifest s3://...` writes the failed key set for a scoped retry via `--s3-key-list`.

Motivated by the #3855 Orange residual: a cache-bust reingest logged `processed=487, errors=281` (36.6% failed) yet exited 0, hiding the partial failure for 3 cycles.

Closes #4619

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component. `reingest_from_s3.py` is an operator-run ECS one-shot script invoked on demand via `scripts/ecs-run-task.sh`, not a continuously-deployed service. New behavior (exit-code gating, WARNING summary, manifest write) is fully covered by hermetic unit tests (`TestPrefixMaxErrorRatioExit`, `TestStandardModeErrorRatioExit`, `TestEmitPartialFailureWarning`, `TestPrefixPartialFailureStats`, `TestParseS3Uri`, `TestProcessPrefixDocumentErrorClass`).
- [x] Verification evidence posted on issue (see A.8)
