### PR TITLE
fix(ingestion): match judge_aliases partial-index predicate in ON CONFLICT (#4636)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1452,7 +1452,8 @@ def _maybe_arbitrate(
         INSERT INTO judge_aliases
             (judge_id, raw_name, source, confidence, is_verified)
         VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
-        ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
+        ON CONFLICT (judge_id, lower(raw_name), source)
+            WHERE source IS NOT NULL DO NOTHING
         """,
         (judge_id, roster_normalized, confidence),
     )
@@ -1462,7 +1463,8 @@ def _maybe_arbitrate(
         INSERT INTO judge_aliases
             (judge_id, raw_name, source, confidence, is_verified)
         VALUES (%s::uuid, %s, %s, 1.0, FALSE)
-        ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
+        ON CONFLICT (judge_id, lower(raw_name), source)
+            WHERE source IS NOT NULL DO NOTHING
         """,
         (judge_id, raw_name, source),
     )
@@ -1773,7 +1775,8 @@ def resolve_judge(
                 """
                 INSERT INTO judge_aliases (judge_id, raw_name, source, confidence, is_verified)
                 VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
-                ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
+                ON CONFLICT (judge_id, lower(raw_name), source)
+            WHERE source IS NOT NULL DO NOTHING
                 """,
                 (judge_id, pending_roster_alias, pending_roster_alias_confidence),
             )

--- a/packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py
+++ b/packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py
@@ -119,6 +119,59 @@ class TestRosterTypoArbitration:
             f"Expected >= 2 judge_aliases INSERT calls (old typo + new name), got {insert_calls}"
         )
 
+    def test_arbitration_alias_inserts_match_partial_unique_index(self) -> None:
+        """Arbitration-promotion judge_aliases INSERTs carry the partial-index predicate.
+
+        Regression for #3855: migration 54 creates a PARTIAL unique index
+        ``idx_judge_aliases_judge_raw_source_uniq`` on
+        ``(judge_id, lower(raw_name), source) WHERE source IS NOT NULL``.
+        PostgreSQL only accepts a partial index as an ``ON CONFLICT`` arbiter
+        when the conflict clause repeats the index predicate. The
+        arbitration-promotion INSERTs in ``_maybe_arbitrate`` previously used
+        ``ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING`` with no
+        ``WHERE source IS NOT NULL`` — which Postgres rejects at runtime with
+        ``InvalidColumnReference: there is no unique or exclusion constraint
+        matching the ON CONFLICT specification``, aborting the transaction. On
+        the Orange OC multimodal reingest this aborted 50% of the PDFs
+        mid-split, so the null judge/dept rulings never drained. Every
+        judge_aliases INSERT that targets the partial index by column list must
+        also carry the ``WHERE source IS NOT NULL`` predicate.
+        """
+        mock_conn, mock_cur = _make_mock_conn()
+
+        mock_cur.fetchone.side_effect = [
+            None,  # Step 1: no alias
+            None,  # Step 2: no exact canonical
+            ("ca-san_diego",),  # Step 3b: court_code
+            ({"D1": "Mattew C. Braner"},),  # Step 3b: snapshot
+            ("existing-judge-uuid",),  # Step 3b: judge with roster name exists
+        ]
+        mock_cur.fetchall.side_effect = [
+            [],  # Step 3: no near-duplicates
+            # Arbitration: alias table has one non-roster source already -> promote
+            [("matthew c. braner", "sd_calendar")],
+        ]
+
+        resolve_judge(mock_conn, "MATTHEW C. BRANER", "court-uuid-1", source="sd_calendar")
+
+        # Collect the raw SQL of every judge_aliases INSERT the promotion issued.
+        alias_insert_sql = [
+            call.args[0]
+            for call in mock_cur.execute.call_args_list
+            if call.args and "INSERT INTO judge_aliases" in call.args[0]
+        ]
+        assert alias_insert_sql, "Expected at least one judge_aliases INSERT during promotion"
+
+        for sql in alias_insert_sql:
+            # Only INSERTs that name the partial index by its column list need
+            # the predicate; those are the ones that hit the #3855 bug.
+            if "ON CONFLICT (judge_id, lower(raw_name), source)" in sql:
+                assert "source IS NOT NULL" in sql, (
+                    "judge_aliases ON CONFLICT targeting the partial unique index "
+                    "must repeat its 'WHERE source IS NOT NULL' predicate, else "
+                    "Postgres raises InvalidColumnReference (regression #3855):\n" + sql
+                )
+
     def test_single_non_roster_source_does_not_override_yet(self) -> None:
         """A single-source contradiction with no corroboration leaves canonical untouched.
 


### PR DESCRIPTION
## Summary

`resolve_judge`'s arbitration-promotion path issued three
`INSERT INTO judge_aliases ... ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING`
statements, but migration 54 created that unique index as a **partial** index
(`WHERE source IS NOT NULL`). PostgreSQL only accepts a partial index as an
`ON CONFLICT` arbiter when the conflict clause repeats the index predicate, so
each arbitration promotion raised `InvalidColumnReference` and aborted the
transaction — cascading `InFailedSqlTransaction` to every subsequent statement
on the connection. This aborted 50% (19/38 PDFs) of the #3855 Orange OC
multimodal reingest mid-split, leaving null judge/dept rulings undrained.

The fix appends `WHERE source IS NOT NULL` to all three `ON CONFLICT` clauses so
they match the partial index. Both inserted rows always supply a non-null
`source`, so the predicate never excludes a legitimate conflict.

Closes #4636

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `test_arbitration_alias_inserts_match_partial_unique_index` + existing 14 in test_db_judge_resolve.py)
- [ ] CI green

### Post-deploy verification
- [ ] Re-run the #3855 Orange OC targeted reingest (38 residual PDFs) on dev against the deployed fix; confirm error_ratio 0 (no `InFailedSqlTransaction`)
- [ ] Verification evidence posted on issue (see A.8)
