### PR TITLE
fix(ingestion): drop UNKNOWN- rulings with role-literal/placeholder titles (#4628)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -47,6 +47,12 @@ from .llm_schema import (
     FieldConfidence,
 )
 from .llm_utils import parse_llm_json, strip_llm_json_fences
+from .title_heuristics import (
+    BRACKETED_PLACEHOLDER_TITLE_RE as _BRACKETED_PLACEHOLDER_TITLE_RE,
+)
+from .title_heuristics import (
+    is_role_literal_title as _is_role_literal_title,
+)
 
 logger = structlog.get_logger(__name__)
 
@@ -148,76 +154,12 @@ _ROLE_LITERAL_TITLE_RE = re.compile(
     re.IGNORECASE,
 )
 
-# A single role token, allowing singular/plural and the cross-prefixed forms.
-# Used by :func:`_is_role_literal_title` to test whether a ``/``-separated piece
-# of a title segment is a pure role word.  See #4618.
-_ROLE_TOKEN = r"(?:Cross-)?(?:Plaintiff|Defendant|Petitioner|Respondent|Complainant)s?"
-
-# Matches a title segment (one side of ``v.``) that is ENTIRELY a role-literal
-# compound — every ``/``-separated piece is a role token, with no trailing real
-# text.  Anchored start-to-end so ``Defendants Inc.`` (real company) does NOT
-# match while ``Defendants/Cross-Complainants`` does.  See #4618.
-_ROLE_LITERAL_SEGMENT_RE = re.compile(
-    rf"^\s*{_ROLE_TOKEN}(?:\s*/\s*{_ROLE_TOKEN})*\s*$",
-    re.IGNORECASE,
-)
-
-# Splits a title on the ``v.``/``vs.``/``v``/``vs`` party separator using a word
-# boundary so it does not fire inside a real word.  See #4618.
-_VS_SEPARATOR_RE = re.compile(r"\bv[s]?\.?\s+", re.IGNORECASE)
-
-
-def _is_role_literal_title(title: str | None) -> bool:
-    """Return True when EITHER side of the ``v.`` separator is a role-literal (#4618).
-
-    A *role-literal title* is one where the LLM substituted a role word
-    ("Plaintiff", "Defendant", "Petitioner", "Respondent", their plurals, and the
-    cross-prefixed / ``/``-joined compounds) for a real party name, on the left,
-    the right, or both sides of the ``v.``/``vs.`` separator. Examples that match:
-
-    - ``Plaintiff v. General Motors, LLC`` (left)
-    - ``Acme Corp v. Defendants`` (right)
-    - ``Tcfi Cp Llc v. Defendants/Cross-Complainants`` (right compound)
-    - ``Plaintiff/Petitioner v. Defendant/Respondent`` (both)
-
-    The detection is anchored to the WHOLE segment, so a real party name that
-    merely contains a role word as a substring is NOT flagged:
-
-    - ``Smith v. Defendants Inc.`` (trailing real text → not role-literal)
-    - ``Plaintiff Holdings LLC v. Smith`` (leading role word + real text)
-    - ``Aasi v. American Honda`` / ``Doe v. Roe`` (clean)
-
-    Returns ``False`` for ``None``, empty, whitespace-only, or any title without a
-    recognisable ``v.`` separator.
-    """
-    if not title or not title.strip():
-        return False
-    parts = _VS_SEPARATOR_RE.split(title, maxsplit=1)
-    if len(parts) != 2:
-        return False
-    left, right = parts
-    return bool(_ROLE_LITERAL_SEGMENT_RE.match(left) or _ROLE_LITERAL_SEGMENT_RE.match(right))
-
-
-# Matches a case_title that contains an LLM-hallucinated bracketed placeholder
-# for a party name, e.g. "Ezra Arce v. [Defendant not specified]" or
-# "[Plaintiff name unknown] v. Smith".  The bracket must contain a role word
-# (plaintiff/defendant/petitioner/respondent/party/name/case) followed by a
-# qualifier (not specified, unknown, missing, not listed, not provided, tbd).
-# No anchor — the bracket can appear anywhere in the title.  See #3988.
-#
-# Explicit non-match envelope (do NOT widen without product confirmation — #4002):
-#   - Role-only:        [DEFENDANT], [Defendant 1]  — no qualifier word present
-#   - Qualifier-only:   [TBD], [Insert defendant here]  — no leading role word
-#   - Possessives:      [defendant's name]  — possessive breaks the role-word token
-#   - Ordinals:         [Defendant 1]  — digit suffix is not a qualifier keyword
-#   - Free-form:        [Name to be determined]  — "Name" alone is not a role word
-#                       used in this position; qualifier phrase not in the allowlist
-_BRACKETED_PLACEHOLDER_TITLE_RE = re.compile(
-    r"\[(?:plaintiff|defendant|petitioner|respondent|party|name|case)[^\]]*"
-    r"(?:not specified|unknown|missing|not listed|not provided|tbd)[^\]]*\]",
-    re.IGNORECASE,
-)
+# The role-literal / bracketed-placeholder title primitives (``_is_role_literal_title``
+# and ``_BRACKETED_PLACEHOLDER_TITLE_RE``) now live in the shared, dependency-light
+# :mod:`framework.title_heuristics` module and are re-imported at the top of this
+# file under their historical underscore-prefixed names (#4628).  Note:
+# ``_ROLE_LITERAL_TITLE_RE`` above is a SEPARATE left-anchored legacy symbol and
+# stays defined locally.
 
 # ---------------------------------------------------------------------------
 # LLM result cache

--- a/packages/scraper-framework/src/framework/title_heuristics.py
+++ b/packages/scraper-framework/src/framework/title_heuristics.py
@@ -1,0 +1,104 @@
+"""Shared, dependency-light heuristics for uninformative party titles.
+
+Single source of truth for detecting *role-literal* party titles
+(``Plaintiffs v. Defendant``) and *bracketed-placeholder* titles
+(``... v. [Defendant not specified]``).  These primitives were extracted
+verbatim out of :mod:`framework.llm_extractor` so both the extractor-stage
+orphan-drop filter and the leaf :mod:`validation.deterministic` DB-write gate
+can share them.
+
+This module intentionally imports **only** the standard-library :mod:`re` so
+the leaf ``validation`` layer can depend on it without pulling in the heavy
+``anthropic`` import chain that :mod:`framework.llm_extractor` carries.
+
+See #4618 (role-literal on either side of ``v.``), #3988/#4002 (bracketed
+placeholder envelope), and #4628 (uninformative-title orphan-drop gate).
+"""
+
+from __future__ import annotations
+
+import re
+
+# A single role token, allowing singular/plural and the cross-prefixed forms.
+# Used by :func:`is_role_literal_title` to test whether a ``/``-separated piece
+# of a title segment is a pure role word.  See #4618.
+ROLE_TOKEN = r"(?:Cross-)?(?:Plaintiff|Defendant|Petitioner|Respondent|Complainant)s?"
+
+# Matches a title segment (one side of ``v.``) that is ENTIRELY a role-literal
+# compound — every ``/``-separated piece is a role token, with no trailing real
+# text.  Anchored start-to-end so ``Defendants Inc.`` (real company) does NOT
+# match while ``Defendants/Cross-Complainants`` does.  See #4618.
+ROLE_LITERAL_SEGMENT_RE = re.compile(
+    rf"^\s*{ROLE_TOKEN}(?:\s*/\s*{ROLE_TOKEN})*\s*$",
+    re.IGNORECASE,
+)
+
+# Splits a title on the ``v.``/``vs.``/``v``/``vs`` party separator using a word
+# boundary so it does not fire inside a real word.  See #4618.
+VS_SEPARATOR_RE = re.compile(r"\bv[s]?\.?\s+", re.IGNORECASE)
+
+
+def is_role_literal_title(title: str | None) -> bool:
+    """Return True when EITHER side of the ``v.`` separator is a role-literal (#4618).
+
+    A *role-literal title* is one where the LLM substituted a role word
+    ("Plaintiff", "Defendant", "Petitioner", "Respondent", their plurals, and the
+    cross-prefixed / ``/``-joined compounds) for a real party name, on the left,
+    the right, or both sides of the ``v.``/``vs.`` separator. Examples that match:
+
+    - ``Plaintiff v. General Motors, LLC`` (left)
+    - ``Acme Corp v. Defendants`` (right)
+    - ``Tcfi Cp Llc v. Defendants/Cross-Complainants`` (right compound)
+    - ``Plaintiff/Petitioner v. Defendant/Respondent`` (both)
+
+    The detection is anchored to the WHOLE segment, so a real party name that
+    merely contains a role word as a substring is NOT flagged:
+
+    - ``Smith v. Defendants Inc.`` (trailing real text → not role-literal)
+    - ``Plaintiff Holdings LLC v. Smith`` (leading role word + real text)
+    - ``Aasi v. American Honda`` / ``Doe v. Roe`` (clean)
+
+    Returns ``False`` for ``None``, empty, whitespace-only, or any title without a
+    recognisable ``v.`` separator.
+    """
+    if not title or not title.strip():
+        return False
+    parts = VS_SEPARATOR_RE.split(title, maxsplit=1)
+    if len(parts) != 2:
+        return False
+    left, right = parts
+    return bool(ROLE_LITERAL_SEGMENT_RE.match(left) or ROLE_LITERAL_SEGMENT_RE.match(right))
+
+
+# Matches a case_title that contains an LLM-hallucinated bracketed placeholder
+# for a party name, e.g. "Ezra Arce v. [Defendant not specified]" or
+# "[Plaintiff name unknown] v. Smith".  The bracket must contain a role word
+# (plaintiff/defendant/petitioner/respondent/party/name/case) followed by a
+# qualifier (not specified, unknown, missing, not listed, not provided, tbd).
+# No anchor — the bracket can appear anywhere in the title.  See #3988.
+#
+# Explicit non-match envelope (do NOT widen without product confirmation — #4002):
+#   - Role-only:        [DEFENDANT], [Defendant 1]  — no qualifier word present
+#   - Qualifier-only:   [TBD], [Insert defendant here]  — no leading role word
+#   - Possessives:      [defendant's name]  — possessive breaks the role-word token
+#   - Ordinals:         [Defendant 1]  — digit suffix is not a qualifier keyword
+#   - Free-form:        [Name to be determined]  — "Name" alone is not a role word
+#                       used in this position; qualifier phrase not in the allowlist
+BRACKETED_PLACEHOLDER_TITLE_RE = re.compile(
+    r"\[(?:plaintiff|defendant|petitioner|respondent|party|name|case)[^\]]*"
+    r"(?:not specified|unknown|missing|not listed|not provided|tbd)[^\]]*\]",
+    re.IGNORECASE,
+)
+
+
+def has_uninformative_party_title(title: str | None) -> bool:
+    """True when *title* is empty/whitespace, a role-literal, or a bracketed placeholder.
+
+    A title that is a role literal (``Plaintiffs v. Defendant``) or a bracketed
+    LLM placeholder (``... v. [Defendant not specified]``) carries no real party
+    information — for the purpose of the ``UNKNOWN-`` orphan-drop gate it is
+    equivalent to a null/empty title.
+    """
+    if title is None or not title.strip():
+        return True
+    return is_role_literal_title(title) or bool(BRACKETED_PLACEHOLDER_TITLE_RE.search(title))

--- a/packages/scraper-framework/src/validation/deterministic.py
+++ b/packages/scraper-framework/src/validation/deterministic.py
@@ -26,6 +26,8 @@ import re
 from dataclasses import dataclass, field
 from datetime import date
 
+from framework.title_heuristics import has_uninformative_party_title
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -288,36 +290,48 @@ def check_unknown_and_null_title_fail(
     case_number: str | None,
     case_title: str | None,
 ) -> DeterministicRuleResult:
-    """Reject rulings with BOTH a synthetic UNKNOWN- case_number AND a null/empty title.
+    """Reject rulings with a synthetic UNKNOWN- case_number AND an uninformative title.
 
-    This is a narrow, high-confidence rejection rule (#2571).  When both the
-    case number and the case title are missing after all extraction and
+    This is a narrow, high-confidence rejection rule (#2571, extended #4628).
+    When the case number is missing (synthetic ``UNKNOWN-`` prefix) AND the
+    case title carries no real party information after all extraction and
     enrichment paths have run, the ruling is almost certainly an orphaned
     fragment of a bad LLM split — for example, a multi-Issue MSJ/MSA ruling
     that was over-split into per-Issue fragments, each of which lacks case
     metadata because that only appears at the top of the parent entry.
 
+    A title is treated as *uninformative* (equivalent to a null title) when it
+    is null/empty/whitespace OR a **role-literal** placeholder
+    (``Plaintiffs v. Defendant`` — the LLM emitted the role word instead of a
+    real party name, on either side of ``v.``) OR a **bracketed** LLM
+    placeholder (``... v. [Defendant not specified]``).  Before #4628 those
+    role-literal / bracketed titles were treated as real titles, so junk rows
+    like Santa Clara's ``UNKNOWN-<uuid>`` + ``Plaintiffs v. Defendant`` slipped
+    past this gate and reached ``derived.rulings``.
+
     Storing such fragments pollutes the DB with UNKNOWN-prefixed cases and
     wrong motion types.  This rule returns ``fail`` (not ``flag``) so the
     caller skips the DB write entirely, ensuring that the 3-way extraction
-    failure (UNKNOWN case_number + NULL title + wrong motion_type) described
-    in #2571 cannot reach ``derived.rulings``.
+    failure (UNKNOWN case_number + uninformative title + wrong motion_type)
+    described in #2571 cannot reach ``derived.rulings``.
 
-    The sibling rule ``check_case_number_not_unknown`` keeps its ``flag``
-    behaviour for rulings that have a title but no case_number — those can
-    still be healed later by cross-case title lookup and are safer to keep.
+    A REAL title (``Smith v. Jones``) with an UNKNOWN- case_number still passes
+    this rule — the real party names give a heal-by-title path, and the sibling
+    rule ``check_case_number_not_unknown`` keeps its ``flag`` behaviour for
+    those.  A real (non-UNKNOWN) case_number also always passes, even paired
+    with a role-literal title, so genuine pseudonym cases are preserved.
     """
     has_unknown_case_number = case_number is not None and case_number.startswith("UNKNOWN-")
-    has_empty_title = case_title is None or not case_title.strip()
 
-    if has_unknown_case_number and has_empty_title:
+    if has_unknown_case_number and has_uninformative_party_title(case_title):
         return DeterministicRuleResult(
             rule="unknown_and_null_title_fail",
             result="fail",
             reason=(
                 "case_number starts with 'UNKNOWN-' AND case_title is "
-                "null/empty — ruling is almost certainly a bad-split "
-                "fragment (see #2571); rejecting to protect DB integrity"
+                "null/empty/role-literal/placeholder — ruling is almost "
+                "certainly a bad-split fragment (see #2571, #4628); "
+                "rejecting to protect DB integrity"
             ),
         )
     return DeterministicRuleResult(rule="unknown_and_null_title_fail", result="pass")

--- a/packages/scraper-framework/tests/test_deterministic_validation.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation.py
@@ -348,6 +348,36 @@ class TestUnknownAndNullTitleFail:
         result = check_unknown_and_null_title_fail("C24-01160", "Smith v. Jones")
         assert result.result == "pass"
 
+    def test_fail_unknown_case_number_and_role_literal_title(self) -> None:
+        """#4628 — UNKNOWN case_number + a left-side role-literal title must fail.
+
+        This is the exact Santa Clara repro: the LLM emitted the role word
+        ("Plaintiffs"/"Defendant") instead of a real party name, so the title
+        carries no party information and must be treated like a null title.
+        """
+        result = check_unknown_and_null_title_fail("UNKNOWN-5f0a7206", "Plaintiffs v. Defendant")
+        assert result.result == "fail"
+        assert "UNKNOWN-" in (result.reason or "")
+
+    def test_fail_unknown_case_number_and_right_role_literal_title(self) -> None:
+        """#4628 — role-literal on the RIGHT side of ``v.`` is also uninformative."""
+        result = check_unknown_and_null_title_fail("UNKNOWN-5f0a7206", "Acme Corp v. Defendants")
+        assert result.result == "fail"
+
+    def test_fail_unknown_case_number_and_bracketed_placeholder_title(self) -> None:
+        """#4628 — a bracketed LLM placeholder title is uninformative."""
+        result = check_unknown_and_null_title_fail(
+            "UNKNOWN-5f0a7206", "Ezra Arce v. [Defendant not specified]"
+        )
+        assert result.result == "fail"
+
+    def test_pass_real_case_number_and_role_literal_title(self) -> None:
+        """#4628 — a REAL case_number preserves the row even with a role-literal
+        title; only the synthetic UNKNOWN- prefix triggers the rejection.
+        """
+        result = check_unknown_and_null_title_fail("24CV123456", "Plaintiffs v. Defendant")
+        assert result.result == "pass"
+
 
 # ---------------------------------------------------------------------------
 # ruling_text_reasonable_length
@@ -913,6 +943,20 @@ class TestRunDeterministicRules:
             case_title=None,
             hearing_date=date(2026, 3, 30),
             captured_at=date(2026, 3, 29),
+        )
+        assert result.overall == "fail"
+        assert any(
+            r.rule == "unknown_and_null_title_fail" and r.result == "fail" for r in result.rules
+        )
+
+    def test_unknown_and_role_literal_title_rejected_via_aggregator(self) -> None:
+        """#4628 — UNKNOWN case_number AND a role-literal title must fail aggregator."""
+        result = run_deterministic_rules(
+            ruling_text="The motion for summary adjudication is granted.",
+            case_number="UNKNOWN-5f0a7206",
+            case_title="Plaintiffs v. Defendant",
+            hearing_date=None,
+            captured_at=None,
         )
         assert result.overall == "fail"
         assert any(

--- a/packages/scraper-framework/tests/test_title_heuristics.py
+++ b/packages/scraper-framework/tests/test_title_heuristics.py
@@ -1,0 +1,60 @@
+"""Tests for the shared title-heuristics module (#4628).
+
+``framework.title_heuristics`` is the single source of truth for role-literal
+and bracketed-placeholder party-title detection.  The primitives were extracted
+verbatim out of ``framework.llm_extractor`` so both the extractor-stage
+orphan-drop filter and the leaf ``validation.deterministic`` DB-write gate can
+share them without pulling the heavy ``anthropic`` import into the validation
+layer.
+"""
+
+from __future__ import annotations
+
+from framework.title_heuristics import (
+    has_uninformative_party_title,
+    is_role_literal_title,
+)
+
+
+class TestHasUninformativePartyTitle:
+    """Tests for the ``has_uninformative_party_title`` helper."""
+
+    def test_none_is_uninformative(self) -> None:
+        assert has_uninformative_party_title(None) is True
+
+    def test_empty_string_is_uninformative(self) -> None:
+        assert has_uninformative_party_title("") is True
+
+    def test_whitespace_is_uninformative(self) -> None:
+        assert has_uninformative_party_title("   ") is True
+
+    def test_left_role_literal_is_uninformative(self) -> None:
+        assert has_uninformative_party_title("Plaintiffs v. Defendant") is True
+
+    def test_right_role_literal_is_uninformative(self) -> None:
+        assert has_uninformative_party_title("Acme Corp v. Defendants") is True
+
+    def test_bracketed_placeholder_is_uninformative(self) -> None:
+        assert has_uninformative_party_title("Ezra Arce v. [Defendant not specified]") is True
+
+    def test_real_title_is_informative(self) -> None:
+        assert has_uninformative_party_title("Smith v. Jones") is False
+
+    def test_real_pseudonym_title_is_informative(self) -> None:
+        assert has_uninformative_party_title("Doe v. Roe") is False
+
+
+class TestIsRoleLiteralTitleParity:
+    """Lock the moved ``is_role_literal_title`` behaviour (parity with #4618)."""
+
+    def test_left_role_literal(self) -> None:
+        assert is_role_literal_title("Plaintiff v. General Motors, LLC") is True
+
+    def test_right_role_literal(self) -> None:
+        assert is_role_literal_title("Acme Corp v. Defendants") is True
+
+    def test_real_title_not_role_literal(self) -> None:
+        assert is_role_literal_title("Smith v. Defendants Inc.") is False
+
+    def test_none_not_role_literal(self) -> None:
+        assert is_role_literal_title(None) is False


### PR DESCRIPTION
## Summary

Role-literal `case_title` rows paired with a synthetic `UNKNOWN-<uuid>` case_number survived the DB-write deterministic gate and were written to `derived.rulings` (Santa Clara: 3 rows). The gate `check_unknown_and_null_title_fail` rejected `UNKNOWN-` + null/empty title (#2571) but treated a role-literal title like "Plaintiffs v. Defendant" as a real title. This PR extends the gate to treat a role-literal / bracketed-placeholder title as equivalent to null/empty when the case_number is `UNKNOWN-`. Title heuristics are extracted into a shared pure-regex `framework/title_heuristics.py` (single source of truth for the extractor and the validation gate). County-agnostic; runs on both fresh-ingest and rebuild.

The issue proposed fixing `_drop_role_literal_orphan_rulings`, but a probe against the real SC data showed that is the wrong layer — at the extractor filter `case_number` is empty, never `UNKNOWN-<uuid>` (that value is synthesized downstream in `worker.py`). See the layer-correction note on the issue.

Closes #4628

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (scraper-framework full suite: 8371 passed, 3 skipped; new regression tests fail before the fix)
- [x] CI green

### Post-deploy verification
- [ ] Confirm the deployed scraper image's `check_unknown_and_null_title_fail("UNKNOWN-...", "Plaintiffs v. Defendant")` returns `fail` (exercise the gate on the running image)
- [ ] Verification evidence posted on issue (see A.8)

Note: the literal AC1 verify ("SC role-literal count = 0 after a Santa Clara rebuild") is the #3843 follow-up — this PR ships only the guard, not the data cleanup.
