### PR TITLE
fix(ingestion): detect role-literal titles on either side of v. (#4618)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -92,6 +92,9 @@ from framework.llm_extractor import (
     _ROLE_LITERAL_TITLE_RE as _ROLE_LITERAL_TITLE_RE,
 )
 from framework.llm_extractor import (
+    _is_role_literal_title as _is_role_literal_title,
+)
+from framework.llm_extractor import (
     _rebuild_title_from_parties as _rebuild_title_from_parties,
 )
 from framework.llm_utils import parse_llm_json
@@ -683,8 +686,7 @@ def _llm_extract_rulings(
 
         case_title = entry.get("extracted_case_title")
         if case_title and (
-            _ROLE_LITERAL_TITLE_RE.match(case_title)
-            or _BRACKETED_PLACEHOLDER_TITLE_RE.search(case_title)
+            _is_role_literal_title(case_title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(case_title)
         ):
             rebuilt = _rebuild_title_from_parties(case_title, parties)
             if rebuilt is not None:

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -136,14 +136,68 @@ _SB_CASE_NUMBER_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Matches a case_title that is a role-literal placeholder: the LLM emitted the
-# role word ("Plaintiff", "Defendant", "Petitioner", "Respondent") as the party
-# name instead of the real name from the ruling body.  Both singular and plural
-# forms are covered.  See #2565.
+# Matches a case_title whose LEFT segment is a role-literal placeholder: the LLM
+# emitted the role word ("Plaintiff", "Defendant", "Petitioner", "Respondent") as
+# the party name instead of the real name from the ruling body.  Both singular and
+# plural forms are covered.  Left-anchored only — kept for back-compat and as the
+# left-side building block of :func:`_is_role_literal_title`, which extends
+# detection to a role-literal placeholder on EITHER side of ``v.`` (#4618).
+# See #2565.
 _ROLE_LITERAL_TITLE_RE = re.compile(
     r"^\s*(?:Plaintiff|Defendant|Petitioner|Respondent)s?\s+v[s]?\.?\s",
     re.IGNORECASE,
 )
+
+# A single role token, allowing singular/plural and the cross-prefixed forms.
+# Used by :func:`_is_role_literal_title` to test whether a ``/``-separated piece
+# of a title segment is a pure role word.  See #4618.
+_ROLE_TOKEN = r"(?:Cross-)?(?:Plaintiff|Defendant|Petitioner|Respondent|Complainant)s?"
+
+# Matches a title segment (one side of ``v.``) that is ENTIRELY a role-literal
+# compound — every ``/``-separated piece is a role token, with no trailing real
+# text.  Anchored start-to-end so ``Defendants Inc.`` (real company) does NOT
+# match while ``Defendants/Cross-Complainants`` does.  See #4618.
+_ROLE_LITERAL_SEGMENT_RE = re.compile(
+    rf"^\s*{_ROLE_TOKEN}(?:\s*/\s*{_ROLE_TOKEN})*\s*$",
+    re.IGNORECASE,
+)
+
+# Splits a title on the ``v.``/``vs.``/``v``/``vs`` party separator using a word
+# boundary so it does not fire inside a real word.  See #4618.
+_VS_SEPARATOR_RE = re.compile(r"\bv[s]?\.?\s+", re.IGNORECASE)
+
+
+def _is_role_literal_title(title: str | None) -> bool:
+    """Return True when EITHER side of the ``v.`` separator is a role-literal (#4618).
+
+    A *role-literal title* is one where the LLM substituted a role word
+    ("Plaintiff", "Defendant", "Petitioner", "Respondent", their plurals, and the
+    cross-prefixed / ``/``-joined compounds) for a real party name, on the left,
+    the right, or both sides of the ``v.``/``vs.`` separator. Examples that match:
+
+    - ``Plaintiff v. General Motors, LLC`` (left)
+    - ``Acme Corp v. Defendants`` (right)
+    - ``Tcfi Cp Llc v. Defendants/Cross-Complainants`` (right compound)
+    - ``Plaintiff/Petitioner v. Defendant/Respondent`` (both)
+
+    The detection is anchored to the WHOLE segment, so a real party name that
+    merely contains a role word as a substring is NOT flagged:
+
+    - ``Smith v. Defendants Inc.`` (trailing real text → not role-literal)
+    - ``Plaintiff Holdings LLC v. Smith`` (leading role word + real text)
+    - ``Aasi v. American Honda`` / ``Doe v. Roe`` (clean)
+
+    Returns ``False`` for ``None``, empty, whitespace-only, or any title without a
+    recognisable ``v.`` separator.
+    """
+    if not title or not title.strip():
+        return False
+    parts = _VS_SEPARATOR_RE.split(title, maxsplit=1)
+    if len(parts) != 2:
+        return False
+    left, right = parts
+    return bool(_ROLE_LITERAL_SEGMENT_RE.match(left) or _ROLE_LITERAL_SEGMENT_RE.match(right))
+
 
 # Matches a case_title that contains an LLM-hallucinated bracketed placeholder
 # for a party name, e.g. "Ezra Arce v. [Defendant not specified]" or
@@ -1416,13 +1470,15 @@ def _rebuild_title_from_parties(
     title: str | None,
     parties: list,
 ) -> str | None:
-    """Rebuild a role-literal ``case_title`` from ``extracted_parties`` (#2565).
+    """Rebuild a role-literal ``case_title`` from ``extracted_parties`` (#2565, #4618).
 
-    If *title* matches ``_ROLE_LITERAL_TITLE_RE`` (e.g. ``"Plaintiff v. Defendant"``),
-    attempt to reconstruct ``"<first-plaintiff> v. <first-defendant>"`` from
-    *parties*.  Returns ``None`` when the title does not match the pattern or
-    when the required parties are not available (so the caller can leave the
-    field unchanged or emit a warning).
+    If *title* is role-literal per :func:`_is_role_literal_title` — a role word on
+    EITHER side of ``v.``, e.g. ``"Plaintiff v. Defendant"`` or
+    ``"Acme Corp v. Defendants"`` — or matches
+    ``_BRACKETED_PLACEHOLDER_TITLE_RE``, attempt to reconstruct
+    ``"<first-plaintiff> v. <first-defendant>"`` from *parties*.  Returns ``None``
+    when the title is not a placeholder or when the required parties are not
+    available (so the caller can leave the field unchanged or emit a warning).
 
     Parameters
     ----------
@@ -1440,14 +1496,16 @@ def _rebuild_title_from_parties(
         parties are insufficient to rebuild.
     """
     if not title or not (
-        _ROLE_LITERAL_TITLE_RE.match(title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(title)
+        _is_role_literal_title(title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(title)
     ):
         return None
 
     # Determine which role pair to look for.  Petitions use petitioner/respondent;
-    # everything else uses plaintiff/defendant.
+    # everything else uses plaintiff/defendant.  With right-side placeholders the
+    # role word may be on the right (e.g. ``"<RealName> v. Respondents"``), so a
+    # petitioner/respondent token on EITHER side selects that pair (#4618).
     title_lower = title.lower().strip()
-    if title_lower.startswith("petitioner"):
+    if "petitioner" in title_lower or "respondent" in title_lower:
         plaintiff_roles = {"petitioner"}
         defendant_roles = {"respondent"}
     else:
@@ -2145,8 +2203,9 @@ def _drop_short_unsubstantive_rulings(
 # case_number instead of the real one.
 #
 # Drop condition (all three must hold):
-#   * ``_ROLE_LITERAL_TITLE_RE`` matches ``extracted_case_title``, OR
-#     ``_BRACKETED_PLACEHOLDER_TITLE_RE`` matches anywhere in the title
+#   * ``_is_role_literal_title`` is True for ``extracted_case_title`` (role word
+#     on EITHER side of ``v.`` — #4618), OR ``_BRACKETED_PLACEHOLDER_TITLE_RE``
+#     matches anywhere in the title
 #   * ``extracted_case_number`` is None or empty string
 #   * ``entry_number`` is None
 #
@@ -2168,8 +2227,10 @@ def _drop_role_literal_orphan_rulings(
        ``extracted_case_title``, and ``entry_number`` (a stub
        cross-reference text like "Ctrl Click on Line N …").
     2. A **body-section orphan** with empty ``extracted_case_number``,
-       a role-literal title like ``"Plaintiff v. FCA"`` (matching
-       ``_ROLE_LITERAL_TITLE_RE``), and no ``entry_number``.
+       a role-literal title like ``"Plaintiff v. FCA"`` or
+       ``"Acme Corp v. Defendants"`` (detected by
+       :func:`_is_role_literal_title` on either side of ``v.`` — #4618), and
+       no ``entry_number``.
 
     The orphan is an artefact of multi-page PDF parsing — the ruling body
     starts on a fresh page without a proper case header, so the LLM
@@ -2180,7 +2241,8 @@ def _drop_role_literal_orphan_rulings(
     Rules:
 
     - A ruling is dropped when ALL THREE conditions hold:
-      1. ``_ROLE_LITERAL_TITLE_RE`` matches ``extracted_case_title``, OR
+      1. ``_is_role_literal_title`` is True for ``extracted_case_title`` (role
+         word on either side of ``v.`` — #4618), OR
          ``_BRACKETED_PLACEHOLDER_TITLE_RE`` matches anywhere in the title
       2. ``extracted_case_number`` is None or empty
       3. ``entry_number`` is None
@@ -2196,7 +2258,7 @@ def _drop_role_literal_orphan_rulings(
         has_case_number = bool(ruling.extracted_case_number)
         has_entry_number = ruling.entry_number is not None
         if (
-            (_ROLE_LITERAL_TITLE_RE.match(title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(title))
+            (_is_role_literal_title(title) or _BRACKETED_PLACEHOLDER_TITLE_RE.search(title))
             and not has_case_number
             and not has_entry_number
         ):

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -4201,6 +4201,121 @@ class TestLlmExtractRulingsRoleLiteralTitle:
         assert len(result) == 1
         assert result[0].case_title == "Aasi v. American Honda"
 
+    def test_role_literal_right_side_dropped_when_no_parties(self) -> None:
+        """Right-side role-literal 'Acme Corp v. Defendants' + no parties → None (#4618)."""
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV11111",
+                "extracted_case_title": "Acme Corp v. Defendants",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV11111</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title is None
+
+    def test_role_literal_right_side_compound_dropped_when_no_parties(self) -> None:
+        """Right-side compound 'Tcfi Cp Llc v. Defendants/Cross-Complainants' → None (#4618)."""
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV22222",
+                "extracted_case_title": "Tcfi Cp Llc v. Defendants/Cross-Complainants",
+                "outcome": "granted",
+                "ruling_text": "The motion is GRANTED.",
+                "parties": [],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV22222</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title is None
+
+    def test_role_literal_right_side_rebuilt_from_parties(self) -> None:
+        """Right-side role-literal WITH real parties → rebuilt to plaintiff v. defendant (#4618)."""
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV33333",
+                "extracted_case_title": "Acme Corp v. Defendants",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [
+                    {"name": "Acme Corp", "role": "plaintiff"},
+                    {"name": "General Motors, LLC", "role": "defendant"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV33333</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Acme Corp v. General Motors, LLC"
+
+    def test_role_literal_right_side_respondent_rebuilt_petitioner_pair(self) -> None:
+        """Right-side 'Respondents' selects the petitioner/respondent pair on rebuild (#4618)."""
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCP44444",
+                "extracted_case_title": "Jane Roe v. Respondents",
+                "outcome": "granted",
+                "ruling_text": "The petition is GRANTED.",
+                "parties": [
+                    {"name": "Jane Roe", "role": "petitioner"},
+                    {"name": "City of Los Angeles", "role": "respondent"},
+                ],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCP44444</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Jane Roe v. City of Los Angeles"
+
+    def test_role_literal_real_company_defendants_inc_passthrough(self) -> None:
+        """'Smith v. Defendants Inc.' is a real company → passes through unchanged (#4618).
+
+        No parties supplied so the reversed-title sanitizer cannot fire; the
+        false-positive guard must leave this real-company title intact.
+        """
+        rulings_data = [
+            {
+                "extracted_case_number": "25STCV55555",
+                "extracted_case_title": "Smith v. Defendants Inc.",
+                "outcome": "denied",
+                "ruling_text": "The motion is DENIED.",
+                "parties": [],
+            }
+        ]
+        mock_response = _make_llm_response(rulings_data)
+        with patch("ingestion.llm_providers.call_llm", return_value=mock_response):
+            result = _llm_extract_rulings(
+                "<html><body><div id='speechSynthesis'>Case Number: 25STCV55555</div></body></html>"
+            )
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].case_title == "Smith v. Defendants Inc."
+
 
 # ---------------------------------------------------------------------------
 # TestLlmExtractRulingsReversedTitle — reversed case_title correction (#3846)

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -4850,6 +4850,40 @@ class TestRoleLiteralOrphanDrop:
         assert len(result) == 1
         assert result[0].extracted_case_number == "25CV458975"
 
+    def test_drops_right_side_role_literal_orphan(self) -> None:
+        """Right-side role-literal orphan (no case_number, no entry) is dropped (#4618)."""
+        orphan = ExtractedRuling(
+            extracted_case_title="Tcfi Cp Llc v. Defendants/Cross-Complainants",
+            extracted_case_number=None,
+            entry_number=None,
+            ruling_text="The Court rules as follows: DENIED." * 30,
+        )
+        result = _drop_role_literal_orphan_rulings([orphan])
+        assert result == []
+
+    def test_preserves_right_side_role_literal_lookalike_with_case_number(self) -> None:
+        """A real-company 'X v. Defendants Inc.' WITH a case_number is preserved (#4618)."""
+        ruling = ExtractedRuling(
+            extracted_case_title="Smith v. Defendants Inc.",
+            extracted_case_number="24CV654321",
+            entry_number=None,
+            ruling_text="The motion is DENIED." * 50,
+        )
+        result = _drop_role_literal_orphan_rulings([ruling])
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "24CV654321"
+
+    def test_preserves_right_side_role_literal_lookalike_orphan(self) -> None:
+        """'X v. Defendants Inc.' is NOT role-literal → not dropped even as an orphan (#4618)."""
+        ruling = ExtractedRuling(
+            extracted_case_title="Smith v. Defendants Inc.",
+            extracted_case_number=None,
+            entry_number=None,
+            ruling_text="The motion is DENIED." * 50,
+        )
+        result = _drop_role_literal_orphan_rulings([ruling])
+        assert len(result) == 1
+
     # ------------------------------------------------------------------
     # SC end-to-end via _join_page_rows (#3663 AC1 + AC2)
     # ------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
+++ b/packages/scraper-framework/tests/test_san_bernardino_multi_case.py
@@ -31,6 +31,7 @@ from framework.llm_extractor import (
     _BRACKETED_PLACEHOLDER_TITLE_RE,
     _SB_CASE_NUMBER_RE,
     _disjoint_plaintiff_names,
+    _is_role_literal_title,
     _rebuild_title_from_parties,
     _sanitize_san_bernardino_rulings,
     _truncate_concatenated_case_titles,
@@ -566,3 +567,62 @@ def test_sanitize_sb_rulings_inherited_case_number_no_anchor_parties_is_noop() -
     result = _sanitize_san_bernardino_rulings(rulings, case_number_re=_SB_CASE_NUMBER_RE)
     # Conservative: anchor has no plaintiffs so subsequent is left unchanged
     assert result[1].extracted_case_number == shared_cn
+
+
+# ---------------------------------------------------------------------------
+# _is_role_literal_title — detection on EITHER side of v. (#4618)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # Left-anchored (old regex behaviour — must still detect)
+        "Plaintiff v. General Motors, LLC",
+        "Defendant v. Smith",
+        "Petitioner v. Smith",
+        "Respondent v. Smith",
+        "Plaintiffs v. Smith",
+        "Defendants v. Smith",
+        # Right-only (the new behaviour — previously MISSED)
+        "Acme Corp v. Defendants",
+        "Tcfi Cp Llc v. Defendants/Cross-Complainants",
+        "Smith v. Defendant",
+        "Plaintiff/Petitioner v. Defendant/Respondent",
+        "Jane Roe v. Respondents",
+        # vs. / vs / v separator variants
+        "Acme Corp vs. Defendants",
+        "Acme Corp vs Defendants",
+        "Acme Corp v Defendants",
+    ],
+)
+def test_is_role_literal_title_detected(title: str) -> None:
+    """A role-literal placeholder on either side of v. is detected (#4618)."""
+    assert _is_role_literal_title(title) is True
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        # Segment merely starts with / contains a role word but has real text
+        "Smith v. Defendants Inc.",
+        "Plaintiff Holdings LLC v. Smith",
+        # Clean real-party titles
+        "Aasi v. American Honda",
+        "Doe v. Roe",
+        # No separator at all
+        "In re Estate of Smith",
+        # Compound where one piece is NOT a role token
+        "Acme Corp v. Defendants/Acme",
+    ],
+)
+def test_is_role_literal_title_false_positive_guard(title: str) -> None:
+    """A real party name that merely contains a role word is NOT flagged (#4618)."""
+    assert _is_role_literal_title(title) is False
+
+
+def test_is_role_literal_title_none_and_empty_return_false() -> None:
+    """None and empty-string inputs return False (#4618)."""
+    assert _is_role_literal_title(None) is False
+    assert _is_role_literal_title("") is False
+    assert _is_role_literal_title("   ") is False


### PR DESCRIPTION
## Summary

`_ROLE_LITERAL_TITLE_RE` was left-anchored, so it caught `Plaintiff v. X` but missed right-side role-literal placeholders like `X v. Defendants` and `Tcfi Cp Llc v. Defendants/Cross-Complainants`. Those titles were written to `derived.cases` verbatim and could not be cleared by an LA rebuild (this blocks #3971 AC#1). This PR adds `_is_role_literal_title()`, which detects a role-literal placeholder on EITHER side of the `v.`/`vs.` separator while preserving the false-positive guard (real names like `Smith v. Defendants Inc.` are NOT flagged), and wires it into all three downstream gate sites.

Regex before/after:
- Before (left-only): `^\s*(?:Plaintiff|Defendant|Petitioner|Respondent)s?\s+v[s]?\.?\s` via `.match()`.
- After: split on `\bv[s]?\.?\s+`, test each stripped side against `^\s*<role-token>(?:\s*/\s*<role-token>)*\s*$` (anchored start-to-end), where `<role-token>` = `(?:Cross-)?(?:Plaintiff|Defendant|Petitioner|Respondent|Complainant)s?`. Match on either side ⇒ role-literal.

Closes #4618

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed-component verification needed in this PR. AC#3 (#3971 AC#1 query → 0) requires deploy + `rebuild_db.py --county "Los Angeles"`, which #3971 owns; merging this auto-unblocks #3971.
- [x] Verification evidence posted on issue (see A.8)
