### PR TITLE
feat(scraping): anti-bot proxy/CAPSolver health probe + distinct 407 proxy-auth logging (#4638)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
               tests/courts/test_sd_pipeline.py
               tests/courts/test_sf_civil_tentatives.py
               tests/courts/test_sf_tentatives.py
+              tests/courts/test_proxy_auth_diagnosis_wiring.py
               tests/courts/test_ventura_tentatives.py
               tests/courts/test_ventura_dept_judges.py
     defaults:

--- a/packages/scraper-framework/src/courts/ca/sd_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sd_tentatives.py
@@ -42,6 +42,7 @@ from bs4 import BeautifulSoup
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScraperConfig
 from framework.browser import apply_stealth as _apply_stealth
 from framework.events import EventBus
+from framework.proxy_health import diagnose_and_log_proxy_auth
 from framework.storage import S3Archiver
 
 logger = structlog.get_logger(__name__)
@@ -741,6 +742,11 @@ class SDTentativeRulingsScraper(BaseScraper):
             "Failed to solve Cloudflare challenge after all retries",
             max_retries=CF_MAX_RETRIES,
         )
+        # The all-retries failure surfaced only as opaque Chromium timeouts.
+        # When a proxy is configured, run a stdlib probe through the SAME proxy
+        # so a Bright Data 407 credential rejection is logged distinctly (#4638).
+        if self._proxy_url:
+            await asyncio.to_thread(diagnose_and_log_proxy_auth, self._log, self._proxy_url)
         return False
 
     async def _poll_cf_clearance(self, context: Any) -> bool:

--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -75,6 +75,7 @@ from bs4 import BeautifulSoup
 from framework import BaseScraper, CapturedDocument, ContentFormat, ScheduleWindow, ScraperConfig
 from framework.browser import apply_stealth as _apply_stealth
 from framework.events import EventBus
+from framework.proxy_health import diagnose_and_log_proxy_auth
 from framework.storage import S3Archiver
 from framework.turnstile_solver import solve_turnstile
 
@@ -869,6 +870,11 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
             "Failed to acquire session after all retries",
             max_retries=SESSION_MAX_RETRIES,
         )
+        # The all-retries failure surfaced only as opaque Chromium timeouts.
+        # When a proxy is configured, run a stdlib probe through the SAME proxy
+        # so a Bright Data 407 credential rejection is logged distinctly (#4638).
+        if self._proxy_url:
+            await asyncio.to_thread(diagnose_and_log_proxy_auth, self._log, self._proxy_url)
         return None
 
     async def _try_acquire_session(self, async_playwright: Any) -> str | None:

--- a/packages/scraper-framework/src/framework/proxy_health.py
+++ b/packages/scraper-framework/src/framework/proxy_health.py
@@ -1,0 +1,226 @@
+"""Proxy / anti-bot infra health classification (#4633 / #4638).
+
+Shared, stdlib-only home for HTTP ``407`` proxy-auth-failure classification.
+Reused by both the anti-bot scrapers (``sd_tentatives``, ``sf_civil_tentatives``)
+and the operator probe script (``scripts/probe_antibot_proxy.py``) so there is a
+single tested definition of "is this a proxy credential rejection or a plain
+timeout?".
+
+Background (#4633): a lapsed Bright Data residential proxy credential took down
+the SD + SF anti-bot scrapers, but the failure surfaced only as an opaque
+Chromium ``net::ERR_TIMED_OUT``. Chromium masks the repeated ``407`` CONNECT
+challenge as a timeout; urllib surfaces the raw ``Tunnel connection failed: 407
+Auth failed``. Because Bright Data authenticates by customer/zone user:pass
+embedded in the proxy URL (not by source IP), a ``407`` is location-independent
+— it fails identically from a laptop and from the scraper VPC — so a secondary
+stdlib probe through the SAME proxy against a neutral non-court target
+distinguishes a *proxy auth failure* from a *court block* or a genuine timeout.
+
+Only the stdlib is used for the network legs (``urllib``) so this module stays
+dependency-light and runnable anywhere.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+# Short, honest User-Agent so the request is not obviously a bare urllib client.
+_USER_AGENT = "judgemind-proxy-health/1.0"
+
+# Substrings in a proxy error string that indicate an HTTP 407 credential
+# rejection. A plain timeout ('timed out', Chromium 'net::ERR_TIMED_OUT') and a
+# connection refusal carry none of these, so they classify as UNREACHABLE.
+_AUTH_MARKERS = ("407", "auth failed", "proxy authentication required")
+
+
+class ProxyAuthStatus(enum.Enum):
+    """Outcome of a proxy egress probe."""
+
+    HEALTHY = "healthy"
+    AUTH_FAILED = "auth_failed"  # HTTP 407 — proxy credential rejected
+    UNREACHABLE = "unreachable"  # timeout / conn refused / DNS — NOT an auth failure
+    NO_PROXY = "no_proxy"  # no proxy_url configured
+
+
+@dataclass
+class EgressProbeResult:
+    """Result of a single :func:`probe_http_egress` call."""
+
+    status: ProxyAuthStatus
+    http_status: int | None
+    latency_s: float | None
+    detail: str
+    body: str | None = None  # response body (the egress IP, for api.ipify.org)
+
+
+def classify_proxy_error(error_text: str) -> ProxyAuthStatus:
+    """Classify a proxy error string.
+
+    Returns :attr:`ProxyAuthStatus.AUTH_FAILED` when the text carries a 407
+    marker (``407``, ``auth failed``, ``proxy authentication required``);
+    otherwise :attr:`ProxyAuthStatus.UNREACHABLE`.
+
+    This is the crux of the module: it maps urllib's raw ``Tunnel connection
+    failed: 407 Auth failed`` to ``AUTH_FAILED`` while a plain ``timed out`` /
+    Chromium ``net::ERR_TIMED_OUT`` stays ``UNREACHABLE``.
+    """
+    lowered = (error_text or "").lower()
+    for marker in _AUTH_MARKERS:
+        if marker in lowered:
+            return ProxyAuthStatus.AUTH_FAILED
+    return ProxyAuthStatus.UNREACHABLE
+
+
+def _default_opener_factory(proxy_url: str | None) -> urllib.request.OpenerDirector:
+    """Build a real urllib opener, routing through ``proxy_url`` when set."""
+    if proxy_url:
+        handler = urllib.request.ProxyHandler({"http": proxy_url, "https": proxy_url})
+        return urllib.request.build_opener(handler)
+    return urllib.request.build_opener()
+
+
+def probe_http_egress(
+    target_url: str,
+    *,
+    proxy_url: str | None = None,
+    timeout: float = 15.0,
+    opener_factory: Callable[[str | None], Any] | None = None,
+) -> EgressProbeResult:
+    """Perform a single timed GET to ``target_url``, optionally through a proxy.
+
+    * ``proxy_url`` ``None`` -> direct request (control leg).
+    * ``proxy_url`` set -> route through a urllib ``ProxyHandler``.
+
+    A ``407`` surfaces as an :class:`urllib.error.HTTPError` with ``code == 407``
+    for an HTTP target, or (for an HTTPS CONNECT tunnel) as an
+    :class:`urllib.error.URLError` whose reason contains ``407 Auth failed``.
+    Both are mapped to :attr:`ProxyAuthStatus.AUTH_FAILED`. A ``2xx`` response is
+    ``HEALTHY`` with the body captured (the egress IP, for ``api.ipify.org``).
+
+    ``opener_factory`` is an injection seam for tests; the default builds a real
+    urllib opener with the proxy handler.
+    """
+    factory = opener_factory or _default_opener_factory
+    request = urllib.request.Request(target_url, headers={"User-Agent": _USER_AGENT})
+    start = time.monotonic()
+    try:
+        opener = factory(proxy_url)
+        response = opener.open(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        latency = time.monotonic() - start
+        # HTTPError is a file-like response object; close it to avoid leaking
+        # the underlying connection / file descriptor on repeated errors
+        # (the 407 this probe detects, or any other server error). fp=None is a
+        # no-op, so this is safe for synthesized errors in tests too.
+        exc.close()
+        if exc.code == 407:
+            return EgressProbeResult(
+                status=ProxyAuthStatus.AUTH_FAILED,
+                http_status=407,
+                latency_s=latency,
+                detail=f"HTTP 407 proxy authentication required: {exc}",
+            )
+        return EgressProbeResult(
+            status=ProxyAuthStatus.UNREACHABLE,
+            http_status=exc.code,
+            latency_s=latency,
+            detail=f"HTTP {exc.code}: {exc}",
+        )
+    except urllib.error.URLError as exc:
+        latency = time.monotonic() - start
+        reason = str(exc.reason)
+        status = classify_proxy_error(reason)
+        return EgressProbeResult(
+            status=status,
+            http_status=407 if status is ProxyAuthStatus.AUTH_FAILED else None,
+            latency_s=latency,
+            detail=reason,
+        )
+    except Exception as exc:  # noqa: BLE001 — any transport error is "unreachable"
+        latency = time.monotonic() - start
+        return EgressProbeResult(
+            status=ProxyAuthStatus.UNREACHABLE,
+            http_status=None,
+            latency_s=latency,
+            detail=str(exc),
+        )
+
+    latency = time.monotonic() - start
+    try:
+        raw = response.read()
+    finally:
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+    body = raw.decode("utf-8", errors="replace").strip() if raw else ""
+    getcode = getattr(response, "getcode", None)
+    http_status = getattr(response, "status", None)
+    if http_status is None and callable(getcode):
+        http_status = getcode()
+    return EgressProbeResult(
+        status=ProxyAuthStatus.HEALTHY,
+        http_status=http_status,
+        latency_s=latency,
+        detail="ok",
+        body=body,
+    )
+
+
+def diagnose_and_log_proxy_auth(
+    log: Any,
+    proxy_url: str | None,
+    *,
+    neutral_url: str = "https://api.ipify.org",
+    timeout: float = 15.0,
+    probe: Callable[..., EgressProbeResult] = probe_http_egress,
+) -> ProxyAuthStatus:
+    """Diagnose an opaque proxied-navigation failure and log distinctly.
+
+    After a proxied navigation fails opaquely (Chromium ``net::ERR_TIMED_OUT``),
+    run a stdlib probe through the SAME proxy against a neutral non-court target.
+    When the proxy rejects auth with ``407``, emit a distinct
+    ``proxy.auth_failed`` structlog event so a Bright Data credential lapse
+    surfaces explicitly instead of the opaque timeout. Returns the classified
+    status.
+
+    * ``proxy_url`` falsy -> return :attr:`ProxyAuthStatus.NO_PROXY`; do not
+      probe, do not log.
+    * ``AUTH_FAILED`` -> ``log.error("proxy.auth_failed", proxy_status=407, ...)``
+      with a rotation hint.
+    * otherwise -> ``log.info("proxy.auth_check", status=..., ...)``.
+
+    ``probe`` is injectable for tests. ``log`` is a structlog BoundLogger (the
+    scraper's ``self._log``).
+    """
+    if not proxy_url:
+        return ProxyAuthStatus.NO_PROXY
+
+    result = probe(neutral_url, proxy_url=proxy_url, timeout=timeout)
+
+    if result.status is ProxyAuthStatus.AUTH_FAILED:
+        log.error(
+            "proxy.auth_failed",
+            proxy_status=407,
+            neutral_target=neutral_url,
+            detail=result.detail,
+            latency_s=result.latency_s,
+            hint=(
+                "proxy credential rejected (HTTP 407) — rotate SD_PROXY_URL / "
+                "Bright Data zone password; not a court block or timeout"
+            ),
+        )
+    else:
+        log.info(
+            "proxy.auth_check",
+            status=result.status.value,
+            neutral_target=neutral_url,
+            detail=result.detail,
+            latency_s=result.latency_s,
+        )
+    return result.status

--- a/packages/scraper-framework/src/framework/turnstile_solver.py
+++ b/packages/scraper-framework/src/framework/turnstile_solver.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from dataclasses import dataclass
 
 import httpx
 import structlog
@@ -39,6 +40,9 @@ logger = structlog.get_logger(__name__)
 
 # CAPSolver API base URL.
 CAPSOLVER_API_BASE = "https://api.capsolver.com"
+
+# CAPSolver balance endpoint path (POST {clientKey}).
+CAPSOLVER_BALANCE_PATH = "/getBalance"
 
 # Default overall timeout in seconds for solve_turnstile (the issue notes
 # typical solve time is 10-30s; we keep 120s headroom for CAPSolver's
@@ -51,6 +55,99 @@ POLL_INTERVAL_SECONDS = 3.0
 
 # CAPSolver task type for Turnstile solves without a proxy.
 TASK_TYPE_TURNSTILE_PROXYLESS = "AntiTurnstileTaskProxyLess"
+
+
+@dataclass
+class CapsolverBalance:
+    """Result of a CAPSolver ``getBalance`` credential-health check."""
+
+    valid: bool
+    balance: float | None
+    error_code: str | None
+    error_description: str | None
+
+
+async def get_balance(api_key: str | None, *, timeout: float = 30.0) -> CapsolverBalance:
+    """Check a CAPSolver key's validity and remaining balance via ``getBalance``.
+
+    ``POST /getBalance {clientKey}``. Semantics:
+
+    * Missing/empty key -> ``valid=False`` without making an API call.
+    * ``errorId == 0`` -> ``valid=True`` with ``balance`` from the response.
+    * ``errorId != 0`` (e.g. ``ERROR_KEY_DOES_NOT_EXIST``) -> ``valid=False``
+      with ``error_code`` / ``error_description`` populated.
+    * Any httpx/JSON error -> ``valid=False`` with a detail string.
+
+    Note (#4633): CAPSolver returns HTTP ``400`` with an ``errorId`` body for an
+    invalid key, so this deliberately does NOT call ``raise_for_status`` — it
+    parses the JSON body regardless of status code to surface ``errorCode``
+    distinctly rather than reporting an opaque HTTP failure.
+
+    Args:
+        api_key: The CAPSolver API key (``clientKey``).
+        timeout: Request timeout in seconds.
+
+    Returns:
+        A :class:`CapsolverBalance` describing key validity and balance.
+    """
+    key = api_key or ""
+    if not key:
+        return CapsolverBalance(
+            valid=False,
+            balance=None,
+            error_code=None,
+            error_description="no api key",
+        )
+
+    try:
+        async with httpx.AsyncClient(
+            base_url=CAPSOLVER_API_BASE,
+            timeout=timeout,
+            headers={"Content-Type": "application/json"},
+        ) as client:
+            response = await client.post(CAPSOLVER_BALANCE_PATH, json={"clientKey": key})
+    except httpx.HTTPError as exc:
+        logger.error("capsolver.get_balance_http_error", error=str(exc))
+        return CapsolverBalance(
+            valid=False,
+            balance=None,
+            error_code=None,
+            error_description=str(exc),
+        )
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        logger.error("capsolver.get_balance_invalid_json", error=str(exc))
+        return CapsolverBalance(
+            valid=False,
+            balance=None,
+            error_code=None,
+            error_description=f"invalid json: {exc}",
+        )
+
+    error_id = data.get("errorId", 0)
+    if error_id != 0:
+        logger.error(
+            "capsolver.get_balance_api_error",
+            error_id=error_id,
+            error_code=data.get("errorCode"),
+            error_description=data.get("errorDescription"),
+        )
+        return CapsolverBalance(
+            valid=False,
+            balance=None,
+            error_code=data.get("errorCode"),
+            error_description=data.get("errorDescription"),
+        )
+
+    balance = data.get("balance")
+    return CapsolverBalance(
+        valid=True,
+        balance=balance,
+        error_code=None,
+        error_description=None,
+    )
 
 
 async def solve_turnstile(

--- a/packages/scraper-framework/tests/courts/test_proxy_auth_diagnosis_wiring.py
+++ b/packages/scraper-framework/tests/courts/test_proxy_auth_diagnosis_wiring.py
@@ -1,0 +1,135 @@
+"""Integration tests: SD/SF scrapers run proxy-auth diagnosis on all-retries
+failure when a proxy is configured (#4638).
+
+These assert the wiring — that ``_solve_cloudflare`` / ``_acquire_session``
+invoke ``diagnose_and_log_proxy_auth`` with the proxy URL after exhausting
+retries — without standing up a full playwright stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import courts.ca.sd_tentatives as sd_mod
+import courts.ca.sf_civil_tentatives as sf_mod
+from courts.ca.sd_tentatives import SDTentativeRulingsScraper
+from courts.ca.sf_civil_tentatives import SFCivilTentativeRulingsScraper
+from framework.models import ScraperConfig
+
+pytestmark = pytest.mark.regression
+
+PROXY_URL = "http://user:pass@proxy.example:33335"
+
+
+def _sd_config() -> ScraperConfig:
+    return ScraperConfig(
+        scraper_id="ca-sd-tentatives-test",
+        state="CA",
+        county="San Diego",
+        court="Superior Court",
+        target_urls=["https://odyroa.sdcourt.ca.gov"],
+        request_delay_seconds=0.0,
+    )
+
+
+def _sf_config() -> ScraperConfig:
+    return ScraperConfig(
+        scraper_id="ca-sf-civil-tentatives-test",
+        state="CA",
+        county="San Francisco",
+        court="Superior Court",
+        target_urls=["https://webapps.sftc.org"],
+        request_delay_seconds=0.0,
+    )
+
+
+class TestSDProxyAuthDiagnosisWiring:
+    def test_diagnosis_invoked_on_all_retries_failure_with_proxy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scraper = SDTentativeRulingsScraper(_sd_config(), case_numbers=["X"], proxy_url=PROXY_URL)
+        assert scraper._proxy_url == PROXY_URL
+
+        diag = MagicMock()
+        monkeypatch.setattr(sd_mod, "diagnose_and_log_proxy_auth", diag)
+        monkeypatch.setattr(sd_mod, "CF_MAX_RETRIES", 1)
+
+        page = AsyncMock()
+        page.goto = AsyncMock(side_effect=RuntimeError("net::ERR_TIMED_OUT"))
+        page.context = AsyncMock()
+
+        result = asyncio.run(scraper._solve_cloudflare(page))
+
+        assert result is False
+        diag.assert_called_once()
+        # Called with (self._log, self._proxy_url).
+        args = diag.call_args.args
+        assert args[1] == PROXY_URL
+
+    def test_diagnosis_not_invoked_without_proxy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        scraper = SDTentativeRulingsScraper(_sd_config(), case_numbers=["X"])
+        # Ensure no ambient proxy env leaks in.
+        scraper._proxy_url = None
+
+        diag = MagicMock()
+        monkeypatch.setattr(sd_mod, "diagnose_and_log_proxy_auth", diag)
+        monkeypatch.setattr(sd_mod, "CF_MAX_RETRIES", 1)
+
+        page = AsyncMock()
+        page.goto = AsyncMock(side_effect=RuntimeError("net::ERR_TIMED_OUT"))
+        page.context = AsyncMock()
+
+        result = asyncio.run(scraper._solve_cloudflare(page))
+
+        assert result is False
+        diag.assert_not_called()
+
+
+class TestSFProxyAuthDiagnosisWiring:
+    def test_diagnosis_invoked_on_all_retries_failure_with_proxy(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CAPSOLVER_API_KEY", raising=False)
+        scraper = SFCivilTentativeRulingsScraper(config=_sf_config(), proxy_url=PROXY_URL)
+        assert scraper._proxy_url == PROXY_URL
+
+        diag = MagicMock()
+        monkeypatch.setattr(sf_mod, "diagnose_and_log_proxy_auth", diag)
+        monkeypatch.setattr(sf_mod, "SESSION_MAX_RETRIES", 1)
+
+        async def _fail_try_acquire(_pw: Any) -> str | None:
+            return None
+
+        scraper._try_acquire_session = _fail_try_acquire  # type: ignore[assignment]
+
+        result = asyncio.run(scraper._acquire_session())
+
+        assert result is None
+        diag.assert_called_once()
+        args = diag.call_args.args
+        assert args[1] == PROXY_URL
+
+    def test_diagnosis_not_invoked_without_proxy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CAPSOLVER_API_KEY", raising=False)
+        monkeypatch.delenv("SF_PROXY_URL", raising=False)
+        monkeypatch.delenv("SD_PROXY_URL", raising=False)
+        scraper = SFCivilTentativeRulingsScraper(config=_sf_config())
+        scraper._proxy_url = None
+
+        diag = MagicMock()
+        monkeypatch.setattr(sf_mod, "diagnose_and_log_proxy_auth", diag)
+        monkeypatch.setattr(sf_mod, "SESSION_MAX_RETRIES", 1)
+
+        async def _fail_try_acquire(_pw: Any) -> str | None:
+            return None
+
+        scraper._try_acquire_session = _fail_try_acquire  # type: ignore[assignment]
+
+        result = asyncio.run(scraper._acquire_session())
+
+        assert result is None
+        diag.assert_not_called()

--- a/packages/scraper-framework/tests/test_probe_antibot_proxy.py
+++ b/packages/scraper-framework/tests/test_probe_antibot_proxy.py
@@ -1,0 +1,207 @@
+"""Tests for scripts/probe_antibot_proxy.py (#4638).
+
+The script is imported via importlib after inserting scripts/ on sys.path, the
+same pattern as test_cc_dual_run_diff_script.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from framework.proxy_health import EgressProbeResult, ProxyAuthStatus
+from framework.turnstile_solver import CapsolverBalance
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+probe = import_module("probe_antibot_proxy")
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _healthy_egress(
+    target_url: str, *, proxy_url: str | None = None, **_kwargs: Any
+) -> EgressProbeResult:
+    return EgressProbeResult(
+        status=ProxyAuthStatus.HEALTHY,
+        http_status=200,
+        latency_s=0.4,
+        detail="ok",
+        body="44.224.204.57" if proxy_url is None else None,
+    )
+
+
+def _auth_failed_egress(
+    target_url: str, *, proxy_url: str | None = None, **_kwargs: Any
+) -> EgressProbeResult:
+    if proxy_url is None:
+        # The direct control leg is healthy — egress itself is fine.
+        return EgressProbeResult(
+            status=ProxyAuthStatus.HEALTHY,
+            http_status=200,
+            latency_s=0.4,
+            detail="ok",
+            body="44.224.204.57",
+        )
+    return EgressProbeResult(
+        status=ProxyAuthStatus.AUTH_FAILED,
+        http_status=407,
+        latency_s=1.29,
+        detail="Tunnel connection failed: 407 Auth failed",
+    )
+
+
+async def _valid_balance(_key: Any) -> CapsolverBalance:
+    return CapsolverBalance(valid=True, balance=12.5, error_code=None, error_description=None)
+
+
+async def _invalid_balance(_key: Any) -> CapsolverBalance:
+    return CapsolverBalance(
+        valid=False,
+        balance=None,
+        error_code="ERROR_KEY_DOES_NOT_EXIST",
+        error_description="clientKey is invalid",
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunChecks:
+    def test_auth_failed_proxy_rows_report_auth_failed(self) -> None:
+        results = probe.run_checks(
+            "http://user:pass@proxy:1234",
+            "bad-key",
+            egress_probe=_auth_failed_egress,
+            balance_fn=_invalid_balance,
+        )
+        by_name = {r.name: r for r in results}
+        assert by_name[probe.DIRECT_EGRESS].status == ProxyAuthStatus.HEALTHY.value
+        assert by_name[probe.PROXIED_NEUTRAL].status == ProxyAuthStatus.AUTH_FAILED.value
+        assert by_name[probe.PROXIED_SD_PORTAL].status == ProxyAuthStatus.AUTH_FAILED.value
+        assert by_name[probe.PROXIED_SF_CAPTCHA].status == ProxyAuthStatus.AUTH_FAILED.value
+        assert by_name[probe.CAPSOLVER_BALANCE].status == "invalid"
+        assert "ERROR_KEY_DOES_NOT_EXIST" in by_name[probe.CAPSOLVER_BALANCE].detail
+
+    def test_all_healthy_and_valid(self) -> None:
+        results = probe.run_checks(
+            "http://user:pass@proxy:1234",
+            "good-key",
+            egress_probe=_healthy_egress,
+            balance_fn=_valid_balance,
+        )
+        by_name = {r.name: r for r in results}
+        assert by_name[probe.PROXIED_NEUTRAL].status == ProxyAuthStatus.HEALTHY.value
+        assert by_name[probe.CAPSOLVER_BALANCE].status == "valid"
+
+    def test_no_proxy_marks_proxied_rows_no_proxy(self) -> None:
+        results = probe.run_checks(
+            None,
+            "good-key",
+            egress_probe=_healthy_egress,
+            balance_fn=_valid_balance,
+        )
+        by_name = {r.name: r for r in results}
+        assert by_name[probe.DIRECT_EGRESS].status == ProxyAuthStatus.HEALTHY.value
+        assert by_name[probe.PROXIED_NEUTRAL].status == ProxyAuthStatus.NO_PROXY.value
+
+
+# ---------------------------------------------------------------------------
+# format_table
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTable:
+    def test_renders_header_and_one_row_per_check(self) -> None:
+        results = probe.run_checks(
+            "http://user:pass@proxy:1234",
+            "good-key",
+            egress_probe=_healthy_egress,
+            balance_fn=_valid_balance,
+        )
+        table = probe.format_table(results)
+        lines = table.splitlines()
+        # Header + separator + 5 checks.
+        assert lines[0].split()[0] == "CHECK"
+        assert "STATUS" in lines[0]
+        assert len(lines) == 2 + len(results)
+        for r in results:
+            assert r.name in table
+        assert "healthy" in table
+
+    def test_auth_failed_status_appears(self) -> None:
+        results = probe.run_checks(
+            "http://user:pass@proxy:1234",
+            "bad-key",
+            egress_probe=_auth_failed_egress,
+            balance_fn=_invalid_balance,
+        )
+        table = probe.format_table(results)
+        assert ProxyAuthStatus.AUTH_FAILED.value in table
+
+
+# ---------------------------------------------------------------------------
+# main — exit codes
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_exit_1_on_auth_failed(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("SD_PROXY_URL", "http://user:pass@proxy:1234")
+        monkeypatch.setenv("CAPSOLVER_API_KEY", "bad-key")
+        monkeypatch.setattr(probe, "probe_http_egress", _auth_failed_egress)
+        monkeypatch.setattr(probe, "get_balance", _invalid_balance)
+        code = probe.main([])
+        assert code == 1
+        out = capsys.readouterr().out
+        assert ProxyAuthStatus.AUTH_FAILED.value in out
+
+    def test_exit_0_on_all_healthy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SD_PROXY_URL", "http://user:pass@proxy:1234")
+        monkeypatch.setenv("CAPSOLVER_API_KEY", "good-key")
+        monkeypatch.setattr(probe, "probe_http_egress", _healthy_egress)
+        monkeypatch.setattr(probe, "get_balance", _valid_balance)
+        code = probe.main([])
+        assert code == 0
+
+    def test_json_output(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        monkeypatch.setenv("SD_PROXY_URL", "http://user:pass@proxy:1234")
+        monkeypatch.setenv("CAPSOLVER_API_KEY", "good-key")
+        monkeypatch.setattr(probe, "probe_http_egress", _healthy_egress)
+        monkeypatch.setattr(probe, "get_balance", _valid_balance)
+        code = probe.main(["--json"])
+        assert code == 0
+        import json as _json
+
+        payload = _json.loads(capsys.readouterr().out)
+        assert isinstance(payload, list)
+        assert {r["name"] for r in payload} == {
+            probe.DIRECT_EGRESS,
+            probe.PROXIED_NEUTRAL,
+            probe.PROXIED_SD_PORTAL,
+            probe.PROXIED_SF_CAPTCHA,
+            probe.CAPSOLVER_BALANCE,
+        }
+
+    def test_exit_1_when_proxy_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SD_PROXY_URL", raising=False)
+        monkeypatch.setenv("CAPSOLVER_API_KEY", "good-key")
+        monkeypatch.setattr(probe, "probe_http_egress", _healthy_egress)
+        monkeypatch.setattr(probe, "get_balance", _valid_balance)
+        code = probe.main([])
+        # proxied_neutral is NO_PROXY -> not healthy -> exit 1.
+        assert code == 1

--- a/packages/scraper-framework/tests/test_proxy_health.py
+++ b/packages/scraper-framework/tests/test_proxy_health.py
@@ -1,0 +1,227 @@
+"""Tests for framework.proxy_health — 407 proxy-auth classification (#4638)."""
+
+from __future__ import annotations
+
+import urllib.error
+from typing import Any
+
+from structlog.testing import capture_logs
+
+from framework.proxy_health import (
+    EgressProbeResult,
+    ProxyAuthStatus,
+    classify_proxy_error,
+    diagnose_and_log_proxy_auth,
+    probe_http_egress,
+)
+
+
+class _FakeResponse:
+    """Minimal stand-in for a urllib response object."""
+
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+        self.closed = False
+
+    def read(self) -> bytes:
+        return self._body
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeOpener:
+    def __init__(self, *, exc: Exception | None = None, response: Any = None) -> None:
+        self._exc = exc
+        self._response = response
+
+    def open(self, request: Any, timeout: float | None = None) -> Any:
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# classify_proxy_error
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyProxyError:
+    def test_tunnel_407_is_auth_failed(self) -> None:
+        assert (
+            classify_proxy_error("Tunnel connection failed: 407 Auth failed")
+            is ProxyAuthStatus.AUTH_FAILED
+        )
+
+    def test_operation_timed_out_is_unreachable(self) -> None:
+        assert (
+            classify_proxy_error("<urlopen error [Errno 60] Operation timed out>")
+            is ProxyAuthStatus.UNREACHABLE
+        )
+
+    def test_chromium_masked_timeout_is_unreachable(self) -> None:
+        # The whole reason we do a secondary stdlib probe: the raw Chromium
+        # string is NOT a 407.
+        assert classify_proxy_error("net::ERR_TIMED_OUT") is ProxyAuthStatus.UNREACHABLE
+
+    def test_proxy_authentication_required_is_auth_failed(self) -> None:
+        assert (
+            classify_proxy_error("407 Proxy Authentication Required") is ProxyAuthStatus.AUTH_FAILED
+        )
+
+    def test_empty_string_is_unreachable(self) -> None:
+        assert classify_proxy_error("") is ProxyAuthStatus.UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# probe_http_egress
+# ---------------------------------------------------------------------------
+
+
+class TestProbeHttpEgress:
+    def test_tunnel_407_url_error_is_auth_failed(self) -> None:
+        opener = _FakeOpener(exc=urllib.error.URLError("Tunnel connection failed: 407 Auth failed"))
+        result = probe_http_egress(
+            "https://api.ipify.org",
+            proxy_url="http://user:pass@proxy:1234",
+            opener_factory=lambda _proxy: opener,
+        )
+        assert result.status is ProxyAuthStatus.AUTH_FAILED
+        assert result.http_status == 407
+        assert result.latency_s is not None
+
+    def test_timeout_url_error_is_unreachable(self) -> None:
+        opener = _FakeOpener(
+            exc=urllib.error.URLError("<urlopen error [Errno 60] Operation timed out>")
+        )
+        result = probe_http_egress(
+            "https://api.ipify.org",
+            proxy_url="http://user:pass@proxy:1234",
+            opener_factory=lambda _proxy: opener,
+        )
+        assert result.status is ProxyAuthStatus.UNREACHABLE
+        assert result.http_status is None
+
+    def test_200_response_is_healthy_with_body(self) -> None:
+        opener = _FakeOpener(response=_FakeResponse(b"44.224.204.57\n", status=200))
+        result = probe_http_egress(
+            "https://api.ipify.org",
+            opener_factory=lambda _proxy: opener,
+        )
+        assert result.status is ProxyAuthStatus.HEALTHY
+        assert result.http_status == 200
+        assert result.body == "44.224.204.57"
+
+    def test_http_error_407_is_auth_failed(self) -> None:
+        http_error = urllib.error.HTTPError(
+            url="http://api.ipify.org",
+            code=407,
+            msg="Proxy Authentication Required",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+        opener = _FakeOpener(exc=http_error)
+        result = probe_http_egress(
+            "http://api.ipify.org",
+            proxy_url="http://user:pass@proxy:1234",
+            opener_factory=lambda _proxy: opener,
+        )
+        assert result.status is ProxyAuthStatus.AUTH_FAILED
+        assert result.http_status == 407
+
+    def test_http_error_non_407_is_unreachable(self) -> None:
+        http_error = urllib.error.HTTPError(
+            url="http://api.ipify.org",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,  # type: ignore[arg-type]
+            fp=None,
+        )
+        opener = _FakeOpener(exc=http_error)
+        result = probe_http_egress(
+            "http://api.ipify.org",
+            opener_factory=lambda _proxy: opener,
+        )
+        assert result.status is ProxyAuthStatus.UNREACHABLE
+        assert result.http_status == 503
+
+    def test_unexpected_error_is_unreachable(self) -> None:
+        opener = _FakeOpener(exc=ConnectionResetError("boom"))
+        result = probe_http_egress(
+            "https://api.ipify.org",
+            opener_factory=lambda _proxy: opener,
+        )
+        assert result.status is ProxyAuthStatus.UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# diagnose_and_log_proxy_auth
+# ---------------------------------------------------------------------------
+
+
+def _auth_failed_probe(*_args: Any, **_kwargs: Any) -> EgressProbeResult:
+    return EgressProbeResult(
+        status=ProxyAuthStatus.AUTH_FAILED,
+        http_status=407,
+        latency_s=1.29,
+        detail="Tunnel connection failed: 407 Auth failed",
+    )
+
+
+def _unreachable_probe(*_args: Any, **_kwargs: Any) -> EgressProbeResult:
+    return EgressProbeResult(
+        status=ProxyAuthStatus.UNREACHABLE,
+        http_status=None,
+        latency_s=15.0,
+        detail="timed out",
+    )
+
+
+class TestDiagnoseAndLogProxyAuth:
+    def test_auth_failed_emits_distinct_event(self) -> None:
+        import structlog
+
+        log = structlog.get_logger("test")
+        with capture_logs() as logs:
+            status = diagnose_and_log_proxy_auth(
+                log,
+                "http://user:pass@proxy:1234",
+                probe=_auth_failed_probe,
+            )
+        assert status is ProxyAuthStatus.AUTH_FAILED
+        auth_events = [e for e in logs if e.get("event") == "proxy.auth_failed"]
+        assert len(auth_events) == 1
+        assert auth_events[0]["proxy_status"] == 407
+        assert auth_events[0]["log_level"] == "error"
+
+    def test_unreachable_does_not_emit_auth_failed(self) -> None:
+        import structlog
+
+        log = structlog.get_logger("test")
+        with capture_logs() as logs:
+            status = diagnose_and_log_proxy_auth(
+                log,
+                "http://user:pass@proxy:1234",
+                probe=_unreachable_probe,
+            )
+        assert status is ProxyAuthStatus.UNREACHABLE
+        assert not [e for e in logs if e.get("event") == "proxy.auth_failed"]
+        # A plain timeout still records an info-level auth_check.
+        assert [e for e in logs if e.get("event") == "proxy.auth_check"]
+
+    def test_no_proxy_returns_no_proxy_without_probing(self) -> None:
+        import structlog
+
+        calls: list[Any] = []
+
+        def _tracking_probe(*args: Any, **kwargs: Any) -> EgressProbeResult:
+            calls.append((args, kwargs))
+            return _auth_failed_probe()
+
+        log = structlog.get_logger("test")
+        with capture_logs() as logs:
+            status = diagnose_and_log_proxy_auth(log, None, probe=_tracking_probe)
+        assert status is ProxyAuthStatus.NO_PROXY
+        assert calls == []
+        assert logs == []

--- a/packages/scraper-framework/tests/test_turnstile_solver.py
+++ b/packages/scraper-framework/tests/test_turnstile_solver.py
@@ -8,6 +8,7 @@ import respx
 
 from framework.turnstile_solver import (
     CAPSOLVER_API_BASE,
+    get_balance,
     solve_turnstile,
 )
 
@@ -385,3 +386,73 @@ class TestSolveTurnstileExplicitKeyBeatsEnv:
         assert token == "TOK"
         body = _json.loads(create.calls[0].request.content)
         assert body["clientKey"] == "explicit-key"
+
+
+class TestGetBalance:
+    """get_balance reports CAPSolver key validity + remaining credit (#4638)."""
+
+    @pytest.mark.asyncio
+    async def test_valid_response_returns_balance(self) -> None:
+        """errorId 0 with a balance -> valid=True, balance parsed."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/getBalance").mock(
+                return_value=httpx.Response(200, json={"errorId": 0, "balance": 12.5})
+            )
+            result = await get_balance(API_KEY)
+        assert result.valid is True
+        assert result.balance == 12.5
+        assert result.error_code is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_key_400_body_reports_error_code(self) -> None:
+        """The #4633 invalid-key response — HTTP 400 with an errorId body."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/getBalance").mock(
+                return_value=httpx.Response(
+                    400,
+                    json={
+                        "errorId": 1,
+                        "errorCode": "ERROR_KEY_DOES_NOT_EXIST",
+                        "errorDescription": "clientKey is invalid",
+                    },
+                )
+            )
+            result = await get_balance(API_KEY)
+        assert result.valid is False
+        assert result.error_code == "ERROR_KEY_DOES_NOT_EXIST"
+        assert result.error_description == "clientKey is invalid"
+
+    @pytest.mark.asyncio
+    async def test_empty_key_makes_no_api_call(self) -> None:
+        """Empty key -> valid=False without hitting the API."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE, assert_all_called=False) as router:
+            route = router.post("/getBalance").mock(
+                return_value=httpx.Response(200, json={"errorId": 0, "balance": 1.0})
+            )
+            result = await get_balance("")
+        assert result.valid is False
+        assert result.balance is None
+        assert not route.called
+
+    @pytest.mark.asyncio
+    async def test_none_key_makes_no_api_call(self) -> None:
+        """None key -> valid=False without hitting the API."""
+        result = await get_balance(None)
+        assert result.valid is False
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_invalid(self) -> None:
+        """A transport-level error -> valid=False with a detail string."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/getBalance").mock(side_effect=httpx.ConnectError("boom"))
+            result = await get_balance(API_KEY)
+        assert result.valid is False
+        assert result.error_description is not None
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_returns_invalid(self) -> None:
+        """A non-JSON body -> valid=False."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/getBalance").mock(return_value=httpx.Response(200, text="not json"))
+            result = await get_balance(API_KEY)
+        assert result.valid is False

--- a/scripts/probe_antibot_proxy.py
+++ b/scripts/probe_antibot_proxy.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Anti-bot infra health probe — proxy (Bright Data 407 detection) + CAPSolver.
+
+Operator re-verification tool after rotating the residential proxy / CAPSolver
+credentials (see #4633 / #4638). In #4633 a lapsed Bright Data residential proxy
+credential took down the SD + SF anti-bot scrapers, surfacing only as an opaque
+Chromium ``net::ERR_TIMED_OUT`` — the true cause was an HTTP ``407 Auth failed``
+on the proxy CONNECT. There was no committed tool to check credential health, so
+the investigation had to write a throwaway stdlib probe. This is that probe,
+committed.
+
+Runs five checks and prints a per-check status table:
+
+1. direct egress IP (control) — proves AWS/laptop egress itself is healthy.
+2. proxied egress via a neutral target (``api.ipify.org``) — isolates *proxy
+   auth* from *court blocks*: a neutral non-court target that still fails means
+   the proxy itself is rejecting us, not the court.
+3. proxied reachability of the SD portal.
+4. proxied reachability of the SF captcha gateway.
+5. CAPSolver ``getBalance`` — key validity + remaining credit.
+
+Because Bright Data authenticates by customer/zone user:pass embedded in the
+proxy URL (not by source IP), a ``407`` is location-independent — the probe is
+meaningful to run from anywhere.
+
+Usage::
+
+    scripts/with-secret.sh \\
+        -e SD_PROXY_URL=judgemind/proxy/residential \\
+        -e CAPSOLVER_API_KEY=judgemind/capsolver/api-key \\
+        -- packages/scraper-framework/.venv/bin/python scripts/probe_antibot_proxy.py
+
+Exit code: ``0`` when the proxied-neutral check is HEALTHY AND CAPSolver is
+valid; ``1`` otherwise (so it doubles as a credential-health gate). Pass
+``--json`` to emit the results as JSON instead of the table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json as _json
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+
+from framework.proxy_health import (
+    EgressProbeResult,
+    ProxyAuthStatus,
+    probe_http_egress,
+)
+from framework.turnstile_solver import CapsolverBalance, get_balance
+
+SD_PORTAL_URL = "https://odyroa.sdcourt.ca.gov/portal/"
+SF_CAPTCHA_URL = "https://webapps.sftc.org/captcha/captcha.dll"
+NEUTRAL_URL = "https://api.ipify.org"
+
+# Check names — stable identifiers used by the exit-code gate.
+DIRECT_EGRESS = "direct_egress"
+PROXIED_NEUTRAL = "proxied_neutral"
+PROXIED_SD_PORTAL = "proxied_sd_portal"
+PROXIED_SF_CAPTCHA = "proxied_sf_captcha"
+CAPSOLVER_BALANCE = "capsolver_balance"
+
+
+@dataclass
+class CheckResult:
+    """One row of the probe status table."""
+
+    name: str
+    status: str
+    http_status: int | None
+    latency_s: float | None
+    detail: str
+
+
+def _egress_to_check(name: str, result: EgressProbeResult) -> CheckResult:
+    detail = result.detail
+    if result.body:
+        detail = f"egress_ip={result.body}"
+    return CheckResult(
+        name=name,
+        status=result.status.value,
+        http_status=result.http_status,
+        latency_s=result.latency_s,
+        detail=detail,
+    )
+
+
+def _balance_to_check(balance: CapsolverBalance) -> CheckResult:
+    if balance.valid:
+        return CheckResult(
+            name=CAPSOLVER_BALANCE,
+            status="valid",
+            http_status=None,
+            latency_s=None,
+            detail=f"balance={balance.balance}",
+        )
+    if balance.error_code:
+        detail = f"{balance.error_code}: {balance.error_description}"
+    else:
+        detail = balance.error_description or "invalid"
+    return CheckResult(
+        name=CAPSOLVER_BALANCE,
+        status="invalid",
+        http_status=None,
+        latency_s=None,
+        detail=detail,
+    )
+
+
+def run_checks(
+    proxy_url: str | None,
+    capsolver_key: str | None,
+    *,
+    egress_probe: Callable[..., EgressProbeResult] | None = None,
+    balance_fn: Callable[..., object] | None = None,
+) -> list[CheckResult]:
+    """Run the five anti-bot health checks and return one row each.
+
+    ``egress_probe`` and ``balance_fn`` are injectable so tests can supply fakes
+    and avoid any network I/O. ``balance_fn`` is an async coroutine function
+    (defaults to :func:`framework.turnstile_solver.get_balance`); it is driven
+    via ``asyncio.run`` so ``run_checks`` itself stays synchronous.
+    """
+    egress_probe = egress_probe or probe_http_egress
+    balance_fn = balance_fn or get_balance
+
+    results: list[CheckResult] = []
+
+    # 1. Direct control — no proxy.
+    direct = egress_probe(NEUTRAL_URL, proxy_url=None)
+    results.append(_egress_to_check(DIRECT_EGRESS, direct))
+
+    # 2-4. Proxied legs (neutral, SD portal, SF captcha).
+    proxied_targets = (
+        (PROXIED_NEUTRAL, NEUTRAL_URL),
+        (PROXIED_SD_PORTAL, SD_PORTAL_URL),
+        (PROXIED_SF_CAPTCHA, SF_CAPTCHA_URL),
+    )
+    for name, url in proxied_targets:
+        if proxy_url:
+            result = egress_probe(url, proxy_url=proxy_url)
+            results.append(_egress_to_check(name, result))
+        else:
+            results.append(
+                CheckResult(
+                    name=name,
+                    status=ProxyAuthStatus.NO_PROXY.value,
+                    http_status=None,
+                    latency_s=None,
+                    detail="SD_PROXY_URL unset",
+                )
+            )
+
+    # 5. CAPSolver balance.
+    balance = asyncio.run(balance_fn(capsolver_key))
+    results.append(_balance_to_check(balance))
+
+    return results
+
+
+def format_table(results: list[CheckResult]) -> str:
+    """Render a fixed-width per-check status table with a header row."""
+    headers = ("CHECK", "STATUS", "HTTP", "LATENCY", "DETAIL")
+    rows: list[tuple[str, str, str, str, str]] = []
+    for r in results:
+        rows.append(
+            (
+                r.name,
+                r.status,
+                "" if r.http_status is None else str(r.http_status),
+                "" if r.latency_s is None else f"{r.latency_s:.2f}s",
+                r.detail,
+            )
+        )
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def _fmt(row: tuple[str, ...]) -> str:
+        return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row))
+
+    lines = [_fmt(headers), _fmt(tuple("-" * w for w in widths))]
+    lines.extend(_fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+def _exit_code(results: list[CheckResult]) -> int:
+    by_name = {r.name: r for r in results}
+    neutral = by_name.get(PROXIED_NEUTRAL)
+    balance = by_name.get(CAPSOLVER_BALANCE)
+    neutral_ok = neutral is not None and neutral.status == ProxyAuthStatus.HEALTHY.value
+    balance_ok = balance is not None and balance.status == "valid"
+    return 0 if (neutral_ok and balance_ok) else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Read credentials from env, run the checks, print, and return an exit code."""
+    parser = argparse.ArgumentParser(
+        description="Anti-bot infra health probe (proxy 407 + CAPSolver)."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the results as JSON instead of the status table",
+    )
+    args = parser.parse_args(argv)
+
+    proxy_url = os.environ.get("SD_PROXY_URL", "")
+    capsolver_key = os.environ.get("CAPSOLVER_API_KEY", "")
+
+    results = run_checks(proxy_url or None, capsolver_key)
+
+    if args.json:
+        print(_json.dumps([asdict(r) for r in results], indent=2))
+    else:
+        print(format_table(results))
+
+    return _exit_code(results)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Instrument-before-guess preventatives for the #4633 anti-bot credential-lapse failure class so the next recurrence self-diagnoses. Adds a shared `framework/proxy_health.py` that classifies an HTTP `407` proxy-auth rejection distinctly from a plain timeout and emits a `proxy.auth_failed` structured log (wired into `sd_tentatives` + `sf_civil_tentatives` on the all-retries failure path), a `turnstile_solver.get_balance` CAPSolver credential check, and a committed operator health probe `scripts/probe_antibot_proxy.py`.

In #4633 a lapsed Bright Data residential proxy credential took the SD + SF anti-bot scrapers down, but the failure surfaced only as an opaque Chromium `net::ERR_TIMED_OUT` — the true cause was a `407 Auth failed` on the proxy CONNECT. This change makes that cause explicit and gives the operator a re-verification tool after rotating credentials.

Closes #4638

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (8387 passed, 3 skipped; diff coverage 96%)
- [x] CI green (canonical merge gate: mergeable=MERGEABLE, ci-passed=success)

### Post-deploy verification
- [x] Probe runs end-to-end as a committed CLI — `scripts/probe_antibot_proxy.py` renders the per-check status table (evidence on #4638: real direct-egress 200 + NO_PROXY rows without a secret; simulated 407 -> `auth_failed` rows).
- [x] The `proxy.auth_failed` (407) log-line detection is exercised — simulated 407 emits `proxy.auth_failed` distinctly; a plain timeout emits `proxy.auth_check` (info) and NOT `proxy.auth_failed` (evidence on #4638; asserted by `test_proxy_health.py` + `test_proxy_auth_diagnosis_wiring.py`).
- [x] Verification evidence posted on issue (#4638 comment).
