### PR TITLE
feat(ingestion): default-on partial-failure exit gate for cache-bust prefix reingests (#4624)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -630,6 +630,22 @@ Best practices:
 | Fix wrong **identity-anchor** fields (`judge_id`, `case_id`) on existing rulings | `rebuild_db.py --reset --county <name>` | Identity anchors use preserve-first `COALESCE(rulings.col, EXCLUDED.col)` semantics in `insert_ruling` (#2475) — a plain rebuild (no `--reset`) cannot replace an existing wrong `judge_id` or `case_id` with a corrected one. `--reset` truncates the county's `derived.*` rows first so the next ingest writes the corrected anchors freshly. Correctable facts (`hearing_date`, `outcome`, `motion_type`, `department`, `ruling_text`, `ruling_text_html`, `summary`) use incoming-wins semantics and update without `--reset`. See `packages/scraper-framework/src/ingestion/db.py::insert_ruling` for the full column classification. (#3732, #4284) |
 | Full database rebuild from scratch | `rebuild_db.py --reset` | `--reset` is opt-in and truncates derived tables before re-processing everything from S3. |
 
+**Partial-failure exit gate (#4624).** A `--bust-llm-cache` **prefix** reingest
+fails loud by default — it exits non-zero when more than 10% of keys error, so
+a run that silently lost data (the #3855 Orange residual OOM-killed 167/768
+PDFs and exited 0) surfaces as a non-zero exit instead of a false success. The
+gate is on automatically for the cache-bust prefix path:
+
+```
+scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --prefix orange/ --bust-llm-cache
+```
+
+Override the threshold with `--max-error-ratio 0.05` (your value always wins),
+or opt out with `--no-fail-on-errors` for a run where partial failure is
+expected. Standard (DB-row) mode and non-cache-bust prefix runs keep the
+pre-#4619 opt-in behavior — pass `--max-error-ratio` explicitly there if you
+want the gate. See #4619 and #4624.
+
 ### One-off / permanent script convention
 
 Every top-level `scripts/*.py` file (excluding the `archive/`, `eval/`, `tests/`, and `spotcheck/` subdirectories) must carry exactly one of these headers in the first 50 lines:

--- a/docs/agent/llm-cache.md
+++ b/docs/agent/llm-cache.md
@@ -56,6 +56,23 @@ Example invocation:
 scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county orange --bust-llm-cache
 ```
 
+**Partial-failure exit gate (#4624).** For `--bust-llm-cache` **prefix**
+reingests, the script fails loud by default — it exits non-zero when more than
+10% of keys error, so a run that silently lost data (the #3855 OOM failure
+mode) surfaces as a non-zero exit instead of a false success. You do not need
+to pass anything to get this; the gate is the default for the cache-bust prefix
+path:
+
+```
+scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --prefix orange/ --bust-llm-cache
+```
+
+To override the threshold pass `--max-error-ratio 0.05` (your value always
+wins). To opt out of the gate entirely for a run where partial failure is
+expected, pass `--no-fail-on-errors`. Standard (DB-row) mode and non-cache-bust
+prefix runs keep the pre-#4619 opt-in behavior — pass `--max-error-ratio`
+explicitly there if you want the gate. See #4619 and #4624.
+
 ## When surgical DB cleanup is appropriate
 
 The default cleanup path for `derived.*` data is always `rebuild_db.py --county <name>` per CLAUDE.md. Prefer a rebuild when the bad data exists in S3 (i.e., the raw document is fine and the ingestion pipeline will produce correct output on replay).

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -15452,3 +15452,271 @@ class TestStandardModeErrorRatioExit:
         argv = ["reingest_from_s3", "--county", "Fresno"]
         with patch("sys.argv", argv):
             reingest.main()  # must not raise
+
+
+class TestResolveEffectiveMaxErrorRatio:
+    """Unit tests for the #4624 effective-threshold resolver.
+
+    Pinpoints the decision logic that makes the partial-failure exit gate the
+    default for --bust-llm-cache prefix reingests while leaving every other
+    path's exit-code contract untouched (#4619).
+    """
+
+    def test_cache_bust_prefix_defaults_to_gate(self) -> None:
+        """The headline #4624 behavior: a --bust-llm-cache prefix reingest with
+        no explicit threshold defaults to the 10% gate."""
+        result = reingest._resolve_effective_max_error_ratio(
+            explicit_max_error_ratio=None,
+            no_fail_on_errors=False,
+            prefix="orange/",
+            bust_llm_cache=True,
+        )
+        assert result == reingest._DEFAULT_CACHE_BUST_PREFIX_MAX_ERROR_RATIO
+        assert result == 0.10
+
+    def test_prefix_without_bust_is_unchanged(self) -> None:
+        """A prefix reingest WITHOUT --bust-llm-cache keeps the opt-in
+        contract — no default gate."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=None,
+                no_fail_on_errors=False,
+                prefix="orange/",
+                bust_llm_cache=False,
+            )
+            is None
+        )
+
+    def test_bust_without_prefix_is_unchanged(self) -> None:
+        """--bust-llm-cache in standard (no --prefix) mode keeps the opt-in
+        contract — the default gate is scoped to the prefix path only."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=None,
+                no_fail_on_errors=False,
+                prefix=None,
+                bust_llm_cache=True,
+            )
+            is None
+        )
+
+    def test_standard_mode_is_unchanged(self) -> None:
+        """Plain standard mode (no prefix, no bust) keeps the opt-in
+        contract."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=None,
+                no_fail_on_errors=False,
+                prefix=None,
+                bust_llm_cache=False,
+            )
+            is None
+        )
+
+    def test_explicit_threshold_wins_over_default(self) -> None:
+        """An explicit --max-error-ratio always wins, even on the cache-bust
+        prefix path that would otherwise default to 0.10."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=0.5,
+                no_fail_on_errors=False,
+                prefix="orange/",
+                bust_llm_cache=True,
+            )
+            == 0.5
+        )
+
+    def test_explicit_zero_threshold_wins(self) -> None:
+        """An explicit --max-error-ratio 0.0 (fail on any error) is honored,
+        not swallowed by the default — 0.0 is not None."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=0.0,
+                no_fail_on_errors=False,
+                prefix="orange/",
+                bust_llm_cache=True,
+            )
+            == 0.0
+        )
+
+    def test_no_fail_on_errors_opts_out_of_default(self) -> None:
+        """--no-fail-on-errors disables the cache-bust prefix default."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=None,
+                no_fail_on_errors=True,
+                prefix="orange/",
+                bust_llm_cache=True,
+            )
+            is None
+        )
+
+    def test_no_fail_on_errors_overrides_explicit_threshold(self) -> None:
+        """--no-fail-on-errors overrides --max-error-ratio when both are
+        passed — the opt-out always wins."""
+        assert (
+            reingest._resolve_effective_max_error_ratio(
+                explicit_max_error_ratio=0.05,
+                no_fail_on_errors=True,
+                prefix="orange/",
+                bust_llm_cache=True,
+            )
+            is None
+        )
+
+
+class TestCacheBustPrefixDefaultGateExit:
+    """main() exit-code gating for the #4624 default-on cache-bust prefix
+    gate.  Exercises the full main() dispatch, not just the resolver."""
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_default_gate_fires_on_cache_bust_partial_failure(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """The headline regression: --prefix + --bust-llm-cache with a partial
+        failure above 10% exits non-zero WITHOUT any --max-error-ratio flag."""
+        mock_run_prefix.return_value = {
+            "total_keys": 768,
+            "processed": 601,
+            "errors": 167,
+            "skipped": 0,
+            "error_ratio": 167 / 768,  # ~0.217, the #3855 incident shape
+        }
+        argv = ["reingest_from_s3", "--prefix", "orange/", "--bust-llm-cache"]
+        with patch("sys.argv", argv):
+            with pytest.raises(SystemExit) as exc:
+                reingest.main()
+        assert exc.value.code == 1
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_default_gate_all_success_exits_zero(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """A clean --bust-llm-cache prefix run (error_ratio 0.0) must still
+        exit 0 — the default gate must not break legitimate all-success
+        runs."""
+        mock_run_prefix.return_value = {
+            "total_keys": 768,
+            "processed": 768,
+            "errors": 0,
+            "skipped": 0,
+            "error_ratio": 0.0,
+        }
+        argv = ["reingest_from_s3", "--prefix", "orange/", "--bust-llm-cache"]
+        with patch("sys.argv", argv):
+            reingest.main()  # all-success → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_default_gate_below_threshold_exits_zero(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """A --bust-llm-cache prefix run with a single-key error below the 10%
+        default does NOT exit non-zero (permissive default)."""
+        mock_run_prefix.return_value = {
+            "total_keys": 100,
+            "processed": 95,
+            "errors": 5,
+            "skipped": 0,
+            "error_ratio": 0.05,  # below the 0.10 default
+        }
+        argv = ["reingest_from_s3", "--prefix", "orange/", "--bust-llm-cache"]
+        with patch("sys.argv", argv):
+            reingest.main()  # below default threshold → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_no_fail_on_errors_opts_out_of_default_gate(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """--no-fail-on-errors disables the default gate even on a cache-bust
+        prefix partial failure above 10%."""
+        mock_run_prefix.return_value = {
+            "total_keys": 768,
+            "processed": 601,
+            "errors": 167,
+            "skipped": 0,
+            "error_ratio": 167 / 768,
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "orange/",
+            "--bust-llm-cache",
+            "--no-fail-on-errors",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()  # opt-out → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_explicit_threshold_overrides_default_gate(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """An explicit --max-error-ratio above the observed ratio keeps a
+        cache-bust prefix run green even though the default 0.10 gate would
+        have failed it."""
+        mock_run_prefix.return_value = {
+            "total_keys": 100,
+            "processed": 85,
+            "errors": 15,
+            "skipped": 0,
+            "error_ratio": 0.15,  # above 0.10 default, below explicit 0.5
+        }
+        argv = [
+            "reingest_from_s3",
+            "--prefix",
+            "orange/",
+            "--bust-llm-cache",
+            "--max-error-ratio",
+            "0.5",
+        ]
+        with patch("sys.argv", argv):
+            reingest.main()  # explicit threshold not exceeded → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest_from_prefix")
+    def test_non_cache_bust_prefix_partial_failure_exits_zero(
+        self,
+        mock_run_prefix: MagicMock,
+    ) -> None:
+        """A prefix reingest WITHOUT --bust-llm-cache keeps the #4619 opt-in
+        contract: a partial failure above 10% still exits 0 when no
+        --max-error-ratio is passed (the default gate must NOT leak onto the
+        non-cache-bust prefix path)."""
+        mock_run_prefix.return_value = {
+            "total_keys": 100,
+            "processed": 70,
+            "errors": 30,
+            "skipped": 0,
+            "error_ratio": 0.30,
+        }
+        argv = ["reingest_from_s3", "--prefix", "orange/"]
+        with patch("sys.argv", argv):
+            reingest.main()  # no bust → opt-in contract → no SystemExit
+
+    @patch.dict(os.environ, {"DATABASE_URL": "postgres://test:test@test/test"})
+    @patch("reingest_from_s3.run_reingest")
+    def test_standard_mode_with_bust_partial_failure_exits_zero(
+        self,
+        mock_run: MagicMock,
+    ) -> None:
+        """Standard (DB-row) mode with --bust-llm-cache keeps the #4619 opt-in
+        contract: the default gate is scoped to the prefix path, so a partial
+        failure here still exits 0 without --max-error-ratio."""
+        mock_run.return_value = {
+            "total_processed": 5,
+            "total_updated": 5,
+            "total_llm_skipped": 0,
+            "error_ratio": 0.5,
+        }
+        argv = ["reingest_from_s3", "--county", "Fresno", "--bust-llm-cache"]
+        with patch("sys.argv", argv):
+            reingest.main()  # standard mode → opt-in contract → no SystemExit

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -174,11 +174,23 @@ Options:
                         (parent #4397) and #4419 (extended to prefix mode).
     --max-error-ratio R Fail the process (exit non-zero) when the observed
                         error ratio strictly exceeds R (a fraction 0.0-1.0,
-                        e.g. 0.05 for 5%).  When unset (default), the exit
-                        code is unchanged — all-success and partial-failure
-                        both exit 0 — preserving the ECS-oneshot exit-code
-                        contract for existing callers.  Applies to both
-                        --prefix and standard mode.  See #4619.
+                        e.g. 0.05 for 5%).  When unset, the exit code is
+                        unchanged for standard mode and non-cache-bust prefix
+                        runs — all-success and partial-failure both exit 0 —
+                        preserving the ECS-oneshot exit-code contract for
+                        existing callers (#4619).  **Exception (#4624):** a
+                        ``--bust-llm-cache`` prefix reingest defaults to a
+                        0.10 (10%) gate when this flag is unset, so the path
+                        that recreated the #3855 incident fails loud by
+                        default.  Pass --no-fail-on-errors to opt out, or an
+                        explicit --max-error-ratio to set your own threshold.
+                        Applies to both --prefix and standard mode.
+    --no-fail-on-errors Opt out of the partial-failure exit gate entirely,
+                        even for --bust-llm-cache prefix reingests where it is
+                        on by default (#4624).  Exits 0 on partial failure
+                        like every pre-#4619 caller.  Overrides
+                        --max-error-ratio when both are passed.  Reserved for
+                        runs where partial failure is expected.
     --write-failed-manifest s3://bucket/key
                         In --prefix mode, when at least one key fails, write
                         the failed keys (one per line) to this S3 object so a
@@ -5050,14 +5062,68 @@ def run_reingest(
     return result
 
 
+# Default partial-failure exit-gate threshold applied automatically to
+# ``--bust-llm-cache`` prefix reingests when the operator does not pass an
+# explicit ``--max-error-ratio`` and does not opt out via
+# ``--no-fail-on-errors`` (#4624).  A cache-bust prefix reingest is the exact
+# path that recreated the #3855 incident (Orange residual OOM-killed 167/768
+# PDFs, exited 0).  ``--bust-llm-cache`` runs re-extract every key through the
+# LLM, so a non-trivial error fraction is always a signal that the run
+# silently lost data — failing loud by default closes the "operator forgot
+# --max-error-ratio" gap that is the same root cause as the original
+# incident.  0.10 (10%) is deliberately permissive: it does not trip on the
+# occasional single-key transcription error in a small prefix, but it does
+# catch the bulk-OOM / bulk-timeout failure mode #3855 produced.
+_DEFAULT_CACHE_BUST_PREFIX_MAX_ERROR_RATIO = 0.10
+
+
+def _resolve_effective_max_error_ratio(
+    *,
+    explicit_max_error_ratio: float | None,
+    no_fail_on_errors: bool,
+    prefix: str | None,
+    bust_llm_cache: bool,
+) -> float | None:
+    """Decide the effective partial-failure exit threshold for this run (#4624).
+
+    Resolution order (first match wins):
+
+    1.  ``--no-fail-on-errors`` → return ``None`` (explicit opt-out).  The run
+        exits 0 on partial failure exactly like every pre-#4619 caller.  This
+        is the escape hatch for the rare run where partial failure is expected
+        (e.g. a known-bad prefix being drained best-effort).
+    2.  An explicit ``--max-error-ratio`` → return it verbatim (operator chose
+        their own threshold; their choice always wins, including ``0.0`` for
+        a fail-on-any-error run or a deliberately high ceiling).
+    3.  A ``--bust-llm-cache`` **prefix** reingest with no explicit threshold →
+        return :data:`_DEFAULT_CACHE_BUST_PREFIX_MAX_ERROR_RATIO`.  This is the
+        new default-on gate: the cache-bust prefix path that recreated #3855
+        now fails loud unless the operator opts out.
+    4.  Anything else (standard DB-row mode, non-cache-bust prefix runs) →
+        return ``None``, preserving the existing opt-in exit-code contract so
+        no existing caller's exit behavior changes (#4619).
+
+    Returning ``None`` means :func:`_enforce_max_error_ratio` is a no-op and
+    the run exits 0 regardless of error ratio — the backward-compatible path.
+    """
+    if no_fail_on_errors:
+        return None
+    if explicit_max_error_ratio is not None:
+        return explicit_max_error_ratio
+    if prefix and bust_llm_cache:
+        return _DEFAULT_CACHE_BUST_PREFIX_MAX_ERROR_RATIO
+    return None
+
+
 def _enforce_max_error_ratio(max_error_ratio: float | None, error_ratio: float) -> None:
     """Exit non-zero when ``error_ratio`` strictly exceeds the threshold.
 
-    No-op when ``max_error_ratio`` is ``None`` (the flag was not passed) — this
-    preserves the ECS-oneshot exit-code contract for existing callers, which
-    exit 0 on partial failure.  Only a set threshold that is strictly exceeded
-    triggers ``sys.exit(1)``; all-success and below-threshold both return.
-    See #4619.
+    No-op when ``max_error_ratio`` is ``None`` (no gate is in effect for this
+    run — neither an explicit ``--max-error-ratio`` nor the #4624 cache-bust
+    prefix default applied).  This preserves the ECS-oneshot exit-code contract
+    for existing callers, which exit 0 on partial failure.  Only a set
+    threshold that is strictly exceeded triggers ``sys.exit(1)``; all-success
+    and below-threshold both return.  See #4619 and #4624.
     """
     if max_error_ratio is None:
         return
@@ -5246,10 +5312,11 @@ def main() -> None:
             "split-child rows; DB-row mode skips them to avoid #2416). "
             "See #4049.  Combine with --s3-key-list to narrow the scan to a "
             "hand-picked subset of keys under the prefix instead of the whole "
-            "prefix (#3855).  Combine with --max-error-ratio to fail the run "
-            "when too large a fraction of keys error, and "
-            "--write-failed-manifest to capture the failed keys for a scoped "
-            "retry (#4619)."
+            "prefix (#3855).  With --bust-llm-cache, the run fails loud by "
+            "default when more than 10% of keys error (#4624) — pass "
+            "--max-error-ratio to set your own threshold or --no-fail-on-errors "
+            "to opt out — and --write-failed-manifest to capture the failed "
+            "keys for a scoped retry (#4619)."
         ),
     )
     parser.add_argument(
@@ -5353,6 +5420,19 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--no-fail-on-errors",
+        action="store_true",
+        dest="no_fail_on_errors",
+        help=(
+            "Opt out of the partial-failure exit gate entirely, even for "
+            "--bust-llm-cache prefix reingests where the gate is on by default "
+            "(#4624).  The run exits 0 on partial failure exactly like every "
+            "pre-#4619 caller.  Reserved for the rare run where partial "
+            "failure is expected (e.g. a known-bad prefix being drained "
+            "best-effort).  Overrides --max-error-ratio when both are passed."
+        ),
+    )
+    parser.add_argument(
         "--write-failed-manifest",
         type=str,
         default=None,
@@ -5413,7 +5493,15 @@ def main() -> None:
             skipped=stats["skipped"],
             judge_prepass_judges_seeded=stats.get("judge_prepass_judges_seeded"),
         )
-        _enforce_max_error_ratio(args.max_error_ratio, stats.get("error_ratio", 0.0))
+        effective_max_error_ratio = _resolve_effective_max_error_ratio(
+            explicit_max_error_ratio=args.max_error_ratio,
+            no_fail_on_errors=args.no_fail_on_errors,
+            prefix=args.prefix,
+            bust_llm_cache=args.bust_llm_cache,
+        )
+        _enforce_max_error_ratio(
+            effective_max_error_ratio, stats.get("error_ratio", 0.0)
+        )
         return
 
     # Standard mode: query the database for existing document records.
@@ -5461,7 +5549,18 @@ def main() -> None:
         llm_api_calls=stats.get("llm_api_calls", 0),
         estimated_cost_usd=stats.get("estimated_cost_usd", 0),
     )
-    _enforce_max_error_ratio(args.max_error_ratio, stats.get("error_ratio", 0.0))
+    # Standard (DB-row) mode is not a prefix run, so the #4624 cache-bust
+    # prefix default never applies here — the resolver returns the explicit
+    # --max-error-ratio (or None) unchanged, preserving the #4619 opt-in
+    # contract.  Routing through the shared resolver keeps both call sites
+    # honoring --no-fail-on-errors identically.
+    effective_max_error_ratio = _resolve_effective_max_error_ratio(
+        explicit_max_error_ratio=args.max_error_ratio,
+        no_fail_on_errors=args.no_fail_on_errors,
+        prefix=args.prefix,
+        bust_llm_cache=args.bust_llm_cache,
+    )
+    _enforce_max_error_ratio(effective_max_error_ratio, stats.get("error_ratio", 0.0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Makes the reingest partial-failure exit gate the **default for `--bust-llm-cache` prefix reingests** — the exact path that recreated the #3855 incident (Orange residual OOM-killed 167/768 PDFs, exited 0). #4619 added an opt-in `--max-error-ratio` flag, but the #3855 root cause is operator forgetfulness, so an opt-in flag can be forgotten the same way. This follow-up flips the cache-bust prefix path to fail-loud-by-default while preserving the #4619 opt-in exit-code contract for every other caller.

**Chose Option B** (one-line rationale): the flag already exists; the gap that recreates the incident is "operator forgets to pass it," so the gate must default on for the cache-bust prefix path. Doc updates (Option A) ship alongside as the residual guidance.

Closes #4624

### New default behavior

A `--prefix … --bust-llm-cache` run with no `--max-error-ratio` now exits non-zero when the error ratio strictly exceeds **0.10 (10%)**. All-success (0.0) and below-threshold runs still exit 0.

### Backward-compat (resolution order, first match wins)

1. `--no-fail-on-errors` → None (opt out; new escape hatch)
2. explicit `--max-error-ratio` → verbatim (operator's value always wins, incl. 0.0)
3. cache-bust prefix + no explicit threshold → 0.10 default
4. everything else (standard DB-row mode, non-cache-bust prefix) → None (unchanged #4619 opt-in contract)

**Caller audit:** no automated caller passes `--prefix --bust-llm-cache`. `drain_splitter_carry_forward_clusters.py` calls `run_reingest(...)` directly (standard mode), not `main()` with `--prefix` — unaffected. ECS-oneshot exit-code contract preserved for all existing invocations.

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (475 in test_reingest_from_s3.py, incl. 15 new regression tests)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (script run on demand via scripts/ecs-run-task.sh; verified via unit tests + lint/format/markdown checks)
- [ ] Verification evidence posted on issue (see A.8)
