### PR TITLE
fix(scraping): stop CC dual-run total-coverage failures churning the agent queue (#4631)

### DIFF
--- a/.github/workflows/cc-dual-run-diff.yml
+++ b/.github/workflows/cc-dual-run-diff.yml
@@ -101,13 +101,20 @@ jobs:
           PY
 
           HEALTHY=$(python3 -c "import json; print(json.load(open('/tmp/check_json.txt'))['healthy'])")
+          # agent_actionable distinguishes a genuine per-department scraper
+          # regression (agent-fixable) from a total-coverage failure (portal
+          # not yet authoritative — no agent fix exists). Default True for
+          # older JSON so we never silently suppress a real regression. See
+          # #4631.
+          ACTIONABLE=$(python3 -c "import json; print(json.load(open('/tmp/check_json.txt')).get('agent_actionable', True))")
           if [ "$HEALTHY" = "True" ]; then
             echo "healthy=true" >> "$GITHUB_OUTPUT"
             echo "CC dual-run diff: healthy — no missing_portal departments."
           else
             echo "healthy=false" >> "$GITHUB_OUTPUT"
-            echo "CC dual-run diff: breach detected (exit code $EXIT_CODE)."
+            echo "CC dual-run diff: breach detected (exit code $EXIT_CODE, agent_actionable=$ACTIONABLE)."
           fi
+          echo "agent_actionable=$ACTIONABLE" >> "$GITHUB_OUTPUT"
 
       - name: Extract alert summary
         if: steps.check.outputs.healthy == 'false'
@@ -196,50 +203,114 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           CHECK_DATE: ${{ steps.args.outputs.check_date }}
+          AGENT_ACTIONABLE: ${{ steps.check.outputs.agent_actionable }}
         run: |
           TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-          {
-            echo "## CC Dual-Run Diff Alert — Portal Coverage Regression"
-            echo ""
-            echo "The portal scraper (\`ca-cc-tentatives-portal\`) is missing"
-            echo "one or more departments that the retired scraper"
-            echo "(\`ca-cc-tentatives\`) captured on **${CHECK_DATE}**."
-            echo "This may indicate a coverage regression in the new portal scraper."
-            echo ""
-            echo "### Missing Departments"
-            echo ""
-            cat /tmp/alert_summary.md
-            echo ""
-            echo ""
-            echo "### Context"
-            echo ""
-            echo "- **Workflow run:** ${RUN_URL}"
-            echo "- **Timestamp:** ${TIMESTAMP}"
-            echo "- **Date checked:** ${CHECK_DATE}"
-            echo "- **Check script:** \`scripts/cc-dual-run-diff.py\`"
-            echo "- **Parent issue:** #2601 (CC portal migration)"
-            echo ""
-            echo "### Next Steps"
-            echo ""
-            echo "1. Verify the portal scraper is running:"
-            echo "   \`scripts/ecs-logs.sh /ecs/judgemind-scraper-ca-cc-tentatives-portal-dev --lines 200\`"
-            echo "2. Check the retired scraper logs for comparison:"
-            echo "   \`scripts/ecs-logs.sh /ecs/judgemind-scraper-ca-cc-tentatives-dev --lines 200\`"
-            echo "3. Visit contracosta.courts.ca.gov for the missing departments"
-            echo "   to confirm rulings were posted that day."
-            echo "4. If the portal genuinely missed them, file a \`priority/p1\`"
-            echo "   bug against \`ca-cc-tentatives-portal\`."
-            echo ""
-            echo "This issue was created automatically by the CC dual-run diff"
-            echo "workflow. It will not create duplicates while this issue is open."
-          } > /tmp/issue_body.md
+          if [ "$AGENT_ACTIONABLE" = "True" ]; then
+            # Genuine per-department regression: the portal IS live and
+            # capturing current rulings but misses one or more departments.
+            # An agent can fix this — keep it p1 + agent/ready.
+            ISSUE_TITLE="CC portal scraper missing departments on ${CHECK_DATE}"
+            ISSUE_LABELS="priority/p1,area/scraping,cc-dual-run-alert,agent/ready"
+            {
+              echo "## CC Dual-Run Diff Alert — Portal Coverage Regression"
+              echo ""
+              echo "The portal scraper (\`ca-cc-tentatives-portal\`) is missing"
+              echo "one or more departments that the retired scraper"
+              echo "(\`ca-cc-tentatives\`) captured on **${CHECK_DATE}**, while"
+              echo "still capturing others. This indicates a per-department"
+              echo "coverage regression in the new portal scraper."
+              echo ""
+              echo "### Missing Departments"
+              echo ""
+              cat /tmp/alert_summary.md
+              echo ""
+              echo ""
+              echo "### Context"
+              echo ""
+              echo "- **Workflow run:** ${RUN_URL}"
+              echo "- **Timestamp:** ${TIMESTAMP}"
+              echo "- **Date checked:** ${CHECK_DATE}"
+              echo "- **Check script:** \`scripts/cc-dual-run-diff.py\`"
+              echo "- **Parent issue:** #2601 (CC portal migration)"
+              echo ""
+              echo "### Next Steps"
+              echo ""
+              echo "1. Verify the portal scraper is running:"
+              echo "   \`scripts/ecs-logs.sh /ecs/judgemind-scraper-ca-cc-tentatives-portal-dev --lines 200\`"
+              echo "2. Check the retired scraper logs for comparison:"
+              echo "   \`scripts/ecs-logs.sh /ecs/judgemind-scraper-ca-cc-tentatives-dev --lines 200\`"
+              echo "3. Visit contracosta.courts.ca.gov for the missing departments"
+              echo "   to confirm rulings were posted that day."
+              echo ""
+              echo "This issue was created automatically by the CC dual-run diff"
+              echo "workflow. It will not create duplicates while this issue is open."
+            } > /tmp/issue_body.md
+          else
+            # Total-coverage failure: the portal captured NOTHING while the
+            # retired scraper captured rulings. This is NOT a per-department
+            # regression — during the Phase 2 dual-run it is the expected
+            # "portal not yet the authoritative publication channel" signal
+            # (see docs/investigations/contra-costa-portal-migration-2026-04.md
+            # and #4631). No agent code change can capture data the upstream
+            # portal does not yet serve, so this is a human-triage tracker
+            # (p3, NOT agent/ready), not an autonomous work item.
+            ISSUE_TITLE="CC portal dual-run: total-coverage gap on ${CHECK_DATE} (portal not yet authoritative)"
+            ISSUE_LABELS="priority/p3,area/scraping,cc-dual-run-alert"
+            {
+              echo "## CC Dual-Run Diff — Total-Coverage Gap (portal not yet authoritative)"
+              echo ""
+              echo "The portal scraper (\`ca-cc-tentatives-portal\`) captured"
+              echo "**nothing** for **${CHECK_DATE}** while the retired scraper"
+              echo "(\`ca-cc-tentatives\`) captured rulings. This is a"
+              echo "total-coverage gap, **not** a per-department regression."
+              echo ""
+              echo "During the Phase 2 dual-run this is the expected"
+              echo "\"portal not yet the authoritative publication channel\""
+              echo "signal: Contra Costa still publishes current tentative"
+              echo "rulings only on the retired site, and the new portal's"
+              echo "Views endpoint exposes only stale seed data. No portal"
+              echo "**scraper** fix can capture rulings the upstream portal"
+              echo "does not serve, so this is a human-triage tracker"
+              echo "(\`priority/p3\`, no \`agent/ready\`) rather than an"
+              echo "autonomous work item."
+              echo ""
+              cat /tmp/alert_summary.md
+              echo ""
+              echo ""
+              echo "### Context"
+              echo ""
+              echo "- **Workflow run:** ${RUN_URL}"
+              echo "- **Timestamp:** ${TIMESTAMP}"
+              echo "- **Date checked:** ${CHECK_DATE}"
+              echo "- **Check script:** \`scripts/cc-dual-run-diff.py\`"
+              echo "- **Parent issue:** #2601 (CC portal migration)"
+              echo ""
+              echo "### Human triage"
+              echo ""
+              echo "1. Confirm the portal is still not the authoritative"
+              echo "   channel — the public \`/online-services/tentative-rulings\`"
+              echo "   page still iframes \`retired.cc-courts.org\`. If so, no"
+              echo "   action is needed; the retired scraper still has full"
+              echo "   coverage. Keep dual-running until the court cuts over."
+              echo "2. Only if the portal HAS gone live with current rulings"
+              echo "   but the scraper stopped fetching (judge-discovery /"
+              echo "   fetch break), add \`agent/ready\` + \`priority/p1\` and"
+              echo "   check the scraper logs:"
+              echo "   \`scripts/ecs-logs.sh /ecs/judgemind-scraper-ca-cc-tentatives-portal-dev --lines 200\`"
+              echo ""
+              echo "This issue was created automatically by the CC dual-run diff"
+              echo "workflow. It will not create duplicates while this issue is open"
+              echo "and auto-closes when the portal regains coverage."
+            } > /tmp/issue_body.md
+          fi
 
           ISSUE_URL=$(gh issue create \
             --repo "${{ github.repository }}" \
-            --title "CC portal scraper missing departments on ${CHECK_DATE}" \
+            --title "$ISSUE_TITLE" \
             --body-file /tmp/issue_body.md \
-            --label "priority/p1,area/scraping,cc-dual-run-alert,agent/ready")
+            --label "$ISSUE_LABELS")
 
           echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
           echo "created=true" >> "$GITHUB_OUTPUT"

--- a/packages/scraper-framework/tests/test_cc_dual_run_diff_script.py
+++ b/packages/scraper-framework/tests/test_cc_dual_run_diff_script.py
@@ -365,3 +365,104 @@ class TestTotalCoverageSignal:
         assert metadata["retired_total"] == 1
         assert metadata["portal_total"] == 0
         assert "total-coverage failure" in metadata["total_coverage_headline"]
+
+
+# ---------------------------------------------------------------------------
+# 6. agent_actionable classification — #4631
+# ---------------------------------------------------------------------------
+
+
+class TestAgentActionable:
+    """A total-coverage failure (portal captured nothing) is NOT agent-actionable
+    — it is the expected "portal not yet authoritative" Phase-2 signal, which no
+    agent code change can fix. A per-department gap (portal live but missing a
+    department) IS a genuine regression and stays agent-actionable. See #4631.
+    """
+
+    def test_total_coverage_failure_is_not_agent_actionable(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Retired has dept 16; portal captured nothing → total-coverage failure.
+        rows = [
+            _row_retired("16", "C24-01001"),
+        ]
+        conn = _make_conn(rows)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            exit_code = main(["--date", TARGET_DATE_STR])
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["portal_total_zero"] is True
+        assert payload["agent_actionable"] is False
+        # Exit-code semantics unchanged: a missing_portal row still exits 1.
+        assert exit_code == 1
+
+    def test_partial_department_gap_is_agent_actionable(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # Portal is live (captured dept 16) but missing dept 30 → real regression.
+        rows = [
+            _row_retired("16", "C24-01001"),
+            _row_retired("30", "N25-0001"),
+            _row_portal(_PORTAL_S3_KEY_DEPT16, "C24-01001"),
+        ]
+        conn = _make_conn(rows)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            exit_code = main(["--date", TARGET_DATE_STR])
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["portal_total_zero"] is False
+        assert payload["missing_portal_count"] == 1
+        assert payload["agent_actionable"] is True
+        assert exit_code == 1
+
+    def test_healthy_is_not_agent_actionable(self, capsys: pytest.CaptureFixture[str]) -> None:
+        # Both scrapers agree → healthy, nothing to action.
+        rows = [
+            _row_retired("16", "C24-01001"),
+            _row_portal(_PORTAL_S3_KEY_DEPT16, "C24-01001"),
+        ]
+        conn = _make_conn(rows)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            exit_code = main(["--date", TARGET_DATE_STR])
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["healthy"] is True
+        assert payload["agent_actionable"] is False
+        assert exit_code == 0
+
+    def test_metrics_metadata_carries_agent_actionable(self) -> None:
+        rows = [
+            _row_retired("16", "C24-01001"),
+        ]
+        cur = _make_cursor(rows)
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch.dict("os.environ", {"DATABASE_URL": "postgresql://fake"}),
+            patch("psycopg.connect", return_value=conn),
+        ):
+            main(["--date", TARGET_DATE_STR])
+
+        insert_calls = [
+            c
+            for c in cur.execute.call_args_list
+            if "data_quality_metrics" in str(c).lower() and "INSERT" in str(c).upper()
+        ]
+        assert len(insert_calls) >= 1
+        metadata = json.loads(insert_calls[0].args[1][-1])
+        assert metadata["agent_actionable"] is False

--- a/scripts/cc-dual-run-diff.py
+++ b/scripts/cc-dual-run-diff.py
@@ -219,6 +219,7 @@ def _write_metrics_row(
     retired_total: int,
     portal_total: int,
     total_coverage_headline: str,
+    agent_actionable: bool,
 ) -> None:
     """Insert one row into ``telemetry.data_quality_metrics``."""
     metadata_obj: dict[str, Any] = {
@@ -229,6 +230,7 @@ def _write_metrics_row(
         "retired_total": retired_total,
         "portal_total": portal_total,
         "total_coverage_headline": total_coverage_headline,
+        "agent_actionable": agent_actionable,
     }
     metadata_json = json.dumps(metadata_obj)
 
@@ -324,6 +326,27 @@ def main(argv: list[str] | None = None) -> int:
         # per-department gaps — see issue #4600.
         signal = compute_total_coverage_signal(diff_rows)
 
+        # Whether this breach is actionable by an autonomous agent (#4631).
+        #
+        # A *per-department gap* (portal is live and capturing current rulings
+        # but misses one or more departments) is a genuine scraper regression
+        # an agent can fix — it stays agent-actionable.
+        #
+        # A *total-coverage failure* (``portal_total_zero`` — portal captured
+        # nothing at all while the retired scraper captured something) is NOT
+        # a per-department regression. During the Phase 2 dual-run, this is the
+        # expected "portal not yet the authoritative publication channel"
+        # signal: the Contra Costa court still publishes current rulings only
+        # on the retired site (the public /online-services/tentative-rulings
+        # page still iframes retired.cc-courts.org), so the portal's Views
+        # endpoint exposes only stale seed data and there is nothing current
+        # for the portal scraper to capture. No agent code change can conjure
+        # data the upstream portal does not serve, so filing it as an
+        # ``agent/ready`` p1 bug just churns the work queue every day. It is
+        # surfaced to humans as a low-priority tracker instead (the workflow
+        # keys issue labels/body on this flag).
+        agent_actionable = missing_portal_count > 0 and not signal.portal_total_zero
+
         # Serialize diff rows for JSON output and metrics storage
         diff_payload: list[dict[str, Any]] = [
             {
@@ -347,6 +370,7 @@ def main(argv: list[str] | None = None) -> int:
             retired_total=signal.retired_total,
             portal_total=signal.portal_total,
             total_coverage_headline=signal.headline,
+            agent_actionable=agent_actionable,
         )
 
     healthy = missing_portal_count == 0
@@ -355,6 +379,7 @@ def main(argv: list[str] | None = None) -> int:
         print(format_summary(diff_rows))
     else:
         payload: dict[str, Any] = {
+            "agent_actionable": agent_actionable,
             "date": target_date.isoformat(),
             "diff": diff_payload,
             "healthy": healthy,


### PR DESCRIPTION
## Summary

Closes #4631.

The CC dual-run diff alert (`cc-dual-run-diff.yml`) files a `priority/p1` `agent/ready` bug on **every** `missing_portal` breach. Issue #4631 is one such alert: it reports the portal captured **0 of 23** rulings the retired scraper captured, and has re-fired daily since 2026-07-06.

### Root cause — the portal scraper is NOT broken

I verified the current portal state end-to-end before touching any code:

| Evidence | Result |
| --- | --- |
| Public `/online-services/tentative-rulings` page | **Still iframes** `retired.cc-courts.org/civil/motions-hearings-tentative.aspx` |
| Portal `/tentative-rulings` judge dropdown | 6 judges discovered correctly (`_parse_judge_dropdown` returns 6 — #4594 works) |
| Portal rulings across all 6 judges | ~9 **stale** entries, all dated **Jan–Mar 2025**; zero current rulings |
| Retired site (`retired.cc-courts.org`) | Fresh daily PDFs through **Jul 9, 2026** across all departments |
| Portal current-dept PDF (`/system/files/general/14_070926.pdf`) | **404** — portal does not host current PDFs |

This matches `docs/investigations/contra-costa-portal-migration-2026-04.md`: *"The new portal is not yet the authoritative publication channel — the retired site still has fresh daily rulings for all 10 departments."* That is still true today.

So the "0 of 23" is because **the Contra Costa court has not migrated live tentative-ruling publishing to the new portal.** PRs #4594 (judge discovery) and #4605 (detail parser) already fixed the real scraper bugs; the portal scraper correctly captures what the portal exposes (nothing current). **There is no portal-scraper code fix that captures data the upstream portal does not serve.**

### The actionable defect — recurring false p1 churn

A **total-coverage failure** (portal captured nothing at all) is the expected "portal not ready for cutover" Phase-2 signal, not a per-department regression. Filing it as an `agent/ready` p1 every day churns the autonomous work queue (this very task is an example) for a condition no agent can resolve.

### Change

Classify breaches via a new `agent_actionable` flag:

- **Per-department gap** (portal live but missing a department) → genuine scraper regression → stays `priority/p1` + `agent/ready` (unchanged behavior).
- **Total-coverage failure** (`portal_total_zero`) → human-triage tracker → `priority/p3`, **no** `agent/ready`, reframed body explaining the portal-not-ready condition and how to escalate if the portal genuinely went live and the scraper broke.

`agent_actionable = missing_portal_count > 0 and not portal_total_zero`.

The workflow's dedup + auto-close paths are unchanged: while the tracker is open the workflow only comments (no new issue, no repeat Telegram ping), and it auto-closes when the portal regains coverage.

### Files

- `scripts/cc-dual-run-diff.py` — emit `agent_actionable` in JSON output + `telemetry.data_quality_metrics` metadata.
- `.github/workflows/cc-dual-run-diff.yml` — branch issue title/labels/body on `agent_actionable`; extract the flag in the check step (defaults `True` for older JSON so a real regression is never silently suppressed).
- `packages/scraper-framework/tests/test_cc_dual_run_diff_script.py` — 4 new tests.

## Test plan

- [x] `pytest tests/test_cc_dual_run_diff_script.py tests/test_dual_run_diff.py` — 46 passed
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] Workflow YAML parses (`yaml.safe_load`)
- [x] Total-coverage failure → `agent_actionable=False`; partial gap → `True`; healthy → `False`; metadata carries the flag

## Notes

Implemented directly (not via ralph) given the deep investigation context; the testable core (script classification) has unit tests and the pre-push hook ran the full `scraper-framework` suite + coverage floor + workflow checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
