### PR TITLE
fix(ingestion): apply PDF sanitizers symmetrically on fresh and cache-hit paths (#4625)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -2294,36 +2294,43 @@ def _drop_role_literal_orphan_rulings(
 # structurally not portable to the PDF cache-hit path.
 
 
-def _apply_pdf_cache_hit_filters(
-    rulings: list[ExtractedRuling],
-    *,
-    content_key: str,
-) -> list[ExtractedRuling]:
-    """Re-apply post-processing filters on the PDF cache-hit path (#2513).
+def _apply_pdf_post_join_filters(rulings: list[ExtractedRuling]) -> list[ExtractedRuling]:
+    """Run the shared PDF post-processing filter tail (#4625).
 
-    Mirrors the subset of filters in :func:`_join_page_rows` that operate
-    purely on the final ``ExtractedRuling[]`` list.  Order matches
-    ``_join_page_rows`` so the cache-hit output is equivalent to what a
-    fresh extraction would produce.
+    This is the single source of truth for the filter sequence that BOTH PDF
+    paths run AFTER cross-reference resolution: the fresh-extract path
+    (:func:`_join_page_rows`, cache miss) and the cache-hit path
+    (:func:`_apply_pdf_cache_hit_filters`, ``rebuild_db.py``).  Keeping it in
+    one place guarantees the same input PDF yields identical
+    ``derived.rulings`` output whether or not the Gemini LLM cache is warm —
+    the fully-rebuildable ``derived.*`` contract requires rebuild == capture.
 
-    Cross-reference resolution (#3608) runs first so stub rulings that carry
-    ``entry_number`` are resolved before the drop/dedup filters discard them,
-    mirroring the filter ordering in the fresh-extract path.
+    Cross-reference resolution (#2317/#3857/#3608) is intentionally NOT part of
+    this helper: the fresh path passes entry_number/case_number index maps it
+    builds while joining page rows, whereas the cache-hit path has no maps.
+    Each caller therefore invokes ``_resolve_cross_references`` itself and then
+    delegates the remaining tail here.
 
-    The county sanitizers (Riverside + San Bernardino) run at the end of the
-    chain too (#4028) — they had previously only been wired into the text
-    cache-hit path, but SB and Riverside tentative rulings are PDFs, so the
-    #3898 inherited-case-number guard and the role-literal title rebuild never
-    fired on a ``rebuild_db.py`` cache hit.  All three sanitizers are no-ops
-    on non-SB / non-Riverside case numbers and are idempotent, so running them
-    on the PDF path is safe for every county.
+    The filter order is significant — see the inline notes for the rationale:
 
-    Logs ``llm_extractor.cache_hit_filters_dropped`` at info level if the
-    filters dropped rows — useful for observing the effect of filter
-    widening in production without re-running LLM calls.
+    - ``_drop_role_literal_orphan_rulings`` (#3663): drop SC body-section
+      orphans BEFORE the calendar-listing filter so the orphan's long
+      ruling_text does not confuse the calendar-only heuristic.
+    - ``_drop_calendar_listing_rulings`` (#2446) / ``_drop_short_unsubstantive_rulings``
+      (#2645): drop OC calendar-only / empty-cell noise rows; both run after
+      cross-reference resolution so legitimate shared text is not misclassified.
+    - ``_truncate_concatenated_case_titles`` (#2562) / ``_truncate_repeated_name_tails``:
+      run BEFORE dedup so the truncated title is a more accurate dedup signal.
+    - ``_deduplicate_ruling_texts`` (#2096): null out duplicate ruling_text.
+    - ``_filter_citation_artifacts`` (#2448): drop RJN citation artifacts.
+    - County sanitizers (Riverside #2565/#3898, San Bernardino) plus the
+      county-agnostic ``_drop_riverside_no_tentative_ruling_stubs`` (#3715):
+      the two case-number-gated sanitizers are no-ops on non-SB / non-Riverside
+      case numbers and idempotent, so running them on the PDF path is safe for
+      every county; the stub-dropper IS county-agnostic and drops bare
+      "No tentative ruling." stubs (< 200 chars, no cross_reference_source) on
+      every county including Orange.
     """
-    original_count = len(rulings)
-    rulings = _resolve_cross_references(rulings)
     rulings = _drop_role_literal_orphan_rulings(rulings)
     rulings = _drop_calendar_listing_rulings(rulings)
     rulings = _drop_short_unsubstantive_rulings(rulings)
@@ -2334,6 +2341,41 @@ def _apply_pdf_cache_hit_filters(
     rulings = _sanitize_riverside_rulings(rulings, case_number_re=_RIVERSIDE_CASE_NUMBER_RE)
     rulings = _drop_riverside_no_tentative_ruling_stubs(rulings)
     rulings = _sanitize_san_bernardino_rulings(rulings, case_number_re=_SB_CASE_NUMBER_RE)
+    return rulings
+
+
+def _apply_pdf_cache_hit_filters(
+    rulings: list[ExtractedRuling],
+    *,
+    content_key: str,
+) -> list[ExtractedRuling]:
+    """Re-apply post-processing filters on the PDF cache-hit path (#2513).
+
+    Runs the identical filter tail as the fresh-extract path via the shared
+    :func:`_apply_pdf_post_join_filters` helper (#4625), so the cache-hit
+    output is equivalent to what a fresh extraction would produce.
+
+    Cross-reference resolution (#3608) runs first so stub rulings that carry
+    ``entry_number`` are resolved before the drop/dedup filters discard them,
+    mirroring the filter ordering in the fresh-extract path.
+
+    The county sanitizers (Riverside + San Bernardino) run at the end of the
+    shared tail (#4028).  Per ``extraction_config.py``, RIVERSIDE and SAN
+    BERNARDINO are ``ExtractionMethod.LLM`` (the text path), and only ORANGE is
+    ``ExtractionMethod.MULTIMODAL`` (the PDF path that reaches this function) —
+    so SB/Riverside tentative rulings never actually flow through here.  The two
+    case-number-gated sanitizers run on the PDF path purely for symmetry and
+    idempotency (they are no-ops on Orange case numbers); the county-agnostic
+    ``_drop_riverside_no_tentative_ruling_stubs`` DOES apply to Orange and drops
+    bare "No tentative ruling." stubs.
+
+    Logs ``llm_extractor.cache_hit_filters_dropped`` at info level if the
+    filters dropped rows — useful for observing the effect of filter
+    widening in production without re-running LLM calls.
+    """
+    original_count = len(rulings)
+    rulings = _resolve_cross_references(rulings)
+    rulings = _apply_pdf_post_join_filters(rulings)
     if len(rulings) != original_count:
         logger.info(
             "llm_extractor.cache_hit_filters_dropped",
@@ -4601,54 +4643,15 @@ def _join_page_rows(
         rulings, entry_number_to_index or None, case_number_to_index
     )
 
-    # Post-processing: drop SC body-section orphans (#3663).
-    # SC multi-page PDFs produce a body-section row with an empty
-    # case_number, role-literal title ("Plaintiff v. FCA"), and no
-    # entry_number.  Must run AFTER cross-reference resolution so any
-    # calendar row that WAS resolved keeps its real ruling_text, and the
-    # orphan — which has no entry_number and thus was never a cross-ref
-    # target — is discarded.  Run BEFORE the calendar-listing filter so the
-    # orphan's long ruling_text doesn't confuse the calendar-only heuristic.
-    rulings = _drop_role_literal_orphan_rulings(rulings)
-
-    # Post-processing: drop calendar-listing-only rows (#2446).
-    # Orange County department calendar PDFs sometimes list cases with only
-    # the motion-type heading or "OFF-CALENDAR" marker in place of an actual
-    # tentative ruling body.  These rows are not substantive rulings.  Run
-    # this AFTER cross-reference resolution so legitimate shared text is
-    # not accidentally classified as calendar-only.
-    rulings = _drop_calendar_listing_rulings(rulings)
-
-    # Post-processing: drop short-unsubstantive rulings that slipped
-    # through the pattern-based calendar-listing filter (#2645).  Catches
-    # empty-cell OC calendar rows where the LLM filled ruling_text with
-    # noise (case caption fragment, motion label without disposition)
-    # instead of a real tentative ruling body.  Must run AFTER the
-    # pattern-based filter so pattern-matched rows log under their specific
-    # marker, and AFTER cross-reference resolution so shared text isn't
-    # misclassified as unsubstantive.
-    rulings = _drop_short_unsubstantive_rulings(rulings)
-
-    # Post-processing: truncate concatenated case titles (#2562).
-    # Santa Clara multi-case PDFs sometimes produce an ``extracted_case_title``
-    # that fuses adjacent calendar lines ("Smith v. Jones Doe v. Roe").  Run
-    # this BEFORE ``_deduplicate_ruling_texts`` because the truncated title
-    # is a more accurate signal for downstream dedup heuristics and for the
-    # deterministic flag rule ``check_no_multiple_adversarial_patterns`` in
-    # the worker's validation step.
-    rulings = _truncate_concatenated_case_titles(rulings)
-    rulings = _truncate_repeated_name_tails(rulings)
-
-    # Post-processing: deduplicate identical ruling texts (#2096).
-    # The LLM sometimes produces the same ruling text for multiple cases
-    # in the same PDF.  Keep only the first occurrence; null out duplicates.
-    rulings = _deduplicate_ruling_texts(rulings)
-
-    # Post-processing: remove citation artifacts (#2448).
-    # When a PDF contains a Request for Judicial Notice citing many other
-    # courts' orders, the LLM may return each citation as a separate ruling.
-    # Filter those out using title+length heuristics.
-    rulings = _filter_citation_artifacts(rulings)
+    # Post-processing: run the shared PDF filter tail (#4625).  This is the
+    # SAME sequence applied on the cache-hit path by
+    # ``_apply_pdf_cache_hit_filters``, so a fresh extraction and a rebuild
+    # cache hit produce identical ``ExtractedRuling[]`` output.  The helper
+    # docstring documents each filter's ordering rationale (orphan drop ->
+    # calendar-listing -> short-unsubstantive -> title truncation -> dedup ->
+    # citation-artifact -> county sanitizers + the county-agnostic
+    # no-tentative-ruling stub dropper).
+    rulings = _apply_pdf_post_join_filters(rulings)
 
     return rulings
 

--- a/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
+++ b/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
@@ -20,13 +20,15 @@ happen.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from framework.llm_extractor import (
     PDF_PER_PAGE_PROMPT,
     LlmExtractor,
     _apply_pdf_cache_hit_filters,
+    _apply_pdf_post_join_filters,
     _apply_text_cache_hit_filters,
+    _join_page_rows,
 )
 from framework.llm_schema import EXTRACTION_SYSTEM_PROMPT, ExtractedParty, ExtractedRuling
 
@@ -374,8 +376,11 @@ class TestApplyPdfCacheHitFilters:
 
     # -----------------------------------------------------------------------
     # County sanitizers now run on the PDF cache-hit path too (#4028).
-    # SB and Riverside tentative rulings are PDFs, so on a rebuild cache hit
-    # these sanitizers must fire just as they do on the text path.
+    # Per extraction_config.py, RIVERSIDE and SAN BERNARDINO use
+    # ExtractionMethod.LLM (the text path); only ORANGE is MULTIMODAL/PDF, so
+    # SB/Riverside never actually flow through this path.  The case-number-gated
+    # sanitizers run here purely for symmetry/idempotency (no-ops on Orange
+    # numbers); the county-agnostic stub-dropper does apply to Orange (#4625).
     # -----------------------------------------------------------------------
 
     def test_sb_inherited_case_number_guard_fires_on_pdf_cache_hit(self) -> None:
@@ -849,3 +854,193 @@ class TestCacheHitFilterReapplicationRegression:
         # Only the real ruling survives — seven stale listings dropped.
         assert len(rulings) == 1
         assert rulings[0].extracted_case_number == "30-2024-A"
+
+
+# ---------------------------------------------------------------------------
+# Regression: fresh PDF path and cache-hit path apply an IDENTICAL filter tail
+# ---------------------------------------------------------------------------
+
+
+class TestPdfPathFilterSymmetry:
+    """Fresh PDF path and cache-hit path must produce identical output (#4625).
+
+    PR #4613 added the three county sanitizers (including the county-agnostic
+    ``_drop_riverside_no_tentative_ruling_stubs``) to the PDF cache-hit path
+    but NOT to the fresh-extract path (``_join_page_rows``).  The same input
+    PDF therefore produced different ``derived.rulings`` output depending only
+    on whether the Gemini LLM cache was warm — breaking the rebuild == capture
+    invariant for the fully-rebuildable ``derived.*`` tier.
+
+    These tests drive the same logical input through both paths and assert the
+    resulting ``ExtractedRuling`` lists are equal.  The decisive case is an
+    Orange-style (non-Riverside / non-SB) bare "No tentative ruling." stub that
+    the county-agnostic dropper must remove on BOTH paths.
+    """
+
+    # An Orange-style (non-Riverside / non-SB) "No tentative ruling." stub of
+    # 100-199 chars: long enough to escape BOTH the calendar-listing filter
+    # (rejects > 100 chars) and the short-unsubstantive filter (only fires
+    # < 100 chars), so the ONLY filter that drops it is the county-agnostic
+    # ``_drop_riverside_no_tentative_ruling_stubs`` (< 200 chars + regex match).
+    # This isolates the divergence #4625 fixes: on main the fresh path lacked
+    # that dropper, so this stub survived a fresh capture but was dropped on a
+    # rebuild cache hit.
+    _ORANGE_STUB_TEXT = (
+        "Motion to Compel Further Responses to Form Interrogatories\n"
+        "No tentative ruling. Appearances are required at the hearing."
+    )
+    _REAL_RULING_TEXT = (
+        "The demurrer is SUSTAINED with leave to amend. Plaintiff shall file "
+        "an amended complaint within twenty (20) days of service of this order."
+    )
+
+    def test_orange_stub_isolates_county_agnostic_dropper(self) -> None:
+        """The Orange stub fixture is dropped ONLY by the stub dropper (#4625).
+
+        Guards the test's own premise: the stub is >= 100 chars (escapes the
+        calendar-listing and short-unsubstantive filters) and < 200 chars
+        (caught by ``_drop_riverside_no_tentative_ruling_stubs``).
+        """
+        assert 100 <= len(self._ORANGE_STUB_TEXT) < 200
+
+    def test_unit_helper_drops_orange_no_tentative_stub(self) -> None:
+        """The shared helper drops a non-Riverside/non-SB "No tentative ruling." stub."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01393434",
+                extracted_case_title="Real v. Ruling",
+                ruling_text=self._REAL_RULING_TEXT,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-01393435",
+                extracted_case_title="Stub v. Case",
+                ruling_text=self._ORANGE_STUB_TEXT,
+            ),
+        ]
+        filtered = _apply_pdf_post_join_filters(rulings)
+        assert [r.extracted_case_number for r in filtered] == ["30-2024-01393434"]
+
+    def _build_rulings(self) -> list[ExtractedRuling]:
+        """The same logical input for both paths: one real ruling + one stub."""
+        return [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01393434",
+                extracted_case_title="Smith v. Jones",
+                ruling_text=self._REAL_RULING_TEXT,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-01393435",
+                extracted_case_title="Doe v. Roe",
+                ruling_text=self._ORANGE_STUB_TEXT,
+            ),
+        ]
+
+    def test_fresh_path_drops_orange_no_tentative_stub(self) -> None:
+        """The fresh ``_join_page_rows`` path drops the Orange stub (#4625).
+
+        On main this FAILS — the fresh path did not run the county-agnostic
+        stub dropper, so the stub survived.
+        """
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-01393434 Smith v. Jones",
+                "ruling_text": self._REAL_RULING_TEXT,
+            },
+            {
+                "entry_number": 2,
+                "case_info": "30-2024-01393435 Doe v. Roe",
+                "ruling_text": self._ORANGE_STUB_TEXT,
+            },
+        ]
+        fresh = _join_page_rows(rows)
+        # The real ruling survives, the stub is dropped.  (``_join_page_rows``
+        # normalizes the OC case number by stripping the ``30-`` court prefix.)
+        assert len(fresh) == 1
+        assert fresh[0].ruling_text == self._REAL_RULING_TEXT
+
+    def test_fresh_and_cache_hit_paths_produce_identical_output(self) -> None:
+        """Same logical input -> identical rulings on cache miss vs. cache hit (#4625).
+
+        Drives the SAME ``ExtractedRuling`` list (post-join, pre-tail) through
+        both the fresh-extract filter tail (``_apply_pdf_post_join_filters``,
+        the cache-miss path) and the cache-hit path
+        (``_apply_pdf_cache_hit_filters``).  On main these diverge — the fresh
+        path lacked the county-agnostic stub dropper, so the Orange stub
+        survived a fresh capture but was dropped on a rebuild cache hit — so
+        the equality assertion FAILS.  After the fix both drop the stub.
+        """
+        fresh = _apply_pdf_post_join_filters(self._build_rulings())
+        cache_hit = _apply_pdf_cache_hit_filters(self._build_rulings(), content_key="abc123def456")
+
+        def _key(rs: list[ExtractedRuling]) -> list[tuple[str | None, str | None]]:
+            return [(r.extracted_case_number, r.ruling_text) for r in rs]
+
+        assert _key(fresh) == _key(cache_hit)
+        assert [r.extracted_case_number for r in fresh] == ["30-2024-01393434"]
+
+    def test_extract_from_pdf_cold_and_warm_cache_agree(self) -> None:
+        """End-to-end: ``extract_from_pdf`` agrees on cache miss vs. cache hit (#4625).
+
+        Cold cache exercises the fresh path (mocked per-page extraction ->
+        ``_join_page_rows``); warm cache exercises the cache-hit path.  The
+        warm payload simulates the pre-#4625 un-sanitized cache entry (stub
+        still present), proving the cache-hit path converges with the now
+        symmetric fresh path.
+        """
+        page_rows = [
+            {
+                "entry_number": 1,
+                "case_info": "30-2024-01393434 Smith v. Jones",
+                "ruling_text": self._REAL_RULING_TEXT,
+            },
+            {
+                "entry_number": 2,
+                "case_info": "30-2024-01393435 Doe v. Roe",
+                "ruling_text": self._ORANGE_STUB_TEXT,
+            },
+        ]
+
+        # --- Cold cache: fresh extraction path ---
+        cold_cache = MagicMock()
+        cold_cache.get.return_value = None
+        fresh_extractor = _build_extractor_with_cache(cold_cache)
+        with (
+            patch(
+                "framework.llm_extractor._render_pdf_pages",
+                return_value=[(b"img", "image/png")],
+            ),
+            patch.object(fresh_extractor, "_extract_single_page", return_value=page_rows),
+        ):
+            fresh_rulings = fresh_extractor.extract_from_pdf(b"pdf-bytes-content")
+
+        # The fresh path wrote its (now-sanitized) output to the cache.
+        cold_cache.put.assert_called_once()
+        cached_payload = cold_cache.put.call_args.args[2]
+
+        # --- Warm cache: cache-hit path on a stale (un-sanitized) payload ---
+        stale_payload: list[dict[str, Any]] = [
+            {
+                "extracted_case_number": "30-2024-01393434",
+                "extracted_case_title": "Smith v. Jones",
+                "ruling_text": self._REAL_RULING_TEXT,
+            },
+            {
+                "extracted_case_number": "30-2024-01393435",
+                "extracted_case_title": "Doe v. Roe",
+                "ruling_text": self._ORANGE_STUB_TEXT,
+            },
+        ]
+        warm_cache = MagicMock()
+        warm_cache.get.return_value = stale_payload
+        warm_extractor = _build_extractor_with_cache(warm_cache)
+        warm_rulings = warm_extractor.extract_from_pdf(b"pdf-bytes-content")
+
+        # Both paths drop the stub: same surviving ruling set.  (Compare on
+        # ruling_text/count — the fresh path normalizes the OC ``30-`` case
+        # number prefix in ``_join_page_rows`` while the cache-hit path echoes
+        # the stored value verbatim; that normalization is unrelated to #4625.)
+        assert [r.ruling_text for r in fresh_rulings] == [r.ruling_text for r in warm_rulings]
+        assert [r.ruling_text for r in fresh_rulings] == [self._REAL_RULING_TEXT]
+        # The fresh path's CACHED output also has the stub dropped (1 entry).
+        assert [c["ruling_text"] for c in cached_payload] == [self._REAL_RULING_TEXT]


### PR DESCRIPTION
## Summary

PR #4613 wired the three county sanitizers into the PDF **cache-hit** filter chain (`_apply_pdf_cache_hit_filters`) but not the **fresh** PDF path (`_join_page_rows`, cache miss), so the same Orange PDF produced different `derived.rulings` depending only on whether the Gemini LLM cache was warm — breaking the fully-rebuildable `derived.*` contract (rebuild must equal capture). This factors the post-cross-reference filter tail into a single shared helper `_apply_pdf_post_join_filters` called by both PDF paths so they can no longer diverge, and corrects the stale docstring claim that SB/Riverside tentative rulings are PDFs (they are `ExtractionMethod.LLM`/text path; only Orange is `MULTIMODAL`/PDF).

The highest-impact divergence was the county-agnostic `_drop_riverside_no_tentative_ruling_stubs`: a bare "No tentative ruling." stub was kept on fresh extract but dropped on rebuild. It now runs on both paths.

Closes #4625

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] Scraper change: confirm the ingestion worker processes an Orange multimodal PDF on dev without errors; the cache-hit and fresh paths now run the identical filter tail (logic-level fix verified by regression tests `TestPdfPathFilterSymmetry`; no data backfill required since the fix only affects newly-extracted/rebuilt rulings going forward)
- [ ] Verification evidence posted on issue (see A.8)
