### PR TITLE
fix(scraping): match Fresno's new alpha-suffix ruling filenames; exclude low-volume LA appellate (#4629)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
@@ -21,8 +21,10 @@ Link text format: date only — e.g. "March 10, 2026"
   No judge name or department in link text; department is extracted from the
   PDF filename (e.g. "03-10-26-dept-403.pdf" → department "403").
 
-PDF URL pattern: /system/files/tentative-rulings/{MM}-{DD}-{YY}-dept-{NNN}[_N].pdf
-  The optional "_N" suffix (e.g. "_0") appears on revised uploads.
+PDF URL pattern: /system/files/tentative-rulings/{MM}-{DD}-{YY}-dept-{NNN}[-XXX][_N].pdf
+  The optional "-XXX" alpha code (e.g. "-hbv", clerk/judge initials) was
+  added to every ruling filename by the court around 2026-06-14 (#4629);
+  the optional "_N" suffix (e.g. "_0") appears on revised uploads.
   Links whose URL filename does not match this pattern are skipped at
   capture time via ``_HREF_FILTER_RE`` — the court occasionally posts
   non-ruling PDFs (e-Court transition notices, holiday closure
@@ -97,14 +99,22 @@ _FILENAME_DATE_RE = re.compile(
 )
 
 # URL filter: a legitimate Fresno tentative-ruling PDF has a filename in the
-# format "MM-DD-YY-dept-NNN[_N].pdf".  Non-ruling PDFs (e-Court transition
-# notices, holiday closure announcements, "we moved" banners) the court
-# occasionally posts to the same index page have filenames that do not
+# format "MM-DD-YY-dept-NNN[-XXX][_N].pdf".  Non-ruling PDFs (e-Court
+# transition notices, holiday closure announcements, "we moved" banners) the
+# court occasionally posts to the same index page have filenames that do not
 # match this pattern (e.g. "eCourt-transition-notice.pdf").  Skipping
 # non-matching URLs at capture time prevents all-NULL-metadata noise rows
 # in derived.rulings (#2644).
+#
+# The optional "-XXX" segment is a trailing alpha code (typically the issuing
+# clerk / judge initials, e.g. "-hbv", "-iec", "-syc") the court began
+# appending to every ruling filename around 2026-06-14 — e.g.
+# "07-08-26-dept-403-hbv.pdf", "07-02-26-dept-503-qpq_0.pdf".  Before this
+# segment was allowed, the filter rejected every ruling PDF, producing a
+# multi-week zero-record silent outage (#4629).  The optional "_N" revision
+# suffix (e.g. "_0") may follow the alpha code on re-uploaded rulings.
 _HREF_FILTER_RE = re.compile(
-    r"/\d{2}-\d{2}-\d{2}-dept-\d{2,3}(?:_\d+)?\.pdf$",
+    r"/\d{2}-\d{2}-\d{2}-dept-\d{2,3}(?:-[a-z]+)?(?:_\d+)?\.pdf$",
     re.IGNORECASE,
 )
 

--- a/packages/scraper-framework/tests/courts/test_fresno_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_fresno_tentatives.py
@@ -1416,6 +1416,42 @@ def test_fresno_href_filter_accepts_ruling_urls() -> None:
     )
 
 
+def test_fresno_href_filter_accepts_alpha_suffix_urls() -> None:
+    """_HREF_FILTER_RE matches the trailing alpha-code filename format (#4629).
+
+    Around 2026-06-14 the court began appending a short alpha code (clerk /
+    judge initials, e.g. "-hbv", "-iec", "-syc") to every ruling filename.
+    The previous pattern required the filename to end at "dept-NNN[_N].pdf",
+    so it rejected EVERY ruling PDF and produced a multi-week zero-record
+    silent outage.  These are the exact URLs observed on the live index page.
+    """
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/07-08-26-dept-403-hbv.pdf")
+        is not None
+    )
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/07-09-26-dept-501-iec.pdf")
+        is not None
+    )
+    # Alpha code followed by the "_N" revision suffix.
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/07-02-26-dept-503-qpq_0.pdf")
+        is not None
+    )
+    # Uppercase initials must match too (case-insensitive).
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/07-08-26-dept-403-DTT.pdf")
+        is not None
+    )
+    # The department is still extractable from the new filename format.
+    assert _fresno_dept_from_filename("07-08-26-dept-403-hbv.pdf") == "403"
+    assert _fresno_dept_from_filename("07-02-26-dept-503-qpq_0.pdf") == "503"
+    # And the hearing date is still extractable.
+    dt = _fresno_hearing_date_from_filename("07-08-26-dept-403-hbv.pdf")
+    assert dt is not None
+    assert (dt.year, dt.month, dt.day) == (2026, 7, 8)
+
+
 def test_fresno_href_filter_rejects_admin_notice_urls() -> None:
     """_HREF_FILTER_RE rejects non-ruling PDFs (e-Court transition notices, etc.)."""
     # The real #2644 scenario: an e-Court transition notice PDF posted to

--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -567,6 +567,19 @@ class TestModuleExclusions:
         """Quarterly cadence — most runs legitimately return zero."""
         assert "ca-governor-appointments" in zrs.EXCLUSIONS
 
+    def test_excludes_la_tentatives_appellate_after_4629(self) -> None:
+        """LA Appellate Division is low-volume, zero-by-design most of the time.
+
+        The casetype=appellate scraper cleanly detects the empty state
+        ("Appellate division has no published rulings", context=empty_state)
+        and reports status=success/records=0. Its multi-week zero streak is
+        the expected steady state, not a silent outage — so it is excluded
+        like ca-governor-appointments. The high-volume civil variant
+        (ca-la-tentatives-civil) must stay OUT of EXCLUSIONS. See #4629.
+        """
+        assert "ca-la-tentatives-appellate" in zrs.EXCLUSIONS
+        assert "ca-la-tentatives-civil" not in zrs.EXCLUSIONS
+
     def test_excludes_federal_courtlistener_opinions_after_4571(self) -> None:
         """CourtListener federal-opinions retired per #4571 / #4474.
 

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -141,6 +141,15 @@ EXCLUSIONS: set[str] = {
     # Governor appointments scraper runs quarterly-ish; most runs legitimately
     # return zero records. Exclude until dedicated health signal is wired.
     "ca-governor-appointments",
+    # LA Appellate Division (casetype=appellate) is a single low-volume
+    # division that publishes tentative rulings only rarely — its scraper
+    # cleanly detects the empty state ("Appellate division has no published
+    # rulings", context=empty_state) and reports status=success/records=0.
+    # This is zero-by-design most of the time, exactly like governor
+    # appointments, so a multi-week zero streak is the expected steady state
+    # rather than a silent outage. Distinct from ca-la-tentatives-civil, which
+    # is high-volume and stays under the silent-outage guard. See #4629.
+    "ca-la-tentatives-appellate",
     # CourtListener federal-opinions scraper retired per #4571 / #4474 — its
     # envelopes drove dev ElastiCache OOM and wedged the dispatcher. Kept in
     # EXCLUSIONS so the silent-outage guard does not alert on the now-retired


### PR DESCRIPTION
## Summary

Addresses two of the five scraper zero-record breaches tracked in #4629. The
alert is an aggregate over independent CA tentative-ruling scrapers that each
have a **distinct** root cause — this PR fixes the two that are
code/config-actionable; the remaining three (anti-bot session failures) are
tracked separately (see #4629 triage comment + follow-up).

### 1. Fresno — court changed PDF filenames (real data loss)

`ca-fresno-tentatives-civil` found 21 PDF links on every run but **skipped all
of them**. Around 2026-06-14 the court began appending a 3-letter alpha code
(clerk/judge initials) to every ruling filename:

```
07-08-26-dept-403-hbv.pdf
07-02-26-dept-503-qpq_0.pdf   (alpha code + "_N" revision suffix)
```

The capture-time URL filter `_HREF_FILTER_RE` required the filename to end at
`dept-NNN[_N].pdf`, so the new `-hbv` / `-qpq` segment made every ruling PDF
fail the filter — a multi-week silent outage (28 consecutive zero-record runs).

**Fix:** allow an optional `-<alpha>` segment before the optional `_N` revision
suffix: `/\d{2}-\d{2}-\d{2}-dept-\d{2,3}(?:-[a-z]+)?(?:_\d+)?\.pdf$`. The #2644
non-ruling-PDF filter behavior is preserved (admin notices like
`eCourt-transition-notice.pdf` are still rejected because they don't start with
`MM-DD-YY-dept-`). Department and hearing-date extraction from the filename are
unchanged and still work on the new format.

### 2. LA Appellate — zero-by-design low-volume source (false positive)

`ca-la-tentatives-appellate` is a single low-volume Appellate Division that
publishes tentative rulings only rarely. Its scraper cleanly detects the empty
state (`Appellate division has no published rulings`, `context=empty_state`)
and reports `status=success / records=0`. A multi-week zero streak is the
expected steady state, not a silent outage — exactly like the already-excluded
`ca-governor-appointments`. Added it to `EXCLUSIONS` in
`check-scraper-zero-record-streak.py`. The high-volume `ca-la-tentatives-civil`
variant (231 records/run) stays under the guard.

## Root-cause evidence (dev CloudWatch, `/ecs/judgemind-scraper-dev`, 2026-07-09)

- Fresno: `Found PDF links count=21` followed by 21× `Skipping PDF link — URL
  does not match expected pattern` → `Run complete records=0`.
- LA appellate: `Fetching appellate main page` → `Appellate division has no
  published rulings context=empty_state` → `records=0 status=success`.

## Tests

- `test_fresno_href_filter_accepts_alpha_suffix_urls` — the exact live URLs
  (`-hbv`, `-iec`, `-qpq_0`, uppercase initials) now match; dept + hearing-date
  extraction still work. Existing `#2644` admin-notice rejection tests still pass.
- `test_excludes_la_tentatives_appellate_after_4629` — appellate is excluded,
  civil is not.
- Full Fresno suite (114 tests) and zero-record-streak suite (43 tests) green.

## Scope note

This PR does **not** close #4629. The remaining breaches
(`ca-sd-tentatives`, `ca-sd-pipeline`, `ca-sf-tentatives-civil`, and the newly
observed `ca-riverside-tentatives-civil`) are anti-bot session-acquisition
failures (Cloudflare / CAPTCHA-gateway timeouts through the shared residential
proxy, plus a 403) with a separate root cause requiring infra work — tracked in
the #4629 triage comment and a dedicated p1 follow-up.

Addresses #4629.
